### PR TITLE
Add contribution guidelines and code of conduct

### DIFF
--- a/geo/src/algorithm/CODE_OF_CONDUCT.md
+++ b/geo/src/algorithm/CODE_OF_CONDUCT.md
@@ -1,0 +1,36 @@
+# The Rust-Geo Code of Conduct
+
+This document is based on, and aims to track the [Rust Code of Conduct](https://www.rust-lang.org/conduct.html)
+
+## Conduct
+
+* We are committed to providing a friendly, safe and welcoming environment for all, regardless of level of experience, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, nationality, or other similar characteristic.
+* On IRC, please avoid using overtly sexual nicknames or other nicknames that might detract from a friendly, safe and welcoming environment for all.
+* Please be kind and courteous. There's no need to be mean or rude.
+* Respect that people have differences of opinion and that every design or implementation choice carries a trade-off and numerous costs. There is seldom a right answer.
+* Please keep unstructured critique to a minimum. If you have solid ideas you want to experiment with, make a fork and see how it works.
+* We will exclude you from interaction if you insult, demean or harass anyone. That is not welcome behavior. We interpret the term "harassment" as including the definition in the <a href="http://citizencodeofconduct.org/">Citizen Code of Conduct</a>; if you have any lack of clarity about what might be included in that concept, please read their definition. In particular, we don't tolerate behavior that excludes people in socially marginalized groups.
+* Private harassment is also unacceptable. No matter who you are, if you feel you have been or are being harassed or made uncomfortable by a community member, please contact one of the channel ops or any of the [core team][mod_team] immediately. Whether you're a regular contributor or a newcomer, we care about making this community a safe place for you and we've got your back.
+* Likewise any spamming, trolling, flaming, baiting or other attention-stealing behavior is not welcome.
+
+## Moderation
+
+
+These are the policies for upholding our community's standards of conduct. If you feel that a thread needs moderation, please contact the [core team][mod_team].
+
+1. Remarks that violate the Rust standards of conduct, including hateful, hurtful, oppressive, or exclusionary remarks, are not allowed. (Cursing is allowed, but never targeting another user, and never in a hateful manner.)
+2. Remarks that moderators find inappropriate, whether listed in the code of conduct or not, are also not allowed.
+3. Moderators will first respond to such remarks with a warning.
+4. If the warning is unheeded, the user will be "kicked," i.e., kicked out of the communication channel to cool off.
+5. If the user comes back and continues to make trouble, they will be banned, i.e., indefinitely excluded.
+6. Moderators may choose at their discretion to un-ban the user if it was a first offense and they offer the offended party a genuine apology.
+7. If a moderator bans someone and you think it was unjustified, please take it up with that moderator, or with a different moderator, **in private**. Complaints about bans in-channel are not allowed.
+8. Moderators are held to a higher standard than other community members. If a moderator creates an inappropriate situation, they should expect less leeway than others.
+
+In the Rust-Geo community we strive to go the extra step to look out for each other. Don't just aim to be technically unimpeachable, try to be your best self. In particular, avoid flirting with offensive or sensitive issues, particularly if they're off-topic; this all too often leads to unnecessary fights, hurt feelings, and damaged trust; worse, it can drive people away from the community entirely.
+
+And if someone takes issue with something you said or did, resist the urge to be defensive. Just stop doing what it was they complained about and apologize. Even if you feel you were misinterpreted or unfairly accused, chances are good there was something you could've communicated better — remember that it's your responsibility to make your fellow Rustaceans comfortable. Everyone wants to get along and we are all here first and foremost because we want to talk about cool technology. You will find that people will be eager to assume good intent and forgive as long as you earn their trust.
+
+*Adapted from the [Node.js Policy on Trolling](http://blog.izs.me/post/30036893703/policy-on-trolling) as well as the [Contributor Covenant v1.3.0](https://www.contributor-covenant.org/version/1/3/0/).*
+
+[mod_team]: https://github.com/orgs/georust/teams/core

--- a/geo/src/algorithm/CODE_OF_CONDUCT.md
+++ b/geo/src/algorithm/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-# The Rust-Geo Code of Conduct
+# The GeoRust Code of Conduct
 
 This document is based on, and aims to track the [Rust Code of Conduct](https://www.rust-lang.org/conduct.html)
 
@@ -27,7 +27,7 @@ These are the policies for upholding our community's standards of conduct. If yo
 7. If a moderator bans someone and you think it was unjustified, please take it up with that moderator, or with a different moderator, **in private**. Complaints about bans in-channel are not allowed.
 8. Moderators are held to a higher standard than other community members. If a moderator creates an inappropriate situation, they should expect less leeway than others.
 
-In the Rust-Geo community we strive to go the extra step to look out for each other. Don't just aim to be technically unimpeachable, try to be your best self. In particular, avoid flirting with offensive or sensitive issues, particularly if they're off-topic; this all too often leads to unnecessary fights, hurt feelings, and damaged trust; worse, it can drive people away from the community entirely.
+In the GeoRust community we strive to go the extra step to look out for each other. Don't just aim to be technically unimpeachable, try to be your best self. In particular, avoid flirting with offensive or sensitive issues, particularly if they're off-topic; this all too often leads to unnecessary fights, hurt feelings, and damaged trust; worse, it can drive people away from the community entirely.
 
 And if someone takes issue with something you said or did, resist the urge to be defensive. Just stop doing what it was they complained about and apologize. Even if you feel you were misinterpreted or unfairly accused, chances are good there was something you could've communicated better — remember that it's your responsibility to make your fellow Rustaceans comfortable. Everyone wants to get along and we are all here first and foremost because we want to talk about cool technology. You will find that people will be eager to assume good intent and forgive as long as you earn their trust.
 

--- a/geo/src/algorithm/CODE_OF_CONDUCT.md
+++ b/geo/src/algorithm/CODE_OF_CONDUCT.md
@@ -4,19 +4,21 @@ This document is based on, and aims to track the [Rust Code of Conduct](https://
 
 ## Conduct
 
+**Contact**: [mods@georust.org](mailto:mods@georust.org)
+
 * We are committed to providing a friendly, safe and welcoming environment for all, regardless of level of experience, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, nationality, or other similar characteristic.
 * On IRC, please avoid using overtly sexual nicknames or other nicknames that might detract from a friendly, safe and welcoming environment for all.
 * Please be kind and courteous. There's no need to be mean or rude.
 * Respect that people have differences of opinion and that every design or implementation choice carries a trade-off and numerous costs. There is seldom a right answer.
 * Please keep unstructured critique to a minimum. If you have solid ideas you want to experiment with, make a fork and see how it works.
 * We will exclude you from interaction if you insult, demean or harass anyone. That is not welcome behavior. We interpret the term "harassment" as including the definition in the <a href="http://citizencodeofconduct.org/">Citizen Code of Conduct</a>; if you have any lack of clarity about what might be included in that concept, please read their definition. In particular, we don't tolerate behavior that excludes people in socially marginalized groups.
-* Private harassment is also unacceptable. No matter who you are, if you feel you have been or are being harassed or made uncomfortable by a community member, please contact one of the channel ops or any of the [core team][mod_team] immediately. Whether you're a regular contributor or a newcomer, we care about making this community a safe place for you and we've got your back.
+* Private harassment is also unacceptable. No matter who you are, if you feel you have been or are being harassed or made uncomfortable by a community member, please contact one of the channel ops or any of the [GeoRust moderation team][mod_team] immediately. Whether you're a regular contributor or a newcomer, we care about making this community a safe place for you and we've got your back.
 * Likewise any spamming, trolling, flaming, baiting or other attention-stealing behavior is not welcome.
 
 ## Moderation
 
 
-These are the policies for upholding our community's standards of conduct. If you feel that a thread needs moderation, please contact the [core team][mod_team].
+These are the policies for upholding our community's standards of conduct. If you feel that a thread needs moderation, please contact the [GeoRust moderation team][mod_team].
 
 1. Remarks that violate the Rust standards of conduct, including hateful, hurtful, oppressive, or exclusionary remarks, are not allowed. (Cursing is allowed, but never targeting another user, and never in a hateful manner.)
 2. Remarks that moderators find inappropriate, whether listed in the code of conduct or not, are also not allowed.
@@ -33,4 +35,4 @@ And if someone takes issue with something you said or did, resist the urge to be
 
 *Adapted from the [Node.js Policy on Trolling](http://blog.izs.me/post/30036893703/policy-on-trolling) as well as the [Contributor Covenant v1.3.0](https://www.contributor-covenant.org/version/1/3/0/).*
 
-[mod_team]: https://github.com/orgs/georust/teams/core
+[mod_team]: mailto:mods@georust.org

--- a/geo/src/algorithm/CONTRIBUTING.md
+++ b/geo/src/algorithm/CONTRIBUTING.md
@@ -1,0 +1,99 @@
+# Contributing to Rust-Geo
+[contributing-to-rust]: #contributing-to-rust-geo
+
+Thank you for your interest in contributing to Rust-Geo! There are many ways to
+contribute, and we appreciate all of them. This document is a bit long, so here's links to the major sections:
+
+* [Feature Requests](#feature-requests)
+* [Bug Reports](#bug-reports)
+* [Pull Requests](#pull-requests)
+* [Writing Tests and Documentation](#writing-documentation)
+
+As a reminder, all contributors are expected to follow our [Code of Conduct][coc].
+
+[coc]: https://github.com/georust/rust-geo/blob/master/CODE_OF_CONDUCT.md
+
+## Feature Requests
+[feature-requests]: #feature-requests
+
+Rust-Geo aims to provide a broad suite of functionality. If you're in any doubt as to whether a feature can be included, simply open an issue and ask. It's a good idea to check open issues and pull requests first, in order to check whether a requested feature is already in progress.
+
+## Bug Reports
+[bug-reports]: #bug-reports
+
+While bugs are unfortunate, they're a reality in software. We can't fix what we
+don't know about, so please report liberally. If you're not sure whether something is a bug or not, feel free to file a bug anyway.
+
+If you have the chance, before reporting a bug, please [search existing
+issues](https://github.com/georust/rust-geo/search?q=&type=Issues&utf8=✓),
+as it's possible that someone else has already reported your error. This doesn't
+always work, and sometimes it's hard to know what to search for, so consider this
+extra credit. We won't mind if you accidentally file a duplicate report.
+
+Similarly, to help others who encountered the bug find your issue,
+consider filing an issue with with a descriptive title, which contains information that might be unique to it.
+This can be the language or compiler feature used, the conditions that trigger the bug,
+or part of the error message if there is any.
+
+Opening an issue is as easy as following [this
+link](https://github.com/georust/rust-geo/issues/new) and filling out the fields.
+Here's a template that you can use to file a bug, though it's not necessary to
+use it exactly:
+
+    <short summary of the bug>
+
+    I tried this code:
+
+    <code sample that causes the bug>
+
+    I expected to see this happen: <explanation>
+
+    Instead, this happened: <explanation>
+
+    ## Meta
+
+    `rustc --version --verbose`:
+
+    Backtrace:
+
+All three components are important: what you did, what you expected, what
+happened instead. Please include the output of `rustc --version --verbose`,
+which includes important information about what platform you're on, what
+version of Rust you're using, etc.
+
+Sometimes, a backtrace is helpful, and so including that is nice. To get
+a backtrace, set the `RUST_BACKTRACE` environment variable to a value
+other than `0`. The easiest way
+to do this is to invoke `rustc` like this:
+
+```bash
+$ RUST_BACKTRACE=1 rustc ...
+```
+
+## Pull Requests
+[pull-requests]: #pull-requests
+
+Pull requests are the primary mechanism we use to change Rust-Geo. GitHub itself has some [great documentation][about-pull-requests] on using the Pull Request feature. We use the "fork and pull" model [described here][development-models], where contributors push changes to their personal fork and create pull requests to
+bring those changes into the source repository.
+
+[about-pull-requests]: https://help.github.com/articles/about-pull-requests/
+[development-models]: https://help.github.com/articles/about-collaborative-development-models/
+
+Please make pull requests against the `master` branch.
+
+All pull requests are reviewed by another person.
+
+After someone has reviewed your pull request, they will leave an annotation
+on the pull request with an `r+`. It will look something like this:
+
+    bors: r+
+
+This tells @bors, our lovable integration bot, that your pull request has
+been approved. The PR then enters the merge queue, where @bors
+will run all the tests on every platform we support. If it all works out,
+@bors will merge your code into `master` and close the pull request.
+
+## Writing Tests and Documentation
+[writing-documentation]: #writing-documentation
+
+Documentation improvements are very welcome. Standard API documentation is generated from the source code itself. If you're adding a new feature, you **must** document its use, and write tests, preferably covering 100% of the added functionality. [Several geometries](geo/src/algorithm/test_fixtures) are provided as test fixtures. If you need help with the format or content of docs, or help writing some tests, don't hesitate to ask.


### PR DESCRIPTION
See [here](https://github.com/orgs/georust/teams/core/discussions/2) for prior discussion. This is a first effort, adapted from the originals at https://github.com/rust-lang/rust. I haven't specified any humans as part of the mod team, as this doesn't really make sense for us  – I've just said "contact the  the core team". Maybe we'd prefer specifically contactable people?