### PR TITLE
Refactor rstar integration; move bounding box code back into geo crate

### DIFF
--- a/geo-types/src/coordinate.rs
+++ b/geo-types/src/coordinate.rs
@@ -116,3 +116,33 @@ where
             && T::ulps_eq(&self.y, &other.y, epsilon, max_ulps)
     }
 }
+
+#[cfg(feature = "rstar")]
+// These are required for rstar RTree
+impl<T> ::rstar::Point for Coordinate<T>
+where
+    T: ::num_traits::Float + ::rstar::RTreeNum,
+{
+    type Scalar = T;
+
+    const DIMENSIONS: usize = 2;
+
+    fn generate(generator: impl Fn(usize) -> Self::Scalar) -> Self {
+        Coordinate { x: generator(0), y: generator(1) }
+    }
+
+    fn nth(&self, index: usize) -> Self::Scalar {
+        match index {
+            0 => self.x,
+            1 => self.y,
+            _ => unreachable!(),
+        }
+    }
+    fn nth_mut(&mut self, index: usize) -> &mut Self::Scalar {
+        match index {
+            0 => &mut self.x,
+            1 => &mut self.y,
+            _ => unreachable!(),
+        }
+    }
+}

--- a/geo-types/src/lib.rs
+++ b/geo-types/src/lib.rs
@@ -152,12 +152,12 @@ mod tests {
         use rstar::primitives::Line as RStarLine;
         use rstar::{PointDistance, RTreeObject};
 
-        let rl = RStarLine::new(Point::new(0.0, 0.0), Point::new(5.0, 5.0));
+        let rl = RStarLine::new(Coordinate { x: 0.0, y: 0.0 }, Coordinate { x: 5.0, y: 5.0 });
         let l = Line::new(Coordinate { x: 0.0, y: 0.0 }, Coordinate { x: 5., y: 5. });
         assert_eq!(rl.envelope(), l.envelope());
         // difference in 15th decimal place
-        assert_relative_eq!(26.0, rl.distance_2(&Point::new(4.0, 10.0)));
-        assert_relative_eq!(25.999999999999996, l.distance_2(&Point::new(4.0, 10.0)));
+        assert_relative_eq!(26.0, rl.distance_2(&Coordinate { x: 4.0, y: 10.0 }));
+        assert_relative_eq!(25.999999999999996, l.distance_2(&Coordinate { x: 4.0, y: 10.0 }));
     }
 
     #[test]

--- a/geo-types/src/line.rs
+++ b/geo-types/src/line.rs
@@ -159,11 +159,11 @@ impl<T> ::rstar::RTreeObject for Line<T>
 where
     T: ::num_traits::Float + ::rstar::RTreeNum,
 {
-    type Envelope = ::rstar::AABB<Point<T>>;
+    type Envelope = ::rstar::AABB<Coordinate<T>>;
 
     fn envelope(&self) -> Self::Envelope {
-        let bounding_rect = crate::private_utils::line_bounding_rect(*self);
-        ::rstar::AABB::from_corners(bounding_rect.min().into(), bounding_rect.max().into())
+        let iter = std::iter::once(&self.start).chain(std::iter::once(&self.end));
+        ::rstar::AABB::from_points(iter)
     }
 }
 
