### PR TITLE
Simplify indices

### DIFF
--- a/geo-types/src/lib.rs
+++ b/geo-types/src/lib.rs
@@ -63,7 +63,8 @@ pub mod private_utils;
 #[macro_use]
 extern crate approx;
 
-mod test {
+#[cfg(test)]
+mod tests {
     use super::*;
 
     #[test]

--- a/geo/benches/simplify.rs
+++ b/geo/benches/simplify.rs
@@ -16,6 +16,14 @@ fn criterion_benchmark(c: &mut Criterion) {
         });
     });
 
+    c.bench_function("simplify vw simple f64", |bencher| {
+        let points = include!("../src/algorithm/test_fixtures/norway_main.rs");
+        let ls: LineString<f64> = points.into();
+        bencher.iter(|| {
+            let _ = ls.simplifyvw(&0.0005);
+        });
+    });
+
     c.bench_function("simplify vwp f32", |bencher| {
         let points = include!("../src/algorithm/test_fixtures/norway_main.rs");
         let ls: LineString<f32> = points.into();

--- a/geo/src/algorithm/simplify.rs
+++ b/geo/src/algorithm/simplify.rs
@@ -36,24 +36,14 @@ where
 }
 
 // Wrapper for the RDP algorithm, returning simplified point indices
-fn rdp_indices<T>(points: &[Point<T>], epsilon: &T) -> Vec<usize>
+fn rdp_indices<'a, T>(points: &[RdpIndex<'a, T>], epsilon: &T) -> Vec<usize>
 where
     T: Float,
 {
-    compute_rdp(
-        &points
-            .iter()
-            .enumerate()
-            .map(|(idx, point)| RdpIndex {
-                index: idx,
-                point: point,
-            })
-            .collect::<Vec<RdpIndex<T>>>(),
-        epsilon,
-    )
-    .iter()
-    .map(|rdpindex| rdpindex.index)
-    .collect::<Vec<usize>>()
+    compute_rdp(points, epsilon)
+        .iter()
+        .map(|rdpindex| rdpindex.index)
+        .collect::<Vec<usize>>()
 }
 
 // Ramer–Douglas-Peucker line simplification algorithm
@@ -174,7 +164,19 @@ where
     T: Float,
 {
     fn simplify_idx(&self, epsilon: &T) -> Vec<usize> {
-        rdp_indices(&self.clone().into_points(), epsilon)
+        rdp_indices(
+            &self
+                .clone()
+                .into_points()
+                .iter()
+                .enumerate()
+                .map(|(idx, point)| RdpIndex {
+                    index: idx,
+                    point: point,
+                })
+                .collect::<Vec<RdpIndex<T>>>(),
+            epsilon,
+        )
     }
 }
 

