### PR TITLE
algorithm: Merge polygon area calculation into a single function

### DIFF
--- a/geo/src/algorithm/area.rs
+++ b/geo/src/algorithm/area.rs
@@ -34,7 +34,8 @@ where
     fn area(&self) -> T;
 }
 
-fn get_linestring_area<T>(linestring: &LineString<T>) -> T
+// Calculation of simple (no interior holes) Polygon area
+pub fn get_linestring_area<T>(linestring: &LineString<T>) -> T
 where
     T: Float,
 {


### PR DESCRIPTION
Fix for https://github.com/georust/geo/issues/250.
I considered using the map/sum iterator, but that would have required changing many type restrictions. Let me know if that would be better.

Signed-off-by: Alexandru Copot <alex.mihai.c@gmail.com>