### PR TITLE
Replaced spade with rstar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
   include:
     - env: GEO_TYPES_FEATURES=""
     - env: GEO_TYPES_FEATURES="--features serde"
-    - env: GEO_TYPES_FEATURES="--features spade"
+    - env: GEO_TYPES_FEATURES="--features rstar"
     - env: GEO_FEATURES=""
     - env: GEO_FEATURES="--features postgis-integration"
     - env: GEO_FEATURES="--features use-proj"

--- a/geo-types/Cargo.toml
+++ b/geo-types/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "geo-types"
+
 version = "0.2.2"
 authors = ["Corey Farwell <coreyf@rwell.org>"]
 license = "MIT/Apache-2.0"
@@ -12,4 +13,4 @@ description = "Geospatial primitive data types"
 [dependencies]
 num-traits = "0.2"
 serde = { version = "1", optional = true, features = ["derive"] }
-spade = { version = "1.5.1", optional = true }
+rstar = { version = "0.1", optional = true }

--- a/geo-types/src/lib.rs
+++ b/geo-types/src/lib.rs
@@ -4,8 +4,8 @@ extern crate num_traits;
 #[macro_use]
 extern crate serde;
 
-#[cfg(feature = "spade")]
-extern crate spade;
+#[cfg(feature = "rstar")]
+extern crate rstar;
 
 use num_traits::{Num, NumCast};
 
