### PR TITLE
Introduce point!, line_string!, and polygon! macros.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,18 +27,31 @@ The primitive types also provide the basis for other functionality in the `Geo` 
 ## Example
 
 ```rust
-use geo::{Polygon, LineString};
+use geo::{line_string, polygon};
 use geo::convexhull::ConvexHull;
 
 // An L shape
-let coords = vec![(0.0, 0.0), (4.0, 0.0), (4.0, 1.0), (1.0, 1.0), (1.0, 4.0), (0.0, 4.0), (0.0, 0.0)];
-// conversions to geo types are provided from several kinds of coordinate sequences
-let poly = Polygon::new(coords.into(), vec![]);
+let poly = polygon![
+    (x: 0.0, y: 0.0),
+    (x: 4.0, y: 0.0),
+    (x: 4.0, y: 1.0),
+    (x: 1.0, y: 1.0),
+    (x: 1.0, y: 4.0),
+    (x: 0.0, y: 4.0),
+    (x: 0.0, y: 0.0),
+];
 
-// uses the QuickHull algorithm to calculate the polygon's convex hull
+// Ccalculate the polygon's convex hull
 let hull = poly.convex_hull();
-let correct = vec![(0.0, 0.0), (0.0, 4.0), (1.0, 4.0), (4.0, 1.0), (4.0, 0.0), (0.0, 0.0)]
-assert_eq!(hull.exterior, correct.into());
+
+assert_eq!(hull.exterior(), line_string![
+    (x: 0.0, y: 0.0),
+    (x: 0.0, y: 4.0),
+    (x: 1.0, y: 4.0),
+    (x: 4.0, y: 1.0),
+    (x: 4.0, y: 0.0),
+    (x: 0.0, y: 0.0),
+]);
 ```
 
 ## Contributing

