### PR TITLE
Remove trait object arguments for MapCoord traits.

### DIFF
--- a/geo/src/algorithm/map_coords.rs
+++ b/geo/src/algorithm/map_coords.rs
@@ -723,9 +723,9 @@ mod test {
             Point::new(3.0, 3.0),
         ]
         .into();
-        let bad = bad_ls.try_map_coords(&|&(x, y)| f(x, y));
+        let bad = bad_ls.try_map_coords(|&(x, y)| f(x, y));
         assert!(bad.is_err());
-        let good = good_ls.try_map_coords(&|&(x, y)| f(x, y));
+        let good = good_ls.try_map_coords(|&(x, y)| f(x, y));
         assert!(good.is_ok());
         assert_eq!(
             good.unwrap(),

--- a/geo/src/algorithm/rotate.rs
+++ b/geo/src/algorithm/rotate.rs
@@ -124,7 +124,7 @@ where
     fn rotate_around_point(&self, angle: T, point: Point<T>) -> Self {
         let (sin_theta, cos_theta) = angle.to_radians().sin_cos();
         let (x0, y0) = point.x_y();
-        self.map_coords(&|&(x, y)| rotate_inner(x, y, x0, y0, sin_theta, cos_theta).x_y())
+        self.map_coords(|&(x, y)| rotate_inner(x, y, x0, y0, sin_theta, cos_theta).x_y())
     }
 }
 

--- a/geo/src/algorithm/translate.rs
+++ b/geo/src/algorithm/translate.rs
@@ -40,11 +40,11 @@ where
     G: MapCoords<T, T, Output = G> + MapCoordsInplace<T>,
 {
     fn translate(&self, xoff: T, yoff: T) -> Self {
-        self.map_coords(&|&(x, y)| (x + xoff, y + yoff))
+        self.map_coords(|&(x, y)| (x + xoff, y + yoff))
     }
 
     fn translate_inplace(&mut self, xoff: T, yoff: T) {
-        self.map_coords_inplace(&|&(x, y)| (x + xoff, y + yoff))
+        self.map_coords_inplace(|&(x, y)| (x + xoff, y + yoff))
     }
 }
 


### PR DESCRIPTION
Now callers don't need to pass a reference to a closure, they can just
pass the closure. No performance difference.