### PR TITLE
Extract PostGIS integration from 'geo' to a separate 'geo-postgis' crate.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ matrix:
   include:
     - env: GEO_FEATURES="" GEO_TYPES_FEATURES="" RUN_TARPAULIN=1
     - env: GEO_FEATURES="--features use-proj"
-    - env: GEO_FEATURES="--features postgis-integration"
     - env: GEO_FEATURES="--features use-serde"
     - env: GEO_TYPES_FEATURES="--features serde"
     - env: GEO_TYPES_FEATURES="--features rstar"
@@ -28,6 +27,7 @@ before_install:
     fi
 
 script:
+  - (cd geo-postgis && cargo build && cargo test)
   - (cd geo-types && cargo build --release $GEO_TYPES_FEATURES && cargo test --release $GEO_TYPES_FEATURES)
   - (cd geo && cargo build --release $GEO_FEATURES && cargo test --release $GEO_FEATURES)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["geo", "geo-types"]
+members = ["geo", "geo-types", "geo-postgis"]

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ The `geo` crate provides geospatial primitive types such as `Point`, `LineString
 - Simplification and convex hull operations
 - Euclidean and Haversine distance measurement
 - Intersection checks
-- Transformation to and from PostGIS types
 - Affine transforms such as rotation and translation.
 
 Please refer to [the documentation](https://docs.rs/geo) for a complete list.

--- a/geo-postgis/Cargo.toml
+++ b/geo-postgis/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "geo-postgis"
+version = "0.1.0"
+authors = ["Corey Farwell <coreyf@rwell.org>"]
+license = "MIT/Apache-2.0"
+repository = "https://github.com/georust/geo" # TODO: change this?
+documentation = "https://docs.rs/geo-postgis/"
+readme = "../README.md" # TODO
+keywords = ["gis", "geo", "geography", "geospatial"] # TODO
+description = "" # TODO
+edition = "2018"
+
+[dependencies]
+postgis = "0.7"
+# Swap the next two lines when publishing
+# geo-types = "0.5"
+geo-types = { path = "../geo-types" }

--- a/geo-postgis/Cargo.toml
+++ b/geo-postgis/Cargo.toml
@@ -3,11 +3,11 @@ name = "geo-postgis"
 version = "0.1.0"
 authors = ["Corey Farwell <coreyf@rwell.org>"]
 license = "MIT/Apache-2.0"
-repository = "https://github.com/georust/geo" # TODO: change this?
+repository = "https://github.com/georust/geo"
 documentation = "https://docs.rs/geo-postgis/"
 readme = "../README.md" # TODO
-keywords = ["gis", "geo", "geography", "geospatial"] # TODO
-description = "" # TODO
+keywords = ["gis", "geo", "geography", "geospatial", "postgis"]
+description = "Conversion between `geo-types` and `postgis` types."
 edition = "2018"
 
 [dependencies]

--- a/geo-postgis/src/from_postgis.rs
+++ b/geo-postgis/src/from_postgis.rs
@@ -1,4 +1,4 @@
-use crate::{
+use geo_types::{
     Geometry, GeometryCollection, LineString, MultiLineString, MultiPoint, MultiPolygon, Point,
     Polygon,
 };

--- a/geo-postgis/src/lib.rs
+++ b/geo-postgis/src/lib.rs
@@ -1,0 +1,42 @@
+//! Conversion between [`geo-types`] and [`postgis`] types.
+//!
+//! # Examples
+//!
+//! Convert a `postgis` point to a `geo-types` point:
+//!
+//! [`geo-types`]: https://crates.io/crates/geo-types
+//! [`postgis`]: https://crates.io/crates/postgis
+//!
+//! ```rust
+//! use geo_postgis::FromPostgis;
+//!
+//! let postgis_point = postgis::ewkb::Point { x: 1., y: -2., srid: None };
+//!
+//! let geo_point = geo_types::Point::from_postgis(&postgis_point);
+//!
+//! assert_eq!(
+//!     geo_types::point!(x: 1., y: -2.),
+//!     geo_point,
+//! );
+//! ```
+//!
+//! Convert a `geo-types` point to a `postgis` point:
+//!
+//! ```rust
+//! use geo_postgis::ToPostgis;
+//!
+//! let geo_point = geo_types::point!(x: 1., y: -2.);
+//!
+//! let postgis_point = geo_point.to_postgis_with_srid(None);
+//!
+//! assert_eq!(
+//!     postgis::ewkb::Point { x: 1., y: -2., srid: None },
+//!     postgis_point,
+//! );
+//! ```
+
+mod to_postgis;
+pub use to_postgis::ToPostgis;
+
+mod from_postgis;
+pub use from_postgis::FromPostgis;

