### PR TITLE
Impl iter() and iter_mut() for some geometries

### DIFF
--- a/src/algorithm/area.rs
+++ b/src/algorithm/area.rs
@@ -24,7 +24,10 @@ where
     fn area(&self) -> T;
 }
 
-fn get_linestring_area<T>(linestring: &LineString<T>) -> T where T: Float {
+fn get_linestring_area<T>(linestring: &LineString<T>) -> T
+where
+    T: Float,
+{
     twice_signed_ring_area(linestring) / (T::one() + T::one())
 }
 
@@ -55,11 +58,8 @@ where
     T: Float,
 {
     fn area(&self) -> T {
-        self.0
-            .iter()
-            .fold(T::zero(), |total, next| {
-                total + next.area()
-            })
+        self.iter()
+            .fold(T::zero(), |total, next| total + next.area())
     }
 }
 

--- a/src/algorithm/boundingbox.rs
+++ b/src/algorithm/boundingbox.rs
@@ -130,7 +130,7 @@ where
     /// Return the BoundingBox for a MultiLineString
     ///
     fn bbox(&self) -> Self::Output {
-        get_bbox(self.0.iter().flat_map(|line| line.0.iter()))
+        get_bbox(self.iter().flat_map(|line| line.iter()))
     }
 }
 
@@ -159,7 +159,7 @@ where
     /// Return the BoundingBox for a MultiPolygon
     ///
     fn bbox(&self) -> Self::Output {
-        get_bbox(self.0.iter().flat_map(|poly| (poly.exterior).0.iter()))
+        get_bbox(self.iter().flat_map(|poly| poly.exterior.iter()))
     }
 }
 

--- a/src/algorithm/boundingbox.rs
+++ b/src/algorithm/boundingbox.rs
@@ -74,7 +74,7 @@ where
     /// Return the BoundingBox for a MultiPoint
     ///
     fn bbox(&self) -> Self::Output {
-        get_bbox(&self.0)
+        get_bbox(self.iter())
     }
 }
 
@@ -116,7 +116,7 @@ where
     /// Return the BoundingBox for a LineString
     ///
     fn bbox(&self) -> Self::Output {
-        get_bbox(&self.0)
+        get_bbox(self.iter())
     }
 }
 
@@ -144,8 +144,7 @@ where
     /// Return the BoundingBox for a Polygon
     ///
     fn bbox(&self) -> Self::Output {
-        let line = &self.exterior;
-        get_bbox(&line.0)
+        get_bbox(self.exterior.iter())
     }
 }
 

