### PR TITLE
Adding tarpaulin with coveralls to CI pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ before_cache:
         cargo install cargo-tarpaulin -f;
     fi
 
+
 before_install:
   - if [ "${GEO_FEATURES}" == "--features use-proj" ]; then
         sudo apt-get update;

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
 
 before_cache:
   - if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
-        cargo install cargo-tarpaulin -f
+        cargo install cargo-tarpaulin -f;
     fi
 
 before_install:
@@ -36,5 +36,5 @@ script:
 
 after_success:
   - if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
-      cargo tarpaulin --ciserver travis-ci --coveralls $TRAVIS_JOB_ID
+      cargo tarpaulin --ciserver travis-ci --coveralls $TRAVIS_JOB_ID;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ language: rust
 
 cache: cargo
 
+addons:
+  apt:
+    packages:
+      - libssl-dev
+
 matrix:
   include:
     - env: GEO_TYPES_FEATURES=""
@@ -11,6 +16,11 @@ matrix:
     - env: GEO_FEATURES="--features postgis-integration"
     - env: GEO_FEATURES="--features use-proj"
     - env: GEO_FEATURES="--features use-serde"
+
+before_cache:
+  - if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
+        cargo install cargo-tarpaulin -f
+    fi
 
 before_install:
   - if [ "${GEO_FEATURES}" == "--features use-proj" ]; then
@@ -23,3 +33,8 @@ before_install:
 script:
   - (cd geo-types && cargo build --release $GEO_TYPES_FEATURES && cargo test --release $GEO_TYPES_FEATURES)
   - (cd geo && cargo build --release $GEO_FEATURES && cargo test --release $GEO_FEATURES)
+
+after_success:
+  - if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
+      cargo tarpaulin --ciserver travis-ci --coveralls $TRAVIS_JOB_ID
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
     - env: GEO_FEATURES="--features use-serde"
 
 before_cache:
-  - if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
+  - if [[ "${TRAVIS_RUST_VERSION}" == stable ]]; then
         cargo install cargo-tarpaulin -f;
     fi
 
@@ -35,6 +35,8 @@ script:
   - (cd geo && cargo build --release $GEO_FEATURES && cargo test --release $GEO_FEATURES)
 
 after_success:
-  - if [[ "$TRAVIS_RUST_VERSION" == stable ]]; then
-      cargo tarpaulin --ciserver travis-ci --coveralls $TRAVIS_JOB_ID;
+  - if [[ "${TRAVIS_RUST_VERSION}" == stable ]]; then
+      if [[ "${GEO_FEATURES}" == "" ]]; then
+        cargo tarpaulin --ciserver travis-ci --coveralls $TRAVIS_JOB_ID;
+      fi
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ before_cache:
         cargo install cargo-tarpaulin -f;
     fi
 
-
 before_install:
   - if [ "${GEO_FEATURES}" == "--features use-proj" ]; then
         sudo apt-get update;

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://travis-ci.org/georust/geo.svg?branch=master)](https://travis-ci.org/georust/geo)
 [![geo on Crates.io](https://meritbadge.herokuapp.com/geo)](https://crates.io/crates/geo)
+[![Coverage Status](https://coveralls.io/repos/github/georust/geo/badge.svg?branch=trying)](https://coveralls.io/github/georust/geo?branch=trying)
 
 # geo
 


### PR DESCRIPTION
Closes #274 

Hello everyone! :wave: 

With this PR I am adding tarpaulin with coveralls coverage reporting to the CI pipeline. Not sure if this project already has coveralls setup, or Travis Pro?

I found these instructions on [coveralls.io](coveralls.io)
![Screenshot from 2019-08-24 15-17-00](https://user-images.githubusercontent.com/12220672/63642001-dc457400-c685-11e9-84d1-b071940a0815.png)

## Implementation
This is basically straight from the tarpaulin readme https://github.com/xd009642/tarpaulin#travis-ci-and-coverage-sites

## Usage
To use tarpaulin locally you need to install it with cargo.
```
cargo install cargo-tarpaulin
```

Now you can run tarpaulin.
```
cargo tarpaulin -v
```

## Coverage Report
* 89.01% coverage
* 4724/5307 lines covered
![Peek 2019-08-24 15-36](https://user-images.githubusercontent.com/12220672/63641995-ca63d100-c685-11e9-9082-0252ee15f4b9.gif)
