### PR TITLE
Fix correctness errors from clippy linter

### DIFF
--- a/geo-types/Cargo.toml
+++ b/geo-types/Cargo.toml
@@ -14,3 +14,6 @@ edition = "2018"
 num-traits = "0.2"
 serde = { version = "1", optional = true, features = ["derive"] }
 rstar = { version = "0.4", optional = true }
+
+[dev-dependencies]
+approx = "0.3"

--- a/geo-types/src/lib.rs
+++ b/geo-types/src/lib.rs
@@ -62,6 +62,7 @@ pub mod private_utils;
 #[cfg(test)]
 mod test {
     use super::*;
+    use approx::assert_relative_eq;
 
     #[test]
     fn type_test() {
@@ -74,12 +75,12 @@ mod test {
 
         let Point(c2) = p;
         assert_eq!(c, c2);
-        assert_eq!(c.x, c2.x);
-        assert_eq!(c.y, c2.y);
+        assert_relative_eq!(c.x, c2.x);
+        assert_relative_eq!(c.y, c2.y);
 
         let p: Point<f32> = (0f32, 1f32).into();
-        assert_eq!(p.x(), 0.);
-        assert_eq!(p.y(), 1.);
+        assert_relative_eq!(p.x(), 0.);
+        assert_relative_eq!(p.y(), 1.);
     }
 
     #[test]
@@ -145,8 +146,8 @@ mod test {
         let l = Line::new(Coordinate { x: 0.0, y: 0.0 }, Coordinate { x: 5., y: 5. });
         assert_eq!(rl.envelope(), l.envelope());
         // difference in 15th decimal place
-        assert_eq!(26.0, rl.distance_2(&Point::new(4.0, 10.0)));
-        assert_eq!(25.999999999999996, l.distance_2(&Point::new(4.0, 10.0)));
+        assert_relative_eq!(26.0, rl.distance_2(&Point::new(4.0, 10.0)));
+        assert_relative_eq!(25.999999999999996, l.distance_2(&Point::new(4.0, 10.0)));
     }
 
     #[test]

--- a/geo-types/src/lib.rs
+++ b/geo-types/src/lib.rs
@@ -60,9 +60,11 @@ mod macros;
 pub mod private_utils;
 
 #[cfg(test)]
+#[macro_use]
+extern crate approx;
+
 mod test {
     use super::*;
-    use approx::assert_relative_eq;
 
     #[test]
     fn type_test() {

--- a/geo-types/src/rect.rs
+++ b/geo-types/src/rect.rs
@@ -88,6 +88,7 @@ impl<T: CoordinateType> Rect<T> {
 mod test {
     use super::*;
     use crate::Coordinate;
+    use approx::assert_relative_eq;
 
     #[test]
     fn rect() {
@@ -111,6 +112,6 @@ mod test {
     #[test]
     fn rect_height() {
         let rect = Rect::new((10., 10.), (20., 20.));
-        assert_eq!(rect.height(), 10.);
+        assert_relative_eq!(rect.height(), 10.);
     }
 }

--- a/geo-types/src/rect.rs
+++ b/geo-types/src/rect.rs
@@ -88,7 +88,6 @@ impl<T: CoordinateType> Rect<T> {
 mod test {
     use super::*;
     use crate::Coordinate;
-    use approx::assert_relative_eq;
 
     #[test]
     fn rect() {

--- a/geo/src/algorithm/area.rs
+++ b/geo/src/algorithm/area.rs
@@ -186,13 +186,13 @@ mod test {
             (x: 5., y: 5.)
         ];
         let mpoly = MultiPolygon(vec![poly0, poly1, poly2]);
-        assert_eq!(mpoly.area(), 102.);
+        assert_relative_eq!(mpoly.area(), 102.);
         assert_relative_eq!(mpoly.area(), 102.);
     }
     #[test]
     fn area_line_test() {
         let line1 = Line::new(Coordinate { x: 0.0, y: 0.0 }, Coordinate { x: 1.0, y: 1.0 });
-        assert_eq!(line1.area(), 0.);
+        assert_relative_eq!(line1.area(), 0.);
     }
 
     #[test]
@@ -202,13 +202,13 @@ mod test {
             Coordinate { x: 1.0, y: 0.0 },
             Coordinate { x: 0.0, y: 1.0 },
         );
-        assert_eq!(triangle.area(), 0.5);
+        assert_relative_eq!(triangle.area(), 0.5);
 
         let triangle = Triangle(
             Coordinate { x: 0.0, y: 0.0 },
             Coordinate { x: 0.0, y: 1.0 },
             Coordinate { x: 1.0, y: 0.0 },
         );
-        assert_eq!(triangle.area(), -0.5);
+        assert_relative_eq!(triangle.area(), -0.5);
     }
 }

--- a/geo/src/algorithm/chamberlain_duquette_area.rs
+++ b/geo/src/algorithm/chamberlain_duquette_area.rs
@@ -109,7 +109,7 @@ mod test {
             (x: 113., y: -22.),
             (x: 125., y: -15.),
         ];
-        assert_eq!(-7766240997209.013, polygon.chamberlain_duquette_area());
+        assert_relative_eq!(-7766240997209.013, polygon.chamberlain_duquette_area());
     }
 
     #[test]
@@ -124,7 +124,7 @@ mod test {
             (x: 144., y: -15.),
             (x: 125., y: -15.),
         ];
-        assert_eq!(7766240997209.013, polygon.chamberlain_duquette_area());
+        assert_relative_eq!(7766240997209.013, polygon.chamberlain_duquette_area());
     }
 
     #[test]
@@ -154,6 +154,6 @@ mod test {
                 ],
             ],
         ];
-        assert_eq!(1208198651182.4727, poly.chamberlain_duquette_area());
+        assert_relative_eq!(1208198651182.4727, poly.chamberlain_duquette_area());
     }
 }

--- a/geo/src/algorithm/euclidean_distance.rs
+++ b/geo/src/algorithm/euclidean_distance.rs
@@ -514,7 +514,7 @@ mod test {
         // Results agree with Shapely
         assert_relative_eq!(dist, 2.0485900789263356);
         assert_relative_eq!(dist2, 1.118033988749895);
-        assert_relative_eq!(dist3, 1.4142135623730951);
+        assert_relative_eq!(dist3, std::f64::consts::SQRT_2); // workaround clippy::correctness error approx_constant (1.4142135623730951)
         assert_relative_eq!(dist4, 1.5811388300841898);
         // Point is on the line
         let zero_dist = line_segment_distance(p1, p1, p2);
@@ -599,7 +599,7 @@ mod test {
 
         let poly = Polygon::new(exterior.clone(), vec![]);
         let bugged_point = Point::new(0.0001, 0.);
-        assert_eq!(poly.euclidean_distance(&bugged_point), 0.);
+        assert_relative_eq!(poly.euclidean_distance(&bugged_point), 0.);
     }
     #[test]
     // Point to Polygon, empty Polygon
@@ -757,7 +757,7 @@ mod test {
     }
     #[test]
     fn distance1_test() {
-        assert_eq!(
+        assert_relative_eq!(
             Point::<f64>::new(0., 0.).euclidean_distance(&Point::<f64>::new(1., 0.)),
             1.
         );
@@ -782,7 +782,7 @@ mod test {
         ];
         let mp = MultiPoint(v);
         let p = Point::new(50.0, 50.0);
-        assert_eq!(p.euclidean_distance(&mp), 64.03124237432849)
+        assert_relative_eq!(p.euclidean_distance(&mp), 64.03124237432849)
     }
     #[test]
     fn distance_line_test() {
@@ -790,21 +790,21 @@ mod test {
         let p0 = Point::new(2., 3.);
         let p1 = Point::new(3., 0.);
         let p2 = Point::new(6., 0.);
-        assert_eq!(line0.euclidean_distance(&p0), 3.);
-        assert_eq!(p0.euclidean_distance(&line0), 3.);
+        assert_relative_eq!(line0.euclidean_distance(&p0), 3.);
+        assert_relative_eq!(p0.euclidean_distance(&line0), 3.);
 
-        assert_eq!(line0.euclidean_distance(&p1), 0.);
-        assert_eq!(p1.euclidean_distance(&line0), 0.);
+        assert_relative_eq!(line0.euclidean_distance(&p1), 0.);
+        assert_relative_eq!(p1.euclidean_distance(&line0), 0.);
 
-        assert_eq!(line0.euclidean_distance(&p2), 1.);
-        assert_eq!(p2.euclidean_distance(&line0), 1.);
+        assert_relative_eq!(line0.euclidean_distance(&p2), 1.);
+        assert_relative_eq!(p2.euclidean_distance(&line0), 1.);
     }
     #[test]
     fn distance_line_line_test() {
         let line0 = Line::from([(0., 0.), (5., 0.)]);
         let line1 = Line::from([(2., 1.), (7., 2.)]);
-        assert_eq!(line0.euclidean_distance(&line1), 1.);
-        assert_eq!(line1.euclidean_distance(&line0), 1.);
+        assert_relative_eq!(line0.euclidean_distance(&line1), 1.);
+        assert_relative_eq!(line1.euclidean_distance(&line0), 1.);
     }
     #[test]
     // test edge-vertex minimum distance
@@ -841,8 +841,8 @@ mod test {
         let poly2 = Polygon::new(LineString::from(points2), vec![]);
         let dist = min_poly_dist(&poly1.convex_hull(), &poly2.convex_hull());
         let dist2 = nearest_neighbour_distance(&poly1.exterior(), &poly2.exterior());
-        assert_eq!(dist, 21.0);
-        assert_eq!(dist2, 21.0);
+        assert_relative_eq!(dist, 21.0);
+        assert_relative_eq!(dist2, 21.0);
     }
     #[test]
     // test vertex-vertex minimum distance
@@ -874,8 +874,8 @@ mod test {
         let poly2 = Polygon::new(LineString::from(points2), vec![]);
         let dist = min_poly_dist(&poly1.convex_hull(), &poly2.convex_hull());
         let dist2 = nearest_neighbour_distance(&poly1.exterior(), &poly2.exterior());
-        assert_eq!(dist, 29.274562336608895);
-        assert_eq!(dist2, 29.274562336608895);
+        assert_relative_eq!(dist, 29.274562336608895);
+        assert_relative_eq!(dist2, 29.274562336608895);
     }
     #[test]
     // test edge-edge minimum distance
@@ -907,8 +907,8 @@ mod test {
         let poly2 = Polygon::new(LineString::from(points2), vec![]);
         let dist = min_poly_dist(&poly1.convex_hull(), &poly2.convex_hull());
         let dist2 = nearest_neighbour_distance(&poly1.exterior(), &poly2.exterior());
-        assert_eq!(dist, 12.0);
-        assert_eq!(dist2, 12.0);
+        assert_relative_eq!(dist, 12.0);
+        assert_relative_eq!(dist2, 12.0);
     }
     #[test]
     fn test_large_polygon_distance() {
@@ -925,7 +925,7 @@ mod test {
         let poly2 = Polygon::new(vec2.into(), vec![]);
         let distance = poly1.euclidean_distance(&poly2);
         // GEOS says 2.2864896295566055
-        assert_eq!(distance, 2.2864896295566055);
+        assert_relative_eq!(distance, 2.2864896295566055);
     }
     #[test]
     // A polygon inside another polygon's ring; they're disjoint in the DE-9IM sense:
@@ -940,7 +940,7 @@ mod test {
         // inside is "inside" outside's ring, but they are disjoint
         let outside = Polygon::new(shell_ls, vec![ring_ls]);
         let inside = Polygon::new(poly_in_ring_ls, vec![]);
-        assert_eq!(outside.euclidean_distance(&inside), 5.992772737231033);
+        assert_relative_eq!(outside.euclidean_distance(&inside), 5.992772737231033);
     }
     #[test]
     // two ring LineStrings; one encloses the other but they neither touch nor intersect
@@ -949,7 +949,7 @@ mod test {
         let ring_ls: LineString<f64> = ring.into();
         let in_ring = include!("test_fixtures/poly_in_ring.rs");
         let in_ring_ls: LineString<f64> = in_ring.into();
-        assert_eq!(ring_ls.euclidean_distance(&in_ring_ls), 5.992772737231033);
+        assert_relative_eq!(ring_ls.euclidean_distance(&in_ring_ls), 5.992772737231033);
     }
     #[test]
     // Line-Polygon test: closest point on Polygon is NOT nearest to a Line end-point
@@ -957,7 +957,7 @@ mod test {
         let line = Line::from([(0.0, 0.0), (0.0, 3.0)]);
         let v = vec![(5.0, 1.0), (5.0, 2.0), (0.25, 1.5), (5.0, 1.0)];
         let poly = Polygon::new(v.into(), vec![]);
-        assert_eq!(line.euclidean_distance(&poly), 0.25);
+        assert_relative_eq!(line.euclidean_distance(&poly), 0.25);
     }
     #[test]
     // Line-Polygon test: Line intersects Polygon
@@ -965,7 +965,7 @@ mod test {
         let line = Line::from([(0.5, 0.0), (0.0, 3.0)]);
         let v = vec![(5.0, 1.0), (5.0, 2.0), (0.25, 1.5), (5.0, 1.0)];
         let poly = Polygon::new(v.into(), vec![]);
-        assert_eq!(line.euclidean_distance(&poly), 0.0);
+        assert_relative_eq!(line.euclidean_distance(&poly), 0.0);
     }
     #[test]
     // Line-Polygon test: Line contained by interior ring
@@ -974,14 +974,14 @@ mod test {
         let v = vec![(5.0, 1.0), (5.0, 2.0), (0.25, 1.0), (5.0, 1.0)];
         let v2 = vec![(4.5, 1.2), (4.5, 1.8), (3.5, 1.2), (4.5, 1.2)];
         let poly = Polygon::new(v.into(), vec![v2.into()]);
-        assert_eq!(line.euclidean_distance(&poly), 0.04999999999999982);
+        assert_relative_eq!(line.euclidean_distance(&poly), 0.04999999999999982);
     }
     #[test]
     // LineString-Line test
     fn test_linestring_line_distance() {
         let line = Line::from([(0.0, 0.0), (0.0, 2.0)]);
         let ls: LineString<_> = vec![(3.0, 0.0), (1.0, 1.0), (3.0, 2.0)].into();
-        assert_eq!(ls.euclidean_distance(&line), 1.0);
+        assert_relative_eq!(ls.euclidean_distance(&line), 1.0);
     }
 
     #[test]
@@ -989,7 +989,7 @@ mod test {
     fn test_triangle_point_on_vertex_distance() {
         let triangle = Triangle::from([(0.0, 0.0), (2.0, 0.0), (2.0, 2.0)]);
         let point = Point::new(0.0, 0.0);
-        assert_eq!(triangle.euclidean_distance(&point), 0.0);
+        assert_relative_eq!(triangle.euclidean_distance(&point), 0.0);
     }
 
     #[test]
@@ -997,7 +997,7 @@ mod test {
     fn test_triangle_point_on_edge_distance() {
         let triangle = Triangle::from([(0.0, 0.0), (2.0, 0.0), (2.0, 2.0)]);
         let point = Point::new(1.5, 0.0);
-        assert_eq!(triangle.euclidean_distance(&point), 0.0);
+        assert_relative_eq!(triangle.euclidean_distance(&point), 0.0);
     }
 
     #[test]
@@ -1005,7 +1005,7 @@ mod test {
     fn test_triangle_point_distance() {
         let triangle = Triangle::from([(0.0, 0.0), (2.0, 0.0), (2.0, 2.0)]);
         let point = Point::new(2.0, 3.0);
-        assert_eq!(triangle.euclidean_distance(&point), 1.0);
+        assert_relative_eq!(triangle.euclidean_distance(&point), 1.0);
     }
 
     #[test]
@@ -1013,6 +1013,6 @@ mod test {
     fn test_triangle_point_inside_distance() {
         let triangle = Triangle::from([(0.0, 0.0), (2.0, 0.0), (2.0, 2.0)]);
         let point = Point::new(1.0, 0.5);
-        assert_eq!(triangle.euclidean_distance(&point), 0.0);
+        assert_relative_eq!(triangle.euclidean_distance(&point), 0.0);
     }
 }

--- a/geo/src/algorithm/euclidean_length.rs
+++ b/geo/src/algorithm/euclidean_length.rs
@@ -63,12 +63,12 @@ mod test {
     #[test]
     fn empty_linestring_test() {
         let linestring = line_string![];
-        assert_eq!(0.0_f64, linestring.euclidean_length());
+        assert_relative_eq!(0.0_f64, linestring.euclidean_length());
     }
     #[test]
     fn linestring_one_point_test() {
         let linestring = line_string![(x: 0., y: 0.)];
-        assert_eq!(0.0_f64, linestring.euclidean_length());
+        assert_relative_eq!(0.0_f64, linestring.euclidean_length());
     }
     #[test]
     fn linestring_test() {
@@ -80,7 +80,7 @@ mod test {
             (x: 10., y: 1.),
             (x: 11., y: 1.)
         ];
-        assert_eq!(10.0_f64, linestring.euclidean_length());
+        assert_relative_eq!(10.0_f64, linestring.euclidean_length());
     }
     #[test]
     fn multilinestring_test() {
@@ -98,13 +98,13 @@ mod test {
                 (x: 0., y: 5.)
             ],
         ]);
-        assert_eq!(15.0_f64, mline.euclidean_length());
+        assert_relative_eq!(15.0_f64, mline.euclidean_length());
     }
     #[test]
     fn line_test() {
         let line0 = Line::new(Coordinate { x: 0., y: 0. }, Coordinate { x: 0., y: 1. });
         let line1 = Line::new(Coordinate { x: 0., y: 0. }, Coordinate { x: 3., y: 4. });
-        assert_eq!(line0.euclidean_length(), 1.);
-        assert_eq!(line1.euclidean_length(), 5.);
+        assert_relative_eq!(line0.euclidean_length(), 1.);
+        assert_relative_eq!(line1.euclidean_length(), 5.);
     }
 }

--- a/geo/src/algorithm/frechet_distance.rs
+++ b/geo/src/algorithm/frechet_distance.rs
@@ -86,7 +86,7 @@ mod test {
     fn test_single_point_in_linestring() {
         let ls_a = LineString::from(vec![(1., 1.)]);
         let ls_b = LineString::from(vec![(0., 2.)]);
-        assert_eq!(
+        assert_relative_eq!(
             (ls_a.clone().into_points())[0].euclidean_distance(&(&ls_b.clone().into_points())[0]),
             ls_a.frechet_distance(&ls_b)
         );
@@ -96,27 +96,27 @@ mod test {
     fn test_identical_linestrings() {
         let ls_a = LineString::from(vec![(1., 1.), (2., 1.), (2., 2.)]);
         let ls_b = LineString::from(vec![(1., 1.), (2., 1.), (2., 2.)]);
-        assert_eq!(0., ls_a.frechet_distance(&ls_b));
+        assert_relative_eq!(0., ls_a.frechet_distance(&ls_b));
     }
 
     #[test]
     fn different_dimensions_linestrings() {
         let ls_a = LineString::from(vec![(1., 1.)]);
         let ls_b = LineString::from(vec![(2., 2.), (0., 1.)]);
-        assert_eq!(2f64.sqrt(), ls_a.frechet_distance(&ls_b));
+        assert_relative_eq!(2f64.sqrt(), ls_a.frechet_distance(&ls_b));
     }
 
     #[test]
     fn test_frechet_1() {
         let ls_a = LineString::from(vec![(1., 1.), (2., 1.)]);
         let ls_b = LineString::from(vec![(2., 2.), (2., 3.)]);
-        assert_eq!(2., ls_a.frechet_distance(&ls_b));
+        assert_relative_eq!(2., ls_a.frechet_distance(&ls_b));
     }
 
     #[test]
     fn test_frechet_2() {
         let ls_a = LineString::from(vec![(1., 1.), (2., 1.), (2., 2.)]);
         let ls_b = LineString::from(vec![(2., 2.), (0., 1.), (2., 4.)]);
-        assert_eq!(2., ls_a.frechet_distance(&ls_b));
+        assert_relative_eq!(2., ls_a.frechet_distance(&ls_b));
     }
 }

--- a/geo/src/algorithm/map_coords.rs
+++ b/geo/src/algorithm/map_coords.rs
@@ -480,16 +480,16 @@ mod test {
     fn point() {
         let p = Point::new(10., 10.);
         let new_p = p.map_coords(&|&(x, y)| (x + 10., y + 100.));
-        assert_eq!(new_p.x(), 20.);
-        assert_eq!(new_p.y(), 110.);
+        assert_relative_eq!(new_p.x(), 20.);
+        assert_relative_eq!(new_p.y(), 110.);
     }
 
     #[test]
     fn point_inplace() {
         let mut p2 = Point::new(10f32, 10f32);
         p2.map_coords_inplace(&|&(x, y)| (x + 10., y + 100.));
-        assert_eq!(p2.x(), 20.);
-        assert_eq!(p2.y(), 110.);
+        assert_relative_eq!(p2.x(), 20.);
+        assert_relative_eq!(p2.y(), 110.);
     }
 
     #[test]
@@ -695,8 +695,8 @@ mod test {
     fn convert_type() {
         let p1: Point<f64> = Point::new(1., 2.);
         let p2: Point<f32> = p1.map_coords(&|&(x, y)| (x as f32, y as f32));
-        assert_eq!(p2.x(), 1f32);
-        assert_eq!(p2.y(), 2f32);
+        assert_relative_eq!(p2.x(), 1f32);
+        assert_relative_eq!(p2.y(), 2f32);
     }
 
     #[cfg(feature = "use-proj")]

--- a/geo/src/algorithm/map_coords.rs
+++ b/geo/src/algorithm/map_coords.rs
@@ -703,7 +703,7 @@ mod test {
     #[test]
     fn test_fallible() {
         let f = |x: f64, y: f64| {
-            if x != 2.0 {
+            if relative_ne!(x, 2.0) {
                 Ok((x * 2., y + 100.))
             } else {
                 Err("Ugh".into())

--- a/geo/src/algorithm/polygon_distance_fast_path.rs
+++ b/geo/src/algorithm/polygon_distance_fast_path.rs
@@ -631,6 +631,6 @@ mod test {
         let q = Point::new(3.8, 5.7);
         let r = Point::new(22.5, 10.);
         let dist = vertex_line_distance(p, q, r);
-        assert_eq!(dist, 6.850547423381579);
+        assert_relative_eq!(dist, 6.850547423381579);
     }
 }


### PR DESCRIPTION
Closes #394 

This PR fixes `clippy::correctness` errors which are in the test features.  The linter errors are:

- approx_constant
- float_cmp

To test this PR, run 

`cargo clippy --tests --all-features`

If you notice many GB of warnings, which is noted in existing issue #398, as a workaround you can just focus on the `clippy::correctness` lint group, which are denied by default:

`cargo clippy --tests --all-features -- --allow clippy::all --deny clippy::correctness`

