### PR TITLE
speed up ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,12 @@ addons:
 
 matrix:
   include:
-    - env: GEO_TYPES_FEATURES="" GEO_FEATURES="" RUN_TARPAULIN=1
+    - env: GEO_FEATURES="" GEO_TYPES_FEATURES="" RUN_TARPAULIN=1
+    - env: GEO_FEATURES="--features use-proj"
+    - env: GEO_FEATURES="--features postgis-integration"
+    - env: GEO_FEATURES="--features use-serde"
     - env: GEO_TYPES_FEATURES="--features serde"
     - env: GEO_TYPES_FEATURES="--features rstar"
-    - env: GEO_FEATURES="--features postgis-integration"
-    - env: GEO_FEATURES="--features use-proj"
-    - env: GEO_FEATURES="--features use-serde"
 
 before_install:
   - if [ "${GEO_FEATURES}" == "--features use-proj" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,9 @@ addons:
 
 matrix:
   include:
-    - env: GEO_TYPES_FEATURES=""
+    - env: GEO_TYPES_FEATURES="" GEO_FEATURES="" RUN_TARPAULIN=1
     - env: GEO_TYPES_FEATURES="--features serde"
     - env: GEO_TYPES_FEATURES="--features rstar"
-    - env: GEO_FEATURES="" RUN_TARPAULIN=1
     - env: GEO_FEATURES="--features postgis-integration"
     - env: GEO_FEATURES="--features use-proj"
     - env: GEO_FEATURES="--features use-serde"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,17 +17,17 @@ matrix:
     - env: GEO_FEATURES="--features use-proj"
     - env: GEO_FEATURES="--features use-serde"
 
-before_cache:
-  - if [[ "${TRAVIS_RUST_VERSION}" == stable ]]; then
-        cargo install cargo-tarpaulin -f;
-    fi
-
 before_install:
   - if [ "${GEO_FEATURES}" == "--features use-proj" ]; then
         sudo apt-get update;
         wget https://github.com/OSGeo/PROJ/releases/download/7.0.0/proj-7.0.0.tar.gz;
         tar -xzvf proj-7.0.0.tar.gz;
         pushd proj-7.0.0 && ./configure --prefix=/usr && make && sudo make install && popd;
+    fi
+  - if [[ "${TRAVIS_RUST_VERSION}" == stable ]]; then
+      if [[ "${GEO_FEATURES}" == "" ]]; then
+        cargo install cargo-tarpaulin;
+      fi
     fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
     - env: GEO_TYPES_FEATURES=""
     - env: GEO_TYPES_FEATURES="--features serde"
     - env: GEO_TYPES_FEATURES="--features rstar"
-    - env: GEO_FEATURES=""
+    - env: GEO_FEATURES="" RUN_TARPAULIN=1
     - env: GEO_FEATURES="--features postgis-integration"
     - env: GEO_FEATURES="--features use-proj"
     - env: GEO_FEATURES="--features use-serde"
@@ -24,10 +24,8 @@ before_install:
         tar -xzvf proj-7.0.0.tar.gz;
         pushd proj-7.0.0 && ./configure --prefix=/usr && make && sudo make install && popd;
     fi
-  - if [[ "${TRAVIS_RUST_VERSION}" == stable ]]; then
-      if [[ "${GEO_FEATURES}" == "" ]]; then
-        cargo install cargo-tarpaulin;
-      fi
+  - if [[ "${TRAVIS_RUST_VERSION}" == stable && "${RUN_TARPAULIN}" ]]; then
+      cargo install cargo-tarpaulin;
     fi
 
 script:
@@ -35,8 +33,6 @@ script:
   - (cd geo && cargo build --release $GEO_FEATURES && cargo test --release $GEO_FEATURES)
 
 after_success:
-  - if [[ "${TRAVIS_RUST_VERSION}" == stable ]]; then
-      if [[ "${GEO_FEATURES}" == "" ]]; then
-        cargo tarpaulin --ciserver travis-ci --coveralls $TRAVIS_JOB_ID;
-      fi
+  - if [[ "${TRAVIS_RUST_VERSION}" == stable && "${RUN_TARPAULIN}" ]]; then
+      cargo tarpaulin --ciserver travis-ci --coveralls $TRAVIS_JOB_ID;
     fi


### PR DESCRIPTION
Several CI speedups in separate commits. Probably best to review the commits individually.

**Before**
<img width="1167" alt="Screen Shot 2020-05-09 at 6 15 26 PM" src="https://user-images.githubusercontent.com/217057/81488037-1610d780-9221-11ea-8d63-e3ebbf60b4da.png">

**After**

Overall things are much faster.

First run still builds tarpaulin, which takes an extra ~8m, but still at least only one job does it now, as opposed to before when all jobs did it.

<img width="1093" alt="Screen Shot 2020-05-09 at 6 10 33 PM" src="https://user-images.githubusercontent.com/217057/81487957-6b98b480-9220-11ea-9352-97a6422338ac.png">

Subsequent builds use the cached tarpaulin so we shave off that ~8min.

<img width="1169" alt="Screen Shot 2020-05-09 at 6 10 17 PM" src="https://user-images.githubusercontent.com/217057/81487956-69cef100-9220-11ea-9490-dfcef1bd6edc.png">

The next biggest thing in the CI build is the proj build. One quick fix might be to use the apt package, but I'm assuming we're doing it this way to peg to a specific version so we're not at the whim of ubuntu's proj packaging - is that right @urschrei? 

If I get the inspiration - maybe I'll try to knock out a script to cache the proj build based on version in a followup PR.