@@ -172,8 +172,8 @@ impl<T> ::rstar::PointDistance for Line<T>
 where
     T: ::num_traits::Float + ::rstar::RTreeNum,
 {
-    fn distance_2(&self, point: &Point<T>) -> T {
-        let d = crate::private_utils::point_line_euclidean_distance(*point, *self);
+    fn distance_2(&self, coord: &Coordinate<T>) -> T {
+        let d = crate::private_utils::point_line_euclidean_distance(Point(*coord), *self);
         d.powi(2)
     }
 }

--- a/geo-types/src/line_string.rs
+++ b/geo-types/src/line_string.rs
@@ -236,21 +236,10 @@ impl<T> ::rstar::RTreeObject for LineString<T>
 where
     T: ::num_traits::Float + ::rstar::RTreeNum,
 {
-    type Envelope = ::rstar::AABB<Point<T>>;
+    type Envelope = ::rstar::AABB<Coordinate<T>>;
 
     fn envelope(&self) -> Self::Envelope {
-        use num_traits::Bounded;
-        let bounding_rect = crate::private_utils::line_string_bounding_rect(self);
-        match bounding_rect {
-            None => ::rstar::AABB::from_corners(
-                Point::new(Bounded::min_value(), Bounded::min_value()),
-                Point::new(Bounded::max_value(), Bounded::max_value()),
-            ),
-            Some(b) => ::rstar::AABB::from_corners(
-                Point::new(b.min().x, b.min().y),
-                Point::new(b.max().x, b.max().y),
-            ),
-        }
+        ::rstar::AABB::from_points(self.0.iter())
     }
 }
 
@@ -259,8 +248,8 @@ impl<T> ::rstar::PointDistance for LineString<T>
 where
     T: ::num_traits::Float + ::rstar::RTreeNum,
 {
-    fn distance_2(&self, point: &Point<T>) -> T {
-        let d = crate::private_utils::point_line_string_euclidean_distance(*point, self);
+    fn distance_2(&self, coord: &Coordinate<T>) -> T {
+        let d = crate::private_utils::point_line_string_euclidean_distance(Point(*coord), self);
         if d == T::zero() {
             d
         } else {

--- a/geo-types/src/point.rs
+++ b/geo-types/src/point.rs
@@ -356,33 +356,3 @@ where
         Point::new(self.x() - rhs.x(), self.y() - rhs.y())
     }
 }
-
-#[cfg(feature = "rstar")]
-// These are required for rstar RTree
-impl<T> ::rstar::Point for Point<T>
-where
-    T: ::num_traits::Float + ::rstar::RTreeNum,
-{
-    type Scalar = T;
-
-    const DIMENSIONS: usize = 2;
-
-    fn generate(generator: impl Fn(usize) -> Self::Scalar) -> Self {
-        Point::new(generator(0), generator(1))
-    }
-
-    fn nth(&self, index: usize) -> Self::Scalar {
-        match index {
-            0 => self.0.x,
-            1 => self.0.y,
-            _ => unreachable!(),
-        }
-    }
-    fn nth_mut(&mut self, index: usize) -> &mut Self::Scalar {
-        match index {
-            0 => &mut self.0.x,
-            1 => &mut self.0.y,
-            _ => unreachable!(),
-        }
-    }
-}

--- a/geo-types/src/private_utils.rs
+++ b/geo-types/src/private_utils.rs
@@ -3,72 +3,8 @@
 // hidden module is public so the geo crate can reuse these algorithms to
 // prevent duplication. These functions are _not_ meant for public consumption.
 
-use crate::{Coordinate, CoordinateType, Line, LineString, Point, Rect};
+use crate::{Line, LineString, Point};
 use num_traits::Float;
-
-pub fn line_string_bounding_rect<T>(line_string: &LineString<T>) -> Option<Rect<T>>
-where
-    T: CoordinateType,
-{
-    get_bounding_rect(line_string.0.iter().cloned())
-}
-
-pub fn line_bounding_rect<T>(line: Line<T>) -> Rect<T>
-where
-    T: CoordinateType,
-{
-    let a = line.start;
-    let b = line.end;
-    let (xmin, xmax) = if a.x <= b.x { (a.x, b.x) } else { (b.x, a.x) };
-    let (ymin, ymax) = if a.y <= b.y { (a.y, b.y) } else { (b.y, a.y) };
-
-    Rect::new(
-        Coordinate { x: xmin, y: ymin },
-        Coordinate { x: xmax, y: ymax },
-    )
-}
-
-pub fn get_bounding_rect<I, T>(collection: I) -> Option<Rect<T>>
-where
-    T: CoordinateType,
-    I: IntoIterator<Item = Coordinate<T>>,
-{
-    let mut iter = collection.into_iter();
-    if let Some(pnt) = iter.next() {
-        let mut xrange = (pnt.x, pnt.x);
-        let mut yrange = (pnt.y, pnt.y);
-        for pnt in iter {
-            let (px, py) = pnt.x_y();
-            xrange = get_min_max(px, xrange.0, xrange.1);
-            yrange = get_min_max(py, yrange.0, yrange.1);
-        }
-
-        return Some(Rect::new(
-            Coordinate {
-                x: xrange.0,
-                y: yrange.0,
-            },
-            Coordinate {
-                x: xrange.1,
-                y: yrange.1,
-            },
-        ));
-    }
-    None
-}
-
-fn get_min_max<T>(p: T, min: T, max: T) -> (T, T)
-where
-    T: CoordinateType,
-{
-    if p > max {
-        (min, p)
-    } else if p < min {
-        (p, max)
-    } else {
-        (min, max)
-    }
-}
 
 pub fn line_segment_distance<T>(point: Point<T>, start: Point<T>, end: Point<T>) -> T
 where

--- a/geo/src/algorithm/centroid.rs
+++ b/geo/src/algorithm/centroid.rs
@@ -301,9 +301,7 @@ mod test {
     use crate::algorithm::centroid::Centroid;
     use crate::algorithm::euclidean_distance::EuclideanDistance;
     use crate::line_string;
-    use crate::{
-        polygon, Coordinate, Line, LineString, MultiPolygon, Point, Polygon, Rect,
-    };
+    use crate::{polygon, Coordinate, Line, LineString, MultiPolygon, Point, Polygon, Rect};
     use num_traits::Float;
 
     /// small helper to create a coordinate

--- a/geo/src/algorithm/simplifyvw.rs
+++ b/geo/src/algorithm/simplifyvw.rs
@@ -407,8 +407,8 @@ where
         orig[triangle.right],
     )
     .bounding_rect();
-    let br = Point::new(bounding_rect.min().x, bounding_rect.min().y);
-    let tl = Point::new(bounding_rect.max().x, bounding_rect.max().y);
+    let br = Coordinate { x: bounding_rect.min().x, y: bounding_rect.min().y };
+    let tl = Coordinate { x: bounding_rect.max().x, y: bounding_rect.max().y };
     tree.locate_in_envelope_intersecting(&rstar::AABB::from_corners(br, tl))
         .any(|c| {
             // triangle start point, end point


### PR DESCRIPTION
- Changes `impl<T> rstar::Point for Point<T>` to `impl<T> rstar::Point for Coordinate<T>`
- Updates the `rstar::RTreeObject` implementations to build an `rstar::AABB` using `rstar::AABB::from_points` instead of relying on our own bounding box implementation
- Move bounding box functions out of the shared `private_utils.rs` back into `bounding_rect.rs`

Though, after running benchmarks, this results in `simplify vwp f32` and `simplify vwp f64` becoming 20% slower, and I don't know why. So going to hold off on merging until that's resolved.