### PR TITLE
Introduce Rect constructor that doesn't panic.

### DIFF
--- a/geo-types/src/lib.rs
+++ b/geo-types/src/lib.rs
@@ -59,7 +59,7 @@ mod triangle;
 pub use crate::triangle::Triangle;
 
 mod rect;
-pub use crate::rect::Rect;
+pub use crate::rect::{InvalidRectCoordinatesError, Rect};
 
 #[macro_use]
 mod macros;

--- a/geo-types/src/rect.rs
+++ b/geo-types/src/rect.rs
@@ -34,10 +34,10 @@ impl<T: CoordinateType> Rect<T> {
     where
         C: Into<Coordinate<T>>,
     {
-        Rect::try_new(min, max).expect(RECT_INVALID_BOUNDS_ERROR)
+        Rect::try_new(min, max).unwrap()
     }
 
-    pub fn try_new<C>(min: C, max: C) -> Option<Rect<T>>
+    pub fn try_new<C>(min: C, max: C) -> Result<Rect<T>, InvalidRectCoordinatesError>
     where
         C: Into<Coordinate<T>>,
     {
@@ -47,9 +47,9 @@ impl<T: CoordinateType> Rect<T> {
         };
 
         if rect.has_valid_bounds() {
-            Some(rect)
+            Ok(rect)
         } else {
-            None
+            Err(InvalidRectCoordinatesError)
         }
     }
 
@@ -130,6 +130,17 @@ impl<T: CoordinateType> Rect<T> {
 }
 
 static RECT_INVALID_BOUNDS_ERROR: &str = "Failed to create Rect: 'min' coordinate's x/y value must be smaller or equal to the 'max' x/y value";
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct InvalidRectCoordinatesError;
+
+impl std::error::Error for InvalidRectCoordinatesError {}
+
+impl std::fmt::Display for InvalidRectCoordinatesError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", RECT_INVALID_BOUNDS_ERROR)
+    }
+}
 
 #[cfg(test)]
 mod test {

--- a/geo-types/src/rect.rs
+++ b/geo-types/src/rect.rs
@@ -34,11 +34,23 @@ impl<T: CoordinateType> Rect<T> {
     where
         C: Into<Coordinate<T>>,
     {
-        let (min, max) = (min.into(), max.into());
+        Rect::try_new(min, max).expect(RECT_INVALID_BOUNDS_ERROR)
+    }
 
-        Self::assert_valid_bounds(min, max);
+    pub fn try_new<C>(min: C, max: C) -> Option<Rect<T>>
+    where
+        C: Into<Coordinate<T>>,
+    {
+        let rect = Rect {
+            min: min.into(),
+            max: max.into(),
+        };
 
-        Rect { min, max }
+        if rect.has_valid_bounds() {
+            Some(rect)
+        } else {
+            None
+        }
     }
 
     pub fn min(self) -> Coordinate<T> {
@@ -50,7 +62,7 @@ impl<T: CoordinateType> Rect<T> {
         C: Into<Coordinate<T>>,
     {
         self.min = min.into();
-        Self::assert_valid_bounds(self.min, self.max);
+        self.assert_valid_bounds();
     }
 
     pub fn max(self) -> Coordinate<T> {
@@ -62,7 +74,7 @@ impl<T: CoordinateType> Rect<T> {
         C: Into<Coordinate<T>>,
     {
         self.max = max.into();
-        Self::assert_valid_bounds(self.min, self.max);
+        self.assert_valid_bounds();
     }
 
     pub fn width(self) -> T {
@@ -106,13 +118,18 @@ impl<T: CoordinateType> Rect<T> {
         ]
     }
 
-    fn assert_valid_bounds(min: Coordinate<T>, max: Coordinate<T>) {
-        assert!(
-            min.x <= max.x && min.y <= max.y,
-            "Failed to create the Rect type: 'min' coordinate's x/y value must be smaller or equal to the 'max' x/y value"
-        );
+    fn assert_valid_bounds(&self) {
+        if !self.has_valid_bounds() {
+            panic!(RECT_INVALID_BOUNDS_ERROR);
+        }
+    }
+
+    fn has_valid_bounds(&self) -> bool {
+        self.min.x <= self.max.x && self.min.y <= self.max.y
     }
 }
+
+static RECT_INVALID_BOUNDS_ERROR: &str = "Failed to create Rect: 'min' coordinate's x/y value must be smaller or equal to the 'max' x/y value";
 
 #[cfg(test)]
 mod test {


### PR DESCRIPTION
`Rect::new` panics if the user supplies invalid rectangle coordinates. This pull request introduces `Rect::try_new` that returns an `Option<Rect>`.