### PR TITLE
derive Eq for other core geo types

### DIFF
--- a/geo-types/src/coordinate.rs
+++ b/geo-types/src/coordinate.rs
@@ -7,34 +7,6 @@ use crate::{CoordinateType, Point};
 /// as an envelope, a precision model, and spatial reference system
 /// information), a `Coordinate` only contains ordinate values and accessor
 /// methods.
-///
-/// ## Equality Examples
-///
-/// ```
-/// use geo_types::Coordinate;
-///
-/// let c1 = Coordinate { x: 1.0, y: 2.0};
-/// let c2 = Coordinate { x: 1.0, y: 2.0} ;
-/// assert_eq!(c1, c2);
-///
-/// let c3 = Coordinate { x: 1.0, y: 2.1};
-/// assert_ne!(c1, c3);
-/// ```
-///
-/// ```
-/// use geo_types::Coordinate;
-///
-/// struct AssertEq<T: Eq>(pub T);
-/// let _: AssertEq<Coordinate<i32>> = AssertEq(Coordinate { x: 1, y: 2 });
-/// ```
-///
-/// ```compile_fail
-/// use geo_types::Coordinate;
-///
-/// struct AssertEq<T: Eq>(pub T);
-/// // Eq impl is not derived for Coordinate<f32> because f32 is not Eq
-/// let _: AssertEq<Coordinate<f32>> = AssertEq(Coordinate { x: 1.0, y: 2.0 });
-/// ```
 #[derive(Eq, PartialEq, Clone, Copy, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Coordinate<T>

--- a/geo-types/src/coordinate.rs
+++ b/geo-types/src/coordinate.rs
@@ -7,7 +7,35 @@ use crate::{CoordinateType, Point};
 /// as an envelope, a precision model, and spatial reference system
 /// information), a `Coordinate` only contains ordinate values and accessor
 /// methods.
-#[derive(PartialEq, Clone, Copy, Debug, Hash)]
+///
+/// ## Equality Examples
+///
+/// ```
+/// use geo_types::Coordinate;
+///
+/// let c1 = Coordinate { x: 1.0, y: 2.0};
+/// let c2 = Coordinate { x: 1.0, y: 2.0} ;
+/// assert_eq!(c1, c2);
+///
+/// let c3 = Coordinate { x: 1.0, y: 2.1};
+/// assert_ne!(c1, c3);
+/// ```
+///
+/// ```
+/// use geo_types::Coordinate;
+///
+/// struct AssertEq<T: Eq>(pub T);
+/// let _: AssertEq<Coordinate<i32>> = AssertEq(Coordinate { x: 1, y: 2 });
+/// ```
+///
+/// ```compile_fail
+/// use geo_types::Coordinate;
+///
+/// struct AssertEq<T: Eq>(pub T);
+/// // Eq impl is not derived for Coordinate<f32> because f32 is not Eq
+/// let _: AssertEq<Coordinate<f32>> = AssertEq(Coordinate { x: 1.0, y: 2.0 });
+/// ```
+#[derive(Eq, PartialEq, Clone, Copy, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Coordinate<T>
 where
@@ -16,8 +44,6 @@ where
     pub x: T,
     pub y: T,
 }
