### PR TITLE
Rewrite Polygon structure to enforce closed LineString rings.

### DIFF
--- a/geo-types/src/lib.rs
+++ b/geo-types/src/lib.rs
@@ -104,8 +104,8 @@ mod test {
         ])];
         let p = Polygon::new(exterior.clone(), interiors.clone());
 
-        assert_eq!(p.exterior, exterior);
-        assert_eq!(p.interiors, interiors);
+        assert_eq!(p.exterior(), &exterior);
+        assert_eq!(p.interiors(), &interiors[..]);
     }
 
     #[test]

--- a/geo-types/src/line_string.rs
+++ b/geo-types/src/line_string.rs
@@ -137,6 +137,17 @@ impl<T: CoordinateType> LineString<T> {
             }
         })
     }
+
+    /// Close the `LineString`. Specifically, if the `LineString` has is at least one coordinate,
+    /// and the value of the first coordinate does not equal the value of the last coordinate, then
+    /// a new coordinate is added to the end with the value of the first coordinate.
+    pub(crate) fn close(&mut self) {
+        if let (Some(first), Some(last)) = (self.0.first().map(|n| *n), self.0.last().map(|n| *n)) {
+            if first != last {
+                self.0.push(first);
+            }
+        }
+    }
 }
 
 /// Turn a `Vec` of `Point`-ish objects into a `LineString`.

--- a/geo-types/src/polygon.rs
+++ b/geo-types/src/polygon.rs
@@ -11,6 +11,16 @@ use {CoordinateType, LineString, Point, Rect};
 /// be _closed_, such that the first and last `Coordinate` of each ring has
 /// the same value.
 ///
+/// # Validity
+///
+/// Besides the closed `LineString` rings guarantee, the `Polygon` structure
+/// does not enforce validity at this time. For example, it is possible to
+/// construct a `Polygon` that has:
+///
+/// - fewer than 3 coordinates per `LineString` ring
+/// - interior rings that intersect other interior rings
+/// - interior rings that extend beyond the exterior ring
+///
 /// # `LineString` closing operation
 ///
 /// Some APIs on `Polygon` result in a closing operation on a `LineString`. The

--- a/geo-types/src/polygon.rs
+++ b/geo-types/src/polygon.rs
@@ -1,64 +1,351 @@
 use num_traits::{Float, Signed};
 use {CoordinateType, LineString, Point, Rect};
 
-/// A bounded 2D area. Its outer boundary (_shell_) is represented by a [`LineString`](struct.LineString.html)
-/// that is both closed and simple (non-intersecting). It may contain 0 or more non-intersecting holes (_rings_), each represented by
-/// a closed simple `LineString`.
+/// A bounded two-dimensional area.
 ///
-/// It has one exterior *ring* or *shell*, and zero or more interior rings, representing holes.
+/// A `Polygon`’s outer boundary (_exterior ring_) is represented by a
+/// [`LineString`]. It may contain zero or more holes (_interior rings_), also
+/// represented by `LineString`s.
 ///
-/// # Examples
+/// The `Polygon` structure guarantees that all exterior and interior rings will
+/// be _closed_, such that the first and last `Coordinate` of each ring has
+/// the same value.
 ///
-/// Polygons can be created from collections of `Point`-like objects, such as arrays or tuples:
+/// # `LineString` closing operation
 ///
