### PR TITLE
Update Geometry enum and GeometryCollection

### DIFF
--- a/geo-types/src/geometry.rs
+++ b/geo-types/src/geometry.rs
@@ -86,7 +86,7 @@ impl<T: CoordinateType> Geometry<T> {
     /// assert_eq!(p2, Point::new(0., 0.,));
     /// ```
     #[deprecated(
-        note = "Will be removed in an upcoming version. Switch to std::convert::TryFrom<Point>"
+        note = "Will be removed in an upcoming version. Switch to std::convert::TryInto<Point>"
     )]
     pub fn into_point(self) -> Option<Point<T>> {
         if let Geometry::Point(x) = self {
@@ -98,7 +98,7 @@ impl<T: CoordinateType> Geometry<T> {
 
     /// If this Geometry is a LineString, then return that LineString, else None.
     #[deprecated(
-        note = "Will be removed in an upcoming version. Switch to std::convert::TryFrom<LineString>"
+        note = "Will be removed in an upcoming version. Switch to std::convert::TryInto<LineString>"
     )]
     pub fn into_line_string(self) -> Option<LineString<T>> {
         if let Geometry::LineString(x) = self {
@@ -110,7 +110,7 @@ impl<T: CoordinateType> Geometry<T> {
 
     /// If this Geometry is a Line, then return that Line, else None.
     #[deprecated(
-        note = "Will be removed in an upcoming version. Switch to std::convert::TryFrom<Line>"
+        note = "Will be removed in an upcoming version. Switch to std::convert::TryInto<Line>"
     )]
     pub fn into_line(self) -> Option<Line<T>> {
         if let Geometry::Line(x) = self {
@@ -122,7 +122,7 @@ impl<T: CoordinateType> Geometry<T> {
 
     /// If this Geometry is a Polygon, then return that, else None.
     #[deprecated(
-        note = "Will be removed in an upcoming version. Switch to std::convert::TryFrom<Polygon>"
+        note = "Will be removed in an upcoming version. Switch to std::convert::TryInto<Polygon>"
     )]
     pub fn into_polygon(self) -> Option<Polygon<T>> {
         if let Geometry::Polygon(x) = self {
@@ -134,7 +134,7 @@ impl<T: CoordinateType> Geometry<T> {
 
     /// If this Geometry is a MultiPoint, then return that, else None.
     #[deprecated(
-        note = "Will be removed in an upcoming version. Switch to std::convert::TryFrom<MultiPoint>"
+        note = "Will be removed in an upcoming version. Switch to std::convert::TryInto<MultiPoint>"
     )]
     pub fn into_multi_point(self) -> Option<MultiPoint<T>> {
         if let Geometry::MultiPoint(x) = self {
@@ -146,7 +146,7 @@ impl<T: CoordinateType> Geometry<T> {
 
     /// If this Geometry is a MultiLineString, then return that, else None.
     #[deprecated(
-        note = "Will be removed in an upcoming version. Switch to std::convert::TryFrom<MultiLineString>"
+        note = "Will be removed in an upcoming version. Switch to std::convert::TryInto<MultiLineString>"
     )]
     pub fn into_multi_line_string(self) -> Option<MultiLineString<T>> {
         if let Geometry::MultiLineString(x) = self {
@@ -158,7 +158,7 @@ impl<T: CoordinateType> Geometry<T> {
 
     /// If this Geometry is a MultiPolygon, then return that, else None.
     #[deprecated(
-        note = "Will be removed in an upcoming version. Switch to std::convert::TryFrom<MultiPolygon>"
+        note = "Will be removed in an upcoming version. Switch to std::convert::TryInto<MultiPolygon>"
     )]
     pub fn into_multi_polygon(self) -> Option<MultiPolygon<T>> {
         if let Geometry::MultiPolygon(x) = self {

--- a/geo-types/src/geometry.rs
+++ b/geo-types/src/geometry.rs
@@ -2,11 +2,27 @@ use crate::{
     CoordinateType, GeometryCollection, Line, LineString, MultiLineString, MultiPoint,
     MultiPolygon, Point, Polygon,
 };
+use num_traits::Float;
+use std::convert::TryFrom;
+use std::error::Error;
+use std::fmt;
 
 /// An enum representing any possible geometry type.
 ///
 /// All `Geo` types can be converted to a `Geometry` member using `.into()` (as part of the
-/// `std::convert::Into` pattern).
+/// `std::convert::Into` pattern), and `Geo` types implement the `TryFrom` trait in order to
+/// convert _back_ from enum members.
+///
+/// # Example
+///
+/// ```
+/// use std::convert::TryFrom;
+/// use geo_types::{Point, point, Geometry, GeometryCollection};
+/// let p = point!(x: 1.0, y: 1.0);
+/// let pe: Geometry<f64> = p.into();
+/// let pn = Point::try_from(pe).unwrap();
+/// ```
+///
 #[derive(PartialEq, Clone, Debug, Hash)]
 pub enum Geometry<T>
 where
@@ -69,6 +85,9 @@ impl<T: CoordinateType> Geometry<T> {
     /// let p2: Point<f32> = g.into_point().unwrap();
     /// assert_eq!(p2, Point::new(0., 0.,));
     /// ```
+    #[deprecated(
+        note = "Will be removed in an upcoming version. Switch to std::convert::TryFrom<Point>"
+    )]
     pub fn into_point(self) -> Option<Point<T>> {
         if let Geometry::Point(x) = self {
             Some(x)
@@ -78,6 +97,9 @@ impl<T: CoordinateType> Geometry<T> {
     }
 
     /// If this Geometry is a LineString, then return that LineString, else None.
+    #[deprecated(
+        note = "Will be removed in an upcoming version. Switch to std::convert::TryFrom<LineString>"
+    )]
     pub fn into_line_string(self) -> Option<LineString<T>> {
         if let Geometry::LineString(x) = self {
             Some(x)
@@ -87,6 +109,9 @@ impl<T: CoordinateType> Geometry<T> {
     }
 
     /// If this Geometry is a Line, then return that Line, else None.
+    #[deprecated(
+        note = "Will be removed in an upcoming version. Switch to std::convert::TryFrom<Line>"
+    )]
     pub fn into_line(self) -> Option<Line<T>> {
         if let Geometry::Line(x) = self {
             Some(x)
@@ -96,6 +121,9 @@ impl<T: CoordinateType> Geometry<T> {
     }
 
     /// If this Geometry is a Polygon, then return that, else None.
+    #[deprecated(
+        note = "Will be removed in an upcoming version. Switch to std::convert::TryFrom<Polygon>"
+    )]
     pub fn into_polygon(self) -> Option<Polygon<T>> {
         if let Geometry::Polygon(x) = self {
             Some(x)
@@ -105,6 +133,9 @@ impl<T: CoordinateType> Geometry<T> {
     }
 
     /// If this Geometry is a MultiPoint, then return that, else None.
+    #[deprecated(
+        note = "Will be removed in an upcoming version. Switch to std::convert::TryFrom<MultiPoint>"
+    )]
     pub fn into_multi_point(self) -> Option<MultiPoint<T>> {
         if let Geometry::MultiPoint(x) = self {
             Some(x)
@@ -114,6 +145,9 @@ impl<T: CoordinateType> Geometry<T> {
     }
 
     /// If this Geometry is a MultiLineString, then return that, else None.
+    #[deprecated(
+        note = "Will be removed in an upcoming version. Switch to std::convert::TryFrom<MultiLineString>"
+    )]
     pub fn into_multi_line_string(self) -> Option<MultiLineString<T>> {
         if let Geometry::MultiLineString(x) = self {
             Some(x)
@@ -123,11 +157,127 @@ impl<T: CoordinateType> Geometry<T> {
     }
 
     /// If this Geometry is a MultiPolygon, then return that, else None.
+    #[deprecated(
+        note = "Will be removed in an upcoming version. Switch to std::convert::TryFrom<MultiPolygon>"
+    )]
     pub fn into_multi_polygon(self) -> Option<MultiPolygon<T>> {
         if let Geometry::MultiPolygon(x) = self {
             Some(x)
         } else {
             None
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct FailedToConvertError;
+
+impl fmt::Display for FailedToConvertError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Could not convert from enum member to concrete type")
+    }
+}
+
+impl Error for FailedToConvertError {
+    fn description(&self) -> &str {
+        "Could not convert from enum member to concrete type"
+    }
+}
+
+impl<T> TryFrom<Geometry<T>> for Point<T>
+where
+    T: Float,
+{
+    type Error = FailedToConvertError;
+
+    fn try_from(geom: Geometry<T>) -> Result<Point<T>, Self::Error> {
+        match geom {
+            Geometry::Point(p) => Ok(p),
+            _ => Err(FailedToConvertError),
+        }
+    }
+}
+
+impl<T> TryFrom<Geometry<T>> for Line<T>
+where
+    T: Float,
+{
+    type Error = FailedToConvertError;
+
+    fn try_from(geom: Geometry<T>) -> Result<Line<T>, Self::Error> {
+        match geom {
+            Geometry::Line(l) => Ok(l),
+            _ => Err(FailedToConvertError),
+        }
+    }
+}
+
+impl<T> TryFrom<Geometry<T>> for LineString<T>
+where
+    T: Float,
+{
+    type Error = FailedToConvertError;
+
+    fn try_from(geom: Geometry<T>) -> Result<LineString<T>, Self::Error> {
+        match geom {
+            Geometry::LineString(ls) => Ok(ls),
+            _ => Err(FailedToConvertError),
+        }
+    }
+}
+
+impl<T> TryFrom<Geometry<T>> for Polygon<T>
+where
+    T: Float,
+{
+    type Error = FailedToConvertError;
+
+    fn try_from(geom: Geometry<T>) -> Result<Polygon<T>, Self::Error> {
+        match geom {
+            Geometry::Polygon(ls) => Ok(ls),
+            _ => Err(FailedToConvertError),
+        }
+    }
+}
+
+impl<T> TryFrom<Geometry<T>> for MultiPoint<T>
+where
+    T: Float,
+{
+    type Error = FailedToConvertError;
+
+    fn try_from(geom: Geometry<T>) -> Result<MultiPoint<T>, Self::Error> {
+        match geom {
+            Geometry::MultiPoint(mp) => Ok(mp),
+            _ => Err(FailedToConvertError),
+        }
+    }
+}
+
+impl<T> TryFrom<Geometry<T>> for MultiLineString<T>
+where
+    T: Float,
+{
+    type Error = FailedToConvertError;
+
+    fn try_from(geom: Geometry<T>) -> Result<MultiLineString<T>, Self::Error> {
+        match geom {
+            Geometry::MultiLineString(mls) => Ok(mls),
+            _ => Err(FailedToConvertError),
+        }
+    }
+}
+
+impl<T> TryFrom<Geometry<T>> for MultiPolygon<T>
+where
+    T: Float,
+{
+    type Error = FailedToConvertError;
+
+    fn try_from(geom: Geometry<T>) -> Result<MultiPolygon<T>, Self::Error> {
+        match geom {
+            Geometry::MultiPolygon(mp) => Ok(mp),
+            _ => Err(FailedToConvertError),
         }
     }
 }

--- a/geo-types/src/geometry_collection.rs
+++ b/geo-types/src/geometry_collection.rs
@@ -1,11 +1,12 @@
 use crate::{CoordinateType, Geometry};
 use std::iter::FromIterator;
+use std::ops::{Index, IndexMut};
 
 /// A collection of [`Geometry`](enum.Geometry.html) types.
 ///
 /// Can be created from a `Vec` of Geometries, or from an Iterator which yields Geometries.
 ///
-/// Iterating over this objects, yields the component Geometries.
+/// Iterating over this object yields its component Geometries.
 #[derive(PartialEq, Clone, Debug, Hash)]
 pub struct GeometryCollection<T>(pub Vec<Geometry<T>>)
 where
@@ -49,5 +50,29 @@ impl<T: CoordinateType> IntoIterator for GeometryCollection<T> {
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
+    }
+}
+
+/// Mutably iterate over all the Geometries in this `GeometryCollection`.
+impl<'a, T: CoordinateType> IntoIterator for &'a mut GeometryCollection<T> {
+    type Item = &'a mut Geometry<T>;
+    type IntoIter = ::std::slice::IterMut<'a, Geometry<T>>;
+
+    fn into_iter(self) -> ::std::slice::IterMut<'a, Geometry<T>> {
+        self.0.iter_mut()
+    }
+}
+
+impl<T: CoordinateType> Index<usize> for GeometryCollection<T> {
+    type Output = Geometry<T>;
+
+    fn index(&self, index: usize) -> &Geometry<T> {
+        self.0.index(index)
+    }
+}
+
+impl<T: CoordinateType> IndexMut<usize> for GeometryCollection<T> {
+    fn index_mut(&mut self, index: usize) -> &mut Geometry<T> {
+        self.0.index_mut(index)
     }
 }

--- a/geo-types/src/geometry_collection.rs
+++ b/geo-types/src/geometry_collection.rs
@@ -6,9 +6,12 @@ use std::ops::{Index, IndexMut};
 ///
 /// It can be created from a `Vec` of Geometries, or from an Iterator which yields Geometries.
 ///
-/// Iterating over this object yields its component Geometries, and it can be indexed into
+/// Looping over this object yields its component Geometry enum members, and it supports iteration and indexing
+/// as well as the various [`MapCoords`](algorithm/map_coords/index.html) functions, which can be directly
+/// applied to the underlying geometry primitives.
 ///
 /// # Examples
+/// ## Looping
 ///
 /// ```
 /// use std::convert::TryFrom;
@@ -20,6 +23,7 @@ use std::ops::{Index, IndexMut};
 ///     println!("{:?}", Point::try_from(geom).unwrap().x());
 /// }
 /// ```
+/// ## Implements `iter()`
 ///
 /// ```
 /// use std::convert::TryFrom;
@@ -30,6 +34,25 @@ use std::ops::{Index, IndexMut};
 /// gc.iter().for_each(|geom| println!("{:?}", geom));
 /// ```
 ///
+/// ## Mutable Iteration
+///
+/// ```
+/// use std::convert::TryFrom;
+/// use geo_types::{Point, point, Geometry, GeometryCollection};
+/// let p = point!(x: 1.0, y: 1.0);
+/// let pe = Geometry::Point(p);
+/// let mut gc = GeometryCollection(vec![pe]);
+/// gc.iter_mut().for_each(|geom| {
+///    if let Geometry::Point(p) = geom {
+///        p.set_x(0.2);
+///    }
+/// });
+/// let updated = gc[0].clone();
+/// assert_eq!(Point::try_from(updated).unwrap().x(), 0.2);
+/// ```
+///
+/// ## Indexing
+///
 /// ```
 /// use std::convert::TryFrom;
 /// use geo_types::{Point, point, Geometry, GeometryCollection};
@@ -38,6 +61,7 @@ use std::ops::{Index, IndexMut};
 /// let gc = GeometryCollection(vec![pe]);
 /// println!("{:?}", gc[0]);
 /// ```
+///
 #[derive(PartialEq, Clone, Debug, Hash)]
 pub struct GeometryCollection<T>(pub Vec<Geometry<T>>)
 where

--- a/geo-types/src/geometry_collection.rs
+++ b/geo-types/src/geometry_collection.rs
@@ -6,8 +6,9 @@ use std::ops::{Index, IndexMut};
 ///
 /// It can be created from a `Vec` of Geometries, or from an Iterator which yields Geometries.
 ///
-/// Looping over this object yields its component Geometry enum members, and it supports iteration and indexing
-/// as well as the various [`MapCoords`](algorithm/map_coords/index.html) functions, which can be directly
+/// Looping over this object yields its component **Geometry enum members** (_not_ the underlying geometry primitives),
+/// and it supports iteration and indexing
+/// as well as the various [`MapCoords`](algorithm/map_coords/index.html) functions, which _are_ directly
 /// applied to the underlying geometry primitives.
 ///
 /// # Examples

--- a/geo-types/src/lib.rs
+++ b/geo-types/src/lib.rs
@@ -74,6 +74,7 @@ extern crate approx;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::convert::TryFrom;
 
     #[test]
     fn type_test() {
@@ -99,7 +100,7 @@ mod tests {
         let p: Point<f32> = Point::new(0., 0.);
         let p1 = p.clone();
         let g: Geometry<f32> = p.into();
-        let p2 = g.into_point().unwrap();
+        let p2 = Point::try_from(g).unwrap();
         assert_eq!(p1, p2);
     }
 


### PR DESCRIPTION
This PR:

- Adds non-consuming iteration functionality (`iter()`, `iter_mut()`) and indexing to `GeometryCollection`
- Adds `TryFrom` impls from `Geometry` enums to `Geo` primitives (deprecating but not removing the previous functions)
- Doctest examples of working with `GeometryCollection`