### PR TITLE
Tweak Geometry method names slightly.

### DIFF
--- a/geo-types/src/geometry.rs
+++ b/geo-types/src/geometry.rs
@@ -61,7 +61,7 @@ impl<T: CoordinateType> Geometry<T> {
     /// ```
     /// use geo_types::*;
     /// let g = Geometry::Point(Point::new(0., 0.));
-    /// let p2: Point<f32> = g.as_point().unwrap();
+    /// let p2: Point<f32> = g.into_point().unwrap();
     /// assert_eq!(p2, Point::new(0., 0.,));
     /// ```
     pub fn into_point(self) -> Option<Point<T>> {

--- a/geo-types/src/geometry.rs
+++ b/geo-types/src/geometry.rs
@@ -64,7 +64,7 @@ impl<T: CoordinateType> Geometry<T> {
     /// let p2: Point<f32> = g.as_point().unwrap();
     /// assert_eq!(p2, Point::new(0., 0.,));
     /// ```
-    pub fn as_point(self) -> Option<Point<T>> {
+    pub fn into_point(self) -> Option<Point<T>> {
         if let Geometry::Point(x) = self {
             Some(x)
         } else {
@@ -73,7 +73,7 @@ impl<T: CoordinateType> Geometry<T> {
     }
 
     /// If this Geometry is a LineString, then return that LineString, else None.
-    pub fn as_linestring(self) -> Option<LineString<T>> {
+    pub fn into_line_string(self) -> Option<LineString<T>> {
         if let Geometry::LineString(x) = self {
             Some(x)
         } else {
@@ -82,7 +82,7 @@ impl<T: CoordinateType> Geometry<T> {
     }
 
     /// If this Geometry is a Line, then return that Line, else None.
-    pub fn as_line(self) -> Option<Line<T>> {
+    pub fn into_line(self) -> Option<Line<T>> {
         if let Geometry::Line(x) = self {
             Some(x)
         } else {
@@ -91,7 +91,7 @@ impl<T: CoordinateType> Geometry<T> {
     }
 
     /// If this Geometry is a Polygon, then return that, else None.
-    pub fn as_polygon(self) -> Option<Polygon<T>> {
+    pub fn into_polygon(self) -> Option<Polygon<T>> {
         if let Geometry::Polygon(x) = self {
             Some(x)
         } else {
@@ -100,7 +100,7 @@ impl<T: CoordinateType> Geometry<T> {
     }
 
     /// If this Geometry is a MultiPoint, then return that, else None.
-    pub fn as_multipoint(self) -> Option<MultiPoint<T>> {
+    pub fn into_multi_point(self) -> Option<MultiPoint<T>> {
         if let Geometry::MultiPoint(x) = self {
             Some(x)
         } else {
@@ -109,7 +109,7 @@ impl<T: CoordinateType> Geometry<T> {
     }
 
     /// If this Geometry is a MultiLineString, then return that, else None.
-    pub fn as_multilinestring(self) -> Option<MultiLineString<T>> {
+    pub fn into_multi_line_string(self) -> Option<MultiLineString<T>> {
         if let Geometry::MultiLineString(x) = self {
             Some(x)
         } else {
@@ -118,7 +118,7 @@ impl<T: CoordinateType> Geometry<T> {
     }
 
     /// If this Geometry is a MultiPolygon, then return that, else None.
-    pub fn as_multipolygon(self) -> Option<MultiPolygon<T>> {
+    pub fn into_multi_polygon(self) -> Option<MultiPolygon<T>> {
         if let Geometry::MultiPolygon(x) = self {
             Some(x)
         } else {

--- a/geo-types/src/lib.rs
+++ b/geo-types/src/lib.rs
@@ -84,7 +84,7 @@ mod test {
         let p: Point<f32> = Point::new(0., 0.);
         let p1 = p.clone();
         let g: Geometry<f32> = p.into();
-        let p2 = g.as_point().unwrap();
+        let p2 = g.into_point().unwrap();
         assert_eq!(p1, p2);
     }
 


### PR DESCRIPTION
- The methods take `self`, so they should be called `into_*`
- Consistent with capitals and underscores
  - e.g. `line_string` instead of `linestring` for `LineString`