-/// ```
-/// use geo_types::{Point, LineString, Polygon};
-/// let poly1 = Polygon::new(vec![[0., 0.], [10., 0.]].into(), vec![]);
-/// let poly2 = Polygon::new(vec![(0., 0.), (10., 0.)].into(), vec![]);
-/// ```
+/// Some APIs on `Polygon` result in a closing operation on a `LineString`. The
+/// operation is as follows:
+///
+/// If a `LineString`’s first and last `Coordinate` have different values, a
+/// new `Coordinate` will be appended to the `LineString` with a value equal to
+/// the first `Coordinate`.
+///
+/// [`LineString`]: struct.LineString.html
 #[derive(PartialEq, Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Polygon<T>
 where
     T: CoordinateType,
 {
-    pub exterior: LineString<T>,
-    pub interiors: Vec<LineString<T>>,
+    exterior: LineString<T>,
+    interiors: Vec<LineString<T>>,
 }
 
 impl<T> Polygon<T>
 where
     T: CoordinateType,
 {
-    /// Creates a new polygon.
+    /// Create a new `Polygon` with the provided exterior `LineString` ring and
+    /// interior `LineString` rings.
+    ///
+    /// Upon calling `new`, the exterior and interior `LineString` rings [will
+    /// be closed].
+    ///
+    /// [will be closed]: #linestring-closing-operation
+    ///
+    /// # Examples
+    ///
+    /// Creating a `Polygon` with no interior rings:
+    ///
+    /// ```
+    /// use geo_types::{LineString, Polygon};
+    ///
+    /// let polygon = Polygon::new(LineString::from(vec![
+    ///     (0., 0.),
+    ///     (1., 1.),
+    ///     (1., 0.),
+    ///     (0., 0.),
+    /// ]), vec![]);
+    /// ```
+    ///
+    /// Creating a `Polygon` with an interior ring:
+    ///
+    /// ```
+    /// use geo_types::{LineString, Polygon};
+    ///
+    /// let polygon = Polygon::new(LineString::from(vec![
+    ///     (0., 0.),
+    ///     (1., 1.),
+    ///     (1., 0.),
+    ///     (0., 0.),
+    /// ]), vec![
+    ///     LineString::from(vec![
+    ///         (0.1, 0.1),
+    ///         (0.9, 0.9),
+    ///         (0.9, 0.1),
+    ///         (0.1, 0.1),
+    ///     ])
+    /// ]);
+    /// ```
+    ///
+    /// If the first and last `Coordinate`s of the exterior or interior
+    /// `LineString`s no longer match, those `LineString`s [will be closed]:
+    ///
+    /// ```
+    /// use geo_types::{Coordinate, LineString, Polygon};
+    ///
+    /// let mut polygon = Polygon::new(LineString::from(vec![
+    ///     (0., 0.),
+    ///     (1., 1.),
+    ///     (1., 0.),
+    /// ]), vec![]);
+    ///
+    /// assert_eq!(polygon.exterior(), &LineString::from(vec![
+    ///     (0., 0.),
+    ///     (1., 1.),
+    ///     (1., 0.),
+    ///     (0., 0.),
+    /// ]));
+    /// ```
+    pub fn new(mut exterior: LineString<T>, mut interiors: Vec<LineString<T>>) -> Polygon<T> {
+        exterior.close();
+        for interior in &mut interiors {
+            interior.close();
+        }
+        Polygon {
+            exterior,
+            interiors,
+        }
+    }
+
+    /// Consume the `Polygon`, returning the exterior `LineString` ring and
+    /// a vector of the interior `LineString` rings.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use geo_types::{LineString, Polygon};
+    ///
+    /// let mut polygon = Polygon::new(LineString::from(vec![
+    ///     (0., 0.),
+    ///     (1., 1.),
+    ///     (1., 0.),
+    ///     (0., 0.),
+    /// ]), vec![
+    ///     LineString::from(vec![
+    ///         (0.1, 0.1),
+    ///         (0.9, 0.9),
+    ///         (0.9, 0.1),
+    ///         (0.1, 0.1),
+    ///     ])
+    /// ]);
+    ///
+    /// let (exterior, interiors) = polygon.into_inner();
+    ///
+    /// assert_eq!(exterior, LineString::from(vec![
+    ///     (0., 0.),
+    ///     (1., 1.),
+    ///     (1., 0.),
+    ///     (0., 0.),
+    /// ]));
+    ///
+    /// assert_eq!(interiors, vec![LineString::from(vec![
+    ///     (0.1, 0.1),
+    ///     (0.9, 0.9),
+    ///     (0.9, 0.1),
+    ///     (0.1, 0.1),
+    /// ])]);
+    /// ```
+    pub fn into_inner(self) -> (LineString<T>, Vec<LineString<T>>) {
+        (self.exterior, self.interiors)
+    }
+
+    /// Return a reference to the exterior `LineString` ring.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use geo_types::{LineString, Polygon};
+    ///
+    /// let exterior = LineString::from(vec![
+    ///     (0., 0.),
+    ///     (1., 1.),
+    ///     (1., 0.),
+    ///     (0., 0.),
+    /// ]);
+    ///
+    /// let polygon = Polygon::new(exterior.clone(), vec![]);
+    ///
+    /// assert_eq!(polygon.exterior(), &exterior);
+    /// ```
+    pub fn exterior(&self) -> &LineString<T> {
+        &self.exterior
+    }
+
+    /// Execute the provided closure `f`, which is provided with a mutable
+    /// reference to the exterior `LineString` ring.
+    ///
+    /// After the closure executes, the exterior `LineString` [will be closed].
     ///
     /// # Examples
     ///
     /// ```
     /// use geo_types::{Coordinate, LineString, Polygon};
     ///
-    /// let exterior = LineString(vec![
-    ///     Coordinate { x: 0., y: 0. },
-    ///     Coordinate { x: 1., y: 1. },
-    ///     Coordinate { x: 1., y: 0. },
-    ///     Coordinate { x: 0., y: 0. },
-    /// ]);
-    /// let interiors = vec![LineString(vec![
-    ///     Coordinate { x: 0.1, y: 0.1 },
-    ///     Coordinate { x: 0.9, y: 0.9 },
-    ///     Coordinate { x: 0.9, y: 0.1 },
-    ///     Coordinate { x: 0.1, y: 0.1 },
-    /// ])];
-    /// let p = Polygon::new(exterior.clone(), interiors.clone());
-    /// assert_eq!(p.exterior, exterior);
-    /// assert_eq!(p.interiors, interiors);
+    /// let mut polygon = Polygon::new(LineString::from(vec![
+    ///     (0., 0.),
+    ///     (1., 1.),
+    ///     (1., 0.),
+    ///     (0., 0.),
+    /// ]), vec![]);
+    ///
+    /// polygon.exterior_mut(|exterior| {
+    ///     exterior.0[1] = Coordinate { x: 1., y: 2. };
+    /// });
+    ///
+    /// assert_eq!(polygon.exterior(), &LineString::from(vec![
+    ///     (0., 0.),
+    ///     (1., 2.),
+    ///     (1., 0.),
+    ///     (0., 0.),
+    /// ]));
     /// ```
-    pub fn new(exterior: LineString<T>, interiors: Vec<LineString<T>>) -> Polygon<T> {
-        Polygon {
-            exterior,
-            interiors,
+    ///
+    /// If the first and last `Coordinate`s of the exterior `LineString` no
+    /// longer match, the `LineString` [will be closed]:
+    ///
+    /// ```
+    /// use geo_types::{Coordinate, LineString, Polygon};
+    ///
+    /// let mut polygon = Polygon::new(LineString::from(vec![
+    ///     (0., 0.),
+    ///     (1., 1.),
+    ///     (1., 0.),
+    ///     (0., 0.),
+    /// ]), vec![]);
+    ///
+    /// polygon.exterior_mut(|exterior| {
+    ///     exterior.0[0] = Coordinate { x: 0., y: 1. };
+    /// });
+    ///
+    /// assert_eq!(polygon.exterior(), &LineString::from(vec![
+    ///     (0., 1.),
+    ///     (1., 1.),
+    ///     (1., 0.),
+    ///     (0., 0.),
+    ///     (0., 1.),
+    /// ]));
+    /// ```
+    ///
+    /// [will be closed]: #linestring-closing-operation
+    pub fn exterior_mut<F>(&mut self, mut f: F)
+        where F: FnMut(&mut LineString<T>)
+    {
+        f(&mut self.exterior);
+        self.exterior.close();
+    }
+
+    /// Return a slice of the interior `LineString` rings.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use geo_types::{Coordinate, LineString, Polygon};
+    ///
+    /// let interiors = vec![LineString::from(vec![
+    ///     (0.1, 0.1),
+    ///     (0.9, 0.9),
+    ///     (0.9, 0.1),
+    ///     (0.1, 0.1),
+    /// ])];
+    ///
+    /// let polygon = Polygon::new(LineString::from(vec![
+    ///     (0., 0.),
+    ///     (1., 1.),
+    ///     (1., 0.),
+    ///     (0., 0.),
+    /// ]), interiors.clone());
+    ///
+    /// assert_eq!(interiors, polygon.interiors());
+    /// ```
+    pub fn interiors(&self) -> &[LineString<T>] {
+        &self.interiors
+    }
+
+    /// Execute the provided closure `f`, which is provided with a mutable
+    /// reference to the interior `LineString` rings.
+    ///
+    /// After the closure executes, each of the interior `LineString`s [will be
+    /// closed].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use geo_types::{Coordinate, LineString, Polygon};
+    ///
+    /// let mut polygon = Polygon::new(LineString::from(vec![
+    ///     (0., 0.),
+    ///     (1., 1.),
+    ///     (1., 0.),
+    ///     (0., 0.),
+    /// ]), vec![
+    ///     LineString::from(vec![
+    ///         (0.1, 0.1),
+    ///         (0.9, 0.9),
+    ///         (0.9, 0.1),
+    ///         (0.1, 0.1),
+    ///     ])
+    /// ]);
+    ///
+    /// polygon.interiors_mut(|interiors| {
+    ///     interiors[0].0[1] = Coordinate { x: 0.8, y: 0.8 };
+    /// });
+    ///
+    /// assert_eq!(polygon.interiors(), &[
+    ///     LineString::from(vec![
+    ///         (0.1, 0.1),
+    ///         (0.8, 0.8),
+    ///         (0.9, 0.1),
+    ///         (0.1, 0.1),
+    ///     ])
+    /// ]);
+    /// ```
+    ///
+    /// If the first and last `Coordinate`s of any interior `LineString` no
+    /// longer match, those `LineString`s [will be closed]:
+    ///
+    /// ```
+    /// use geo_types::{Coordinate, LineString, Polygon};
+    ///
+    /// let mut polygon = Polygon::new(LineString::from(vec![
+    ///     (0., 0.),
+    ///     (1., 1.),
+    ///     (1., 0.),
+    ///     (0., 0.),
+    /// ]), vec![
+    ///     LineString::from(vec![
+    ///         (0.1, 0.1),
+    ///         (0.9, 0.9),
+    ///         (0.9, 0.1),
+    ///         (0.1, 0.1),
+    ///     ])
+    /// ]);
+    ///
+    /// polygon.interiors_mut(|interiors| {
+    ///     interiors[0].0[0] = Coordinate { x: 0.1, y: 0.2 };
+    /// });
+    ///
+    /// assert_eq!(polygon.interiors(), &[
+    ///     LineString::from(vec![
+    ///         (0.1, 0.2),
+    ///         (0.9, 0.9),
+    ///         (0.9, 0.1),
+    ///         (0.1, 0.1),
+    ///         (0.1, 0.2),
+    ///     ])
+    /// ]);
+    /// ```
+    ///
+    /// [will be closed]: #linestring-closing-operation
+    pub fn interiors_mut<F>(&mut self, mut f: F)
+        where F: FnMut(&mut [LineString<T>])
+    {
+        f(&mut self.interiors);
+        for mut interior in &mut self.interiors {
+            interior.close();
         }
     }
+
     /// Wrap-around previous-vertex
     fn previous_vertex(&self, current_vertex: &usize) -> usize
     where

--- a/geo/src/algorithm/area.rs
+++ b/geo/src/algorithm/area.rs
@@ -27,7 +27,9 @@ where
     ///
     /// assert_eq!(polygon.area(), 30.);
     ///
-    /// polygon.exterior.0.reverse();
+    /// polygon.exterior_mut(|line_string| {
+    ///     line_string.0.reverse();
+    /// });
     ///
     /// assert_eq!(polygon.area(), -30.);
     /// ```
@@ -56,9 +58,9 @@ where
     T: Float,
 {
     fn area(&self) -> T {
-        self.interiors
+        self.interiors()
             .iter()
-            .fold(get_linestring_area(&self.exterior), |total, next| {
+            .fold(get_linestring_area(self.exterior()), |total, next| {
                 total - get_linestring_area(next)
             })
     }

--- a/geo/src/algorithm/bounding_rect.rs
+++ b/geo/src/algorithm/bounding_rect.rs
@@ -102,7 +102,7 @@ where
     /// Return the BoundingRect for a Polygon
     ///
     fn bounding_rect(&self) -> Self::Output {
-        let line = &self.exterior;
+        let line = self.exterior();
         get_bounding_rect(line.0.iter().cloned())
     }
 }
@@ -120,7 +120,7 @@ where
         get_bounding_rect(
             self.0
                 .iter()
-                .flat_map(|poly| (poly.exterior).0.iter().cloned()),
+                .flat_map(|poly| poly.exterior().0.iter().cloned()),
         )
     }
 }

--- a/geo/src/algorithm/centroid.rs
+++ b/geo/src/algorithm/centroid.rs
@@ -146,7 +146,7 @@ where
     // See here for a formula: http://math.stackexchange.com/a/623849
     // See here for detail on alternative methods: https://fotino.me/calculating-centroids/
     fn centroid(&self) -> Self::Output {
-        let linestring = &self.exterior;
+        let linestring = &self.exterior();
         let vect = &linestring.0;
         if vect.is_empty() {
             return None;
@@ -154,14 +154,14 @@ where
         if vect.len() == 1 {
             Some(Point::new(vect[0].x, vect[0].y))
         } else {
-            let external_centroid = simple_polygon_centroid(&self.exterior)?;
-            if self.interiors.is_empty() {
+            let external_centroid = simple_polygon_centroid(self.exterior())?;
+            if self.interiors().is_empty() {
                 Some(external_centroid)
             } else {
-                let external_area = get_linestring_area(&self.exterior).abs();
+                let external_area = get_linestring_area(self.exterior()).abs();
                 // accumulate interior Polygons
                 let (totals_x, totals_y, internal_area) = self
-                    .interiors
+                    .interiors()
                     .iter()
                     .filter_map(|ring| {
                         let area = get_linestring_area(ring).abs();
@@ -215,7 +215,7 @@ where
                     sum_area_y = sum_area_y + area * p.y();
                 } else {
                     // the polygon is 'flat', we consider it as a linestring
-                    let ls_len = poly.exterior.euclidean_length();
+                    let ls_len = poly.exterior().euclidean_length();
                     if ls_len == T::zero() {
                         sum_x = sum_x + p.x();
                         sum_y = sum_y + p.x();

--- a/geo/src/algorithm/closest_point.rs
+++ b/geo/src/algorithm/closest_point.rs
@@ -115,7 +115,7 @@ impl<F: Float> ClosestPoint<F> for LineString<F> {
 
 impl<F: Float> ClosestPoint<F> for Polygon<F> {
     fn closest_point(&self, p: &Point<F>) -> Closest<F> {
-        let prospectives = self.interiors.iter().chain(iter::once(&self.exterior));
+        let prospectives = self.interiors().iter().chain(iter::once(self.exterior()));
         closest_of(prospectives, *p)
     }
 }
@@ -264,12 +264,12 @@ mod tests {
         let poly = holy_polygon();
         let p = Point::new(1000.0, 12345.6789);
         assert!(
-            !poly.exterior.contains(&p),
+            !poly.exterior().contains(&p),
             "`p` should be outside the polygon!"
         );
 
         let poly_closest = poly.closest_point(&p);
-        let exterior_closest = poly.exterior.closest_point(&p);
+        let exterior_closest = poly.exterior().closest_point(&p);
 
         assert_eq!(poly_closest, exterior_closest);
     }
@@ -277,7 +277,7 @@ mod tests {
     #[test]
     fn polygon_with_point_on_interior_ring() {
         let poly = holy_polygon();
-        let p = poly.interiors[0].0[3];
+        let p = poly.interiors()[0].0[3];
         let should_be = Closest::Intersection(p.into());
 
         let got = poly.closest_point(&p.into());
@@ -288,7 +288,7 @@ mod tests {
     #[test]
     fn polygon_with_point_near_interior_ring() {
         let poly = holy_polygon();
-        let random_ring_corner = poly.interiors[0].0[3];
+        let random_ring_corner = poly.interiors()[0].0[3];
         let p = Point(random_ring_corner).translate(-3.0, 3.0);
 
         let should_be = Closest::SinglePoint(random_ring_corner.into());

--- a/geo/src/algorithm/contains.rs
+++ b/geo/src/algorithm/contains.rs
@@ -164,10 +164,10 @@ where
     T: Float,
 {
     fn contains(&self, p: &Point<T>) -> bool {
-        match get_position(*p, &self.exterior) {
+        match get_position(*p, &self.exterior()) {
             PositionPoint::OnBoundary | PositionPoint::Outside => false,
             _ => self
-                .interiors
+                .interiors()
                 .iter()
                 .all(|ls| get_position(*p, ls) == PositionPoint::Outside),
         }
@@ -192,8 +192,8 @@ where
         // does NOT intersect the exterior or any of the interior boundaries
         self.contains(&line.start_point())
             && self.contains(&line.end_point())
-            && !self.exterior.intersects(line)
-            && !self.interiors.iter().any(|inner| inner.intersects(line))
+            && !self.exterior().intersects(line)
+            && !self.interiors().iter().any(|inner| inner.intersects(line))
     }
 }
 
@@ -203,7 +203,7 @@ where
 {
     fn contains(&self, poly: &Polygon<T>) -> bool {
         // decompose poly's exterior ring into Lines, and check each for containment
-        poly.exterior.lines().all(|line| self.contains(&line))
+        poly.exterior().lines().all(|line| self.contains(&line))
     }
 }
 
@@ -217,7 +217,7 @@ where
             // The Polygon interior is allowed to intersect with the LineString
             // but the Polygon's rings are not
             !self
-                .interiors
+                .interiors()
                 .iter()
                 .any(|ring| ring.intersects(linestring))
         } else {
@@ -404,18 +404,19 @@ mod test {
     fn point_polygon_with_inner_test() {
         let linestring = LineString::from(vec![(0., 0.), (2., 0.), (2., 2.), (0., 2.), (0., 0.)]);
         let inner_linestring = LineString::from(vec![
-            (0.5, 0.5),
-            (1.5, 0.5),
-            (1.5, 1.5),
-            (0.0, 1.5),
-            (0.0, 0.0),
+            [0.5, 0.5],
+            [1.5, 0.5],
+            [1.5, 1.5],
+            [0.0, 1.5],
+            [0.0, 0.0],
         ]);
         let poly = Polygon::new(linestring, vec![inner_linestring]);
-        assert!(poly.contains(&Point::new(0.25, 0.25)));
+        assert!(!poly.contains(&Point::new(0.25, 0.25)));
         assert!(!poly.contains(&Point::new(1., 1.)));
         assert!(!poly.contains(&Point::new(1.5, 1.5)));
         assert!(!poly.contains(&Point::new(1.5, 1.)));
     }
+
     /// Tests: Point in MultiPolygon
     #[test]
     fn empty_multipolygon_test() {

--- a/geo/src/algorithm/convexhull.rs
+++ b/geo/src/algorithm/convexhull.rs
@@ -126,7 +126,7 @@ pub trait ConvexHull<T> {
     /// let correct_hull: LineString<_> = hull_coords.iter().map(|e| Point::new(e.0, e.1)).collect();
     ///
     /// let res = poly.convex_hull();
-    /// assert_eq!(res.exterior, correct_hull);
+    /// assert_eq!(res.exterior(), &correct_hull);
     /// ```
     fn convex_hull(&self) -> Polygon<T>
     where
@@ -139,7 +139,7 @@ where
 {
     fn convex_hull(&self) -> Polygon<T> {
         Polygon::new(
-            LineString::from(quick_hull(&mut self.exterior.clone().into_points())),
+            LineString::from(quick_hull(&mut self.exterior().clone().into_points())),
             vec![],
         )
     }
@@ -153,7 +153,7 @@ where
         let mut aggregated: Vec<Point<T>> = self
             .0
             .iter()
-            .flat_map(|elem| elem.exterior.0.iter().map(|c| Point(*c)))
+            .flat_map(|elem| elem.exterior().0.iter().map(|c| Point(*c)))
             .collect();
         Polygon::new(LineString::from(quick_hull(&mut aggregated)), vec![])
     }
@@ -328,7 +328,7 @@ mod test {
             Coordinate::from((0.0, -10.0)),
         ];
         let res = mp.convex_hull();
-        assert_eq!(res.exterior.0, correct);
+        assert_eq!(res.exterior().0, correct);
     }
     #[test]
     fn quick_hull_linestring_test() {
@@ -352,7 +352,7 @@ mod test {
             Coordinate::from((0.0, -10.0)),
         ];
         let res = mp.convex_hull();
-        assert_eq!(res.exterior.0, correct);
+        assert_eq!(res.exterior().0, correct);
     }
     #[test]
     fn quick_hull_multilinestring_test() {
@@ -367,7 +367,7 @@ mod test {
             Coordinate::from((2.0, 0.0)),
         ];
         let res = mls.convex_hull();
-        assert_eq!(res.exterior.0, correct);
+        assert_eq!(res.exterior().0, correct);
     }
     #[test]
     fn quick_hull_multipolygon_test() {
@@ -384,6 +384,6 @@ mod test {
             Coordinate::from((5.0, 0.0)),
         ];
         let res = mp.convex_hull();
-        assert_eq!(res.exterior.0, correct);
+        assert_eq!(res.exterior().0, correct);
     }
 }

--- a/geo/src/algorithm/extremes.rs
+++ b/geo/src/algorithm/extremes.rs
@@ -73,7 +73,7 @@ fn polymax_naive_indices<T>(u: Point<T>, poly: &Polygon<T>) -> Result<usize, ()>
 where
     T: Float,
 {
-    let vertices = &poly.exterior.0;
+    let vertices = &poly.exterior().0;
     let mut max: usize = 0;
     for (i, _) in vertices.iter().enumerate() {
         // if vertices[i] is above prior vertices[max]
@@ -169,10 +169,10 @@ where
         // safe to unwrap, since we're guaranteeing the polygon's convexity
         let indices = ch.extreme_indices().unwrap();
         ExtremePoint {
-            ymin: Point(ch.exterior.0[indices.ymin]),
-            xmax: Point(ch.exterior.0[indices.xmax]),
-            ymax: Point(ch.exterior.0[indices.ymax]),
-            xmin: Point(ch.exterior.0[indices.xmin]),
+            ymin: Point(ch.exterior().0[indices.ymin]),
+            xmax: Point(ch.exterior().0[indices.xmax]),
+            ymax: Point(ch.exterior().0[indices.ymax]),
+            xmin: Point(ch.exterior().0[indices.xmin]),
         }
     }
 }

--- a/geo/src/algorithm/from_postgis.rs
+++ b/geo/src/algorithm/from_postgis.rs
@@ -46,10 +46,7 @@ where
             return None;
         }
         let exterior = rings.remove(0);
-        Some(Polygon {
-            exterior,
-            interiors: rings,
-        })
+        Some(Polygon::new(exterior, rings))
     }
 }
 impl<'a, T> FromPostgis<&'a T> for MultiPoint<f64>

--- a/geo/src/algorithm/intersects.rs
+++ b/geo/src/algorithm/intersects.rs
@@ -123,8 +123,8 @@ where
     T: Float,
 {
     fn intersects(&self, p: &Polygon<T>) -> bool {
-        p.exterior.intersects(self)
-            || p.interiors.iter().any(|inner| inner.intersects(self))
+        p.exterior().intersects(self)
+            || p.interiors().iter().any(|inner| inner.intersects(self))
             || p.contains(&self.start_point())
             || p.contains(&self.end_point())
     }
@@ -177,9 +177,9 @@ where
 {
     fn intersects(&self, linestring: &LineString<T>) -> bool {
         // line intersects inner or outer polygon edge
-        if self.exterior.intersects(linestring)
+        if self.exterior().intersects(linestring)
             || self
-                .interiors
+                .interiors()
                 .iter()
                 .any(|inner| inner.intersects(linestring))
         {
@@ -251,10 +251,10 @@ where
 {
     fn intersects(&self, polygon: &Polygon<T>) -> bool {
         // self intersects (or contains) any line in polygon
-        self.intersects(&polygon.exterior) ||
-            polygon.interiors.iter().any(|inner_line_string| self.intersects(inner_line_string)) ||
+        self.intersects(polygon.exterior()) ||
+            polygon.interiors().iter().any(|inner_line_string| self.intersects(inner_line_string)) ||
             // self is contained inside polygon
-            polygon.intersects(&self.exterior)
+            polygon.intersects(self.exterior())
     }
 }
 

--- a/geo/src/algorithm/orient.rs
+++ b/geo/src/algorithm/orient.rs
@@ -26,8 +26,8 @@ pub trait Orient<T> {
     /// let oriented_int_ls = LineString::from(oriented_int);
     /// // build corrected Polygon
     /// let oriented = poly.orient(Direction::Default);
-    /// assert_eq!(oriented.exterior.0, oriented_ext_ls.0);
-    /// assert_eq!(oriented.interiors[0].0, oriented_int_ls.0);
+    /// assert_eq!(oriented.exterior().0, oriented_ext_ls.0);
+    /// assert_eq!(oriented.interiors()[0].0, oriented_int_ls.0);
     /// ```
     fn orient(&self, orientation: Direction) -> Self;
 }
@@ -69,7 +69,7 @@ where
     T: CoordinateType,
 {
     let interiors = poly
-        .interiors
+        .interiors()
         .iter()
         .map(|l| {
             l.clone_to_winding_order(match direction {
@@ -79,7 +79,7 @@ where
         })
         .collect();
 
-    let ext_ring = poly.exterior.clone_to_winding_order(match direction {
+    let ext_ring = poly.exterior().clone_to_winding_order(match direction {
         Direction::Default => WindingOrder::CounterClockwise,
         Direction::Reversed => WindingOrder::Clockwise,
     });
@@ -109,7 +109,7 @@ mod test {
         let oriented_int_ls = LineString::from(oriented_int_raw);
         // build corrected Polygon
         let oriented = orient(&poly1, Direction::Default);
-        assert_eq!(oriented.exterior.0, oriented_ext_ls.0);
-        assert_eq!(oriented.interiors[0].0, oriented_int_ls.0);
+        assert_eq!(oriented.exterior().0, oriented_ext_ls.0);
+        assert_eq!(oriented.interiors()[0].0, oriented_int_ls.0);
     }
 }

--- a/geo/src/algorithm/polygon_distance_fast_path.rs
+++ b/geo/src/algorithm/polygon_distance_fast_path.rs
@@ -16,8 +16,8 @@ where
 {
     let poly1_extremes = poly1.extreme_indices().unwrap();
     let poly2_extremes = poly2.extreme_indices().unwrap();
-    let ymin1 = Point(poly1.exterior.0[poly1_extremes.ymin]);
-    let ymax2 = Point(poly2.exterior.0[poly2_extremes.ymax]);
+    let ymin1 = Point(poly1.exterior().0[poly1_extremes.ymin]);
+    let ymax2 = Point(poly2.exterior().0[poly2_extremes.ymax]);
 
     let mut state = Polydist {
         poly1,
@@ -66,7 +66,7 @@ fn prev_vertex<T>(poly: &Polygon<T>, current_vertex: usize) -> usize
 where
     T: Float,
 {
-    (current_vertex + (poly.exterior.0.len() - 1) - 1) % (poly.exterior.0.len() - 1)
+    (current_vertex + (poly.exterior().0.len() - 1) - 1) % (poly.exterior().0.len() - 1)
 }
 
 /// Wrap-around next Polygon index
@@ -74,7 +74,7 @@ fn next_vertex<T>(poly: &Polygon<T>, current_vertex: usize) -> usize
 where
     T: Float,
 {
-    (current_vertex + 1) % (poly.exterior.0.len() - 1)
+    (current_vertex + 1) % (poly.exterior().0.len() - 1)
 }
 
 #[derive(Debug)]
@@ -126,8 +126,8 @@ where
     let sinsq = T::one() - cossq;
     let mut cos = T::zero();
     let mut sin;
-    let pnext = poly.exterior.0[next_vertex(poly, idx)];
-    let pprev = poly.exterior.0[prev_vertex(poly, idx)];
+    let pnext = poly.exterior().0[next_vertex(poly, idx)];
+    let pprev = poly.exterior().0[prev_vertex(poly, idx)];
     let clockwise = Point(pprev).cross_prod(Point(p.0), Point(pnext)) < T::zero();
     let slope_prev;
     let slope_next;
@@ -320,8 +320,8 @@ where
     T: Float + FloatConst + Signed,
 {
     let hundred = T::from(100).unwrap();
-    let pnext = poly.exterior.0[next_vertex(poly, idx)];
-    let pprev = poly.exterior.0[prev_vertex(poly, idx)];
+    let pnext = poly.exterior().0[next_vertex(poly, idx)];
+    let pprev = poly.exterior().0[prev_vertex(poly, idx)];
     let clockwise = Point(pprev).cross_prod(Point(p.0), Point(pnext)) < T::zero();
     let punit;
     if !vertical {
@@ -456,14 +456,14 @@ where
     if (state.ap1 - minangle).abs() < T::from(0.002).unwrap() {
         state.ip1 = true;
         let p1next = next_vertex(state.poly1, state.p1_idx);
-        state.p1next = Point(state.poly1.exterior.0[p1next]);
+        state.p1next = Point(state.poly1.exterior().0[p1next]);
         state.p1_idx = p1next;
         state.alignment = Some(AlignedEdge::VertexP);
     }
     if (state.aq2 - minangle).abs() < T::from(0.002).unwrap() {
         state.iq2 = true;
         let q2next = next_vertex(state.poly2, state.q2_idx);
-        state.q2next = Point(state.poly2.exterior.0[q2next]);
+        state.q2next = Point(state.poly2.exterior().0[q2next]);
         state.q2_idx = q2next;
         state.alignment = match state.alignment {
             None => Some(AlignedEdge::VertexQ),

--- a/geo/src/algorithm/rotate.rs
+++ b/geo/src/algorithm/rotate.rs
@@ -165,14 +165,14 @@ where
     /// Rotate the Polygon about its centroid by the given number of degrees
     fn rotate(&self, angle: T) -> Self {
         // if a polygon has holes, use the centroid of its outer shell as the rotation origin
-        let centroid = if self.interiors.is_empty() {
+        let centroid = if self.interiors().is_empty() {
             self.centroid().unwrap()
         } else {
-            self.exterior.centroid().unwrap()
+            self.exterior().centroid().unwrap()
         };
         Polygon::new(
-            rotate_many(angle, centroid, self.exterior.points_iter()).collect(),
-            self.interiors
+            rotate_many(angle, centroid, self.exterior().points_iter()).collect(),
+            self.interiors()
                 .iter()
                 .map(|ring| rotate_many(angle, centroid, ring.points_iter()).collect())
                 .collect(),
@@ -309,8 +309,8 @@ mod test {
             Coordinate::from((5.672380059021509, 1.2114794859018578)),
             Coordinate::from((4.706454232732441, 1.4702985310043786)),
         ];
-        assert_eq!(rotated.exterior.0, correct_outside);
-        assert_eq!(rotated.interiors[0].0, correct_inside);
+        assert_eq!(rotated.exterior().0, correct_outside);
+        assert_eq!(rotated.interiors()[0].0, correct_inside);
     }
     #[test]
     fn test_rotate_around_point_arbitrary() {

--- a/geo/src/algorithm/simplify.rs
+++ b/geo/src/algorithm/simplify.rs
@@ -93,8 +93,11 @@ where
 {
     fn simplify(&self, epsilon: &T) -> Polygon<T> {
         Polygon::new(
-            self.exterior.simplify(epsilon),
-            self.interiors.iter().map(|l| l.simplify(epsilon)).collect(),
+            self.exterior().simplify(epsilon),
+            self.interiors()
+                .iter()
+                .map(|l| l.simplify(epsilon))
+                .collect(),
         )
     }
 }

--- a/geo/src/algorithm/simplifyvw.rs
+++ b/geo/src/algorithm/simplifyvw.rs
@@ -526,7 +526,7 @@ where
             min_points: 6,
             geomtype: GeomType::Ring,
         };
-        let mut simplified = vwp_wrapper(&gt, &self.exterior, Some(&self.interiors), epsilon);
+        let mut simplified = vwp_wrapper(&gt, self.exterior(), Some(self.interiors()), epsilon);
         let exterior = LineString::from(simplified.remove(0));
         let interiors = simplified.into_iter().map(LineString::from).collect();
         Polygon::new(exterior, interiors)
@@ -571,8 +571,8 @@ where
 {
     fn simplifyvw(&self, epsilon: &T) -> Polygon<T> {
         Polygon::new(
-            self.exterior.simplifyvw(epsilon),
-            self.interiors
+            self.exterior().simplifyvw(epsilon),
+            self.interiors()
                 .iter()
                 .map(|l| l.simplifyvw(epsilon))
                 .collect(),
@@ -696,7 +696,7 @@ mod test {
         ]);
         let poly = Polygon::new(outer.clone(), vec![inner]);
         let simplified = poly.simplifyvw_preserve(&95.4);
-        assert_eq!(simplified.exterior, outer);
+        assert_eq!(simplified.exterior(), &outer);
     }
     #[test]
     fn remove_inner_point_vwp_test() {
@@ -727,8 +727,8 @@ mod test {
         ]);
         let poly = Polygon::new(outer.clone(), vec![inner]);
         let simplified = poly.simplifyvw_preserve(&95.4);
-        assert_eq!(simplified.exterior, outer);
-        assert_eq!(simplified.interiors[0], correct_inner);
+        assert_eq!(simplified.exterior(), &outer);
+        assert_eq!(simplified.interiors()[0], correct_inner);
     }
     #[test]
     fn very_long_vwp_test() {

--- a/geo/src/algorithm/to_postgis.rs
+++ b/geo/src/algorithm/to_postgis.rs
@@ -41,8 +41,8 @@ impl ToPostgis<ewkb::LineString> for Line<f64> {
 }
 impl ToPostgis<ewkb::Polygon> for Polygon<f64> {
     fn to_postgis_with_srid(&self, srid: Option<i32>) -> ewkb::Polygon {
-        let rings = ::std::iter::once(&self.exterior)
-            .chain(self.interiors.iter())
+        let rings = ::std::iter::once(self.exterior())
+            .chain(self.interiors().iter())
             .map(|x| (*x).to_postgis_with_srid(srid))
             .collect();
         ewkb::Polygon { rings, srid }

--- a/geo/src/algorithm/translate.rs
+++ b/geo/src/algorithm/translate.rs
@@ -145,7 +145,7 @@ mod test {
             Coordinate::from((23.0, 19.3)),
             Coordinate::from((22.0, 19.3)),
         ];
-        assert_eq!(rotated.exterior.0, correct_outside);
-        assert_eq!(rotated.interiors[0].0, correct_inside);
+        assert_eq!(rotated.exterior().0, correct_outside);
+        assert_eq!(rotated.interiors()[0].0, correct_inside);
     }
 }


### PR DESCRIPTION
Prior to this pull request, the `exterior` and `interior` fields on a `Polygon` were public, allowing users to modify their `Coordinate`s as they saw fit.

To ensure all rings in a `Polygon`s remain closed, this pull request:

- privatizes the `exterior` and `interior` fields
- adds getters/mutators
- closes all `LineString` rings upon construction or after mutation

Fixes https://github.com/georust/geo/issues/166.