--- a/geo/src/algorithm/simplify.rs
+++ b/geo/src/algorithm/simplify.rs
@@ -154,7 +154,7 @@ impl<T> Simplify<T> for LineString<T>
 where
     T: Float,
 {
-    fn simplify(&self, epsilon: &T) -> LineString<T> {
+    fn simplify(&self, epsilon: &T) -> Self {
         LineString::from(rdp(&self.clone().into_points(), epsilon))
     }
 }
@@ -184,7 +184,7 @@ impl<T> Simplify<T> for MultiLineString<T>
 where
     T: Float,
 {
-    fn simplify(&self, epsilon: &T) -> MultiLineString<T> {
+    fn simplify(&self, epsilon: &T) -> Self {
         MultiLineString(self.0.iter().map(|l| l.simplify(epsilon)).collect())
     }
 }
@@ -193,7 +193,7 @@ impl<T> Simplify<T> for Polygon<T>
 where
     T: Float,
 {
-    fn simplify(&self, epsilon: &T) -> Polygon<T> {
+    fn simplify(&self, epsilon: &T) -> Self {
         Polygon::new(
             self.exterior().simplify(epsilon),
             self.interiors()
@@ -208,7 +208,7 @@ impl<T> Simplify<T> for MultiPolygon<T>
 where
     T: Float,
 {
-    fn simplify(&self, epsilon: &T) -> MultiPolygon<T> {
+    fn simplify(&self, epsilon: &T) -> Self {
         MultiPolygon(self.0.iter().map(|p| p.simplify(epsilon)).collect())
     }
 }

--- a/geo/src/algorithm/simplify.rs
+++ b/geo/src/algorithm/simplify.rs
@@ -127,12 +127,54 @@ pub trait Simplify<T, Epsilon = T> {
         T: Float;
 }
 
+/// Simplifies a geometry, returning the retained _indices_ of the input.
+///
+/// This operation uses the [Ramer–Douglas–Peucker algorithm](https://en.wikipedia.org/wiki/Ramer–Douglas–Peucker_algorithm)
+/// and does not guarantee that the returned geometry is valid.
+pub trait SimplifyIdx<T, Epsilon = T> {
+    /// Returns the simplified indices of a geometry, using the [Ramer–Douglas–Peucker](https://en.wikipedia.org/wiki/Ramer–Douglas–Peucker_algorithm) algorithm
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use geo::{Point, LineString};
+    /// use geo::algorithm::simplify::{SimplifyIdx};
+    ///
+    /// let mut vec = Vec::new();
+    /// vec.push(Point::new(0.0, 0.0));
+    /// vec.push(Point::new(5.0, 4.0));
+    /// vec.push(Point::new(11.0, 5.5));
+    /// vec.push(Point::new(17.3, 3.2));
+    /// vec.push(Point::new(27.8, 0.1));
+    /// let linestring = LineString::from(vec);
+    /// let mut compare = Vec::new();
+    /// compare.push(0_usize);
+    /// compare.push(1_usize);
+    /// compare.push(2_usize);
+    /// compare.push(4_usize);
+    /// let simplified = linestring.simplify_idx(&1.0);
+    /// assert_eq!(simplified, compare)
+    /// ```
+    fn simplify_idx(&self, epsilon: &T) -> Vec<usize>
+    where
+        T: Float;
+}
+
 impl<T> Simplify<T> for LineString<T>
 where
     T: Float,
 {
     fn simplify(&self, epsilon: &T) -> LineString<T> {
         LineString::from(rdp(&self.clone().into_points(), epsilon))
+    }
+}
+
+impl<T> SimplifyIdx<T> for LineString<T>
+where
+    T: Float,
+{
+    fn simplify_idx(&self, epsilon: &T) -> Vec<usize> {
+        rdp_indices(&self.clone().into_points(), epsilon)
     }
 }
 

--- a/geo/src/algorithm/simplifyvw.rs
+++ b/geo/src/algorithm/simplifyvw.rs
@@ -187,6 +187,7 @@ where
         .collect::<Vec<usize>>()
 }
 
+// Wrapper for visvalingam_indices, mapping indices back to points
 fn visvalingam<T>(orig: &LineString<T>, epsilon: &T) -> Vec<Coordinate<T>>
 where
     T: Float,
@@ -456,6 +457,40 @@ pub trait SimplifyVW<T, Epsilon = T> {
         T: Float;
 }
 
+/// Simplifies a geometry, returning the retained _indices_ of the output
+///
+/// This operation uses the Visvalingam-Whyatt algorithm,
+/// and does **not** guarantee that the returned geometry is valid.
+pub trait SimplifyVwIdx<T, Epsilon = T> {
+    /// Returns the simplified representation of a geometry, using the [Visvalingam-Whyatt](http://www.tandfonline.com/doi/abs/10.1179/000870493786962263) algorithm
+    ///
+    /// See [here](https://bost.ocks.org/mike/simplify/) for a graphical explanation
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use geo::{Point, LineString};
+    /// use geo::algorithm::simplifyvw::{SimplifyVwIdx};
+    ///
+    /// let mut vec = Vec::new();
+    /// vec.push(Point::new(5.0, 2.0));
+    /// vec.push(Point::new(3.0, 8.0));
+    /// vec.push(Point::new(6.0, 20.0));
+    /// vec.push(Point::new(7.0, 25.0));
+    /// vec.push(Point::new(10.0, 10.0));
+    /// let linestring = LineString::from(vec);
+    /// let mut compare = Vec::new();
+    /// compare.push(0_usize);
+    /// compare.push(3_usize);
+    /// compare.push(4_usize);
+    /// let simplified = linestring.simplifyvw_idx(&30.0);
+    /// assert_eq!(simplified, compare)
+    /// ```
+    fn simplifyvw_idx(&self, epsilon: &T) -> Vec<usize>
+    where
+        T: Float;
+}
+
 /// Simplifies a geometry, preserving its topology by removing self-intersections
 pub trait SimplifyVWPreserve<T, Epsilon = T> {
     /// Returns the simplified representation of a geometry, using a topology-preserving variant of the
@@ -578,6 +613,15 @@ where
 {
     fn simplifyvw(&self, epsilon: &T) -> LineString<T> {
         LineString::from(visvalingam(self, epsilon))
+    }
+}
+
+impl<T> SimplifyVwIdx<T> for LineString<T>
+where
+    T: Float,
+{
+    fn simplifyvw_idx(&self, epsilon: &T) -> Vec<usize> {
+        visvalingam_indices(self, epsilon)
     }
 }
 


### PR DESCRIPTION
This PR adds a new trait to the `simplify` and `simplifyVW` modules: `SimplifyIdx` and `SimplifyVwIdx`.
Both traits do the same thing: they run the respective simplification algorithm, but return the _indices_ of the simplified `LineString`, instead of the simplified geometry. This is mostly in response to ongoing requests from FFI consumers: because their use-cases don't necessarily map onto the Simple Features geometry model, returning geometries is less useful than returning indices, which can be used as mask values / input into native filter functions.

The only current drawback to these new traits is that because they return `Vec<usize>`, they're only implemented for `LineString`. If there's a more flexible way to do it, I'd love to extend it to some other geometries.

This change introduces some additional indirection for the RDP implementation, but `cargo bench` hasn't shown a perf hit…