### PR TITLE
fix rect intersection

### DIFF
--- a/geo/src/algorithm/intersects.rs
+++ b/geo/src/algorithm/intersects.rs
@@ -211,32 +211,27 @@ where
     T: Float,
 {
     fn intersects(&self, bounding_rect: &Rect<T>) -> bool {
-        // line intersects inner or outer polygon edge
-        if bounding_rect.contains(self) {
-            false
-        } else {
-            let x_overlap = value_in_range(
-                self.min().x,
-                bounding_rect.min().x,
-                bounding_rect.min().x + bounding_rect.width(),
-            ) || value_in_range(
-                bounding_rect.min().x,
-                self.min().x,
-                self.min().x + self.width(),
-            );
+        let x_overlap = value_in_range(
+            self.min().x,
+            bounding_rect.min().x,
+            bounding_rect.max().x
+        ) || value_in_range(
+            bounding_rect.min().x,
+            self.min().x,
+            self.max().x
+        );
 
-            let y_overlap = value_in_range(
-                self.min().y,
-                bounding_rect.min().y,
-                bounding_rect.min().y + bounding_rect.height(),
-            ) || value_in_range(
-                bounding_rect.min().y,
-                self.min().y,
-                self.min().y + self.height(),
-            );
+        let y_overlap = value_in_range(
+            self.min().y,
+            bounding_rect.min().y,
+            bounding_rect.max().y
+        ) || value_in_range(
+            bounding_rect.min().y,
+            self.min().y,
+            self.max().y
+        );
 
-            x_overlap && y_overlap
-        }
+        x_overlap && y_overlap
     }
 }
 
@@ -542,7 +537,7 @@ mod test {
             Rect::new(Coordinate { x: 0., y: 0. }, Coordinate { x: 20., y: 30. });
         // confirmed using GEOS
         assert_eq!(true, bounding_rect_xl.intersects(&bounding_rect_sm));
-        assert_eq!(false, bounding_rect_sm.intersects(&bounding_rect_xl));
+        assert_eq!(true, bounding_rect_sm.intersects(&bounding_rect_xl));
         assert_eq!(true, bounding_rect_sm.intersects(&bounding_rect_s2));
         assert_eq!(true, bounding_rect_s2.intersects(&bounding_rect_sm));
     }

--- a/geo/src/algorithm/intersects.rs
+++ b/geo/src/algorithm/intersects.rs
@@ -542,6 +542,35 @@ mod test {
         assert_eq!(true, bounding_rect_s2.intersects(&bounding_rect_sm));
     }
     #[test]
+    fn rect_interesection_consistent_with_poly_intersection_test() {
+        let bounding_rect_xl = Rect::new(
+            Coordinate { x: -100., y: -200. },
+            Coordinate { x: 100., y: 200. },
+        );
+        let bounding_rect_sm = Rect::new(
+            Coordinate { x: -10., y: -20. },
+            Coordinate { x: 10., y: 20. },
+        );
+        let bounding_rect_s2 =
+            Rect::new(Coordinate { x: 0., y: 0. }, Coordinate { x: 20., y: 30. });
+
+        assert_eq!(true, bounding_rect_xl.to_polygon().intersects(&bounding_rect_sm));
+        assert_eq!(true, bounding_rect_xl.intersects(&bounding_rect_sm.to_polygon()));
+        assert_eq!(true, bounding_rect_xl.to_polygon().intersects(&bounding_rect_sm.to_polygon()));
+
+        assert_eq!(true, bounding_rect_sm.to_polygon().intersects(&bounding_rect_xl));
+        assert_eq!(true, bounding_rect_sm.intersects(&bounding_rect_xl.to_polygon()));
+        assert_eq!(true, bounding_rect_sm.to_polygon().intersects(&bounding_rect_xl.to_polygon()));
+
+        assert_eq!(true, bounding_rect_sm.to_polygon().intersects(&bounding_rect_s2));
+        assert_eq!(true, bounding_rect_sm.intersects(&bounding_rect_s2.to_polygon()));
+        assert_eq!(true, bounding_rect_sm.to_polygon().intersects(&bounding_rect_s2.to_polygon()));
+
+        assert_eq!(true, bounding_rect_s2.to_polygon().intersects(&bounding_rect_sm));
+        assert_eq!(true, bounding_rect_s2.intersects(&bounding_rect_sm.to_polygon()));
+        assert_eq!(true, bounding_rect_s2.to_polygon().intersects(&bounding_rect_sm.to_polygon()));
+    }
+    #[test]
     fn point_intersects_line_test() {
         let p0 = Point::new(2., 4.);
         // vertical line


### PR DESCRIPTION
Addendum to https://github.com/georust/geo/pull/420

This fixes the intersection test for Rect when `self` is contained
wholly within `arg` - it was already working for when `arg` was within
`self` as of #420 