--- a/geo/src/algorithm/area.rs
+++ b/geo/src/algorithm/area.rs
@@ -101,25 +101,30 @@ where
 #[cfg(test)]
 mod test {
     use crate::algorithm::area::Area;
-    use crate::{Coordinate, Line, LineString, MultiPolygon, Polygon, Rect, Triangle};
+    use crate::{line_string, polygon, Coordinate, Line, MultiPolygon, Polygon, Rect, Triangle};
 
     // Area of the polygon
     #[test]
     fn area_empty_polygon_test() {
-        let poly = Polygon::<f64>::new(LineString(Vec::new()), Vec::new());
+        let poly: Polygon<f32> = polygon![];
         assert_relative_eq!(poly.area(), 0.);
     }
 
     #[test]
     fn area_one_point_polygon_test() {
-        let poly = Polygon::new(LineString::from(vec![(1., 0.)]), Vec::new());
+        let poly = polygon![(x: 1., y: 0.)];
         assert_relative_eq!(poly.area(), 0.);
     }
     #[test]
     fn area_polygon_test() {
-        let linestring = LineString::from(vec![(0., 0.), (5., 0.), (5., 6.), (0., 6.), (0., 0.)]);
-        let poly = Polygon::new(linestring, Vec::new());
-        assert_relative_eq!(poly.area(), 30.);
+        let polygon = polygon![
+            (x: 0., y: 0.),
+            (x: 5., y: 0.),
+            (x: 5., y: 6.),
+            (x: 0., y: 6.),
+            (x: 0., y: 0.)
+        ];
+        assert_relative_eq!(polygon.area(), 30.);
     }
     #[test]
     fn rectangle_test() {
@@ -137,26 +142,53 @@ mod test {
     }
     #[test]
     fn area_polygon_inner_test() {
-        let outer = LineString::from(vec![(0., 0.), (10., 0.), (10., 10.), (0., 10.), (0., 0.)]);
-        let inner0 = LineString::from(vec![(1., 1.), (2., 1.), (2., 2.), (1., 2.), (1., 1.)]);
-        let inner1 = LineString::from(vec![(5., 5.), (6., 5.), (6., 6.), (5., 6.), (5., 5.)]);
+        let outer = line_string![
+            (x: 0., y: 0.),
+            (x: 10., y: 0.),
+            (x: 10., y: 10.),
+            (x: 0., y: 10.),
+            (x: 0., y: 0.)
+        ];
+        let inner0 = line_string![
+            (x: 1., y: 1.),
+            (x: 2., y: 1.),
+            (x: 2., y: 2.),
+            (x: 1., y: 2.),
+            (x: 1., y: 1.)
+        ];
+        let inner1 = line_string![
+            (x: 5., y: 5.),
+            (x: 6., y: 5.),
+            (x: 6., y: 6.),
+            (x: 5., y: 6.),
+            (x: 5., y: 5.)
+        ];
         let poly = Polygon::new(outer, vec![inner0, inner1]);
         assert_relative_eq!(poly.area(), 98.);
     }
     #[test]
     fn area_multipolygon_test() {
-        let poly0 = Polygon::new(
-            LineString::from(vec![(0., 0.), (10., 0.), (10., 10.), (0., 10.), (0., 0.)]),
-            Vec::new(),
-        );
-        let poly1 = Polygon::new(
-            LineString::from(vec![(1., 1.), (2., 1.), (2., 2.), (1., 2.), (1., 1.)]),
-            Vec::new(),
-        );
-        let poly2 = Polygon::new(
-            LineString::from(vec![(5., 5.), (6., 5.), (6., 6.), (5., 6.), (5., 5.)]),
-            Vec::new(),
-        );
+        let poly0 = polygon![
+            (x: 0., y: 0.),
+            (x: 10., y: 0.),
+            (x: 10., y: 10.),
+            (x: 0., y: 10.),
+            (x: 0., y: 0.)
+        ];
+        let poly1 = polygon![
+            (x: 1., y: 1.),
+            (x: 2., y: 1.),
+            (x: 2., y: 2.),
+            (x: 1., y: 2.),
+            (x: 1., y: 1.)
+        ];
+        let poly2 = polygon![
+            (x: 5., y: 5.),
+            (x: 6., y: 5.),
+            (x: 6., y: 6.),
+            (x: 5., y: 6.),
+            (x: 5., y: 5.)
+        ];
         let mpoly = MultiPolygon(vec![poly0, poly1, poly2]);
         assert_eq!(mpoly.area(), 102.);
         assert_relative_eq!(mpoly.area(), 102.);

--- a/geo/src/algorithm/bearing.rs
+++ b/geo/src/algorithm/bearing.rs
@@ -45,19 +45,19 @@ where
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use crate::algorithm::bearing::Bearing;
     use crate::algorithm::haversine_destination::HaversineDestination;
+    use crate::point;
 
     #[test]
     fn returns_the_proper_bearing_to_another_point() {
-        let p_1 = Point::<f64>::new(9.177789688110352, 48.776781529534965);
+        let p_1 = point!(x: 9.177789688110352f64, y: 48.776781529534965);
         let p_2 = p_1.haversine_destination(45., 10000.);
         let b_1 = p_1.bearing(p_2);
         assert_relative_eq!(b_1, 45., epsilon = 1.0e-6);
 
-        let p_3 = Point::<f64>::new(9., 47.);
-        let p_4 = Point::<f64>::new(9., 48.);
+        let p_3 = point!(x: 9., y: 47.);
+        let p_4 = point!(x: 9., y: 48.);
         let b_2 = p_3.bearing(p_4);
         assert_relative_eq!(b_2, 0., epsilon = 1.0e-6);
     }

--- a/geo/src/algorithm/bounding_rect.rs
+++ b/geo/src/algorithm/bounding_rect.rs
@@ -139,20 +139,20 @@ where
 #[cfg(test)]
 mod test {
     use crate::algorithm::bounding_rect::BoundingRect;
+    use crate::line_string;
     use crate::{
         Coordinate, Line, LineString, MultiLineString, MultiPoint, MultiPolygon, Polygon, Rect,
     };
 
     #[test]
     fn empty_linestring_test() {
-        let linestring: LineString<f32> = LineString(vec![]);
+        let linestring: LineString<f32> = line_string![];
         let bounding_rect = linestring.bounding_rect();
         assert!(bounding_rect.is_none());
     }
     #[test]
     fn linestring_one_point_test() {
-        let vec = vec![(40.02f64, 116.34)];
-        let linestring = LineString::from(vec);
+        let linestring = line_string![(x: 40.02f64, y: 116.34)];
         let bounding_rect = Rect {
             min: Coordinate {
                 x: 40.02f64,
@@ -167,7 +167,12 @@ mod test {
     }
     #[test]
     fn linestring_test() {
-        let linestring = LineString::from(vec![(1., 1.), (2., -2.), (-3., -3.), (-4., 4.)]);
+        let linestring = line_string![
+            (x: 1., y: 1.),
+            (x: 2., y: -2.),
+            (x: -3., y: -3.),
+            (x: -4., y: 4.)
+        ];
         let bounding_rect = Rect {
             min: Coordinate { x: -4., y: -3. },
             max: Coordinate { x: 2., y: 4. },
@@ -177,10 +182,10 @@ mod test {
     #[test]
     fn multilinestring_test() {
         let multiline = MultiLineString(vec![
-            LineString::from(vec![(1., 1.), (-40., 1.)]),
-            LineString::from(vec![(1., 1.), (50., 1.)]),
-            LineString::from(vec![(1., 1.), (1., -60.)]),
-            LineString::from(vec![(1., 1.), (1., 70.)]),
+            line_string![(x: 1., y: 1.), (x: -40., y: 1.)],
+            line_string![(x: 1., y: 1.), (x: 50., y: 1.)],
+            line_string![(x: 1., y: 1.), (x: 1., y: -60.)],
+            line_string![(x: 1., y: 1.), (x: 1., y: 70.)],
         ]);
         let bounding_rect = Rect {
             min: Coordinate { x: -40., y: -60. },

--- a/geo/src/algorithm/centroid.rs
+++ b/geo/src/algorithm/centroid.rs
@@ -306,8 +306,9 @@ where
 mod test {
     use crate::algorithm::centroid::Centroid;
     use crate::algorithm::euclidean_distance::EuclideanDistance;
+    use crate::line_string;
     use crate::{
-        Coordinate, Line, LineString, MultiPolygon, Point, Polygon, Rect, COORD_PRECISION,
+        polygon, Coordinate, Line, LineString, MultiPolygon, Point, Polygon, Rect, COORD_PRECISION,
     };
     use num_traits::Float;
 
@@ -324,7 +325,7 @@ mod test {
     // Tests: Centroid of LineString
     #[test]
     fn empty_linestring_test() {
-        let linestring: LineString<f32> = LineString(vec![]);
+        let linestring: LineString<f32> = line_string![];
         let centroid = linestring.centroid();
         assert!(centroid.is_none());
     }
@@ -334,20 +335,20 @@ mod test {
             x: 40.02f64,
             y: 116.34,
         };
-        let linestring = LineString(vec![coord]);
+        let linestring = line_string![coord];
         let centroid = linestring.centroid();
         assert_eq!(centroid, Some(Point(coord)));
     }
     #[test]
     fn linestring_test() {
-        let linestring = LineString(vec![
-            Coordinate { x: 1., y: 1. },
-            Coordinate { x: 7., y: 1. },
-            Coordinate { x: 8., y: 1. },
-            Coordinate { x: 9., y: 1. },
-            Coordinate { x: 10., y: 1. },
-            Coordinate { x: 11., y: 1. },
-        ]);
+        let linestring = line_string![
+            (x: 1., y: 1.),
+            (x: 7., y: 1.),
+            (x: 8., y: 1.),
+            (x: 9., y: 1.),
+            (x: 10., y: 1.),
+            (x: 11., y: 1.)
+        ];
         assert_eq!(
             linestring.centroid(),
             Some(Point(Coordinate { x: 6., y: 1. }))
@@ -356,26 +357,27 @@ mod test {
     // Tests: Centroid of Polygon
     #[test]
     fn empty_polygon_test() {
-        let v1 = Vec::new();
-        let v2 = Vec::new();
-        let linestring = LineString::<f64>(v1);
-        let poly = Polygon::new(linestring, v2);
+        let poly: Polygon<f32> = polygon![];
         assert!(poly.centroid().is_none());
     }
     #[test]
     fn polygon_one_point_test() {
         let p = Point(Coordinate { x: 2., y: 1. });
         let v = Vec::new();
-        let linestring = LineString(vec![p.0]);
+        let linestring = line_string![p.0];
         let poly = Polygon::new(linestring, v);
         assert_eq!(poly.centroid(), Some(p));
     }
 
     #[test]
     fn polygon_test() {
-        let v = Vec::new();
-        let linestring = LineString(vec![c(0., 0.), c(2., 0.), c(2., 2.), c(0., 2.), c(0., 0.)]);
-        let poly = Polygon::new(linestring, v);
+        let poly = polygon![
+            (x: 0., y: 0.),
+            (x: 2., y: 0.),
+            (x: 2., y: 2.),
+            (x: 0., y: 2.),
+            (x: 0., y: 0.)
+        ];
         assert_eq!(poly.centroid(), Some(Point::new(1., 1.)));
     }
     #[test]

--- a/geo/src/algorithm/contains.rs
+++ b/geo/src/algorithm/contains.rs
@@ -275,6 +275,7 @@ where
 #[cfg(test)]
 mod test {
     use crate::algorithm::contains::Contains;
+    use crate::line_string;
     use crate::{Coordinate, Line, LineString, MultiPolygon, Point, Polygon, Rect, Triangle};
     #[test]
     // V doesn't contain rect because two of its edges intersect with V's exterior boundary
@@ -556,15 +557,9 @@ mod test {
     fn line_in_polygon_test() {
         let c = |x, y| Coordinate { x, y };
         let line = Line::new(c(0., 1.), c(3., 4.));
-        let linestring0 = LineString(vec![
-            c(-1., 0.),
-            c(5., 0.),
-            c(5., 5.),
-            c(0., 5.),
-            c(-1., 0.),
-        ]);
+        let linestring0 = line_string![c(-1., 0.), c(5., 0.), c(5., 5.), c(0., 5.), c(-1., 0.)];
         let poly0 = Polygon::new(linestring0, Vec::new());
-        let linestring1 = LineString(vec![c(0., 0.), c(0., 2.), c(2., 2.), c(2., 0.), c(0., 0.)]);
+        let linestring1 = line_string![c(0., 0.), c(0., 2.), c(2., 2.), c(2., 0.), c(0., 0.)];
         let poly1 = Polygon::new(linestring1, Vec::new());
         assert!(poly0.contains(&line));
         assert!(!poly1.contains(&line));

--- a/geo/src/algorithm/convexhull.rs
+++ b/geo/src/algorithm/convexhull.rs
@@ -197,7 +197,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{Coordinate, Point};
+    use crate::{line_string, Coordinate, Point};
 
     #[test]
     fn quick_hull_test1() {
@@ -332,18 +332,17 @@ mod test {
     }
     #[test]
     fn quick_hull_linestring_test() {
-        let v = vec![
-            (0.0, 10.0),
-            (1.0, 1.0),
-            (10.0, 0.0),
-            (1.0, -1.0),
-            (0.0, -10.0),
-            (-1.0, -1.0),
-            (-10.0, 0.0),
-            (-1.0, 1.0),
-            (0.0, 10.0),
+        let mp = line_string![
+            (x: 0.0, y: 10.0),
+            (x: 1.0, y: 1.0),
+            (x: 10.0, y: 0.0),
+            (x: 1.0, y: -1.0),
+            (x: 0.0, y: -10.0),
+            (x: -1.0, y: -1.0),
+            (x: -10.0, y: 0.0),
+            (x: -1.0, y: 1.0),
+            (x: 0.0, y: 10.0)
         ];
-        let mp = LineString::from(v);
         let correct = vec![
             Coordinate::from((0.0, -10.0)),
             Coordinate::from((10.0, 0.0)),
@@ -356,8 +355,8 @@ mod test {
     }
     #[test]
     fn quick_hull_multilinestring_test() {
-        let v1 = LineString::from(vec![(0.0, 0.0), (1.0, 10.0)]);
-        let v2 = LineString::from(vec![(1.0, 10.0), (2.0, 0.0), (3.0, 1.0)]);
+        let v1 = line_string![(x: 0.0, y: 0.0), (x: 1.0, y: 10.0)];
+        let v2 = line_string![(x: 1.0, y: 10.0), (x: 2.0, y: 0.0), (x: 3.0, y: 1.0)];
         let mls = MultiLineString(vec![v1, v2]);
         let correct = vec![
             Coordinate::from((2.0, 0.0)),
@@ -371,8 +370,10 @@ mod test {
     }
     #[test]
     fn quick_hull_multipolygon_test() {
-        let ls1 = LineString::from(vec![(0.0, 0.0), (1.0, 10.0), (2.0, 0.0), (0.0, 0.0)]);
-        let ls2 = LineString::from(vec![(3.0, 0.0), (4.0, 10.0), (5.0, 0.0), (3.0, 0.0)]);
+        let ls1 =
+            line_string![(x: 0.0, y: 0.0), (x: 1.0, y: 10.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)];
+        let ls2 =
+            line_string![(x: 3.0, y: 0.0), (x: 4.0, y: 10.0), (x: 5.0, y: 0.0), (x: 3.0, y: 0.0)];
         let p1 = Polygon::new(ls1, vec![]);
         let p2 = Polygon::new(ls2, vec![]);
         let mp = MultiPolygon(vec![p1, p2]);

--- a/geo/src/algorithm/euclidean_length.rs
+++ b/geo/src/algorithm/euclidean_length.rs
@@ -57,42 +57,46 @@ where
 #[cfg(test)]
 mod test {
     use crate::algorithm::euclidean_length::EuclideanLength;
-    use crate::{Coordinate, Line, LineString, MultiLineString};
+    use crate::line_string;
+    use crate::{Coordinate, Line, MultiLineString};
 
     #[test]
     fn empty_linestring_test() {
-        let linestring = LineString::<f64>(Vec::new());
+        let linestring = line_string![];
         assert_eq!(0.0_f64, linestring.euclidean_length());
     }
     #[test]
     fn linestring_one_point_test() {
-        let linestring = LineString::from(vec![(0., 0.)]);
+        let linestring = line_string![(x: 0., y: 0.)];
         assert_eq!(0.0_f64, linestring.euclidean_length());
     }
     #[test]
     fn linestring_test() {
-        let linestring = LineString::from(vec![
-            (1., 1.),
-            (7., 1.),
-            (8., 1.),
-            (9., 1.),
-            (10., 1.),
-            (11., 1.),
-        ]);
+        let linestring = line_string![
+            (x: 1., y: 1.),
+            (x: 7., y: 1.),
+            (x: 8., y: 1.),
+            (x: 9., y: 1.),
+            (x: 10., y: 1.),
+            (x: 11., y: 1.)
+        ];
         assert_eq!(10.0_f64, linestring.euclidean_length());
     }
     #[test]
     fn multilinestring_test() {
         let mline = MultiLineString(vec![
-            LineString::from(vec![
-                (1., 0.),
-                (7., 0.),
-                (8., 0.),
-                (9., 0.),
-                (10., 0.),
-                (11., 0.),
-            ]),
-            LineString::from(vec![(0., 0.), (0., 5.)]),
+            line_string![
+                (x: 1., y: 0.),
+                (x: 7., y: 0.),
+                (x: 8., y: 0.),
+                (x: 9., y: 0.),
+                (x: 10., y: 0.),
+                (x: 11., y: 0.)
+            ],
+            line_string![
+                (x: 0., y: 0.),
+                (x: 0., y: 5.)
+            ],
         ]);
         assert_eq!(15.0_f64, mline.euclidean_length());
     }

--- a/geo/src/algorithm/extremes.rs
+++ b/geo/src/algorithm/extremes.rs
@@ -179,19 +179,20 @@ where
 
 #[cfg(test)]
 mod test {
-
     use super::*;
-    use crate::{LineString, Point};
+    use crate::{point, polygon};
+
     #[test]
     fn test_polygon_extreme_x() {
         // a diamond shape
-        let points_raw = vec![(1.0, 0.0), (2.0, 1.0), (1.0, 2.0), (0.0, 1.0), (1.0, 0.0)];
-        let points = points_raw
-            .iter()
-            .map(|e| Point::new(e.0, e.1))
-            .collect::<Vec<_>>();
-        let poly1 = Polygon::new(LineString::from(points), vec![]);
-        let min_x = polymax_naive_indices(Point::new(-1., 0.), &poly1).unwrap();
+        let poly1 = polygon![
+            (x: 1.0, y: 0.0),
+            (x: 2.0, y: 1.0),
+            (x: 1.0, y: 2.0),
+            (x: 0.0, y: 1.0),
+            (x: 1.0, y: 0.0)
+        ];
+        let min_x = polymax_naive_indices(point!(x: -1., y: 0.), &poly1).unwrap();
         let correct = 3_usize;
         assert_eq!(min_x, correct);
     }
@@ -199,16 +200,15 @@ mod test {
     #[should_panic]
     fn test_extreme_indices_bad_polygon() {
         // non-convex, with a bump on the top-right edge
-        let coords = vec![
-            (1.0, 0.0),
-            (1.3, 1.),
-            (2.0, 1.0),
-            (1.75, 1.75),
-            (1.0, 2.0),
-            (0.0, 1.0),
-            (1.0, 0.0),
+        let poly1 = polygon![
+            (x: 1.0, y: 0.0),
+            (x: 1.3, y: 1.),
+            (x: 2.0, y: 1.0),
+            (x: 1.75, y: 1.75),
+            (x: 1.0, y: 2.0),
+            (x: 0.0, y: 1.0),
+            (x: 1.0, y: 0.0)
         ];
-        let poly1 = Polygon::new(LineString::from(coords), vec![]);
         let extremes = find_extreme_indices(polymax_naive_indices, &poly1).unwrap();
         let correct = Extremes {
             ymin: 0,
@@ -221,16 +221,15 @@ mod test {
     #[test]
     fn test_extreme_indices_good_polygon() {
         // non-convex, with a bump on the top-right edge
-        let coords = vec![
-            (1.0, 0.0),
-            (1.3, 1.),
-            (2.0, 1.0),
-            (1.75, 1.75),
-            (1.0, 2.0),
-            (0.0, 1.0),
-            (1.0, 0.0),
+        let poly1 = polygon![
+            (x: 1.0, y: 0.0),
+            (x: 1.3, y: 1.),
+            (x: 2.0, y: 1.0),
+            (x: 1.75, y: 1.75),
+            (x: 1.0, y: 2.0),
+            (x: 0.0, y: 1.0),
+            (x: 1.0, y: 0.0)
         ];
-        let poly1 = Polygon::new(LineString::from(coords), vec![]);
         let extremes = find_extreme_indices(polymax_naive_indices, &poly1.convex_hull()).unwrap();
         let correct = Extremes {
             ymin: 0,
@@ -243,15 +242,14 @@ mod test {
     #[test]
     fn test_polygon_extreme_wrapper_convex() {
         // convex, with a bump on the top-right edge
-        let coords = vec![
-            (1.0, 0.0),
-            (2.0, 1.0),
-            (1.75, 1.75),
-            (1.0, 2.0),
-            (0.0, 1.0),
-            (1.0, 0.0),
+        let poly1 = polygon![
+            (x: 1.0, y: 0.0),
+            (x: 2.0, y: 1.0),
+            (x: 1.75, y: 1.75),
+            (x: 1.0, y: 2.0),
+            (x: 0.0, y: 1.0),
+            (x: 1.0, y: 0.0)
         ];
-        let poly1 = Polygon::new(LineString::from(coords), vec![]);
         let extremes = find_extreme_indices(polymax_naive_indices, &poly1.convex_hull()).unwrap();
         let correct = Extremes {
             ymin: 0,
@@ -261,13 +259,19 @@ mod test {
         };
         assert_eq!(extremes, correct);
     }
+
     #[test]
     fn test_polygon_extreme_point_x() {
         // a diamond shape
-        let coords = vec![(1.0, 0.0), (2.0, 1.0), (1.0, 2.0), (0.0, 1.0), (1.0, 0.0)];
-        let poly1 = Polygon::new(LineString::from(coords), vec![]);
+        let poly1 = polygon![
+            (x: 1.0, y: 0.0),
+            (x: 2.0, y: 1.0),
+            (x: 1.0, y: 2.0),
+            (x: 0.0, y: 1.0),
+            (x: 1.0, y: 0.0)
+        ];
         let extremes = poly1.extreme_points();
-        let correct = Point::new(0.0, 1.0);
+        let correct = point!(x: 0.0, y: 1.0);
         assert_eq!(extremes.xmin, correct);
     }
 }

--- a/geo/src/algorithm/intersects.rs
+++ b/geo/src/algorithm/intersects.rs
@@ -261,38 +261,48 @@ where
 #[cfg(test)]
 mod test {
     use crate::algorithm::intersects::Intersects;
-    use crate::{Coordinate, Line, LineString, Point, Polygon, Rect};
+    use crate::{line_string, polygon, Coordinate, Line, LineString, Point, Polygon, Rect};
+
     /// Tests: intersection LineString and LineString
     #[test]
     fn empty_linestring1_test() {
-        let linestring = LineString::from(vec![(3., 2.), (7., 6.)]);
-        assert!(!LineString(Vec::new()).intersects(&linestring));
+        let linestring = line_string![(x: 3., y: 2.), (x: 7., y: 6.)];
+        assert!(!line_string![].intersects(&linestring));
     }
     #[test]
     fn empty_linestring2_test() {
-        let linestring = LineString::from(vec![(3., 2.), (7., 6.)]);
+        let linestring = line_string![(x: 3., y: 2.), (x: 7., y: 6.)];
         assert!(!linestring.intersects(&LineString(Vec::new())));
     }
     #[test]
     fn empty_all_linestring_test() {
-        assert!(!LineString::<f64>(Vec::new()).intersects(&LineString(Vec::new())));
+        let empty: LineString<f64> = line_string![];
+        assert!(!empty.intersects(&empty));
     }
     #[test]
     fn intersect_linestring_test() {
-        let linestring = LineString::from(vec![(3., 2.), (7., 6.)]);
-        assert!(linestring.intersects(&LineString::from(vec![(3., 4.), (8., 4.)])));
+        let ls1 = line_string![(x: 3., y: 2.), (x: 7., y: 6.)];
+        let ls2 = line_string![(x: 3., y: 4.), (x: 8., y: 4.)];
+        assert!(ls1.intersects(&ls2));
     }
     #[test]
     fn parallel_linestrings_test() {
-        let linestring = LineString::from(vec![(3., 2.), (7., 6.)]);
-        assert!(!linestring.intersects(&LineString::from(vec![(3., 1.), (7., 5.)])));
+        let ls1 = line_string![(x: 3., y: 2.), (x: 7., y: 6.)];
+        let ls2 = line_string![(x: 3., y: 1.), (x: 7., y: 5.)];
+        assert!(!ls1.intersects(&ls2));
     }
     /// Tests: intersection LineString and Polygon
     #[test]
     fn linestring_in_polygon_test() {
-        let linestring = LineString::from(vec![(0., 0.), (5., 0.), (5., 6.), (0., 6.), (0., 0.)]);
-        let poly = Polygon::new(linestring, Vec::new());
-        assert!(poly.intersects(&LineString::from(vec![(2., 2.), (3., 3.)])));
+        let poly = polygon![
+            (x: 0., y: 0.),
+            (x: 5., y: 0.),
+            (x: 5., y: 6.),
+            (x: 0., y: 6.),
+            (x: 0., y: 0.),
+        ];
+        let ls = line_string![(x: 2., y: 2.), (x: 3., y: 3.)];
+        assert!(poly.intersects(&ls));
     }
     #[test]
     fn linestring_on_boundary_polygon_test() {

--- a/geo/src/algorithm/rotate.rs
+++ b/geo/src/algorithm/rotate.rs
@@ -91,21 +91,25 @@ pub trait RotatePoint<T> {
     /// # Examples
     ///
     /// ```
-    /// use geo::{Point, LineString};
-    /// use geo::algorithm::rotate::{RotatePoint};
+    /// use geo::algorithm::rotate::RotatePoint;
+    /// use geo::{line_string, point};
     ///
-    /// let mut vec = Vec::new();
-    /// vec.push(Point::new(0.0, 0.0));
-    /// vec.push(Point::new(5.0, 5.0));
-    /// vec.push(Point::new(10.0, 10.0));
-    /// let linestring = LineString::from(vec);
-    /// let rotated = linestring.rotate_around_point(-45.0, Point::new(10.0, 0.0));
-    /// let mut correct = Vec::new();
-    /// correct.push(Point::new(2.9289321881345245, 7.071067811865475));
-    /// correct.push(Point::new(10.0, 7.0710678118654755));
-    /// correct.push(Point::new(17.071067811865476, 7.0710678118654755));
-    /// let correct_ls = LineString::from(correct);
-    /// assert_eq!(rotated, correct_ls);
+    /// let ls = line_string![
+    ///     (x: 0.0, y: 0.0),
+    ///     (x: 5.0, y: 5.0),
+    ///     (x: 10.0, y: 10.0)
+    /// ];
+    ///
+    /// let rotated = ls.rotate_around_point(
+    ///     -45.0,
+    ///     point!(x: 10.0, y: 0.0),
+    /// );
+    ///
+    /// assert_eq!(rotated, line_string![
+    ///     (x: 2.9289321881345245, y: 7.071067811865475),
+    ///     (x: 10.0, y: 7.0710678118654755),
+    ///     (x: 17.071067811865476, y: 7.0710678118654755)
+    /// ]);
     /// ```
     fn rotate_around_point(&self, angle: T, point: Point<T>) -> Self
     where
@@ -213,78 +217,74 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{Coordinate, LineString, Point, Polygon};
+    use crate::{line_string, point, polygon, Coordinate, LineString, Point, Polygon};
+
     #[test]
     fn test_rotate_around_point() {
-        let p = Point::new(1.0, 5.0);
+        let p = point!(x: 1.0, y: 5.0);
         let rotated = p.rotate(30.0);
         // results agree with Shapely / GEOS
         assert_eq!(rotated, Point::new(1.0, 5.0));
     }
     #[test]
     fn test_rotate_linestring() {
-        let vec = vec![(0.0, 0.0), (5.0, 5.0), (10.0, 10.0)];
-        let linestring = LineString::from(vec);
+        let linestring = line_string![
+            (x: 0.0, y: 0.0),
+            (x: 5.0, y: 5.0),
+            (x: 10.0, y: 10.0)
+        ];
         let rotated = linestring.rotate(-45.0);
-        let mut correct = Vec::new();
-        correct.push(Point::new(-2.0710678118654755, 5.0));
-        correct.push(Point::new(5.0, 5.0));
-        correct.push(Point::new(12.071067811865476, 5.0));
-        let correct_ls = LineString::from(correct);
         // results agree with Shapely / GEOS
-        assert_eq!(rotated, correct_ls);
+        assert_eq!(
+            rotated,
+            line_string![
+                (x: -2.0710678118654755, y: 5.0),
+                (x: 5.0, y: 5.0),
+                (x: 12.071067811865476, y: 5.0)
+            ]
+        );
     }
     #[test]
     fn test_rotate_polygon() {
-        let coords = vec![
-            (5., 1.),
-            (4., 2.),
-            (4., 3.),
-            (5., 4.),
-            (6., 4.),
-            (7., 3.),
-            (7., 2.),
-            (6., 1.),
-            (5., 1.),
+        let poly1 = polygon![
+            (x: 5., y: 1.),
+            (x: 4., y: 2.),
+            (x: 4., y: 3.),
+            (x: 5., y: 4.),
+            (x: 6., y: 4.),
+            (x: 7., y: 3.),
+            (x: 7., y: 2.),
+            (x: 6., y: 1.),
+            (x: 5., y: 1.)
         ];
-        let poly1 = Polygon::new(LineString::from(coords), vec![]);
         let rotated = poly1.rotate(-15.0);
-        let correct_outside = vec![
-            (4.628808519201685, 1.1805207831176578),
-            (3.921701738015137, 2.405265654509247),
-            (4.180520783117657, 3.3711914807983154),
-            (5.405265654509247, 4.0782982619848624),
-            (6.371191480798315, 3.819479216882342),
-            (7.0782982619848624, 2.594734345490753),
-            (6.819479216882343, 1.6288085192016848),
-            (5.594734345490753, 0.9217017380151371),
-            (4.628808519201685, 1.1805207831176578),
+        let correct = polygon![
+            (x: 4.628808519201685, y: 1.1805207831176578),
+            (x: 3.921701738015137, y: 2.405265654509247),
+            (x: 4.180520783117657, y: 3.3711914807983154),
+            (x: 5.405265654509247, y: 4.0782982619848624),
+            (x: 6.371191480798315, y: 3.819479216882342),
+            (x: 7.0782982619848624, y: 2.594734345490753),
+            (x: 6.819479216882343, y: 1.6288085192016848),
+            (x: 5.594734345490753, y: 0.9217017380151371),
+            (x: 4.628808519201685, y: 1.1805207831176578)
         ];
-        let correct = Polygon::new(
-            LineString(
-                correct_outside
-                    .iter()
-                    .map(|e| Coordinate::from((e.0, e.1)))
-                    .collect::<Vec<_>>(),
-            ),
-            vec![],
-        );
         // results agree with Shapely / GEOS
         assert_eq!(rotated, correct);
     }
     #[test]
     fn test_rotate_polygon_holes() {
-        let ls1 = LineString::from(vec![
-            (5.0, 1.0),
-            (4.0, 2.0),
-            (4.0, 3.0),
-            (5.0, 4.0),
-            (6.0, 4.0),
-            (7.0, 3.0),
-            (7.0, 2.0),
-            (6.0, 1.0),
-            (5.0, 1.0),
-        ]);
+        let ls1 = line_string![
+            (x: 5.0, y: 1.0),
+            (x: 4.0, y: 2.0),
+            (x: 4.0, y: 3.0),
+            (x: 5.0, y: 4.0),
+            (x: 6.0, y: 4.0),
+            (x: 7.0, y: 3.0),
+            (x: 7.0, y: 2.0),
+            (x: 6.0, y: 1.0),
+            (x: 5.0, y: 1.0)
+        ];
 
         let ls2 = LineString::from(vec![(5.0, 1.3), (5.5, 2.0), (6.0, 1.3), (5.0, 1.3)]);
 

--- a/geo/src/algorithm/translate.rs
+++ b/geo/src/algorithm/translate.rs
@@ -7,21 +7,22 @@ pub trait Translate<T> {
     /// # Examples
     ///
     /// ```
-    /// use geo::{Point, LineString};
-    /// use geo::algorithm::translate::{Translate};
+    /// use geo::algorithm::translate::Translate;
+    /// use geo::line_string;
     ///
-    /// let mut vec = Vec::new();
-    /// vec.push(Point::new(0.0, 0.0));
-    /// vec.push(Point::new(5.0, 5.0));
-    /// vec.push(Point::new(10.0, 10.0));
-    /// let linestring = LineString::from(vec);
-    /// let translated = linestring.translate(1.5, 3.5);
-    /// let mut correct = Vec::new();
-    /// correct.push(Point::new(1.5, 3.5));
-    /// correct.push(Point::new(6.5, 8.5));
-    /// correct.push(Point::new(11.5, 13.5));
-    /// let correct_ls = LineString::from(correct);
-    /// assert_eq!(translated, correct_ls);
+    /// let ls = line_string![
+    ///     (x: 0.0, y: 0.0),
+    ///     (x: 5.0, y: 5.0),
+    ///     (x: 10.0, y: 10.0),
+    /// ];
+    ///
+    /// let translated = ls.translate(1.5, 3.5);
+    ///
+    /// assert_eq!(translated, line_string![
+    ///     (x: 1.5, y: 3.5),
+    ///     (x: 6.5, y: 8.5),
+    ///     (x: 11.5, y: 13.5),
+    /// ]);
     /// ```
     fn translate(&self, xoff: T, yoff: T) -> Self
     where
@@ -50,63 +51,56 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{Coordinate, LineString, Point, Polygon};
+    use crate::{line_string, point, polygon, Coordinate, LineString, Polygon};
+
     #[test]
     fn test_translate_point() {
-        let p = Point::new(1.0, 5.0);
+        let p = point!(x: 1.0, y: 5.0);
         let translated = p.translate(30.0, 20.0);
-        assert_eq!(translated, Point::new(31.0, 25.0));
+        assert_eq!(translated, point!(x: 31.0, y: 25.0));
     }
     #[test]
     fn test_translate_linestring() {
-        let linestring = LineString::from(vec![(0.0, 0.0), (5.0, 1.0), (10.0, 0.0)]);
+        let linestring = line_string![
+            (x: 0.0, y: 0.0),
+            (x: 5.0, y: 1.0),
+            (x: 10.0, y: 0.0),
+        ];
         let translated = linestring.translate(17.0, 18.0);
-        let mut correct = Vec::new();
-        correct.push((17.0, 18.0));
-        correct.push((22.0, 19.0));
-        correct.push((27., 18.));
-        let correct_ls = LineString::from(correct);
-        assert_eq!(translated, correct_ls);
+        assert_eq!(
+            translated,
+            line_string![
+                (x: 17.0, y: 18.0),
+                (x: 22.0, y: 19.0),
+                (x: 27., y: 18.),
+            ]
+        );
     }
     #[test]
     fn test_translate_polygon() {
-        let points_raw = vec![
-            (5., 1.),
-            (4., 2.),
-            (4., 3.),
-            (5., 4.),
-            (6., 4.),
-            (7., 3.),
-            (7., 2.),
-            (6., 1.),
-            (5., 1.),
+        let poly1 = polygon![
+            (x: 5., y: 1.),
+            (x: 4., y: 2.),
+            (x: 4., y: 3.),
+            (x: 5., y: 4.),
+            (x: 6., y: 4.),
+            (x: 7., y: 3.),
+            (x: 7., y: 2.),
+            (x: 6., y: 1.),
+            (x: 5., y: 1.),
         ];
-        let points = points_raw
-            .iter()
-            .map(|e| Point::new(e.0, e.1))
-            .collect::<Vec<_>>();
-        let poly1 = Polygon::new(LineString::from(points), vec![]);
         let translated = poly1.translate(17.0, 18.0);
-        let correct_outside = vec![
-            (22.0, 19.0),
-            (21.0, 20.0),
-            (21.0, 21.0),
-            (22.0, 22.0),
-            (23.0, 22.0),
-            (24.0, 21.0),
-            (24.0, 20.0),
-            (23.0, 19.0),
-            (22.0, 19.0),
+        let correct = polygon![
+            (x: 22.0, y: 19.0),
+            (x: 21.0, y: 20.0),
+            (x: 21.0, y: 21.0),
+            (x: 22.0, y: 22.0),
+            (x: 23.0, y: 22.0),
+            (x: 24.0, y: 21.0),
+            (x: 24.0, y: 20.0),
+            (x: 23.0, y: 19.0),
+            (x: 22.0, y: 19.0),
         ];
-        let correct = Polygon::new(
-            LineString(
-                correct_outside
-                    .iter()
-                    .map(|e| Coordinate { x: e.0, y: e.1 })
-                    .collect::<Vec<_>>(),
-            ),
-            vec![],
-        );
         // results agree with Shapely / GEOS
         assert_eq!(translated, correct);
     }

--- a/geo/src/lib.rs
+++ b/geo/src/lib.rs
@@ -26,6 +26,9 @@ mod traits;
 mod types;
 mod utils;
 
+#[macro_use]
+mod macros;
+
 #[cfg(test)]
 #[macro_use]
 extern crate approx;

--- a/geo/src/macros.rs
+++ b/geo/src/macros.rs
@@ -1,0 +1,244 @@
+/// Creates a [`Point`] from the given coordinates.
+///
+/// ```txt
+/// point!(«(x,y)»)
+/// ```
+///
+/// # Examples
+///
+/// Creating a [`Point`], supplying x/y values:
+///
+/// ```
+/// use geo::point;
+///
+/// let p = point!(x: 181.2, y: 51.79);
+///
+/// assert_eq!(p, geo::Point(geo::Coordinate {
+///     x: 181.2,
+///     y: 51.79,
+/// }));
+/// ```
+///
+/// [`Point`]: ./struct.Point.html
+#[macro_export]
+macro_rules! point {
+    (x: $x:expr, y: $y:expr) => {
+        $crate::Point::new($x, $y)
+    };
+}
+
+/// Creates a [`LineString`] containing the given coordinates.
+///
+/// ```txt
+/// line_string![«Coordinate|(x,y)», …]
+/// ```
+///
+/// # Examples
+///
+/// Creating a [`LineString`], supplying x/y values:
+///
+/// ```
+/// use geo::line_string;
+///
+/// let ls = line_string![
+///     (x: -21.95156, y: 64.1446),
+///     (x: -21.951, y: 64.14479),
+///     (x: -21.95044, y: 64.14527),
+///     (x: -21.951445, y: 64.145508)
+/// ];
+///
+/// assert_eq!(ls[1], geo::Coordinate {
+///     x: -21.951,
+///     y: 64.14479
+/// });
+/// ```
+///
+/// Creating a [`LineString`], supplying [`Coordinate`]s:
+///
+/// ```
+/// use geo::line_string;
+///
+/// let coord1 = geo::Coordinate { x: -21.95156, y: 64.1446 };
+/// let coord2 = geo::Coordinate { x: -21.951, y: 64.14479 };
+/// let coord3 = geo::Coordinate { x: -21.95044, y: 64.14527 };
+/// let coord4 = geo::Coordinate { x: -21.951445, y: 64.145508 };
+///
+/// let ls = line_string![coord1, coord2, coord3, coord4];
+///
+/// assert_eq!(ls[1], geo::Coordinate {
+///     x: -21.951,
+///     y: 64.14479
+/// });
+/// ```
+///
+/// [`Coordinate`]: ./struct.Coordinate.html
+/// [`LineString`]: ./struct.LineString.html
+#[macro_export]
+macro_rules! line_string {
+    () => { $crate::LineString(vec![]) };
+    (
+        $((x: $x:expr, y: $y:expr)),*
+        $(,)?
+    ) => {
+        line_string![
+            $(
+                $crate::Coordinate { x: $x, y: $y },
+            )*
+        ]
+    };
+    (
+        $($coord:expr),*
+        $(,)?
+    ) => {
+        $crate::LineString(
+            <[_]>::into_vec(
+                ::std::boxed::Box::new(
+                    [$($coord), *]
+                )
+            )
+        )
+    };
+}
+
+/// Creates a [`Polygon`] containing the given coordinates.
+///
+/// ```txt
+/// polygon![«Coordinate|(x,y)», …]
+/// // or
+/// polygon!(
+///     exterior: [«Coordinate|(x,y)», …],
+///     interiors: [
+///         [«Coordinate|(x,y)», …],
+///         …
+///     ],
+/// )
+/// ```
+///
+/// # Examples
+///
+/// Creating a [`Polygon`] without interior rings, supplying x/y values:
+///
+/// ```
+/// use geo::polygon;
+///
+/// let poly = polygon![
+///     (x: -111., y: 45.),
+///     (x: -111., y: 41.),
+///     (x: -104., y: 41.),
+///     (x: -104., y: 45.),
+/// ];
+///
+/// assert_eq!(
+///     poly.exterior()[1],
+///     geo::Coordinate { x: -111., y: 41. },
+/// );
+/// ```
+///
+/// Creating a [`Polygon`], supplying x/y values:
+///
+/// ```
+/// use geo::polygon;
+///
+/// let poly = polygon!(
+///     exterior: [
+///         (x: -111., y: 45.),
+///         (x: -111., y: 41.),
+///         (x: -104., y: 41.),
+///         (x: -104., y: 45.),
+///     ],
+///     interiors: [
+///         [
+///             (x: -110., y: 44.),
+///             (x: -110., y: 42.),
+///             (x: -105., y: 42.),
+///             (x: -105., y: 44.),
+///         ],
+///     ],
+/// );
+///
+/// assert_eq!(
+///     poly.exterior()[1],
+///     geo::Coordinate { x: -111., y: 41. },
+/// );
+/// ```
+///
+/// [`Coordinate`]: ./struct.Coordinate.html
+/// [`Polygon`]: ./struct.Polygon.html
+#[macro_export]
+macro_rules! polygon {
+    () => { $crate::Polygon::new(line_string![], vec![]) };
+    (
+        exterior: [
+            $((x: $exterior_x:expr, y: $exterior_y:expr)),*
+            $(,)?
+        ],
+        interiors: [
+            $([
+                $((x: $interior_x:expr, y: $interior_y:expr)),*
+                $(,)?
+            ]),*
+            $(,)?
+        ]
+        $(,)?
+    ) => {
+        polygon!(
+            exterior: [
+                $(
+                    $crate::Coordinate { x: $exterior_x, y: $exterior_y },
+                )*
+            ],
+            interiors: [
+                $([
+                    $($crate::Coordinate { x: $interior_x, y: $interior_y }),*
+                ]),*
+
+            ],
+        )
+    };
+    (
+        exterior: [
+            $($exterior_coord:expr),*
+            $(,)?
+        ],
+        interiors: [
+            $([
+                $($interior_coord:expr),*
+                $(,)?
+            ]),*
+            $(,)?
+        ]
+        $(,)?
+    ) => {
+        $crate::Polygon::new(
+            $crate::line_string![
+                $($exterior_coord), *
+            ],
+            <[_]>::into_vec(
+                ::std::boxed::Box::new(
+                    [
+                        $(
+                            $crate::line_string![$($interior_coord),*]
+                        ), *
+                    ]
+                )
+            )
+        )
+    };
+    (
+        $((x: $x:expr, y: $y:expr)),*
+        $(,)?
+    ) => {
+        polygon![
+            $($crate::Coordinate { x: $x, y: $y }),*
+        ]
+    };
+    (
+        $($coord:expr),*
+        $(,)?
+    ) => {
+        $crate::Polygon::new(
+            $crate::line_string![$($coord,)*],
+            vec![],
+        )
+    };
+}


### PR DESCRIPTION
Shorthand way to construct `Point`s, `LineString`s, and `Polygon`s. Constructors require explicit x/y parameters to prevent x/y or y/x ambiguity.

Closes https://github.com/georust/geo/issues/336

# `point!`

Creates a `Point` from the given coordinates.

```rust
point!(«(x,y)»)
```

## Examples

Creating a `Point`, supplying x/y values:

```rust
use geo::point;

let p = point!(x: 181.2, y: 51.79);

assert_eq!(p, geo::Point(geo::Coordinate {
    x: 181.2,
    y: 51.79,
}));
```

# `line_string!`

Creates a `LineString` containing the given coordinates.

```rust
line_string![«Coordinate|(x,y)», …]
```

## Examples

Creating a `LineString`, supplying x/y values:

```rust
use geo::line_string;

let ls = line_string![
    (x: -21.95156, y: 64.1446),
    (x: -21.951, y: 64.14479),
    (x: -21.95044, y: 64.14527),
    (x: -21.951445, y: 64.145508)
];

assert_eq!(ls[1], geo::Coordinate {
    x: -21.951,
    y: 64.14479
});
```

Creating a `LineString`, supplying `Coordinate`s:

```rust
use geo::line_string;

let coord1 = geo::Coordinate { x: -21.95156, y: 64.1446 };
let coord2 = geo::Coordinate { x: -21.951, y: 64.14479 };
let coord3 = geo::Coordinate { x: -21.95044, y: 64.14527 };
let coord4 = geo::Coordinate { x: -21.951445, y: 64.145508 };

let ls = line_string![coord1, coord2, coord3, coord4];

assert_eq!(ls[1], geo::Coordinate {
    x: -21.951,
    y: 64.14479
});
```

# `polygon!`

Creates a `Polygon` containing the given coordinates.

```rust
polygon![«Coordinate|(x,y)», …]
// or
polygon!(
    exterior: [«Coordinate|(x,y)», …],
    interiors: [
        [«Coordinate|(x,y)», …],
        …
    ],
)
```

## Examples

Creating a `Polygon` without interior rings, supplying x/y values:

```rust
use geo::polygon;

let poly = polygon![
    (x: -111., y: 45.),
    (x: -111., y: 41.),
    (x: -104., y: 41.),
    (x: -104., y: 45.),
];

assert_eq!(
    poly.exterior()[1],
    geo::Coordinate { x: -111., y: 41. },
);
```

Creating a `Polygon`, supplying x/y values:

```rust
use geo::polygon;

let poly = polygon!(
    exterior: [
        (x: -111., y: 45.),
        (x: -111., y: 41.),
        (x: -104., y: 41.),
        (x: -104., y: 45.),
    ],
    interiors: [
        [
            (x: -110., y: 44.),
            (x: -110., y: 42.),
            (x: -105., y: 42.),
            (x: -105., y: 44.),
        ],
    ],
);

assert_eq!(
    poly.exterior()[1],
    geo::Coordinate { x: -111., y: 41. },
);
```