### PR TITLE
Add conditional Eq impl for Coordinate, maybe other types?

### DIFF
--- a/geo-types/src/coordinate.rs
+++ b/geo-types/src/coordinate.rs
@@ -17,6 +17,8 @@ where
     pub y: T,
 }
 
+impl<T: CoordinateType> std::cmp::Eq for Coordinate<T> where T: std::cmp::Eq {}
+
 impl<T: CoordinateType> From<(T, T)> for Coordinate<T> {
     fn from(coords: (T, T)) -> Self {
         Coordinate {


### PR DESCRIPTION
I haven't written tests or anything for this but I wanted to throw the PR in to get discussion started.

Many geometry algorithms eg this [optimal algorithm for computing mesh cross-sections and reconstructing the polygons](https://www.researchgate.net/publication/309619647_An_Optimal_Algorithm_for_3D_Triangle_Mesh_Slicing) use Hashtables or similar to keep track of coordinates. This impl lets me put geo Coordinate structs in the Hashtable instead of dealing with a separate struct just for this step.

I haven't put much thought into whether similar one-liner Eq impl's should be added for Linestring, Polygon, etc but I don't really see why not. The use cases are rarer but probably still exist.