### PR TITLE
Fix contains impl of triangle for collinear points

### DIFF
--- a/geo/src/utils.rs
+++ b/geo/src/utils.rs
@@ -127,19 +127,6 @@ where
     }
 }
 
-pub fn sign<T>(
-    point_1: &crate::Coordinate<T>,
-    point_2: &crate::Coordinate<T>,
-    point_3: &crate::Coordinate<T>,
-) -> bool
-where
-    T: crate::CoordinateType,
-{
-    (point_1.x - point_3.x) * (point_2.y - point_3.y)
-        - (point_2.x - point_3.x) * (point_1.y - point_3.y)
-        < T::zero()
-}
-
 #[cfg(test)]
 mod test {
     use super::{partial_max, partial_min};


### PR DESCRIPTION
A fix for #473. It replaces the `Contains` implementation for `Triangle` with the method described [here](https://stackoverflow.com/a/2049712/3751841) and [here](https://stackoverflow.com/a/20861130/3751841).