### PR TITLE
fix vincenty for equatorial and coincident points

### DIFF
--- a/geo/src/algorithm/vincenty_distance.rs
+++ b/geo/src/algorithm/vincenty_distance.rs
@@ -92,9 +92,17 @@ where
                 + (cosU1 * sinU2 - sinU1 * cosU2 * cosLambda)
                     * (cosU1 * sinU2 - sinU1 * cosU2 * cosLambda))
                 .sqrt();
+
             if sinSigma.is_zero() {
-                return Err(FailedToConvergeError);
+                if self == rhs {
+                    // coincident points
+                    return Ok(T::zero());
+                } else {
+                    // anitpodal points, for which vincenty does not converge
+                    return Err(FailedToConvergeError);
+                }
             }
+
             cosSigma = sinU1 * sinU2 + cosU1 * cosU2 * cosLambda;
             sigma = sinSigma.atan2(cosSigma);
             let sinAlpha = cosU1 * cosU2 * sinLambda / sinSigma;
@@ -152,7 +160,7 @@ where
     }
 }
 
-#[derive(Debug)]
+#[derive(Eq, PartialEq, Debug)]
 pub struct FailedToConvergeError;
 
 impl fmt::Display for FailedToConvergeError {
@@ -213,5 +221,23 @@ mod test {
             11131949.079,
             epsilon = 1.0e-3
         );
+    }
+
+    #[test]
+    fn test_vincenty_distance_coincident() {
+        let a = Point::<f64>::new(12.3, 4.56);
+        let b = Point::<f64>::new(12.3, 4.56);
+        assert_relative_eq!(
+            a.vincenty_distance(&b).unwrap(),
+            0.0,
+            epsilon = 1.0e-3
+        );
+    }
+
+    #[test]
+    fn test_vincenty_distance_antipodal() {
+        let a = Point::<f64>::new(2.0, 4.0);
+        let b = Point::<f64>::new(-178.0, -4.0);
+        assert_eq!(a.vincenty_distance(&b), Err(FailedToConvergeError))
     }
 }

--- a/geo/src/algorithm/vincenty_distance.rs
+++ b/geo/src/algorithm/vincenty_distance.rs
@@ -110,6 +110,7 @@ where
 
             if cosSqAlpha.is_zero() {
                 // equatorial geodesics require special handling
+                // per [Algorithms for geodesics, Charles F. F. Karney](https://arxiv.org/pdf/1109.4448.pdf)
                 cos2SigmaM = T::zero()
             } else {
                 cos2SigmaM = cosSigma - t_2 * sinU1 * sinU2 / cosSqAlpha;

--- a/geo/src/algorithm/vincenty_distance.rs
+++ b/geo/src/algorithm/vincenty_distance.rs
@@ -99,7 +99,14 @@ where
             sigma = sinSigma.atan2(cosSigma);
             let sinAlpha = cosU1 * cosU2 * sinLambda / sinSigma;
             cosSqAlpha = t_1 - sinAlpha * sinAlpha;
-            cos2SigmaM = cosSigma - t_2 * sinU1 * sinU2 / cosSqAlpha;
+
+            if cosSqAlpha.is_zero() {
+                // equatorial geodesics require special handling
+                cos2SigmaM = T::zero()
+            } else {
+                cos2SigmaM = cosSigma - t_2 * sinU1 * sinU2 / cosSqAlpha;
+            }
+
             let C = f / t_16 * cosSqAlpha * (t_4 + f * (t_4 - t_3 * cosSqAlpha));
             lambdaP = lambda;
             lambda = L
@@ -194,6 +201,17 @@ mod test {
             a.vincenty_distance(&b).unwrap(),
             55073.68246366003,
             epsilon = 1.0e-6
+        );
+    }
+
+    #[test]
+    fn test_vincenty_distance_equatorial() {
+        let a = Point::<f64>::new(0.0, 0.0);
+        let b = Point::<f64>::new(100.0, 0.0);
+        assert_relative_eq!(
+            a.vincenty_distance(&b).unwrap(),
+            11131949.079,
+            epsilon = 1.0e-3
         );
     }
 }


### PR DESCRIPTION
fixes #418 

From Algorithms for geodesics, Charles F. F. Karney∗
available https://arxiv.org/pdf/1109.4448.pdf

> For equatorial geodesics (φ1 = 0 and α1 = 1 2π), Eq. (11) is
> indeterminate; in this case, take σ1 = 0

Also fixes vincenty for coincident points.