### PR TITLE
Fixed test compilation error introduced by rstar version 0.1.1

### DIFF
--- a/geo-types/src/lib.rs
+++ b/geo-types/src/lib.rs
@@ -130,14 +130,14 @@ mod test {
     #[test]
     /// ensure Line's SpatialObject impl is correct
     fn line_test() {
-        use rstar::primitives::SimpleEdge;
+        use rstar::primitives::Line as RStarLine;
         use rstar::{PointDistance, RTreeObject};
 
-        let se = SimpleEdge::new(Point::new(0.0, 0.0), Point::new(5.0, 5.0));
+        let rl = RStarLine::new(Point::new(0.0, 0.0), Point::new(5.0, 5.0));
         let l = Line::new(Coordinate { x: 0.0, y: 0.0 }, Coordinate { x: 5., y: 5. });
-        assert_eq!(se.envelope(), l.envelope());
+        assert_eq!(rl.envelope(), l.envelope());
         // difference in 15th decimal place
-        assert_eq!(26.0, se.distance_2(&Point::new(4.0, 10.0)));
+        assert_eq!(26.0, rl.distance_2(&Point::new(4.0, 10.0)));
         assert_eq!(25.999999999999996, l.distance_2(&Point::new(4.0, 10.0)));
     }
 


### PR DESCRIPTION
rstar 0.1.1 introduced a breaking change in its API accidentally, this should fix this.
Note that `cargo build` still works, thus, geo's downstream users are not affected I believe.
Just `cargo test` with the rstar feature failed... doh!
I'll follow up soon-ish with a 0.2.0 release which has (rightfully so!) breaking changes, you'll get another PR then...

TL;DR: `cargo update && cargo test` fails atm. This is the fix.