### PR TITLE
Remove COORD_PRECISION and replace usages with approx macros.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## Unreleased
+
+* geo-types: Remove COORD_PRECISION which was an arbitrary constant of 0.1m
+
 ## geo 0.13.0
 
 * Bump geo-types dependency to 0.5.0

--- a/geo-types/Cargo.toml
+++ b/geo-types/Cargo.toml
@@ -11,6 +11,7 @@ description = "Geospatial primitive data types"
 edition = "2018"
 
 [dependencies]
+approx = "0.3"
 num-traits = "0.2"
 serde = { version = "1", optional = true, features = ["derive"] }
 rstar = { version = "0.7", optional = true }

--- a/geo-types/src/lib.rs
+++ b/geo-types/src/lib.rs
@@ -7,6 +7,7 @@
 //! provides geospatial algorithms, while the [`geojson`](https://crates.io/crates/geojson) crate allows serialising
 //! and de-serialising `geo-types` primitives to GeoJSON.
 extern crate num_traits;
+use num_traits::{Num, NumCast};
 
 #[cfg(feature = "serde")]
 #[macro_use]
@@ -15,7 +16,8 @@ extern crate serde;
 #[cfg(feature = "rstar")]
 extern crate rstar;
 
-use num_traits::{Num, NumCast};
+#[macro_use]
+extern crate approx;
 
 /// The type of an x or y value of a point/coordinate.
 ///
@@ -66,10 +68,6 @@ mod macros;
 
 #[doc(hidden)]
 pub mod private_utils;
-
-#[cfg(test)]
-#[macro_use]
-extern crate approx;
 
 #[cfg(test)]
 mod tests {

--- a/geo-types/src/private_utils.rs
+++ b/geo-types/src/private_utils.rs
@@ -6,8 +6,6 @@
 use crate::{Coordinate, CoordinateType, Line, LineString, Point, Rect};
 use num_traits::Float;
 
-pub static COORD_PRECISION: f32 = 1e-1; // 0.1m
-
 pub fn line_string_bounding_rect<T>(line_string: &LineString<T>) -> Option<Rect<T>>
 where
     T: CoordinateType,
@@ -124,7 +122,8 @@ pub fn point_contains_point<T>(p1: Point<T>, p2: Point<T>) -> bool
 where
     T: Float,
 {
-    line_euclidean_length(Line::new(p1, p2)).to_f32().unwrap() < COORD_PRECISION
+    let distance = line_euclidean_length(Line::new(p1, p2)).to_f32().unwrap();
+    relative_eq!(distance, 0.0)
 }
 
 pub fn line_string_contains_point<T>(line_string: &LineString<T>, point: Point<T>) -> bool

--- a/geo/src/algorithm/centroid.rs
+++ b/geo/src/algorithm/centroid.rs
@@ -302,7 +302,7 @@ mod test {
     use crate::algorithm::euclidean_distance::EuclideanDistance;
     use crate::line_string;
     use crate::{
-        polygon, Coordinate, Line, LineString, MultiPolygon, Point, Polygon, Rect, COORD_PRECISION,
+        polygon, Coordinate, Line, LineString, MultiPolygon, Point, Polygon, Rect,
     };
     use num_traits::Float;
 
@@ -512,7 +512,7 @@ mod test {
             .centroid()
             .unwrap()
             .euclidean_distance(&p(4.07142857142857, 1.92857142857143));
-        assert!(dist < COORD_PRECISION);
+        assert_relative_eq!(dist, 0.0, epsilon = 1e-14); // the results is larger than f64::EPSILON
     }
     #[test]
     fn multipolygon_two_polygons_of_opposite_clockwise_test() {

--- a/geo/src/types.rs
+++ b/geo/src/types.rs
@@ -1,8 +1,6 @@
 use crate::{CoordinateType, Point};
 use num_traits::Float;
 
-pub use geo_types::private_utils::COORD_PRECISION;
-
 /// A container for _indices_ of the minimum and maximum `Point`s of a [`Geometry`](enum.Geometry.html).
 #[cfg_attr(feature = "use-serde", derive(Serialize, Deserialize))]
 #[derive(PartialEq, Clone, Copy, Debug)]


### PR DESCRIPTION
## Context

The `COORD_PRECISION` constant is an arbitrary value of questionable utility. Additional background is in PR https://github.com/georust/geo/pull/437

## Action

This pull requests removes `COORD_PRECISION` and instead `approx` crate macros are used for floating point comparisons.

Closes #392
