### PR TITLE
Change closure for exterior_mut() and interiors_mut() to be FnOnce.

### DIFF
--- a/geo-types/src/polygon.rs
+++ b/geo-types/src/polygon.rs
@@ -209,9 +209,9 @@ where
     /// ```
     ///
     /// [will be closed]: #linestring-closing-operation
-    pub fn exterior_mut<F>(&mut self, mut f: F)
+    pub fn exterior_mut<F>(&mut self, f: F)
     where
-        F: FnMut(&mut LineString<T>),
+        F: FnOnce(&mut LineString<T>),
     {
         f(&mut self.exterior);
         self.exterior.close();
@@ -311,9 +311,9 @@ where
     /// ```
     ///
     /// [will be closed]: #linestring-closing-operation
-    pub fn interiors_mut<F>(&mut self, mut f: F)
+    pub fn interiors_mut<F>(&mut self, f: F)
     where
-        F: FnMut(&mut [LineString<T>]),
+        F: FnOnce(&mut [LineString<T>]),
     {
         f(&mut self.interiors);
         for interior in &mut self.interiors {


### PR DESCRIPTION
The current form of `exteriors_mut` accepts a closure of FnMut. This causes this case not to compile:

```
fn update_exterior(poly: &mut Polygon<i64>) {
  let new_exterior = get_some_linestring();
  poly.exterior_mut(|exterior| *exterior = new_exterior);
}
```

While this does:

```
fn update_exterior(poly: &mut Polygon<i64>) {
  let new_exterior = get_some_linestring();
  poly.exterior_mut(|exterior| *exterior = new_exterior.clone());
}
```

FnMut is to allow a closure to have a mutable state, so that it can be called multiple times, modifying that state. The closure is only called once, and the part that is mutable is the parameter to it, so it doesn't need to be an FnMut. FnOnce is a superset of FnMut, so changing the trait bound to be FnOnce should have no affect on existing use cases, while enabling new ones.
