### PR TITLE
Adding Rect constructor to address issue #359: 

### DIFF
--- a/geo-types/src/private_utils.rs
+++ b/geo-types/src/private_utils.rs
@@ -23,10 +23,8 @@ where
     let b = line.end;
     let (xmin, xmax) = if a.x <= b.x { (a.x, b.x) } else { (b.x, a.x) };
     let (ymin, ymax) = if a.y <= b.y { (a.y, b.y) } else { (b.y, a.y) };
-    Rect {
-        min: Coordinate { x: xmin, y: ymin },
-        max: Coordinate { x: xmax, y: ymax },
-    }
+
+    Rect::new(Coordinate { x: xmin, y: ymin }, Coordinate { x: xmax, y: ymax })
 }
 
 pub fn get_bounding_rect<I, T>(collection: I) -> Option<Rect<T>>
@@ -43,16 +41,17 @@ where
             xrange = get_min_max(px, xrange.0, xrange.1);
             yrange = get_min_max(py, yrange.0, yrange.1);
         }
-        return Some(Rect {
-            min: Coordinate {
+
+        return Some(Rect::new(
+            Coordinate {
                 x: xrange.0,
                 y: yrange.0,
             },
-            max: Coordinate {
+            Coordinate {
                 x: xrange.1,
                 y: yrange.1,
             },
-        });
+        ));
     }
     None
 }

--- a/geo-types/src/rect.rs
+++ b/geo-types/src/rect.rs
@@ -12,7 +12,13 @@ where
 }
 
 impl<T: CoordinateType> Rect<T> {
-    /// Creates a new rectangle.
+    /// Constructor to creates a new rectangle from coordinates, where `min` denotes to the
+    /// coordinates of the bottom-right corner, and `max` denotes to the coordinates of the
+    /// top-left corner
+    ///
+    /// # Panics
+    ///
+    /// Panics if `min`'s x/y coordinate is larger than that of the `max`'s.
     ///
     /// # Examples
     ///
@@ -35,7 +41,7 @@ impl<T: CoordinateType> Rect<T> {
 
         assert!(
             min.x <= max.x && min.y <= max.y,
-            "Failed to create the Rectangle: the minimum x/y values must be smaller than the maximum x/y values"
+            "Failed to create the Rect type: 'min' coordinate's x/y value must be smaller or equal to the 'max' x/y value"
         );
 
         Rect { min, max }

--- a/geo-types/src/rect.rs
+++ b/geo-types/src/rect.rs
@@ -34,7 +34,7 @@ impl<T: CoordinateType> Rect<T> {
         let (min, max) = (min.into(), max.into());
 
         assert!(
-            min.x < max.x && min.y < max.y,
+            min.x <= max.x && min.y <= max.y,
             "Failed to create the Rectangle: the minimum x/y values must be smaller than the maximum x/y values"
         );
 
@@ -66,12 +66,6 @@ mod test {
     #[should_panic]
     fn rect_panic() {
         let _ = Rect::new((10, 20), (20, 10));
-    }
-
-    #[test]
-    #[should_panic]
-    fn line_panic() {
-        let _ = Rect::new((10, 20), (10, 20));
     }
 
     #[test]

--- a/geo-types/src/rect.rs
+++ b/geo-types/src/rect.rs
@@ -12,11 +12,77 @@ where
 }
 
 impl<T: CoordinateType> Rect<T> {
+    /// Creates a new rectangle.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use geo_types::{Coordinate, Rect};
+    ///
+    /// let rect = Rect::new(
+    ///     Coordinate { x: 0., y: 0. },
+    ///     Coordinate { x: 10., y: 20. },
+    /// );
+    ///
+    /// assert_eq!(rect.min, Coordinate { x: 0., y: 0. });
+    /// assert_eq!(rect.max, Coordinate { x: 10., y: 20. });
+    /// ```
+    pub fn new<C>(min: C, max: C) -> Rect<T>
+    where
+        C: Into<Coordinate<T>>,
+    {
+        let (min, max) = (min.into(), max.into());
+
+        assert!(
+            min.x < max.x && min.y < max.y,
+            "Failed to create the Rectangle: the minimum x/y values must be smaller than the maximum x/y values"
+        );
+
+        Rect { min, max }
+    }
+
     pub fn width(self) -> T {
         self.max.x - self.min.x
     }
 
     pub fn height(self) -> T {
         self.max.y - self.min.y
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{Coordinate};
+
+    #[test]
+    fn rect() {
+        let rect = Rect::new((10, 10), (20, 20));
+        assert_eq!(rect.min, Coordinate { x: 10, y: 10 });
+        assert_eq!(rect.max, Coordinate { x: 20, y: 20 });
+    }
+
+    #[test]
+    #[should_panic]
+    fn rect_panic() {
+        let _ = Rect::new((10, 20), (20, 10));
+    }
+
+    #[test]
+    #[should_panic]
+    fn line_panic() {
+        let _ = Rect::new((10, 20), (10, 20));
+    }
+
+    #[test]
+    fn rect_width() {
+        let rect = Rect::new((10, 10), (20, 20));
+        assert_eq!(rect.width(), 10);
+    }
+
+    #[test]
+    fn rect_height() {
+        let rect = Rect::new((10., 10.), (20., 20.));
+        assert_eq!(rect.height(), 10.);
     }
 }


### PR DESCRIPTION
To address the issue #359 of lacking a Rect geo-type constructor that can perform coordinates validations, I've made the following changes: 
1. Add a `new` constructor to the Rect geo-type.
2. Update all internal use of the Rect struct literals to the new constructor.

However, existing use of the Rect struct literals in unit tests are left alone.