### PR TITLE
Format code in examples

### DIFF
--- a/geo-types/src/line.rs
+++ b/geo-types/src/line.rs
@@ -22,10 +22,7 @@ where
     /// ```
     /// use geo_types::{Coordinate, Line};
     ///
-    /// let line = Line::new(
-    ///     Coordinate { x: 0., y: 0. },
-    ///     Coordinate { x: 1., y: 2. },
-    /// );
+    /// let line = Line::new(Coordinate { x: 0., y: 0. }, Coordinate { x: 1., y: 2. });
     ///
     /// assert_eq!(line.start, Coordinate { x: 0., y: 0. });
     /// assert_eq!(line.end, Coordinate { x: 1., y: 2. });
@@ -101,8 +98,7 @@ where
     /// # let a = Point(Coordinate { x: 4., y: -12. });
     /// # let b = Point(Coordinate { x: 0., y: 9. });
     /// # assert!(
-    /// Line::new(a, b).slope() ==
-    ///     Line::new(b, a).slope()
+    /// Line::new(a, b).slope() == Line::new(b, a).slope()
     /// # );
     /// ```
     pub fn slope(&self) -> T {
@@ -121,8 +117,7 @@ where
     /// # );
     /// # assert_eq!(
     /// #     line.determinant(),
-    /// line.start.x * line.end.y -
-    ///     line.start.y * line.end.x
+    /// line.start.x * line.end.y - line.start.y * line.end.x
     /// # );
     /// ```
     ///
@@ -133,8 +128,7 @@ where
     /// # let a = Point(Coordinate { x: 4., y: -12. });
     /// # let b = Point(Coordinate { x: 0., y: 9. });
     /// # assert!(
-    /// Line::new(a, b).determinant() ==
-    ///     -Line::new(b, a).determinant()
+    /// Line::new(a, b).determinant() == -Line::new(b, a).determinant()
     /// # );
     /// ```
     pub fn determinant(&self) -> T {

--- a/geo-types/src/line_string.rs
+++ b/geo-types/src/line_string.rs
@@ -10,7 +10,7 @@ use std::ops::{Index, IndexMut};
 /// Create a `LineString` by calling it directly:
 ///
 /// ```
-/// use geo_types::{LineString, Coordinate};
+/// use geo_types::{Coordinate, LineString};
 ///
 /// let line_string = LineString(vec![
 ///     Coordinate { x: 0., y: 0. },
@@ -23,30 +23,22 @@ use std::ops::{Index, IndexMut};
 /// ```
 /// use geo_types::LineString;
 ///
-/// let line_string: LineString<f32> = vec![
-///     (0., 0.),
-///     (10., 0.),
-/// ].into();
+/// let line_string: LineString<f32> = vec![(0., 0.), (10., 0.)].into();
 /// ```
 ///
 /// ```
 /// use geo_types::LineString;
 ///
-/// let line_string: LineString<f64> = vec![
-///     [0., 0.],
-///     [10., 0.],
-/// ].into();
+/// let line_string: LineString<f64> = vec![[0., 0.], [10., 0.]].into();
 /// ```
 //
 /// Or `collect`ing from a `Coordinate` iterator
 ///
 /// ```
-/// use geo_types::{LineString, Coordinate};
+/// use geo_types::{Coordinate, LineString};
 ///
-/// let mut coords_iter = vec![
-///     Coordinate { x: 0., y: 0. },
-///     Coordinate { x: 10., y: 0. }
-/// ].into_iter();
+/// let mut coords_iter =
+///     vec![Coordinate { x: 0., y: 0. }, Coordinate { x: 10., y: 0. }].into_iter();
 ///
 /// let line_string: LineString<f32> = coords_iter.collect();
 /// ```
@@ -54,7 +46,7 @@ use std::ops::{Index, IndexMut};
 /// You can iterate over the coordinates in the `LineString`:
 ///
 /// ```
-/// use geo_types::{LineString, Coordinate};
+/// use geo_types::{Coordinate, LineString};
 ///
 /// let line_string = LineString(vec![
 ///     Coordinate { x: 0., y: 0. },
@@ -69,7 +61,7 @@ use std::ops::{Index, IndexMut};
 /// You can also iterate over the coordinates in the `LineString` as `Point`s:
 ///
 /// ```
-/// use geo_types::{LineString, Coordinate};
+/// use geo_types::{Coordinate, LineString};
 ///
 /// let line_string = LineString(vec![
 ///     Coordinate { x: 0., y: 0. },
@@ -121,18 +113,24 @@ impl<T: CoordinateType> LineString<T> {
     /// # Examples
     ///
     /// ```
-    /// use geo_types::{Line, LineString, Coordinate};
+    /// use geo_types::{Coordinate, Line, LineString};
     ///
     /// let mut coords = vec![(0., 0.), (5., 0.), (7., 9.)];
     /// let line_string: LineString<f32> = coords.into_iter().collect();
     ///
     /// let mut lines = line_string.lines();
     /// assert_eq!(
-    ///     Some(Line::new(Coordinate { x: 0., y: 0. }, Coordinate { x: 5., y: 0. })),
+    ///     Some(Line::new(
+    ///         Coordinate { x: 0., y: 0. },
+    ///         Coordinate { x: 5., y: 0. }
+    ///     )),
     ///     lines.next()
     /// );
     /// assert_eq!(
-    ///     Some(Line::new(Coordinate { x: 5., y: 0. }, Coordinate { x: 7., y: 9. })),
+    ///     Some(Line::new(
+    ///         Coordinate { x: 5., y: 0. },
+    ///         Coordinate { x: 7., y: 9. }
+    ///     )),
     ///     lines.next()
     /// );
     /// assert!(lines.next().is_none());

--- a/geo-types/src/macros.rs
+++ b/geo-types/src/macros.rs
@@ -58,17 +58,32 @@ macro_rules! point {
 /// ```
 /// use geo_types::line_string;
 ///
-/// let coord1 = geo_types::Coordinate { x: -21.95156, y: 64.1446 };
-/// let coord2 = geo_types::Coordinate { x: -21.951, y: 64.14479 };
-/// let coord3 = geo_types::Coordinate { x: -21.95044, y: 64.14527 };
-/// let coord4 = geo_types::Coordinate { x: -21.951445, y: 64.145508 };
+/// let coord1 = geo_types::Coordinate {
+///     x: -21.95156,
+///     y: 64.1446,
+/// };
+/// let coord2 = geo_types::Coordinate {
+///     x: -21.951,
+///     y: 64.14479,
+/// };
+/// let coord3 = geo_types::Coordinate {
+///     x: -21.95044,
+///     y: 64.14527,
+/// };
+/// let coord4 = geo_types::Coordinate {
+///     x: -21.951445,
+///     y: 64.145508,
+/// };
 ///
 /// let ls = line_string![coord1, coord2, coord3, coord4];
 ///
-/// assert_eq!(ls[1], geo_types::Coordinate {
-///     x: -21.951,
-///     y: 64.14479
-/// });
+/// assert_eq!(
+///     ls[1],
+///     geo_types::Coordinate {
+///         x: -21.951,
+///         y: 64.14479
+///     }
+/// );
 /// ```
 ///
 /// [`Coordinate`]: ./struct.Coordinate.html

--- a/geo-types/src/point.rs
+++ b/geo-types/src/point.rs
@@ -6,15 +6,15 @@ use std::ops::Sub;
 
 /// A single point in 2D space.
 ///
-/// Points can be created using the `new(x, y)` constructor, the `point!` macro, a `Coordinate`, or from 
+/// Points can be created using the `new(x, y)` constructor, the `point!` macro, a `Coordinate`, or from
 /// two-element tuples or arrays – see the `From` impl section for a complete list.
 ///
 /// # Examples
 ///
 /// ```
-/// use geo_types::{Point, Coordinate};
+/// use geo_types::{Coordinate, Point};
 /// let p1: Point<f64> = (0., 1.).into();
-/// let c = Coordinate{ x: 10., y: 20.};
+/// let c = Coordinate { x: 10., y: 20. };
 /// let p2: Point<f64> = c.into();
 /// ```
 #[derive(PartialEq, Clone, Copy, Debug, Hash)]
@@ -258,7 +258,7 @@ where
     /// use geo_types::Point;
     ///
     /// let p = Point::new(1.234, 2.345);
-    /// let (x,y): (f32, f32) = p.to_degrees().x_y();
+    /// let (x, y): (f32, f32) = p.to_degrees().x_y();
     /// assert_eq!(x.round(), 71.0);
     /// assert_eq!(y.round(), 134.0);
     /// ```
@@ -276,7 +276,7 @@ where
     /// use geo_types::Point;
     ///
     /// let p = Point::new(180.0, 341.5);
-    /// let (x,y): (f32, f32) = p.to_radians().x_y();
+    /// let (x, y): (f32, f32) = p.to_radians().x_y();
     /// assert_eq!(x.round(), 3.0);
     /// assert_eq!(y.round(), 6.0);
     /// ```

--- a/geo-types/src/polygon.rs
+++ b/geo-types/src/polygon.rs
@@ -60,12 +60,10 @@ where
     /// ```
     /// use geo_types::{LineString, Polygon};
     ///
-    /// let polygon = Polygon::new(LineString::from(vec![
-    ///     (0., 0.),
-    ///     (1., 1.),
-    ///     (1., 0.),
-    ///     (0., 0.),
-    /// ]), vec![]);
+    /// let polygon = Polygon::new(
+    ///     LineString::from(vec![(0., 0.), (1., 1.), (1., 0.), (0., 0.)]),
+    ///     vec![],
+    /// );
     /// ```
     ///
     /// Creating a `Polygon` with an interior ring:
@@ -73,19 +71,15 @@ where
     /// ```
     /// use geo_types::{LineString, Polygon};
     ///
-    /// let polygon = Polygon::new(LineString::from(vec![
-    ///     (0., 0.),
-    ///     (1., 1.),
-    ///     (1., 0.),
-    ///     (0., 0.),
-    /// ]), vec![
-    ///     LineString::from(vec![
+    /// let polygon = Polygon::new(
+    ///     LineString::from(vec![(0., 0.), (1., 1.), (1., 0.), (0., 0.)]),
+    ///     vec![LineString::from(vec![
     ///         (0.1, 0.1),
     ///         (0.9, 0.9),
     ///         (0.9, 0.1),
     ///         (0.1, 0.1),
-    ///     ])
-    /// ]);
+    ///     ])],
+    /// );
     /// ```
     ///
     /// If the first and last `Coordinate`s of the exterior or interior
@@ -94,18 +88,12 @@ where
     /// ```
     /// use geo_types::{Coordinate, LineString, Polygon};
     ///
-    /// let mut polygon = Polygon::new(LineString::from(vec![
-    ///     (0., 0.),
-    ///     (1., 1.),
-    ///     (1., 0.),
-    /// ]), vec![]);
+    /// let mut polygon = Polygon::new(LineString::from(vec![(0., 0.), (1., 1.), (1., 0.)]), vec![]);
     ///
-    /// assert_eq!(polygon.exterior(), &LineString::from(vec![
-    ///     (0., 0.),
-    ///     (1., 1.),
-    ///     (1., 0.),
-    ///     (0., 0.),
-    /// ]));
+    /// assert_eq!(
+    ///     polygon.exterior(),
+    ///     &LineString::from(vec![(0., 0.), (1., 1.), (1., 0.), (0., 0.),])
+    /// );
     /// ```
     pub fn new(mut exterior: LineString<T>, mut interiors: Vec<LineString<T>>) -> Polygon<T> {
         exterior.close();
@@ -126,35 +114,32 @@ where
     /// ```
     /// use geo_types::{LineString, Polygon};
     ///
-    /// let mut polygon = Polygon::new(LineString::from(vec![
-    ///     (0., 0.),
-    ///     (1., 1.),
-    ///     (1., 0.),
-    ///     (0., 0.),
-    /// ]), vec![
-    ///     LineString::from(vec![
+    /// let mut polygon = Polygon::new(
+    ///     LineString::from(vec![(0., 0.), (1., 1.), (1., 0.), (0., 0.)]),
+    ///     vec![LineString::from(vec![
     ///         (0.1, 0.1),
     ///         (0.9, 0.9),
     ///         (0.9, 0.1),
     ///         (0.1, 0.1),
-    ///     ])
-    /// ]);
+    ///     ])],
+    /// );
     ///
     /// let (exterior, interiors) = polygon.into_inner();
     ///
-    /// assert_eq!(exterior, LineString::from(vec![
-    ///     (0., 0.),
-    ///     (1., 1.),
-    ///     (1., 0.),
-    ///     (0., 0.),
-    /// ]));
+    /// assert_eq!(
+    ///     exterior,
+    ///     LineString::from(vec![(0., 0.), (1., 1.), (1., 0.), (0., 0.),])
+    /// );
     ///
-    /// assert_eq!(interiors, vec![LineString::from(vec![
-    ///     (0.1, 0.1),
-    ///     (0.9, 0.9),
-    ///     (0.9, 0.1),
-    ///     (0.1, 0.1),
-    /// ])]);
+    /// assert_eq!(
+    ///     interiors,
+    ///     vec![LineString::from(vec![
+    ///         (0.1, 0.1),
+    ///         (0.9, 0.9),
+    ///         (0.9, 0.1),
+    ///         (0.1, 0.1),
+    ///     ])]
+    /// );
     /// ```
     pub fn into_inner(self) -> (LineString<T>, Vec<LineString<T>>) {
         (self.exterior, self.interiors)
@@ -167,12 +152,7 @@ where
     /// ```
     /// use geo_types::{LineString, Polygon};
     ///
-    /// let exterior = LineString::from(vec![
-    ///     (0., 0.),
-    ///     (1., 1.),
-    ///     (1., 0.),
-    ///     (0., 0.),
-    /// ]);
+    /// let exterior = LineString::from(vec![(0., 0.), (1., 1.), (1., 0.), (0., 0.)]);
     ///
     /// let polygon = Polygon::new(exterior.clone(), vec![]);
     ///
@@ -192,23 +172,19 @@ where
     /// ```
     /// use geo_types::{Coordinate, LineString, Polygon};
     ///
-    /// let mut polygon = Polygon::new(LineString::from(vec![
-    ///     (0., 0.),
-    ///     (1., 1.),
-    ///     (1., 0.),
-    ///     (0., 0.),
-    /// ]), vec![]);
+    /// let mut polygon = Polygon::new(
+    ///     LineString::from(vec![(0., 0.), (1., 1.), (1., 0.), (0., 0.)]),
+    ///     vec![],
+    /// );
     ///
     /// polygon.exterior_mut(|exterior| {
     ///     exterior.0[1] = Coordinate { x: 1., y: 2. };
     /// });
     ///
-    /// assert_eq!(polygon.exterior(), &LineString::from(vec![
-    ///     (0., 0.),
-    ///     (1., 2.),
-    ///     (1., 0.),
-    ///     (0., 0.),
-    /// ]));
+    /// assert_eq!(
+    ///     polygon.exterior(),
+    ///     &LineString::from(vec![(0., 0.), (1., 2.), (1., 0.), (0., 0.),])
+    /// );
     /// ```
     ///
     /// If the first and last `Coordinate`s of the exterior `LineString` no
@@ -217,24 +193,19 @@ where
     /// ```
     /// use geo_types::{Coordinate, LineString, Polygon};
     ///
-    /// let mut polygon = Polygon::new(LineString::from(vec![
-    ///     (0., 0.),
-    ///     (1., 1.),
-    ///     (1., 0.),
-    ///     (0., 0.),
-    /// ]), vec![]);
+    /// let mut polygon = Polygon::new(
+    ///     LineString::from(vec![(0., 0.), (1., 1.), (1., 0.), (0., 0.)]),
+    ///     vec![],
+    /// );
     ///
     /// polygon.exterior_mut(|exterior| {
     ///     exterior.0[0] = Coordinate { x: 0., y: 1. };
     /// });
     ///
-    /// assert_eq!(polygon.exterior(), &LineString::from(vec![
-    ///     (0., 1.),
-    ///     (1., 1.),
-    ///     (1., 0.),
-    ///     (0., 0.),
-    ///     (0., 1.),
-    /// ]));
+    /// assert_eq!(
+    ///     polygon.exterior(),
+    ///     &LineString::from(vec![(0., 1.), (1., 1.), (1., 0.), (0., 0.), (0., 1.),])
+    /// );
     /// ```
     ///
     /// [will be closed]: #linestring-closing-operation
@@ -260,12 +231,10 @@ where
     ///     (0.1, 0.1),
     /// ])];
     ///
-    /// let polygon = Polygon::new(LineString::from(vec![
-    ///     (0., 0.),
-    ///     (1., 1.),
-    ///     (1., 0.),
-    ///     (0., 0.),
-    /// ]), interiors.clone());
+    /// let polygon = Polygon::new(
+    ///     LineString::from(vec![(0., 0.), (1., 1.), (1., 0.), (0., 0.)]),
+    ///     interiors.clone(),
+    /// );
     ///
     /// assert_eq!(interiors, polygon.interiors());
     /// ```
@@ -284,32 +253,29 @@ where
     /// ```
     /// use geo_types::{Coordinate, LineString, Polygon};
     ///
-    /// let mut polygon = Polygon::new(LineString::from(vec![
-    ///     (0., 0.),
-    ///     (1., 1.),
-    ///     (1., 0.),
-    ///     (0., 0.),
-    /// ]), vec![
-    ///     LineString::from(vec![
+    /// let mut polygon = Polygon::new(
+    ///     LineString::from(vec![(0., 0.), (1., 1.), (1., 0.), (0., 0.)]),
+    ///     vec![LineString::from(vec![
     ///         (0.1, 0.1),
     ///         (0.9, 0.9),
     ///         (0.9, 0.1),
     ///         (0.1, 0.1),
-    ///     ])
-    /// ]);
+    ///     ])],
+    /// );
     ///
     /// polygon.interiors_mut(|interiors| {
     ///     interiors[0].0[1] = Coordinate { x: 0.8, y: 0.8 };
     /// });
     ///
-    /// assert_eq!(polygon.interiors(), &[
-    ///     LineString::from(vec![
+    /// assert_eq!(
+    ///     polygon.interiors(),
+    ///     &[LineString::from(vec![
     ///         (0.1, 0.1),
     ///         (0.8, 0.8),
     ///         (0.9, 0.1),
     ///         (0.1, 0.1),
-    ///     ])
-    /// ]);
+    ///     ])]
+    /// );
     /// ```
     ///
     /// If the first and last `Coordinate`s of any interior `LineString` no
@@ -318,33 +284,30 @@ where
     /// ```
     /// use geo_types::{Coordinate, LineString, Polygon};
     ///
-    /// let mut polygon = Polygon::new(LineString::from(vec![
-    ///     (0., 0.),
-    ///     (1., 1.),
-    ///     (1., 0.),
-    ///     (0., 0.),
-    /// ]), vec![
-    ///     LineString::from(vec![
+    /// let mut polygon = Polygon::new(
+    ///     LineString::from(vec![(0., 0.), (1., 1.), (1., 0.), (0., 0.)]),
+    ///     vec![LineString::from(vec![
     ///         (0.1, 0.1),
     ///         (0.9, 0.9),
     ///         (0.9, 0.1),
     ///         (0.1, 0.1),
-    ///     ])
-    /// ]);
+    ///     ])],
+    /// );
     ///
     /// polygon.interiors_mut(|interiors| {
     ///     interiors[0].0[0] = Coordinate { x: 0.1, y: 0.2 };
     /// });
     ///
-    /// assert_eq!(polygon.interiors(), &[
-    ///     LineString::from(vec![
+    /// assert_eq!(
+    ///     polygon.interiors(),
+    ///     &[LineString::from(vec![
     ///         (0.1, 0.2),
     ///         (0.9, 0.9),
     ///         (0.9, 0.1),
     ///         (0.1, 0.1),
     ///         (0.1, 0.2),
-    ///     ])
-    /// ]);
+    ///     ])]
+    /// );
     /// ```
     ///
     /// [will be closed]: #linestring-closing-operation
@@ -367,29 +330,24 @@ where
     /// ```
     /// use geo_types::{Coordinate, LineString, Polygon};
     ///
-    /// let mut polygon = Polygon::new(LineString::from(vec![
-    ///     (0., 0.),
-    ///     (1., 1.),
-    ///     (1., 0.),
-    ///     (0., 0.),
-    /// ]), vec![]);
+    /// let mut polygon = Polygon::new(
+    ///     LineString::from(vec![(0., 0.), (1., 1.), (1., 0.), (0., 0.)]),
+    ///     vec![],
+    /// );
     ///
     /// assert_eq!(polygon.interiors().len(), 0);
     ///
-    /// polygon.interiors_push(vec![
-    ///         (0.1, 0.1),
-    ///         (0.9, 0.9),
-    ///         (0.9, 0.1),
-    ///     ]);
+    /// polygon.interiors_push(vec![(0.1, 0.1), (0.9, 0.9), (0.9, 0.1)]);
     ///
-    /// assert_eq!(polygon.interiors(), &[
-    ///     LineString::from(vec![
+    /// assert_eq!(
+    ///     polygon.interiors(),
+    ///     &[LineString::from(vec![
     ///         (0.1, 0.1),
     ///         (0.9, 0.9),
     ///         (0.9, 0.1),
     ///         (0.1, 0.1),
-    ///     ])
-    /// ]);
+    ///     ])]
+    /// );
     /// ```
     ///
     /// [will be closed]: #linestring-closing-operation

--- a/geo-types/src/rect.rs
+++ b/geo-types/src/rect.rs
@@ -25,10 +25,7 @@ impl<T: CoordinateType> Rect<T> {
     /// ```
     /// use geo_types::{Coordinate, Rect};
     ///
-    /// let rect = Rect::new(
-    ///     Coordinate { x: 0., y: 0. },
-    ///     Coordinate { x: 10., y: 20. },
-    /// );
+    /// let rect = Rect::new(Coordinate { x: 0., y: 0. }, Coordinate { x: 10., y: 20. });
     ///
     /// assert_eq!(rect.min(), Coordinate { x: 0., y: 0. });
     /// assert_eq!(rect.max(), Coordinate { x: 10., y: 20. });

--- a/geo/src/algorithm/bearing.rs
+++ b/geo/src/algorithm/bearing.rs
@@ -14,8 +14,8 @@ pub trait Bearing<T: Float> {
     /// ```
     /// # #[macro_use] extern crate approx;
     /// #
-    /// use geo::Point;
     /// use geo::algorithm::bearing::Bearing;
+    /// use geo::Point;
     ///
     /// let p_1 = Point::<f64>::new(9.177789688110352, 48.776781529534965);
     /// let p_2 = Point::<f64>::new(9.274410083250379, 48.84033282787534);

--- a/geo/src/algorithm/bounding_rect.rs
+++ b/geo/src/algorithm/bounding_rect.rs
@@ -13,8 +13,8 @@ pub trait BoundingRect<T: CoordinateType> {
     /// # Examples
     ///
     /// ```
-    /// use geo::{Point, LineString};
     /// use geo::algorithm::bounding_rect::BoundingRect;
+    /// use geo::{LineString, Point};
     ///
     /// let mut vec = Vec::new();
     /// vec.push(Point::new(40.02f64, 116.34));
@@ -28,7 +28,6 @@ pub trait BoundingRect<T: CoordinateType> {
     /// assert_eq!(116.34, bounding_rect.min().y);
     /// assert_eq!(118.34, bounding_rect.max().y);
     /// ```
-    ///
     fn bounding_rect(&self) -> Self::Output;
 }
 
@@ -40,7 +39,6 @@ where
 
     ///
     /// Return the BoundingRect for a MultiPoint
-    ///
     fn bounding_rect(&self) -> Self::Output {
         get_bounding_rect(self.0.iter().map(|p| p.0))
     }
@@ -72,7 +70,6 @@ where
 
     ///
     /// Return the BoundingRect for a LineString
-    ///
     fn bounding_rect(&self) -> Self::Output {
         line_string_bounding_rect(self)
     }
@@ -86,7 +83,6 @@ where
 
     ///
     /// Return the BoundingRect for a MultiLineString
-    ///
     fn bounding_rect(&self) -> Self::Output {
         get_bounding_rect(self.0.iter().flat_map(|line| line.0.iter().cloned()))
     }
@@ -100,7 +96,6 @@ where
 
     ///
     /// Return the BoundingRect for a Polygon
-    ///
     fn bounding_rect(&self) -> Self::Output {
         let line = self.exterior();
         get_bounding_rect(line.0.iter().cloned())
@@ -115,7 +110,6 @@ where
 
     ///
     /// Return the BoundingRect for a MultiPolygon
-    ///
     fn bounding_rect(&self) -> Self::Output {
         get_bounding_rect(
             self.0

--- a/geo/src/algorithm/centroid.rs
+++ b/geo/src/algorithm/centroid.rs
@@ -20,20 +20,11 @@ use crate::{Line, LineString, MultiPoint, MultiPolygon, Point, Polygon, Rect};
 ///
 /// // rhombus shaped polygon
 /// let polygon = Polygon::new(
-///     LineString::from(vec![
-///        (-2., 1.),
-///        (1., 3.),
-///        (4., 1.),
-///        (1., -1.),
-///        (-2., 1.),
-///     ]),
+///     LineString::from(vec![(-2., 1.), (1., 3.), (4., 1.), (1., -1.), (-2., 1.)]),
 ///     vec![],
 /// );
 ///
-/// assert_eq!(
-///     Point::from((1., 1.)),
-///     polygon.centroid().unwrap(),
-/// );
+/// assert_eq!(Point::from((1., 1.)), polygon.centroid().unwrap(),);
 /// ```
 pub trait Centroid<T: Float> {
     type Output;
@@ -43,8 +34,8 @@ pub trait Centroid<T: Float> {
     /// # Examples
     ///
     /// ```
-    /// use geo::{Point, LineString};
     /// use geo::algorithm::centroid::Centroid;
+    /// use geo::{LineString, Point};
     ///
     /// let mut vec = Vec::new();
     /// vec.push(Point::new(40.02f64, 116.34));
@@ -53,7 +44,6 @@ pub trait Centroid<T: Float> {
     ///
     /// assert_eq!(linestring.centroid().unwrap(), Point::new(40.02, 117.285));
     /// ```
-    ///
     fn centroid(&self) -> Self::Output;
 }
 
@@ -270,8 +260,8 @@ where
 
 ///
 /// ```
-/// use geo::{MultiPoint, Point};
 /// use geo::algorithm::centroid::Centroid;
+/// use geo::{MultiPoint, Point};
 ///
 /// let empty: Vec<Point<f64>> = Vec::new();
 /// let empty_multi_points: MultiPoint<_> = empty.into();
@@ -280,7 +270,6 @@ where
 /// let points: MultiPoint<_> = vec![(5., 1.), (1., 3.), (3., 2.)].into();
 /// assert_eq!(points.centroid(), Some(Point::new(3., 2.)));
 /// ```
-///
 impl<T> Centroid<T> for MultiPoint<T>
 where
     T: Float,

--- a/geo/src/algorithm/contains.rs
+++ b/geo/src/algorithm/contains.rs
@@ -12,8 +12,8 @@ pub trait Contains<Rhs = Self> {
     /// # Examples
     ///
     /// ```
-    /// use geo::{Coordinate, Point, LineString, Polygon};
     /// use geo::algorithm::contains::Contains;
+    /// use geo::{Coordinate, LineString, Point, Polygon};
     ///
     /// let linestring = LineString::from(vec![(0., 0.), (2., 0.), (2., 2.), (0., 2.), (0., 0.)]);
     /// let poly = Polygon::new(linestring.clone(), vec![]);
@@ -26,9 +26,7 @@ pub trait Contains<Rhs = Self> {
     ///
     /// //Point in Polygon
     /// assert!(poly.contains(&Point::new(1., 1.)));
-    ///
     /// ```
-    ///
     fn contains(&self, rhs: &Rhs) -> bool;
 }
 

--- a/geo/src/algorithm/euclidean_distance.rs
+++ b/geo/src/algorithm/euclidean_distance.rs
@@ -27,8 +27,8 @@ pub trait EuclideanDistance<T, Rhs = Self> {
     /// # Examples
     ///
     /// ```
-    /// use geo::{COORD_PRECISION, Point, LineString, Polygon};
     /// use geo::algorithm::euclidean_distance::EuclideanDistance;
+    /// use geo::{LineString, Point, Polygon, COORD_PRECISION};
     ///
     /// // Point to Point example
     /// let p = Point::new(-72.1235, 42.3521);
@@ -45,7 +45,7 @@ pub trait EuclideanDistance<T, Rhs = Self> {
     ///     (7., 3.),
     ///     (7., 2.),
     ///     (6., 1.),
-    ///     (5., 1.)
+    ///     (5., 1.),
     /// ];
     /// let ls: LineString<_> = points.iter().map(|e| Point::new(e.0, e.1)).collect();
     /// let poly = Polygon::new(ls, vec![]);

--- a/geo/src/algorithm/euclidean_length.rs
+++ b/geo/src/algorithm/euclidean_length.rs
@@ -11,8 +11,8 @@ pub trait EuclideanLength<T, RHS = Self> {
     /// # Examples
     ///
     /// ```
-    /// use geo::{Point, LineString, Coordinate};
     /// use geo::algorithm::euclidean_length::EuclideanLength;
+    /// use geo::{Coordinate, LineString, Point};
     ///
     /// let mut vec = Vec::new();
     /// vec.push(Point::new(40.02f64, 116.34));
@@ -21,7 +21,6 @@ pub trait EuclideanLength<T, RHS = Self> {
     ///
     /// println!("EuclideanLength {}", linestring.euclidean_length());
     /// ```
-    ///
     fn euclidean_length(&self) -> T;
 }
 

--- a/geo/src/algorithm/extremes.rs
+++ b/geo/src/algorithm/extremes.rs
@@ -92,11 +92,14 @@ pub trait ExtremeIndices<T: Float + Signed> {
     /// # Examples
     ///
     /// ```
-    /// use geo::{Point, LineString, Polygon};
     /// use geo::extremes::ExtremeIndices;
+    /// use geo::{LineString, Point, Polygon};
     /// // a diamond shape
     /// let points_raw = vec![(1.0, 0.0), (2.0, 1.0), (1.0, 2.0), (0.0, 1.0), (1.0, 0.0)];
-    /// let points = points_raw.iter().map(|e| Point::new(e.0, e.1)).collect::<Vec<_>>();
+    /// let points = points_raw
+    ///     .iter()
+    ///     .map(|e| Point::new(e.0, e.1))
+    ///     .collect::<Vec<_>>();
     /// let poly = Polygon::new(LineString::from(points), vec![]);
     /// // Polygon is both convex and oriented counter-clockwise
     /// let extremes = poly.extreme_indices().unwrap();
@@ -143,8 +146,8 @@ pub trait ExtremePoints<T: Float> {
     /// # Examples
     ///
     /// ```
-    /// use geo::{Point, LineString, Polygon};
     /// use geo::extremes::ExtremePoints;
+    /// use geo::{LineString, Point, Polygon};
     /// let points_raw = vec![(1.0, 0.0), (2.0, 1.0), (1.0, 2.0), (0.0, 1.0), (1.0, 0.0)];
     /// let points = points_raw
     ///     .iter()

--- a/geo/src/algorithm/frechet_distance.rs
+++ b/geo/src/algorithm/frechet_distance.rs
@@ -14,8 +14,8 @@ pub trait FrechetDistance<T, Rhs = Self> {
     /// # Examples
     ///
     /// ```
-    /// use geo::LineString;
     /// use geo::algorithm::frechet_distance::FrechetDistance;
+    /// use geo::LineString;
     ///
     /// let ls_a = LineString::from(vec![(1., 1.), (2., 1.), (2., 2.), (3., 3.)]);
     /// let ls_b = LineString::from(vec![(2., 2.), (0., 1.), (2., 4.), (3., 4.)]);

--- a/geo/src/algorithm/haversine_destination.rs
+++ b/geo/src/algorithm/haversine_destination.rs
@@ -14,8 +14,8 @@ pub trait HaversineDestination<T: Float> {
     /// # Examples
     ///
     /// ```
-    /// use geo::Point;
     /// use geo::algorithm::haversine_destination::HaversineDestination;
+    /// use geo::Point;
     ///
     /// let p_1 = Point::<f64>::new(9.177789688110352, 48.776781529534965);
     /// let p_2 = p_1.haversine_destination(45., 10000.);

--- a/geo/src/algorithm/haversine_distance.rs
+++ b/geo/src/algorithm/haversine_distance.rs
@@ -15,8 +15,8 @@ pub trait HaversineDistance<T, Rhs = Self> {
     /// # Examples
     ///
     /// ```
-    /// use geo::Point;
     /// use geo::prelude::*;
+    /// use geo::Point;
     ///
     /// // New York City
     /// let p1 = Point::<f64>::from((-74.006, 40.7128));
@@ -26,8 +26,8 @@ pub trait HaversineDistance<T, Rhs = Self> {
     /// let distance = p1.haversine_distance(&p2);
     ///
     /// assert_eq!(
-    ///   5_570_222., // meters
-    ///   distance.round()
+    ///     5_570_222., // meters
+    ///     distance.round()
     /// );
     /// ```
     ///

--- a/geo/src/algorithm/haversine_intermediate.rs
+++ b/geo/src/algorithm/haversine_intermediate.rs
@@ -11,23 +11,23 @@ pub trait HaversineIntermediate<T: Float> {
     /// ```
     /// # #[macro_use] extern crate approx;
     /// #
-    /// use geo::Point;
     /// use geo::algorithm::haversine_intermediate::HaversineIntermediate;
+    /// use geo::Point;
     ///
-    /// let p1 = Point::<f64>::new(10.0,  20.0);
+    /// let p1 = Point::<f64>::new(10.0, 20.0);
     /// let p2 = Point::<f64>::new(125.0, 25.0);
-    /// let i20        = p1.haversine_intermediate(&p2, 0.2);
-    /// let i50        = p1.haversine_intermediate(&p2, 0.5);
-    /// let i80        = p1.haversine_intermediate(&p2, 0.8);
-    /// let i20_should = Point::new(29.8,  29.9);
-    /// let i50_should = Point::new(65.8,  37.7);
+    /// let i20 = p1.haversine_intermediate(&p2, 0.2);
+    /// let i50 = p1.haversine_intermediate(&p2, 0.5);
+    /// let i80 = p1.haversine_intermediate(&p2, 0.8);
+    /// let i20_should = Point::new(29.8, 29.9);
+    /// let i50_should = Point::new(65.8, 37.7);
     /// let i80_should = Point::new(103.5, 33.5);
-    /// assert_relative_eq!(i20.x(), i20_should.x(), epsilon=0.2);
-    /// assert_relative_eq!(i20.y(), i20_should.y(), epsilon=0.2);
-    /// assert_relative_eq!(i50.x(), i50_should.x(), epsilon=0.2);
-    /// assert_relative_eq!(i50.y(), i50_should.y(), epsilon=0.2);
-    /// assert_relative_eq!(i80.x(), i80_should.x(), epsilon=0.2);
-    /// assert_relative_eq!(i80.y(), i80_should.y(), epsilon=0.2);
+    /// assert_relative_eq!(i20.x(), i20_should.x(), epsilon = 0.2);
+    /// assert_relative_eq!(i20.y(), i20_should.y(), epsilon = 0.2);
+    /// assert_relative_eq!(i50.x(), i50_should.x(), epsilon = 0.2);
+    /// assert_relative_eq!(i50.y(), i50_should.y(), epsilon = 0.2);
+    /// assert_relative_eq!(i80.x(), i80_should.x(), epsilon = 0.2);
+    /// assert_relative_eq!(i80.y(), i80_should.y(), epsilon = 0.2);
     /// ```
 
     fn haversine_intermediate(&self, other: &Point<T>, f: T) -> Point<T>;

--- a/geo/src/algorithm/haversine_length.rs
+++ b/geo/src/algorithm/haversine_length.rs
@@ -16,21 +16,21 @@ pub trait HaversineLength<T, RHS = Self> {
     /// # Examples
     ///
     /// ```
-    /// use geo::LineString;
     /// use geo::prelude::*;
+    /// use geo::LineString;
     ///
     /// let linestring = LineString::<f64>::from(vec![
-    ///   // New York City
-    ///   (-74.006, 40.7128),
-    ///   // London
-    ///   (-0.1278, 51.5074),
+    ///     // New York City
+    ///     (-74.006, 40.7128),
+    ///     // London
+    ///     (-0.1278, 51.5074),
     /// ]);
     ///
     /// let length = linestring.haversine_length();
     ///
     /// assert_eq!(
-    ///   5_570_222., // meters
-    ///   length.round()
+    ///     5_570_222., // meters
+    ///     length.round()
     /// );
     /// ```
     ///

--- a/geo/src/algorithm/intersects.rs
+++ b/geo/src/algorithm/intersects.rs
@@ -10,16 +10,14 @@ pub trait Intersects<Rhs = Self> {
     /// # Examples
     ///
     /// ```
-    /// use geo::{Coordinate, Point, LineString};
     /// use geo::algorithm::intersects::Intersects;
+    /// use geo::{Coordinate, LineString, Point};
     ///
     /// let linestring = LineString::from(vec![(3., 2.), (7., 6.)]);
     ///
     /// assert!(linestring.intersects(&LineString::from(vec![(3., 4.), (8., 4.)])));
     /// assert!(!linestring.intersects(&LineString::from(vec![(9., 2.), (11., 5.)])));
-    ///
     /// ```
-    ///
     fn intersects(&self, rhs: &Rhs) -> bool;
 }
 

--- a/geo/src/algorithm/map_coords.rs
+++ b/geo/src/algorithm/map_coords.rs
@@ -13,11 +13,11 @@ pub trait MapCoords<T, NT> {
     /// # Examples
     ///
     /// ```
-    /// use geo::Point;
     /// use geo::algorithm::map_coords::MapCoords;
+    /// use geo::Point;
     ///
     /// let p1 = Point::new(10., 20.);
-    /// let p2 = p1.map_coords(|&(x, y)| (x+1000., y*2.));
+    /// let p2 = p1.map_coords(|&(x, y)| (x + 1000., y * 2.));
     ///
     /// assert_eq!(p2, Point::new(1010., 40.));
     /// ```
@@ -48,11 +48,13 @@ pub trait TryMapCoords<T, NT> {
     /// # Examples
     ///
     /// ```
-    /// use geo::Point;
     /// use geo::algorithm::map_coords::TryMapCoords;
+    /// use geo::Point;
     ///
     /// let p1 = Point::new(10., 20.);
-    /// let p2 = p1.try_map_coords(|&(x, y)| Ok((x+1000., y*2.))).unwrap();
+    /// let p2 = p1
+    ///     .try_map_coords(|&(x, y)| Ok((x + 1000., y * 2.)))
+    ///     .unwrap();
     ///
     /// assert_eq!(p2, Point::new(1010., 40.));
     /// ```
@@ -108,11 +110,11 @@ pub trait MapCoordsInplace<T> {
     /// # Examples
     ///
     /// ```
-    /// use geo::Point;
     /// use geo::algorithm::map_coords::MapCoordsInplace;
+    /// use geo::Point;
     ///
     /// let mut p = Point::new(10., 20.);
-    /// p.map_coords_inplace(|&(x, y)| (x+1000., y*2.));
+    /// p.map_coords_inplace(|&(x, y)| (x + 1000., y * 2.));
     ///
     /// assert_eq!(p, Point::new(1010., 40.));
     /// ```

--- a/geo/src/algorithm/mod.rs
+++ b/geo/src/algorithm/mod.rs
@@ -25,9 +25,6 @@ pub mod frechet_distance;
 /// Produces a `Geometry` from PostGIS.
 #[cfg(feature = "postgis-integration")]
 pub mod from_postgis;
-/// Convert a `Geometry` into a PostGIS.
-#[cfg(feature = "postgis-integration")]
-pub mod to_postgis;
 /// Calculate a destination `Point`, given a distance and a bearing.
 pub mod haversine_destination;
 /// Calculate the Haversine distance between two `Geometries`.
@@ -53,6 +50,9 @@ pub mod rotate;
 pub mod simplify;
 /// Simplify `Geometries` using the Visvalingam-Whyatt algorithm. Includes a topology-preserving variant.
 pub mod simplifyvw;
+/// Convert a `Geometry` into a PostGIS.
+#[cfg(feature = "postgis-integration")]
+pub mod to_postgis;
 /// Translate a `Geometry` along the given offsets.
 pub mod translate;
 /// Calculate the Vincenty distance between two `Point`s.

--- a/geo/src/algorithm/orient.rs
+++ b/geo/src/algorithm/orient.rs
@@ -11,13 +11,16 @@ pub trait Orient<T> {
     /// # Examples
     ///
     /// ```
-    /// use geo::{Point, LineString, Polygon};
-    /// use geo::orient::{Orient, Direction};
+    /// use geo::orient::{Direction, Orient};
+    /// use geo::{LineString, Point, Polygon};
     /// // a diamond shape, oriented clockwise outside
     /// let points_ext = vec![(1.0, 0.0), (0.0, 1.0), (1.0, 2.0), (2.0, 1.0), (1.0, 0.0)];
     /// // counter-clockwise interior
     /// let points_int = vec![(1.0, 0.5), (1.5, 1.0), (1.0, 1.5), (0.5, 1.0), (1.0, 0.5)];
-    /// let poly = Polygon::new(LineString::from(points_ext), vec![LineString::from(points_int)]);
+    /// let poly = Polygon::new(
+    ///     LineString::from(points_ext),
+    ///     vec![LineString::from(points_int)],
+    /// );
     /// // a diamond shape, oriented counter-clockwise outside,
     /// let oriented_ext = vec![(1.0, 0.0), (2.0, 1.0), (1.0, 2.0), (0.0, 1.0), (1.0, 0.0)];
     /// let oriented_ext_ls = LineString::from(oriented_ext);

--- a/geo/src/algorithm/rotate.rs
+++ b/geo/src/algorithm/rotate.rs
@@ -58,8 +58,8 @@ pub trait Rotate<T> {
     /// # Examples
     ///
     /// ```
-    /// use geo::{Point, LineString};
-    /// use geo::algorithm::rotate::{Rotate};
+    /// use geo::algorithm::rotate::Rotate;
+    /// use geo::{LineString, Point};
     ///
     /// let mut vec = Vec::new();
     /// vec.push(Point::new(0.0, 0.0));

--- a/geo/src/algorithm/simplify.rs
+++ b/geo/src/algorithm/simplify.rs
@@ -93,8 +93,8 @@ pub trait Simplify<T, Epsilon = T> {
     /// # Examples
     ///
     /// ```
-    /// use geo::{Point, LineString};
-    /// use geo::algorithm::simplify::{Simplify};
+    /// use geo::algorithm::simplify::Simplify;
+    /// use geo::{LineString, Point};
     ///
     /// let mut vec = Vec::new();
     /// vec.push(Point::new(0.0, 0.0));
@@ -127,8 +127,8 @@ pub trait SimplifyIdx<T, Epsilon = T> {
     /// # Examples
     ///
     /// ```
-    /// use geo::{Point, LineString};
-    /// use geo::algorithm::simplify::{SimplifyIdx};
+    /// use geo::algorithm::simplify::SimplifyIdx;
+    /// use geo::{LineString, Point};
     ///
     /// let mut vec = Vec::new();
     /// vec.push(Point::new(0.0, 0.0));
@@ -168,10 +168,7 @@ where
             &self
                 .points_iter()
                 .enumerate()
-                .map(|(idx, point)| RdpIndex {
-                    index: idx,
-                    point,
-                })
+                .map(|(idx, point)| RdpIndex { index: idx, point })
                 .collect::<Vec<RdpIndex<T>>>(),
             epsilon,
         )

--- a/geo/src/algorithm/simplifyvw.rs
+++ b/geo/src/algorithm/simplifyvw.rs
@@ -434,8 +434,8 @@ pub trait SimplifyVW<T, Epsilon = T> {
     /// # Examples
     ///
     /// ```
-    /// use geo::{Point, LineString};
-    /// use geo::algorithm::simplifyvw::{SimplifyVW};
+    /// use geo::algorithm::simplifyvw::SimplifyVW;
+    /// use geo::{LineString, Point};
     ///
     /// let mut vec = Vec::new();
     /// vec.push(Point::new(5.0, 2.0));
@@ -469,8 +469,8 @@ pub trait SimplifyVwIdx<T, Epsilon = T> {
     /// # Examples
     ///
     /// ```
-    /// use geo::{Point, LineString};
-    /// use geo::algorithm::simplifyvw::{SimplifyVwIdx};
+    /// use geo::algorithm::simplifyvw::SimplifyVwIdx;
+    /// use geo::{LineString, Point};
     ///
     /// let mut vec = Vec::new();
     /// vec.push(Point::new(5.0, 2.0));
@@ -518,8 +518,8 @@ pub trait SimplifyVWPreserve<T, Epsilon = T> {
     /// # Examples
     ///
     /// ```
-    /// use geo::{Point, LineString};
-    /// use geo::algorithm::simplifyvw::{SimplifyVWPreserve};
+    /// use geo::algorithm::simplifyvw::SimplifyVWPreserve;
+    /// use geo::{LineString, Point};
     ///
     /// let mut vec = Vec::new();
     /// vec.push(Point::new(10., 60.));

--- a/geo/src/algorithm/vincenty_distance.rs
+++ b/geo/src/algorithm/vincenty_distance.rs
@@ -22,8 +22,8 @@ pub trait VincentyDistance<T, Rhs = Self> {
     /// # Examples
     ///
     /// ```
-    /// use geo::Point;
     /// use geo::prelude::*;
+    /// use geo::Point;
     ///
     /// // New York City
     /// let p1 = Point::<f64>::from((-74.006, 40.7128));
@@ -33,8 +33,8 @@ pub trait VincentyDistance<T, Rhs = Self> {
     /// let distance = p1.vincenty_distance(&p2).unwrap();
     ///
     /// assert_eq!(
-    ///   5_585_234., // meters
-    ///   distance.round()
+    ///     5_585_234., // meters
+    ///     distance.round()
     /// );
     /// ```
     ///

--- a/geo/src/algorithm/vincenty_length.rs
+++ b/geo/src/algorithm/vincenty_length.rs
@@ -16,21 +16,21 @@ pub trait VincentyLength<T, RHS = Self> {
     /// # Examples
     ///
     /// ```
-    /// use geo::LineString;
     /// use geo::prelude::*;
+    /// use geo::LineString;
     ///
     /// let linestring = LineString::<f64>::from(vec![
-    ///   // New York City
-    ///   (-74.006, 40.7128),
-    ///   // London
-    ///   (-0.1278, 51.5074),
+    ///     // New York City
+    ///     (-74.006, 40.7128),
+    ///     // London
+    ///     (-0.1278, 51.5074),
     /// ]);
     ///
     /// let length = linestring.vincenty_length().unwrap();
     ///
     /// assert_eq!(
-    ///   5_585_234., // meters
-    ///   length.round()
+    ///     5_585_234., // meters
+    ///     length.round()
     /// );
     /// ```
     ///

--- a/geo/src/lib.rs
+++ b/geo/src/lib.rs
@@ -1,5 +1,5 @@
 #![doc(html_logo_url = "https://raw.githubusercontent.com/georust/meta/master/logo/logo.png")]
-//! The `geo` crate provides geospatial primitive types such as `Coordinate`, `Point`, `LineString`, and `Polygon` as 
+//! The `geo` crate provides geospatial primitive types such as `Coordinate`, `Point`, `LineString`, and `Polygon` as
 //! well as their `Multi–` equivalents, and provides algorithms and operations such as:
 //!   - Area and centroid calculation
 //!   - Simplification and convex hull operations
@@ -32,7 +32,7 @@
 //! ## GeoJSON
 //! If you wish to read or write `GeoJSON`, use the [`geojson`](https://docs.rs/geojson) crate, with the `geo-types` feature activated.
 //! This provides fallible conversions **to** `geo-types` primitives such as `Point` and `Polygon` from `geojson` `Value`
-//! structs using the standard [`TryFrom`](https://doc.rust-lang.org/stable/std/convert/trait.TryFrom.html) 
+//! structs using the standard [`TryFrom`](https://doc.rust-lang.org/stable/std/convert/trait.TryFrom.html)
 //! and [`TryInto`](https://doc.rust-lang.org/stable/std/convert/trait.TryInto.html) traits,
 //! and conversion **from** `geo-types` primitives to `geojson`
 //! `Value` structs using the [`From`](https://doc.rust-lang.org/stable/std/convert/trait.TryFrom.html) trait.


### PR DESCRIPTION
This PR adds a config for rustfmt which enables formatting of code in
examples, and updates the repo with the reformatted lines.