-
-impl<T: CoordinateType> std::cmp::Eq for Coordinate<T> where T: std::cmp::Eq {}
 
 impl<T: CoordinateType> From<(T, T)> for Coordinate<T> {
     fn from(coords: (T, T)) -> Self {

--- a/geo-types/src/geometry.rs
+++ b/geo-types/src/geometry.rs
@@ -23,7 +23,37 @@ use std::fmt;
 /// let pn = Point::try_from(pe).unwrap();
 /// ```
 ///
-#[derive(PartialEq, Clone, Debug, Hash)]
+/// ## Equality Examples
+///
+/// ```
+/// use geo_types::{Geometry, Point};
+///
+/// let p1 = Point::new(1.0, 2.0);
+/// let p2 = Point::new(1.0, 2.0);
+/// let g1 = Geometry::Point(p1);
+/// let g2 = Geometry::Point(p2);
+/// assert_eq!(g1, g2);
+///
+/// let p3 = Point::new(1.0, 2.1);
+/// let g3 = Geometry::Point(p3);
+/// assert_ne!(g1, g3);
+/// ```
+///
+/// ```
+/// use geo_types::{Geometry, Point};
+///
+/// struct AssertEq<T: Eq>(pub T);
+/// let _: AssertEq<Geometry<i32>> = AssertEq(Geometry::Point(Point::new(1, 2)));
+/// ```
+///
+/// ```compile_fail
+/// use geo_types::{Geometry, Point};
+///
+/// struct AssertEq<T: Eq>(pub T);
+/// // Eq impl is not derived for Geometry<f32> because f32 is not Eq
+/// let _: AssertEq<Geometry<f32>> = AssertEq(Geometry::Point(Point::new(1.0, 2.0)));
+/// ```
+#[derive(Eq, PartialEq, Clone, Debug, Hash)]
 pub enum Geometry<T>
 where
     T: CoordinateType,

--- a/geo-types/src/geometry.rs
+++ b/geo-types/src/geometry.rs
@@ -23,36 +23,6 @@ use std::fmt;
 /// let pn = Point::try_from(pe).unwrap();
 /// ```
 ///
-/// ## Equality Examples
-///
-/// ```
-/// use geo_types::{Geometry, Point};
-///
-/// let p1 = Point::new(1.0, 2.0);
-/// let p2 = Point::new(1.0, 2.0);
-/// let g1 = Geometry::Point(p1);
-/// let g2 = Geometry::Point(p2);
-/// assert_eq!(g1, g2);
-///
-/// let p3 = Point::new(1.0, 2.1);
-/// let g3 = Geometry::Point(p3);
-/// assert_ne!(g1, g3);
-/// ```
-///
-/// ```
-/// use geo_types::{Geometry, Point};
-///
-/// struct AssertEq<T: Eq>(pub T);
-/// let _: AssertEq<Geometry<i32>> = AssertEq(Geometry::Point(Point::new(1, 2)));
-/// ```
-///
-/// ```compile_fail
-/// use geo_types::{Geometry, Point};
-///
-/// struct AssertEq<T: Eq>(pub T);
-/// // Eq impl is not derived for Geometry<f32> because f32 is not Eq
-/// let _: AssertEq<Geometry<f32>> = AssertEq(Geometry::Point(Point::new(1.0, 2.0)));
-/// ```
 #[derive(Eq, PartialEq, Clone, Debug, Hash)]
 pub enum Geometry<T>
 where

--- a/geo-types/src/geometry_collection.rs
+++ b/geo-types/src/geometry_collection.rs
@@ -63,7 +63,7 @@ use std::ops::{Index, IndexMut};
 /// println!("{:?}", gc[0]);
 /// ```
 ///
-#[derive(PartialEq, Clone, Debug, Hash)]
+#[derive(Eq, PartialEq, Clone, Debug, Hash)]
 pub struct GeometryCollection<T>(pub Vec<Geometry<T>>)
 where
     T: CoordinateType;

--- a/geo-types/src/line.rs
+++ b/geo-types/src/line.rs
@@ -1,7 +1,7 @@
 use crate::{Coordinate, CoordinateType, Point};
 
 /// A line segment made up of exactly two [`Point`s](struct.Point.html).
-#[derive(PartialEq, Clone, Copy, Debug, Hash)]
+#[derive(Eq, PartialEq, Clone, Copy, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Line<T>
 where

--- a/geo-types/src/line_string.rs
+++ b/geo-types/src/line_string.rs
@@ -73,7 +73,7 @@ use std::ops::{Index, IndexMut};
 /// }
 /// ```
 
-#[derive(PartialEq, Clone, Debug, Hash)]
+#[derive(Eq, PartialEq, Clone, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct LineString<T>(pub Vec<Coordinate<T>>)
 where

--- a/geo-types/src/multi_line_string.rs
+++ b/geo-types/src/multi_line_string.rs
@@ -6,7 +6,7 @@ use std::iter::FromIterator;
 /// Can be created from a `Vec` of `LineString`s, or from an Iterator which yields `LineString`s.
 ///
 /// Iterating over this objects, yields the component `LineString`s.
-#[derive(PartialEq, Clone, Debug, Hash)]
+#[derive(Eq, PartialEq, Clone, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct MultiLineString<T>(pub Vec<LineString<T>>)
 where

--- a/geo-types/src/multi_point.rs
+++ b/geo-types/src/multi_point.rs
@@ -14,7 +14,7 @@ use std::iter::FromIterator;
 ///     println!("Point x = {}, y = {}", point.x(), point.y());
 /// }
 /// ```
-#[derive(PartialEq, Clone, Debug, Hash)]
+#[derive(Eq, PartialEq, Clone, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct MultiPoint<T>(pub Vec<Point<T>>)
 where

--- a/geo-types/src/multi_polygon.rs
+++ b/geo-types/src/multi_polygon.rs
@@ -6,7 +6,7 @@ use std::iter::FromIterator;
 /// Can be created from a `Vec` of `Polygon`s, or `collect`ed from an Iterator which yields `Polygon`s.
 ///
 /// Iterating over this object yields the component Polygons.
-#[derive(PartialEq, Clone, Debug, Hash)]
+#[derive(Eq, PartialEq, Clone, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct MultiPolygon<T>(pub Vec<Polygon<T>>)
 where

--- a/geo-types/src/point.rs
+++ b/geo-types/src/point.rs
@@ -17,7 +17,35 @@ use std::ops::Sub;
 /// let c = Coordinate { x: 10., y: 20. };
 /// let p2: Point<f64> = c.into();
 /// ```
-#[derive(PartialEq, Clone, Copy, Debug, Hash)]
+///
+/// ## Equality Examples
+///
+/// ```
+/// use geo_types::Point;
+///
+/// let p1 = Point::new(1.0, 2.0);
+/// let p2 = Point::new(1.0, 2.0);
+/// assert_eq!(p1, p2);
+///
+/// let p3 = Point::new(1.0, 2.1);
+/// assert_ne!(p1, p3);
+/// ```
+///
+/// ```
+/// use geo_types::Point;
+///
+/// struct AssertEq<T: Eq>(pub T);
+/// let _: AssertEq<Point<i32>> = AssertEq(Point::new(1, 2));
+/// ```
+///
+/// ```compile_fail
+/// use geo_types::Point;
+///
+/// struct AssertEq<T: Eq>(pub T);
+/// // Eq impl is not derived for Point<f32> because f32 is not Eq
+/// let _: AssertEq<Point<f32>> = AssertEq(Point::new(1.0, 2.0));
+/// ```
+#[derive(Eq, PartialEq, Clone, Copy, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Point<T>(pub Coordinate<T>)
 where

--- a/geo-types/src/point.rs
+++ b/geo-types/src/point.rs
@@ -17,34 +17,6 @@ use std::ops::Sub;
 /// let c = Coordinate { x: 10., y: 20. };
 /// let p2: Point<f64> = c.into();
 /// ```
-///
-/// ## Equality Examples
-///
-/// ```
-/// use geo_types::Point;
-///
-/// let p1 = Point::new(1.0, 2.0);
-/// let p2 = Point::new(1.0, 2.0);
-/// assert_eq!(p1, p2);
-///
-/// let p3 = Point::new(1.0, 2.1);
-/// assert_ne!(p1, p3);
-/// ```
-///
-/// ```
-/// use geo_types::Point;
-///
-/// struct AssertEq<T: Eq>(pub T);
-/// let _: AssertEq<Point<i32>> = AssertEq(Point::new(1, 2));
-/// ```
-///
-/// ```compile_fail
-/// use geo_types::Point;
-///
-/// struct AssertEq<T: Eq>(pub T);
-/// // Eq impl is not derived for Point<f32> because f32 is not Eq
-/// let _: AssertEq<Point<f32>> = AssertEq(Point::new(1.0, 2.0));
-/// ```
 #[derive(Eq, PartialEq, Clone, Copy, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Point<T>(pub Coordinate<T>)

--- a/geo-types/src/polygon.rs
+++ b/geo-types/src/polygon.rs
@@ -31,7 +31,7 @@ use num_traits::{Float, Signed};
 /// the first `Coordinate`.
 ///
 /// [`LineString`]: line_string/struct.LineString.html
-#[derive(PartialEq, Clone, Debug, Hash)]
+#[derive(Eq, PartialEq, Clone, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Polygon<T>
 where

--- a/geo-types/src/rect.rs
+++ b/geo-types/src/rect.rs
@@ -1,7 +1,7 @@
 use crate::{polygon, Coordinate, CoordinateType, Polygon};
 
 /// A bounded 2D quadrilateral whose area is defined by minimum and maximum `Coordinates`.
-#[derive(PartialEq, Clone, Copy, Debug, Hash)]
+#[derive(Eq, PartialEq, Clone, Copy, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Rect<T>
 where

--- a/geo-types/src/triangle.rs
+++ b/geo-types/src/triangle.rs
@@ -1,7 +1,7 @@
 use crate::{polygon, Coordinate, CoordinateType, Line, Polygon};
 
 /// A bounded 2D area whose three vertices are defined by `Coordinate`s.
-#[derive(Copy, Clone, Debug, Hash, PartialEq)]
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Triangle<T: CoordinateType>(pub Coordinate<T>, pub Coordinate<T>, pub Coordinate<T>);
 


### PR DESCRIPTION
Adds `Eq` conformance to other core geo types, building off of https://github.com/georust/geo/pull/431

> Seems reasonable to me! Yeah +1 to adding the same impl for all the other core geo types

Rather than spelling out the impl, I've taken advantage of how `derive` already bounds the generated impl for us. See rust-lang/rust#21237 for more details

I wrote a few doc-tests while developing, but I reverted them in https://github.com/georust/geo/commit/fc33f9fa8da2e3ade6ff0b047d467da91b41ca7e since they're pretty verbose, and seem superfluous since they're only asserting rust language semantics rather than anything substantial in this lib.

I can un-revert them if you'd prefer. 