### PR TITLE
Change COORD_PRECISION from 1e-1 to std::f32::EPSILON.

### DIFF
--- a/geo-types/src/private_utils.rs
+++ b/geo-types/src/private_utils.rs
@@ -6,7 +6,7 @@
 use crate::{Coordinate, CoordinateType, Line, LineString, Point, Rect};
 use num_traits::Float;
 
-pub static COORD_PRECISION: f32 = 1e-1; // 0.1m
+pub static COORD_PRECISION: f32 = std::f32::EPSILON;
 
 pub fn line_string_bounding_rect<T>(line_string: &LineString<T>) -> Option<Rect<T>>
 where

--- a/geo/src/algorithm/euclidean_distance.rs
+++ b/geo/src/algorithm/euclidean_distance.rs
@@ -28,12 +28,12 @@ pub trait EuclideanDistance<T, Rhs = Self> {
     ///
     /// ```
     /// use geo::algorithm::euclidean_distance::EuclideanDistance;
-    /// use geo::{LineString, Point, Polygon, COORD_PRECISION};
+    /// use geo::{LineString, Point, Polygon};
     ///
     /// // Point to Point example
     /// let p = Point::new(-72.1235, 42.3521);
     /// let dist = p.euclidean_distance(&Point::new(-72.1260, 42.45));
-    /// assert!(dist < COORD_PRECISION);
+    /// assert!(dist < 0.1);
     ///
     /// // Point to Polygon example
     /// let points = vec![


### PR DESCRIPTION
Since #392 has been open a while, and it's a 1 line change, I thought I would open this PR. Please let me know if I am misunderstanding why the `0.1m` value was hard-coded.

Fixes #392