--- a/geo-postgis/src/to_postgis.rs
+++ b/geo-postgis/src/to_postgis.rs
@@ -1,4 +1,4 @@
-use crate::{
+use geo_types::{
     Coordinate, Geometry, GeometryCollection, Line, LineString, MultiLineString, MultiPoint,
     MultiPolygon, Point, Polygon,
 };

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -20,7 +20,6 @@ serde = { version = "1.0", optional = true, features = ["derive"] }
 rstar = { version = "0.7" }
 geographiclib-rs = { version = "0.2" }
 
-postgis = { version = "0.7", optional = true }
 proj = { version = "0.16.2", optional = true }
 
 # Swap the next two lines when publishing
@@ -29,7 +28,6 @@ geo-types = { path = "../geo-types", features = ["rstar"] }
 
 [features]
 default = []
-postgis-integration = ["postgis"]
 use-proj = ["proj"]
 use-serde = ["serde", "geo-types/serde"]
 
@@ -76,6 +74,3 @@ harness = false
 [[bench]]
 name = "frechet_distance"
 harness = false
-
-[package.metadata.docs.rs]
-features = ["postgis"]

--- a/geo/src/algorithm/mod.rs
+++ b/geo/src/algorithm/mod.rs
@@ -22,9 +22,6 @@ pub mod euclidean_length;
 pub mod extremes;
 /// Calculate the Frechet distance between two `LineStrings`.
 pub mod frechet_distance;
-/// Produces a `Geometry` from PostGIS.
-#[cfg(feature = "postgis-integration")]
-pub mod from_postgis;
 /// Calculate the Geodesic distance between two `Point`s.
 pub mod geodesic_distance;
 /// Calculate the Geodesic length of a line.
@@ -54,9 +51,6 @@ pub mod rotate;
 pub mod simplify;
 /// Simplify `Geometries` using the Visvalingam-Whyatt algorithm. Includes a topology-preserving variant.
 pub mod simplifyvw;
-/// Convert a `Geometry` into a PostGIS.
-#[cfg(feature = "postgis-integration")]
-pub mod to_postgis;
 /// Translate a `Geometry` along the given offsets.
 pub mod translate;
 /// Calculate the Vincenty distance between two `Point`s.

--- a/geo/src/lib.rs
+++ b/geo/src/lib.rs
@@ -5,7 +5,6 @@
 //!   - Simplification and convex hull operations
 //!   - Distance measurement
 //!   - Intersection checks
-//!   - Transformation to and from PostGIS types
 //!   - Affine transforms such as rotation and translation.
 //!
 //! The primitive types also provide the basis for other functionality in the `Geo` ecosystem, including:
@@ -25,7 +24,6 @@
 //!
 //! ## Optional Features (these can be activated in your `cargo.toml`)
 //! The following optional features are available:
-//! - `from-postgis`: convert `Geometry` types to and from [`PostGIS`](https://docs.rs/postgis) types.
 //! - `use-proj`: enable coordinate conversion and transformation of `Point` geometries using the [`proj`](https://docs.rs/proj) crate
 //! - `use-serde`: enable serialisation of geometries using `serde`.
 //!
@@ -42,8 +40,6 @@ extern crate num_traits;
 #[cfg(feature = "use-serde")]
 #[macro_use]
 extern crate serde;
-#[cfg(feature = "postgis-integration")]
-extern crate postgis;
 #[cfg(feature = "use-proj")]
 extern crate proj;
 extern crate rstar;
@@ -96,8 +92,6 @@ pub mod prelude {
     pub use crate::algorithm::euclidean_length::EuclideanLength;
     pub use crate::algorithm::extremes::ExtremePoints;
     pub use crate::algorithm::frechet_distance::FrechetDistance;
-    #[cfg(feature = "postgis-integration")]
-    pub use crate::algorithm::from_postgis::FromPostgis;
     pub use crate::algorithm::geodesic_distance::GeodesicDistance;
     pub use crate::algorithm::geodesic_length::GeodesicLength;
     pub use crate::algorithm::haversine_destination::HaversineDestination;
@@ -112,8 +106,6 @@ pub mod prelude {
     pub use crate::algorithm::rotate::{Rotate, RotatePoint};
     pub use crate::algorithm::simplify::Simplify;
     pub use crate::algorithm::simplifyvw::SimplifyVW;
-    #[cfg(feature = "postgis-integration")]
-    pub use crate::algorithm::to_postgis::ToPostgis;
     pub use crate::algorithm::translate::Translate;
     pub use crate::algorithm::vincenty_distance::VincentyDistance;
     pub use crate::algorithm::vincenty_length::VincentyLength;


### PR DESCRIPTION
- Reduces `geo`'s full dependency tree quite a bit
- Our PostGIS compatibility feature in `geo` lived in `geo::algorithms`, but is it really an algorithm? It's really more just glue between `geo-types` and `postgis`
- We can move this out to a separate repo if we want

Thoughts?