@@ -59,9 +59,6 @@ pub mod private_utils;
 #[cfg(test)]
 mod test {
     use super::*;
-
-    #[cfg(feature = "spade")]
-    use spade::SpatialObject;
 
     #[test]
     fn type_test() {
@@ -129,17 +126,19 @@ mod test {
         assert_eq!(p.x(), 1_000_000i64);
     }
 
-    #[cfg(feature = "spade")]
+    #[cfg(feature = "rstar")]
     #[test]
     /// ensure Line's SpatialObject impl is correct
     fn line_test() {
-        use spade::primitives::SimpleEdge;
+        use rstar::primitives::SimpleEdge;
+        use rstar::{RTreeObject, PointDistance};
+
         let se = SimpleEdge::new(Point::new(0.0, 0.0), Point::new(5.0, 5.0));
         let l = Line::new(Coordinate { x: 0.0, y: 0.0 }, Coordinate { x: 5., y: 5. });
-        assert_eq!(se.mbr(), l.mbr());
+        assert_eq!(se.envelope(), l.envelope());
         // difference in 15th decimal place
-        assert_eq!(26.0, se.distance2(&Point::new(4.0, 10.0)));
-        assert_eq!(25.999999999999996, l.distance2(&Point::new(4.0, 10.0)));
+        assert_eq!(26.0, se.distance_2(&Point::new(4.0, 10.0)));
+        assert_eq!(25.999999999999996, l.distance_2(&Point::new(4.0, 10.0)));
     }
 
     #[test]

--- a/geo-types/src/line.rs
+++ b/geo-types/src/line.rs
@@ -160,27 +160,28 @@ impl<T: CoordinateType> From<[(T, T); 2]> for Line<T> {
     }
 }
 
-#[cfg(feature = "spade")]
-impl<T> ::spade::SpatialObject for Line<T>
+#[cfg(feature = "rstar")]
+impl<T> ::rstar::RTreeObject for Line<T>
 where
-    T: ::num_traits::Float + ::spade::SpadeNum + ::std::fmt::Debug,
+    T: ::num_traits::Float + ::rstar::RTreeNum
 {
-    type Point = Point<T>;
+    type Envelope = ::rstar::AABB<Point<T>>;
 
-    fn mbr(&self) -> ::spade::BoundingRect<Self::Point> {
+    fn envelope(&self) -> Self::Envelope {
         let bounding_rect = ::private_utils::line_bounding_rect(*self);
-        ::spade::BoundingRect::from_corners(
-            &Point::new(bounding_rect.min.x, bounding_rect.min.y),
-            &Point::new(bounding_rect.max.x, bounding_rect.max.y),
-        )
+        ::rstar::AABB::from_corners(
+            bounding_rect.min.into(),
+            bounding_rect.max.into())
     }
+}
 
-    fn distance2(&self, point: &Self::Point) -> <Self::Point as ::spade::PointN>::Scalar {
+#[cfg(feature = "rstar")]
+impl <T> ::rstar::PointDistance for Line<T> 
+where
+    T: ::num_traits::Float + ::rstar::RTreeNum 
+{
+    fn distance_2(&self, point: &Point<T>) -> T {
         let d = ::private_utils::point_line_euclidean_distance(*point, *self);
-        if d == T::zero() {
-            d
-        } else {
-            d.powi(2)
-        }
+        d.powi(2)        
     }
 }

--- a/geo-types/src/point.rs
+++ b/geo-types/src/point.rs
@@ -350,24 +350,27 @@ where
     }
 }
 
-#[cfg(feature = "spade")]
-// These are required for Spade RTree
-impl<T> ::spade::PointN for Point<T>
+#[cfg(feature = "rstar")]
+// These are required for rstar RTree
+impl<T> ::rstar::Point for Point<T>
 where
-    T: ::num_traits::Float + ::spade::SpadeNum + ::std::fmt::Debug,
+    T: ::num_traits::Float + ::rstar::RTreeNum,
 {
     type Scalar = T;
 
-    fn dimensions() -> usize {
-        2
+    const DIMENSIONS: usize = 2;
+
+    fn generate<F>(f: F) -> Self
+    where
+        F: Fn(usize) -> Self::Scalar,
+    {
+        Point::new(f(0), f(1))
     }
-    fn from_value(value: Self::Scalar) -> Self {
-        Point::new(value, value)
-    }
-    fn nth(&self, index: usize) -> &Self::Scalar {
+
+    fn nth(&self, index: usize) -> Self::Scalar {
         match index {
-            0 => &self.0.x,
-            1 => &self.0.y,
+            0 => self.0.x,
+            1 => self.0.y,
             _ => unreachable!(),
         }
     }
@@ -379,11 +382,6 @@ where
         }
     }
 }
-
-#[cfg(feature = "spade")]
-impl<T> ::spade::TwoDimensional for Point<T> where
-    T: ::num_traits::Float + ::spade::SpadeNum + ::std::fmt::Debug
-{}
 
 impl<T: CoordinateType> From<[T; 2]> for Point<T> {
     fn from(coords: [T; 2]) -> Point<T> {

--- a/geo-types/src/private_utils.rs
+++ b/geo-types/src/private_utils.rs
@@ -1,4 +1,4 @@
-// To implement Spade’s traits in the geo-types crates, we need to access to a
+// To implement RStar’s traits in the geo-types crates, we need to access to a
 // few geospatial algorithms, which are included in this hidden module. This
 // hidden module is public so the geo crate can reuse these algorithms to
 // prevent duplication. These functions are _not_ meant for public consumption.

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -16,11 +16,11 @@ travis-ci = { repository = "georust/geo" }
 [dependencies]
 num-traits = "0.2"
 serde = { version = "1.0", optional = true, features = ["derive"] }
-spade = "1.5.1"
+rstar = { version = "0.1" }
 failure = "0.1.2"
 postgis = { version = "0.6", optional = true }
 proj = { version = "0.5", optional = true }
-geo-types = { version = "0.2", features = ["spade"] }
+geo-types = { path = "../geo-types", features = ["rstar"] }
 
 [features]
 default = []

--- a/geo/src/lib.rs
+++ b/geo/src/lib.rs
@@ -9,7 +9,7 @@ extern crate failure;
 extern crate postgis;
 #[cfg(feature = "use-proj")]
 extern crate proj;
-extern crate spade;
+extern crate rstar;
 
 pub use algorithm::*;
 pub use traits::ToGeo;


### PR DESCRIPTION
Hi there!

I'm in the process of extracting spade's rtree and was finally able to get the geo tests running with the planned replacement crate: `rstar`.
Since the results so far look really promising, I'd like to share them with this PR to get some first reactions.
The goodies:
- Reduced compilation times for `geo` workspace: `cargo clean && cargo build` was reduced to 11s (from 40s) on my local machine
- Benchmark improvements:

> simplify vwp f32        time:   [17.300 ms 17.413 ms 17.551 ms]                          
>                        change: [-70.837% **-70.698%** -70.558%] (p = 0.00 < 0.05)
>                        Performance has improved.

The smaller build times may actually justify to use `rstar` without a feature flag.

Some TODO's before I'm willing to remove the WIP status:
- [x] I'll perform a review of the changes myself again
- [x] The simplify vwp algorithm was adapted a bit, I'll need to investigate if it is still correct. I'll add a comment to the appropriate section and ask for a special review.
- [x] I need to check the test coverage of `rstar` for the methods used by `geo`, Should not be too dramatic, but I want those tests anyway...

Also, `rstars` public interface is likely to change in the near future - however, I would keep `geo` updated should any breaking change make this necessary. That is, after all, in my own interest, as failing geo test cases will likely mean that something is wrong with my changes.

Any thoughts or opinions are welcome. Please keep in mind that, as I just published the `rstar` crate, it will take a while until it is in a polished state. I hope does not pose too much of a problem.