--- a/src/algorithm/centroid.rs
+++ b/src/algorithm/centroid.rs
@@ -30,7 +30,7 @@ fn simple_polygon_area<T>(linestring: &LineString<T>) -> T
 where
     T: Float,
 {
-    if linestring.0.is_empty() || linestring.0.len() == 1 {
+    if linestring.is_empty() || linestring.len() == 1 {
         return T::zero();
     }
     let mut tmp = T::zero();
@@ -80,11 +80,11 @@ where
     // The Centroid of a LineString is the mean of the middle of the segment
     // weighted by the length of the segments.
     fn centroid(&self) -> Self::Output {
-        if self.0.is_empty() {
+        if self.is_empty() {
             return None;
         }
-        if self.0.len() == 1 {
-            Some(self.0[0])
+        if self.len() == 1 {
+            Some(self[0])
         } else {
             let mut sum_x = T::zero();
             let mut sum_y = T::zero();
@@ -118,7 +118,7 @@ where
     // See here for detail on alternative methods: https://fotino.me/calculating-centroids/
     fn centroid(&self) -> Self::Output {
         let linestring = &self.exterior;
-        let vect = &linestring.0;
+        let vect = &linestring;
         if vect.is_empty() {
             return None;
         }
@@ -159,11 +159,10 @@ where
         let mut sum_x = T::zero();
         let mut sum_y = T::zero();
         let mut total_area = T::zero();
-        let vect = &self.0;
-        if vect.is_empty() {
+        if self.is_empty() {
             return None;
         }
-        for poly in &self.0 {
+        for poly in self.iter() {
             // the area is signed
             let area = poly.area().abs();
             total_area = total_area + area;

--- a/src/algorithm/closest_point.rs
+++ b/src/algorithm/closest_point.rs
@@ -121,19 +121,19 @@ impl<F: Float> ClosestPoint<F> for Polygon<F> {
 
 impl<F: Float> ClosestPoint<F> for MultiPolygon<F> {
     fn closest_point(&self, p: &Point<F>) -> Closest<F> {
-        closest_of(self.0.iter(), p)
+        closest_of(self.iter(), p)
     }
 }
 
 impl<F: Float> ClosestPoint<F> for MultiPoint<F> {
     fn closest_point(&self, p: &Point<F>) -> Closest<F> {
-        closest_of(self.0.iter(), p)
+        closest_of(self.iter(), p)
     }
 }
 
 impl<F: Float> ClosestPoint<F> for MultiLineString<F> {
     fn closest_point(&self, p: &Point<F>) -> Closest<F> {
-        closest_of(self.0.iter(), p)
+        closest_of(self.iter(), p)
     }
 }
 

--- a/src/algorithm/contains.rs
+++ b/src/algorithm/contains.rs
@@ -47,11 +47,11 @@ where
 {
     fn contains(&self, p: &Point<T>) -> bool {
         // LineString without points
-        if self.0.is_empty() {
+        if self.is_empty() {
             return false;
         }
         // LineString with one point equal p
-        if self.0.len() == 1 {
+        if self.len() == 1 {
             return self.0[0].contains(p);
         }
         // check if point is a vertex
@@ -151,7 +151,7 @@ where
     // Return the position of the point relative to a linestring
 
     // LineString without points
-    if linestring.0.is_empty() {
+    if linestring.is_empty() {
         return PositionPoint::Outside;
     }
     // Point is on linestring

--- a/src/algorithm/contains.rs
+++ b/src/algorithm/contains.rs
@@ -52,7 +52,7 @@ where
         }
         // LineString with one point equal p
         if self.len() == 1 {
-            return self.0[0].contains(p);
+            return self[0].contains(p);
         }
         // check if point is a vertex
         if self.0.contains(p) {

--- a/src/algorithm/contains.rs
+++ b/src/algorithm/contains.rs
@@ -96,7 +96,7 @@ where
     T: Float,
 {
     fn contains(&self, linestring: &LineString<T>) -> bool {
-        linestring.0.iter().all(|pt| self.contains(pt))
+        linestring.iter().all(|pt| self.contains(pt))
     }
 }
 
@@ -200,7 +200,7 @@ where
     T: Float,
 {
     fn contains(&self, p: &Point<T>) -> bool {
-        self.0.iter().any(|poly| poly.contains(p))
+        self.iter().any(|poly| poly.contains(p))
     }
 }
 
@@ -232,7 +232,7 @@ where
 {
     fn contains(&self, linestring: &LineString<T>) -> bool {
         // All LineString points must be inside the Polygon
-        if linestring.0.iter().all(|point| self.contains(point)) {
+        if linestring.iter().all(|point| self.contains(point)) {
             // The Polygon interior is allowed to intersect with the LineString
             // but the Polygon's rings are not
             !self.interiors

--- a/src/algorithm/convexhull.rs
+++ b/src/algorithm/convexhull.rs
@@ -169,7 +169,7 @@ where
     T: Float,
 {
     fn convex_hull(&self) -> Polygon<T> {
-        Polygon::new(LineString(quick_hull(&mut self.exterior.0.clone())), vec![])
+        Polygon::new(LineString(quick_hull(&mut self.exterior.clone())), vec![])
     }
 }
 
@@ -178,7 +178,7 @@ where
     T: Float,
 {
     fn convex_hull(&self) -> Polygon<T> {
-        let mut aggregated: Vec<Point<T>> = self.0
+        let mut aggregated: Vec<Point<T>> = self
             .iter()
             .flat_map(|elem| elem.exterior.iter().cloned())
             .collect();
@@ -191,7 +191,7 @@ where
     T: Float,
 {
     fn convex_hull(&self) -> Polygon<T> {
-        Polygon::new(LineString(quick_hull(&mut self.0.clone())), vec![])
+        Polygon::new(LineString(quick_hull(&mut self.clone())), vec![])
     }
 }
 
@@ -200,7 +200,7 @@ where
     T: Float,
 {
     fn convex_hull(&self) -> Polygon<T> {
-        let mut aggregated: Vec<Point<T>> = self.0
+        let mut aggregated: Vec<Point<T>> = self
             .iter()
             .flat_map(|elem| elem.iter().cloned())
             .collect();
@@ -213,7 +213,7 @@ where
     T: Float,
 {
     fn convex_hull(&self) -> Polygon<T> {
-        Polygon::new(LineString(quick_hull(&mut self.0.clone())), vec![])
+        Polygon::new(LineString(quick_hull(&mut self.clone())), vec![])
     }
 }
 

--- a/src/algorithm/convexhull.rs
+++ b/src/algorithm/convexhull.rs
@@ -180,7 +180,7 @@ where
     fn convex_hull(&self) -> Polygon<T> {
         let mut aggregated: Vec<Point<T>> = self.0
             .iter()
-            .flat_map(|elem| elem.exterior.0.iter().cloned())
+            .flat_map(|elem| elem.exterior.iter().cloned())
             .collect();
         Polygon::new(LineString(quick_hull(&mut aggregated)), vec![])
     }
@@ -202,7 +202,7 @@ where
     fn convex_hull(&self) -> Polygon<T> {
         let mut aggregated: Vec<Point<T>> = self.0
             .iter()
-            .flat_map(|elem| elem.0.iter().cloned())
+            .flat_map(|elem| elem.iter().cloned())
             .collect();
         Polygon::new(LineString(quick_hull(&mut aggregated)), vec![])
     }

--- a/src/algorithm/distance.rs
+++ b/src/algorithm/distance.rs
@@ -104,7 +104,6 @@ where
     /// Minimum distance from a Point to a MultiPoint
     fn distance(&self, points: &MultiPoint<T>) -> T {
         points
-            .0
             .iter()
             .map(|p| {
                 let (dx, dy) = (self.x() - p.x(), self.y() - p.y());
@@ -131,7 +130,7 @@ where
     /// Minimum distance from a Point to a Polygon
     fn distance(&self, polygon: &Polygon<T>) -> T {
         // No need to continue if the polygon contains the point, or is zero-length
-        if polygon.contains(self) || polygon.exterior.0.is_empty() {
+        if polygon.contains(self) || polygon.exterior.is_empty() {
             return T::zero();
         }
         // fold the minimum interior ring distance if any, followed by the exterior
@@ -168,7 +167,6 @@ where
     /// Minimum distance from a Point to a MultiPolygon
     fn distance(&self, mpolygon: &MultiPolygon<T>) -> T {
         mpolygon
-            .0
             .iter()
             .map(|p| self.distance(p))
             .fold(T::max_value(), |accum, val| accum.min(val))
@@ -191,8 +189,7 @@ where
 {
     /// Minimum distance from a Point to a MultiLineString
     fn distance(&self, mls: &MultiLineString<T>) -> T {
-        mls.0
-            .iter()
+        mls.iter()
             .map(|ls| self.distance(ls))
             .fold(T::max_value(), |accum, val| accum.min(val))
     }

--- a/src/algorithm/distance.rs
+++ b/src/algorithm/distance.rs
@@ -212,7 +212,7 @@ where
     /// Minimum distance from a Point to a LineString
     fn distance(&self, linestring: &LineString<T>) -> T {
         // No need to continue if the point is on the LineString, or it's empty
-        if linestring.contains(self) || linestring.0.is_empty() {
+        if linestring.contains(self) || linestring.is_empty() {
             return T::zero();
         }
         linestring

--- a/src/algorithm/extremes.rs
+++ b/src/algorithm/extremes.rs
@@ -73,7 +73,7 @@ fn polymax_naive_indices<T>(u: &Point<T>, poly: &Polygon<T>) -> Result<usize, ()
 where
     T: Float,
 {
-    let vertices = &poly.exterior.0;
+    let vertices = &poly.exterior;
     let mut max: usize = 0;
     for (i, _) in vertices.iter().enumerate() {
         // if vertices[i] is above prior vertices[max]
@@ -165,10 +165,10 @@ where
         // safe to unwrap, since we're guaranteeing the polygon's convexity
         let indices = ch.extreme_indices().unwrap();
         ExtremePoint {
-            ymin: ch.exterior.0[indices.ymin],
-            xmax: ch.exterior.0[indices.xmax],
-            ymax: ch.exterior.0[indices.ymax],
-            xmin: ch.exterior.0[indices.xmin],
+            ymin: ch.exterior[indices.ymin],
+            xmax: ch.exterior[indices.xmax],
+            ymax: ch.exterior[indices.ymax],
+            xmin: ch.exterior[indices.xmin],
         }
     }
 }

--- a/src/algorithm/haversine_length.rs
+++ b/src/algorithm/haversine_length.rs
@@ -45,6 +45,6 @@ impl<T> HaversineLength<T> for MultiLineString<T>
     where T: Float + FromPrimitive
 {
     fn haversine_length(&self) -> T {
-        self.0.iter().fold(T::zero(), |total, line| total + line.haversine_length())
+        self.iter().fold(T::zero(), |total, line| total + line.haversine_length())
     }
 }

--- a/src/algorithm/haversine_length.rs
+++ b/src/algorithm/haversine_length.rs
@@ -36,7 +36,7 @@ impl<T> HaversineLength<T> for LineString<T>
     where T: Float + FromPrimitive
 {
     fn haversine_length(&self) -> T {
-        self.0.windows(2)
+        self.windows(2)
               .fold(T::zero(), |total_length, p| total_length + p[0].haversine_distance(&p[1]))
     }
 }

--- a/src/algorithm/intersects.rs
+++ b/src/algorithm/intersects.rs
@@ -142,7 +142,7 @@ where
 {
     // See: https://github.com/brandonxiang/geojson-python-utils/blob/33b4c00c6cf27921fb296052d0c0341bd6ca1af2/geojson_utils.py
     fn intersects(&self, linestring: &LineString<T>) -> bool {
-        if self.0.is_empty() || linestring.0.is_empty() {
+        if self.is_empty() || linestring.is_empty() {
             return false;
         }
         for a in self.lines() {

--- a/src/algorithm/intersects.rs
+++ b/src/algorithm/intersects.rs
@@ -181,7 +181,7 @@ where
             true
         } else {
             // or if it's contained in the polygon
-            linestring.0.iter().any(|point| self.contains(point))
+            linestring.iter().any(|point| self.contains(point))
         }
     }
 }

--- a/src/algorithm/length.rs
+++ b/src/algorithm/length.rs
@@ -48,11 +48,8 @@ where
     T: Float,
 {
     fn length(&self) -> T {
-        self.0
-            .iter()
-            .fold(T::zero(), |total, line| {
-                total + line.length()
-            })
+        self.iter()
+            .fold(T::zero(), |total, line| total + line.length())
     }
 }
 

--- a/src/algorithm/map_coords.rs
+++ b/src/algorithm/map_coords.rs
@@ -139,7 +139,7 @@ impl<T: CoordinateType, NT: CoordinateType> MapCoords<T, NT> for LineString<T> {
     type Output = LineString<NT>;
 
     fn map_coords(&self, func: &Fn(&(T, T)) -> (NT, NT)) -> Self::Output {
-        LineString(self.0.iter().map(|p| p.map_coords(func)).collect())
+        LineString(self.iter().map(|p| p.map_coords(func)).collect())
     }
 }
 
@@ -158,8 +158,9 @@ impl<T: CoordinateType, NT: CoordinateType> TryMapCoords<T, NT> for LineString<T
 }
 
 impl<T: CoordinateType> MapCoordsInplace<T> for LineString<T> {
-    fn map_coords_inplace(&mut self, func: &Fn(&(T, T)) -> (T, T)) {
-        for p in self.0.iter_mut() {
+    fn map_coords_inplace(&mut self, func: &Fn(&(T, T)) -> (T, T))
+    {
+        for p in self.iter_mut() {
             p.map_coords_inplace(func);
         }
     }
@@ -206,7 +207,7 @@ impl<T: CoordinateType, NT: CoordinateType> MapCoords<T, NT> for MultiPoint<T> {
     type Output = MultiPoint<NT>;
 
     fn map_coords(&self, func: &Fn(&(T, T)) -> (NT, NT)) -> Self::Output {
-        MultiPoint(self.0.iter().map(|p| p.map_coords(func)).collect())
+        MultiPoint(self.iter().map(|p| p.map_coords(func)).collect())
     }
 }
 
@@ -225,8 +226,9 @@ impl<T: CoordinateType, NT: CoordinateType> TryMapCoords<T, NT> for MultiPoint<T
 }
 
 impl<T: CoordinateType> MapCoordsInplace<T> for MultiPoint<T> {
-    fn map_coords_inplace(&mut self, func: &Fn(&(T, T)) -> (T, T)) {
-        for p in self.0.iter_mut() {
+    fn map_coords_inplace(&mut self, func: &Fn(&(T, T)) -> (T, T))
+    {
+        for p in self.iter_mut() {
             p.map_coords_inplace(func);
         }
     }
@@ -236,7 +238,7 @@ impl<T: CoordinateType, NT: CoordinateType> MapCoords<T, NT> for MultiLineString
     type Output = MultiLineString<NT>;
 
     fn map_coords(&self, func: &Fn(&(T, T)) -> (NT, NT)) -> Self::Output {
-        MultiLineString(self.0.iter().map(|l| l.map_coords(func)).collect())
+        MultiLineString(self.iter().map(|l| l.map_coords(func)).collect())
     }
 }
 
@@ -255,8 +257,9 @@ impl<T: CoordinateType, NT: CoordinateType> TryMapCoords<T, NT> for MultiLineStr
 }
 
 impl<T: CoordinateType> MapCoordsInplace<T> for MultiLineString<T> {
-    fn map_coords_inplace(&mut self, func: &Fn(&(T, T)) -> (T, T)) {
-        for p in self.0.iter_mut() {
+    fn map_coords_inplace(&mut self, func: &Fn(&(T, T)) -> (T, T))
+    {
+        for p in self.iter_mut() {
             p.map_coords_inplace(func);
         }
     }
@@ -266,7 +269,7 @@ impl<T: CoordinateType, NT: CoordinateType> MapCoords<T, NT> for MultiPolygon<T>
     type Output = MultiPolygon<NT>;
 
     fn map_coords(&self, func: &Fn(&(T, T)) -> (NT, NT)) -> Self::Output {
-        MultiPolygon(self.0.iter().map(|p| p.map_coords(func)).collect())
+        MultiPolygon(self.iter().map(|p| p.map_coords(func)).collect())
     }
 }
 
@@ -285,8 +288,9 @@ impl<T: CoordinateType, NT: CoordinateType> TryMapCoords<T, NT> for MultiPolygon
 }
 
 impl<T: CoordinateType> MapCoordsInplace<T> for MultiPolygon<T> {
-    fn map_coords_inplace(&mut self, func: &Fn(&(T, T)) -> (T, T)) {
-        for p in self.0.iter_mut() {
+    fn map_coords_inplace(&mut self, func: &Fn(&(T, T)) -> (T, T))
+    {
+        for p in self.iter_mut() {
             p.map_coords_inplace(func);
         }
     }
@@ -354,7 +358,7 @@ impl<T: CoordinateType, NT: CoordinateType> MapCoords<T, NT> for GeometryCollect
     type Output = GeometryCollection<NT>;
 
     fn map_coords(&self, func: &Fn(&(T, T)) -> (NT, NT)) -> Self::Output {
-        GeometryCollection(self.0.iter().map(|g| g.map_coords(func)).collect())
+        GeometryCollection(self.iter().map(|g| g.map_coords(func)).collect())
     }
 }
 
@@ -373,8 +377,9 @@ impl<T: CoordinateType, NT: CoordinateType> TryMapCoords<T, NT> for GeometryColl
 }
 
 impl<T: CoordinateType> MapCoordsInplace<T> for GeometryCollection<T> {
-    fn map_coords_inplace(&mut self, func: &Fn(&(T, T)) -> (T, T)) {
-        for p in self.0.iter_mut() {
+    fn map_coords_inplace(&mut self, func: &Fn(&(T, T)) -> (T, T))
+    {
+        for p in self.iter_mut() {
             p.map_coords_inplace(func);
         }
     }

--- a/src/algorithm/map_coords.rs
+++ b/src/algorithm/map_coords.rs
@@ -150,7 +150,7 @@ impl<T: CoordinateType, NT: CoordinateType> TryMapCoords<T, NT> for LineString<T
         &self,
         func: &Fn(&(T, T)) -> Result<(NT, NT), Error>,
     ) -> Result<Self::Output, Error> {
-        Ok(LineString(self.0
+        Ok(LineString(self
             .iter()
             .map(|p| p.try_map_coords(func))
             .collect::<Result<Vec<_>, Error>>()?))
@@ -218,7 +218,7 @@ impl<T: CoordinateType, NT: CoordinateType> TryMapCoords<T, NT> for MultiPoint<T
         &self,
         func: &Fn(&(T, T)) -> Result<(NT, NT), Error>,
     ) -> Result<Self::Output, Error> {
-        Ok(MultiPoint(self.0
+        Ok(MultiPoint(self
             .iter()
             .map(|p| p.try_map_coords(func))
             .collect::<Result<Vec<_>, Error>>()?))
@@ -249,7 +249,7 @@ impl<T: CoordinateType, NT: CoordinateType> TryMapCoords<T, NT> for MultiLineStr
         &self,
         func: &Fn(&(T, T)) -> Result<(NT, NT), Error>,
     ) -> Result<Self::Output, Error> {
-        Ok(MultiLineString(self.0
+        Ok(MultiLineString(self
             .iter()
             .map(|l| l.try_map_coords(func))
             .collect::<Result<Vec<_>, Error>>()?))
@@ -280,7 +280,7 @@ impl<T: CoordinateType, NT: CoordinateType> TryMapCoords<T, NT> for MultiPolygon
         &self,
         func: &Fn(&(T, T)) -> Result<(NT, NT), Error>,
     ) -> Result<Self::Output, Error> {
-        Ok(MultiPolygon(self.0
+        Ok(MultiPolygon(self
             .iter()
             .map(|p| p.try_map_coords(func))
             .collect::<Result<Vec<_>, Error>>()?))
@@ -369,7 +369,7 @@ impl<T: CoordinateType, NT: CoordinateType> TryMapCoords<T, NT> for GeometryColl
         &self,
         func: &Fn(&(T, T)) -> Result<(NT, NT), Error>,
     ) -> Result<Self::Output, Error> {
-        Ok(GeometryCollection(self.0
+        Ok(GeometryCollection(self
             .iter()
             .map(|g| g.try_map_coords(func))
             .collect::<Result<Vec<_>, Error>>()?))

--- a/src/algorithm/orient.rs
+++ b/src/algorithm/orient.rs
@@ -46,7 +46,7 @@ where
     T: CoordinateType,
 {
     fn orient(&self, direction: Direction) -> MultiPolygon<T> {
-        MultiPolygon(self.0.iter().map(|poly| poly.orient(direction)).collect())
+        MultiPolygon(self.iter().map(|poly| poly.orient(direction)).collect())
     }
 }
 

--- a/src/algorithm/rotate.rs
+++ b/src/algorithm/rotate.rs
@@ -162,7 +162,7 @@ where
 {
     /// Rotate the contained Polygons about their centroids by the given number of degrees
     fn rotate(&self, angle: T) -> Self {
-        MultiPolygon(self.0.iter().map(|poly| poly.rotate(angle)).collect())
+        MultiPolygon(self.iter().map(|poly| poly.rotate(angle)).collect())
     }
 }
 
@@ -172,7 +172,7 @@ where
 {
     /// Rotate the contained LineStrings about their centroids by the given number of degrees
     fn rotate(&self, angle: T) -> Self {
-        MultiLineString(self.0.iter().map(|ls| ls.rotate(angle)).collect())
+        MultiLineString(self.iter().map(|ls| ls.rotate(angle)).collect())
     }
 }
 
@@ -182,7 +182,7 @@ where
 {
     /// Rotate the contained Points about their centroids by the given number of degrees
     fn rotate(&self, angle: T) -> Self {
-        MultiPoint(self.0.iter().map(|p| p.rotate(angle)).collect())
+        MultiPoint(self.iter().map(|p| p.rotate(angle)).collect())
     }
 }
 

--- a/src/algorithm/rotate.rs
+++ b/src/algorithm/rotate.rs
@@ -130,7 +130,7 @@ where
 {
     /// Rotate the LineString about its centroid by the given number of degrees
     fn rotate(&self, angle: T) -> Self {
-        LineString(rotation_matrix(angle, &self.centroid().unwrap(), &self.0))
+        LineString(rotation_matrix(angle, &self.centroid().unwrap(), &self))
     }
 }
 
@@ -147,10 +147,10 @@ where
             self.exterior.centroid().unwrap()
         };
         Polygon::new(
-            LineString(rotation_matrix(angle, &centroid, &self.exterior.0)),
+            LineString(rotation_matrix(angle, &centroid, &self.exterior)),
             self.interiors
                 .iter()
-                .map(|ring| LineString(rotation_matrix(angle, &centroid, &ring.0)))
+                .map(|ring| LineString(rotation_matrix(angle, &centroid, &ring)))
                 .collect(),
         )
     }

--- a/src/algorithm/simplify.rs
+++ b/src/algorithm/simplify.rs
@@ -88,7 +88,7 @@ where
     T: Float,
 {
     fn simplify(&self, epsilon: &T) -> LineString<T> {
-        LineString(rdp(&self.0, epsilon))
+        LineString(rdp(&self, epsilon))
     }
 }
 

--- a/src/algorithm/simplify.rs
+++ b/src/algorithm/simplify.rs
@@ -97,7 +97,7 @@ where
     T: Float,
 {
     fn simplify(&self, epsilon: &T) -> MultiLineString<T> {
-        MultiLineString(self.0.iter().map(|l| l.simplify(epsilon)).collect())
+        MultiLineString(self.iter().map(|l| l.simplify(epsilon)).collect())
     }
 }
 
@@ -118,7 +118,7 @@ where
     T: Float,
 {
     fn simplify(&self, epsilon: &T) -> MultiPolygon<T> {
-        MultiPolygon(self.0.iter().map(|p| p.simplify(epsilon)).collect())
+        MultiPolygon(self.iter().map(|p| p.simplify(epsilon)).collect())
     }
 }
 

--- a/src/algorithm/simplifyvw.rs
+++ b/src/algorithm/simplifyvw.rs
@@ -214,14 +214,14 @@ where
     // Simplify shell
     rings.push(visvalingam_preserve(
         geomtype,
-        &exterior.0,
+        &exterior,
         epsilon,
         &mut tree,
     ));
     // Simplify interior rings, if any
     if let Some(interior_rings) = interiors {
         for ring in interior_rings {
-            rings.push(visvalingam_preserve(geomtype, &ring.0, epsilon, &mut tree))
+            rings.push(visvalingam_preserve(geomtype, &ring, epsilon, &mut tree))
         }
     }
     rings
@@ -523,8 +523,7 @@ where
 {
     fn simplifyvw_preserve(&self, epsilon: &T) -> MultiLineString<T> {
         MultiLineString(
-            self.0
-                .iter()
+            self.iter()
                 .map(|l| l.simplifyvw_preserve(epsilon))
                 .collect(),
         )
@@ -554,8 +553,7 @@ where
 {
     fn simplifyvw_preserve(&self, epsilon: &T) -> MultiPolygon<T> {
         MultiPolygon(
-            self.0
-                .iter()
+            self.iter()
                 .map(|p| p.simplifyvw_preserve(epsilon))
                 .collect(),
         )
@@ -567,7 +565,7 @@ where
     T: Float,
 {
     fn simplifyvw(&self, epsilon: &T) -> LineString<T> {
-        LineString(visvalingam(&self.0, epsilon))
+        LineString(visvalingam(&self, epsilon))
     }
 }
 
@@ -576,7 +574,7 @@ where
     T: Float,
 {
     fn simplifyvw(&self, epsilon: &T) -> MultiLineString<T> {
-        MultiLineString(self.0.iter().map(|l| l.simplifyvw(epsilon)).collect())
+        MultiLineString(self.iter().map(|l| l.simplifyvw(epsilon)).collect())
     }
 }
 
@@ -600,7 +598,7 @@ where
     T: Float,
 {
     fn simplifyvw(&self, epsilon: &T) -> MultiPolygon<T> {
-        MultiPolygon(self.0.iter().map(|p| p.simplifyvw(epsilon)).collect())
+        MultiPolygon(self.iter().map(|p| p.simplifyvw(epsilon)).collect())
     }
 }
 

--- a/src/algorithm/to_postgis.rs
+++ b/src/algorithm/to_postgis.rs
@@ -43,7 +43,7 @@ macro_rules! to_postgis_impl {
     ($from:ident, $to:path, $name:ident, srid) => {
         impl ToPostgis<$to> for $from<f64> {
             fn to_postgis_with_srid(&self, srid: Option<i32>) -> $to {
-                let $name = self.0.iter()
+                let $name = self.iter()
                     .map(|x| x.to_postgis_with_srid(srid))
                     .collect();
                 $to { $name, srid }
@@ -53,7 +53,7 @@ macro_rules! to_postgis_impl {
     ($from:ident, $to:path, $name:ident) => {
         impl ToPostgis<$to> for $from<f64> {
             fn to_postgis_with_srid(&self, srid: Option<i32>) -> $to {
-                let $name = self.0.iter()
+                let $name = self.iter()
                     .map(|x| x.to_postgis_with_srid(srid))
                     .collect();
                 $to { $name }

--- a/src/algorithm/winding_order.rs
+++ b/src/algorithm/winding_order.rs
@@ -98,8 +98,8 @@ impl<T> Winding<T> for LineString<T>
     /// order, so that the resultant order makes it appear clockwise
     fn points_cw<'a>(&'a self) -> Box<Iterator<Item=&'a Point<T>> + 'a> {
         match self.winding_order() {
-            Some(WindingOrder::CounterClockwise) => Box::new(self.0.iter().rev()),
-            _ => Box::new(self.0.iter()),
+            Some(WindingOrder::CounterClockwise) => Box::new(self.iter().rev()),
+            _ => Box::new(self.iter()),
         }
     }
 
@@ -109,8 +109,8 @@ impl<T> Winding<T> for LineString<T>
     /// order, so that the resultant order makes it appear counter-clockwise
     fn points_ccw<'a>(&'a self) -> Box<Iterator<Item=&'a Point<T>> + 'a> {
         match self.winding_order() {
-            Some(WindingOrder::Clockwise) => Box::new(self.0.iter().rev()),
-            _ => Box::new(self.0.iter()),
+            Some(WindingOrder::Clockwise) => Box::new(self.iter().rev()),
+            _ => Box::new(self.iter()),
         }
     }
 
@@ -118,7 +118,7 @@ impl<T> Winding<T> for LineString<T>
     fn make_cw_winding(&mut self) {
         match self.winding_order() {
             Some(WindingOrder::CounterClockwise) => {
-                self.0.reverse();
+                self.reverse();
             },
             _ => {},
         }
@@ -128,7 +128,7 @@ impl<T> Winding<T> for LineString<T>
     fn make_ccw_winding(&mut self) {
         match self.winding_order() {
             Some(WindingOrder::Clockwise) => {
-                self.0.reverse();
+                self.reverse();
             },
             _ => {}
         }

--- a/src/algorithm/winding_order.rs
+++ b/src/algorithm/winding_order.rs
@@ -1,7 +1,7 @@
 use types::{CoordinateType, LineString, Point};
 
 pub(crate) fn twice_signed_ring_area<T>(linestring: &LineString<T>) -> T where T: CoordinateType {
-    if linestring.0.is_empty() || linestring.0.len() == 1 {
+    if linestring.is_empty() || linestring.len() == 1 {
         return T::zero();
     }
     let mut tmp = T::zero();

--- a/src/types.rs
+++ b/src/types.rs
@@ -542,6 +542,26 @@ where
     }
 }
 
+impl<T> Index<usize> for MultiPoint<T>
+where
+    T: CoordinateType,
+{
+    type Output = Point<T>;
+
+    fn index<'a>(&'a self, index: usize) -> &'a Point<T> {
+        &self.0[index]
+    }
+}
+
+impl<T> IndexMut<usize> for MultiPoint<T>
+where
+    T: CoordinateType,
+{
+    fn index_mut<'a>(&'a mut self, index: usize) -> &'a mut Point<T> {
+        &mut self.0[index]
+    }
+}
+
 /// A line segment made up of exactly two [`Point`s](struct.Point.html)
 #[derive(PartialEq, Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct Line<T>
@@ -628,7 +648,7 @@ where
 /// use geo::{LineString, Point};
 /// let mut line = LineString(vec![Point::new(0., 0.), Point::new(10., 0.)]);
 /// line.iter().for_each(|point| println!("Point x = {}, y = {}", point.x(), point.y()));
-/// 
+///
 /// for point in line {
 ///     println!("Point x = {}, y = {}", point.x(), point.y());
 /// }

--- a/src/types.rs
+++ b/src/types.rs
@@ -6,6 +6,7 @@ use std::ops::Sub;
 use std::fmt::Debug;
 
 use std::iter::{self, FromIterator, Iterator};
+use std::ops::{Deref, DerefMut};
 use algorithm::boundingbox::BoundingBox;
 use algorithm::distance::Distance;
 use spade::SpadeNum;
@@ -521,6 +522,26 @@ impl<T: CoordinateType> IntoIterator for MultiPoint<T> {
     }
 }
 
+impl<T> Deref for MultiPoint<T>
+where
+    T: CoordinateType,
+{
+    type Target = [Point<T>];
+
+    fn deref<'a>(&'a self) -> &'a [Point<T>] {
+        self.0.as_slice()
+    }
+}
+
+impl<T> DerefMut for MultiPoint<T>
+where
+    T: CoordinateType,
+{
+    fn deref_mut<'a>(&'a mut self) -> &'a mut [Point<T>] {
+        self.0.as_mut_slice()
+    }
+}
+
 /// A line segment made up of exactly two [`Point`s](struct.Point.html)
 #[derive(PartialEq, Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct Line<T>
@@ -601,11 +622,13 @@ where
 /// let line: LineString<f32> = points.into_iter().collect();
 /// ```
 ///
-/// You can iterate over the points in the `LineString`
+/// You can iterate over the points in the `LineString`:
 ///
 /// ```
 /// use geo::{LineString, Point};
 /// let line = LineString(vec![Point::new(0., 0.), Point::new(10., 0.)]);
+/// line.iter().for_each(|point| println!("Point x = {}, y = {}", point.x(), point.y()));
+///
 /// for point in line {
 ///     println!("Point x = {}, y = {}", point.x(), point.y());
 /// }
@@ -675,11 +698,32 @@ impl<T: CoordinateType> IntoIterator for LineString<T> {
     }
 }
 
+// This gives us `iter()`
+impl<T> Deref for LineString<T>
+where
+    T: CoordinateType,
+{
+    type Target = [Point<T>];
+
+    fn deref<'a>(&'a self) -> &'a [Point<T>] {
+        self.0.as_slice()
+    }
+}
+
+impl<T> DerefMut for LineString<T>
+where
+    T: CoordinateType,
+{
+    fn deref_mut<'a>(&'a mut self) -> &'a mut [Point<T>] {
+        self.0.as_mut_slice()
+    }
+}
+
 /// A collection of [`LineString`s](struct.LineString.html)
 ///
 /// Can be created from a `Vec` of `LineString`s, or from an Iterator which yields `LineString`s.
 ///
-/// Iterating over this objects, yields the component `LineString`s.
+/// Iterating over this object yields the component `LineString`s.
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub struct MultiLineString<T>(pub Vec<LineString<T>>)
 where
@@ -703,6 +747,26 @@ impl<T: CoordinateType> IntoIterator for MultiLineString<T> {
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
+    }
+}
+
+impl<T> Deref for MultiLineString<T>
+where
+    T: CoordinateType,
+{
+    type Target = [LineString<T>];
+
+    fn deref<'a>(&'a self) -> &'a [LineString<T>] {
+        self.0.as_slice()
+    }
+}
+
+impl<T> DerefMut for MultiLineString<T>
+where
+    T: CoordinateType,
+{
+    fn deref_mut<'a>(&'a mut self) -> &'a mut [LineString<T>] {
+        self.0.as_mut_slice()
     }
 }
 
@@ -830,6 +894,26 @@ impl<T: CoordinateType> IntoIterator for MultiPolygon<T> {
     }
 }
 
+impl<T> Deref for MultiPolygon<T>
+where
+    T: CoordinateType,
+{
+    type Target = [Polygon<T>];
+
+    fn deref<'a>(&'a self) -> &'a [Polygon<T>] {
+        self.0.as_slice()
+    }
+}
+
+impl<T> DerefMut for MultiPolygon<T>
+where
+    T: CoordinateType,
+{
+    fn deref_mut<'a>(&'a mut self) -> &'a mut [Polygon<T>] {
+        self.0.as_mut_slice()
+    }
+}
+
 /// A collection of [`Geometry`](enum.Geometry.html) types
 ///
 /// Can be created from a `Vec` of Geometries, or from an Iterator which yields Geometries.
@@ -878,6 +962,26 @@ where
     MultiLineString(MultiLineString<T>),
     MultiPolygon(MultiPolygon<T>),
     GeometryCollection(GeometryCollection<T>),
+}
+
+impl<T> Deref for GeometryCollection<T>
+where
+    T: CoordinateType,
+{
+    type Target = [Geometry<T>];
+
+    fn deref<'a>(&'a self) -> &'a [Geometry<T>] {
+        self.0.as_slice()
+    }
+}
+
+impl<T> DerefMut for GeometryCollection<T>
+where
+    T: CoordinateType,
+{
+    fn deref_mut<'a>(&'a mut self) -> &'a mut [Geometry<T>] {
+        self.0.as_mut_slice()
+    }
 }
 
 /// The result of trying to find the closest spot on an object to a point.

--- a/src/types.rs
+++ b/src/types.rs
@@ -626,13 +626,21 @@ where
 ///
 /// ```
 /// use geo::{LineString, Point};
-/// let line = LineString(vec![Point::new(0., 0.), Point::new(10., 0.)]);
-///
+/// let mut line = LineString(vec![Point::new(0., 0.), Point::new(10., 0.)]);
 /// line.iter().for_each(|point| println!("Point x = {}, y = {}", point.x(), point.y()));
-///
+/// 
 /// for point in line {
 ///     println!("Point x = {}, y = {}", point.x(), point.y());
 /// }
+/// ```
+/// You can also (mutably) index into its underlying `vec`:
+///
+/// ```
+/// use geo::{LineString, Point};
+/// let mut line = LineString(vec![Point::new(0., 0.), Point::new(10., 0.)]);
+/// assert_eq!(line[1], Point::new(10.0, 0.0));
+/// line[1] = Point::new(11.0, 1.0);
+/// assert_eq!(line[1], Point::new(11.0, 1.0));
 /// ```
 ///
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -622,11 +622,12 @@ where
 /// let line: LineString<f32> = points.into_iter().collect();
 /// ```
 ///
-/// You can iterate over the points in the `LineString`:
+/// You can iterate over the points in the `LineString` using a `for` loop, `iter()`, or `iter_mut()`:
 ///
 /// ```
 /// use geo::{LineString, Point};
 /// let line = LineString(vec![Point::new(0., 0.), Point::new(10., 0.)]);
+///
 /// line.iter().for_each(|point| println!("Point x = {}, y = {}", point.x(), point.y()));
 ///
 /// for point in line {
@@ -640,7 +641,7 @@ where
     T: CoordinateType;
 
 impl<T: CoordinateType> LineString<T> {
-    /// Return an `Line` iterator that yields one `Line` for each line segment
+    /// Return a `Line` iterator that yields one `Line` for each line segment
     /// in the `LineString`.
     ///
     /// # Examples
@@ -723,7 +724,7 @@ where
 ///
 /// Can be created from a `Vec` of `LineString`s, or from an Iterator which yields `LineString`s.
 ///
-/// Iterating over this object yields the component `LineString`s.
+/// Iterating over this object yields its component `LineString`s.
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub struct MultiLineString<T>(pub Vec<LineString<T>>)
 where
@@ -867,7 +868,7 @@ where
 ///
 /// Can be created from a `Vec` of `Polygon`s, or `collect`ed from an Iterator which yields `Polygon`s.
 ///
-/// Iterating over this object yields the component Polygons.
+/// Iterating over this object yields its component Polygons.
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub struct MultiPolygon<T>(pub Vec<Polygon<T>>)
 where
@@ -918,7 +919,7 @@ where
 ///
 /// Can be created from a `Vec` of Geometries, or from an Iterator which yields Geometries.
 ///
-/// Iterating over this objects, yields the component Geometries.
+/// Iterating over this object yields its component Geometries.
 #[derive(PartialEq, Clone, Debug)]
 pub struct GeometryCollection<T>(pub Vec<Geometry<T>>)
 where
@@ -945,25 +946,6 @@ impl<T: CoordinateType> IntoIterator for GeometryCollection<T> {
     }
 }
 
-/// An enum representing any possible geometry type.
-///
-/// All `Geo` types can be converted to a `Geometry` member using `.into()` (as part of the
-/// `std::convert::Into` pattern).
-#[derive(PartialEq, Clone, Debug)]
-pub enum Geometry<T>
-where
-    T: CoordinateType,
-{
-    Point(Point<T>),
-    Line(Line<T>),
-    LineString(LineString<T>),
-    Polygon(Polygon<T>),
-    MultiPoint(MultiPoint<T>),
-    MultiLineString(MultiLineString<T>),
-    MultiPolygon(MultiPolygon<T>),
-    GeometryCollection(GeometryCollection<T>),
-}
-
 impl<T> Deref for GeometryCollection<T>
 where
     T: CoordinateType,
@@ -982,6 +964,25 @@ where
     fn deref_mut<'a>(&'a mut self) -> &'a mut [Geometry<T>] {
         self.0.as_mut_slice()
     }
+}
+
+/// An enum representing any possible geometry type.
+///
+/// All `Geo` types can be converted to a `Geometry` member using `.into()` (as part of the
+/// `std::convert::Into` pattern).
+#[derive(PartialEq, Clone, Debug)]
+pub enum Geometry<T>
+where
+    T: CoordinateType,
+{
+    Point(Point<T>),
+    Line(Line<T>),
+    LineString(LineString<T>),
+    Polygon(Polygon<T>),
+    MultiPoint(MultiPoint<T>),
+    MultiLineString(MultiLineString<T>),
+    MultiPolygon(MultiPolygon<T>),
+    GeometryCollection(GeometryCollection<T>),
 }
 
 /// The result of trying to find the closest spot on an object to a point.

--- a/src/types.rs
+++ b/src/types.rs
@@ -6,7 +6,7 @@ use std::ops::Sub;
 use std::fmt::Debug;
 
 use std::iter::{self, FromIterator, Iterator};
-use std::ops::{Deref, DerefMut};
+use std::ops::{Deref, DerefMut, Index, IndexMut};
 use algorithm::boundingbox::BoundingBox;
 use algorithm::distance::Distance;
 use spade::SpadeNum;
@@ -720,6 +720,26 @@ where
     }
 }
 
+impl<T> Index<usize> for LineString<T>
+where
+    T: CoordinateType,
+{
+    type Output = Point<T>;
+
+    fn index<'a>(&'a self, index: usize) -> &'a Point<T> {
+        &self.0[index]
+    }
+}
+
+impl<T> IndexMut<usize> for LineString<T>
+where
+    T: CoordinateType,
+{
+    fn index_mut<'a>(&'a mut self, index: usize) -> &'a mut Point<T> {
+        &mut self.0[index]
+    }
+}
+
 /// A collection of [`LineString`s](struct.LineString.html)
 ///
 /// Can be created from a `Vec` of `LineString`s, or from an Iterator which yields `LineString`s.
@@ -768,6 +788,26 @@ where
 {
     fn deref_mut<'a>(&'a mut self) -> &'a mut [LineString<T>] {
         self.0.as_mut_slice()
+    }
+}
+
+impl<T> Index<usize> for MultiLineString<T>
+where
+    T: CoordinateType,
+{
+    type Output = LineString<T>;
+
+    fn index<'a>(&'a self, index: usize) -> &'a LineString<T> {
+        &self.0[index]
+    }
+}
+
+impl<T> IndexMut<usize> for MultiLineString<T>
+where
+    T: CoordinateType,
+{
+    fn index_mut<'a>(&'a mut self, index: usize) -> &'a mut LineString<T> {
+        &mut self.0[index]
     }
 }
 
@@ -915,6 +955,26 @@ where
     }
 }
 
+impl<T> Index<usize> for MultiPolygon<T>
+where
+    T: CoordinateType,
+{
+    type Output = Polygon<T>;
+
+    fn index<'a>(&'a self, index: usize) -> &'a Polygon<T> {
+        &self.0[index]
+    }
+}
+
+impl<T> IndexMut<usize> for MultiPolygon<T>
+where
+    T: CoordinateType,
+{
+    fn index_mut<'a>(&'a mut self, index: usize) -> &'a mut Polygon<T> {
+        &mut self.0[index]
+    }
+}
+
 /// A collection of [`Geometry`](enum.Geometry.html) types
 ///
 /// Can be created from a `Vec` of Geometries, or from an Iterator which yields Geometries.
@@ -963,6 +1023,26 @@ where
 {
     fn deref_mut<'a>(&'a mut self) -> &'a mut [Geometry<T>] {
         self.0.as_mut_slice()
+    }
+}
+
+impl<T> Index<usize> for GeometryCollection<T>
+where
+    T: CoordinateType,
+{
+    type Output = Geometry<T>;
+
+    fn index<'a>(&'a self, index: usize) -> &'a Geometry<T> {
+        &self.0[index]
+    }
+}
+
+impl<T> IndexMut<usize> for GeometryCollection<T>
+where
+    T: CoordinateType,
+{
+    fn index_mut<'a>(&'a mut self, index: usize) -> &'a mut Geometry<T> {
+        &mut self.0[index]
     }
 }
 
@@ -1208,5 +1288,10 @@ mod test {
             se.distance2(&Point::new(4.0, 10.0)),
             l.distance2(&Point::new(4.0, 10.0))
         );
+    }
+    #[test]
+    fn index_test() {
+        let ls = LineString::from(vec![Point::new(1.0, 1.0), Point::new(2.0, 2.0)]);
+        assert_eq!(ls[0], ls.0[0]);
     }
 }


### PR DESCRIPTION
Implementing [`Deref`](https://doc.rust-lang.org/std/ops/trait.Deref.html) and [`DerefMut`](https://doc.rust-lang.org/std/ops/trait.DerefMut.html) for `LineString`, `Multi`-geometries, and
`GeometryCollection`  gives us `iter()` and `iter_mut()` for
them, allowing the removal of `self.0` in _lots_ of places.