### PR TITLE
addendum to #490: fixup tests 

### DIFF
--- a/geo/src/algorithm/area.rs
+++ b/geo/src/algorithm/area.rs
@@ -102,11 +102,9 @@ where
         // result in computing the shoelace formula twice.
         let is_negative = area < T::zero();
 
-        let area = self.interiors()
-            .iter()
-            .fold(area.abs(), |total, next| {
-                total - get_linestring_area(next).abs()
-            });
+        let area = self.interiors().iter().fold(area.abs(), |total, next| {
+            total - get_linestring_area(next).abs()
+        });
 
         if is_negative {
             -area
@@ -289,13 +287,14 @@ mod test {
             const ANGLE_INC: f64 = 2. * PI / NUM_VERTICES as f64;
 
             Polygon::new(
-                (0..NUM_VERTICES).map(|i| {
-                    let angle = i as f64 * ANGLE_INC;
-                    Coordinate {
-                        x: angle.cos(),
-                        y: angle.sin(),
-                    }
-                })
+                (0..NUM_VERTICES)
+                    .map(|i| {
+                        let angle = i as f64 * ANGLE_INC;
+                        Coordinate {
+                            x: angle.cos(),
+                            y: angle.sin(),
+                        }
+                    })
                     .collect::<Vec<_>>()
                     .into(),
                 vec![],
@@ -308,9 +307,7 @@ mod test {
         let shift_y = 1.5e8;
 
         use crate::map_coords::MapCoords;
-        let polygon = polygon.map_coords(
-            |&(x, y)| (x + shift_x, y + shift_y)
-        );
+        let polygon = polygon.map_coords(|&(x, y)| (x + shift_x, y + shift_y));
 
         let new_area = polygon.signed_area();
         let err = (area - new_area).abs() / area;

--- a/geo/src/algorithm/map_coords.rs
+++ b/geo/src/algorithm/map_coords.rs
@@ -915,10 +915,7 @@ mod test {
 
     #[test]
     fn rect_map_invert_coords() {
-        let rect = Rect::new(
-            Coordinate{x: 0., y: 0.},
-            Coordinate{x: 1., y: 1.}
-        );
+        let rect = Rect::new(Coordinate { x: 0., y: 0. }, Coordinate { x: 1., y: 1. });
 
         // This call should not panic even though Rect::new
         // constructor panics if min coords > max coords

--- a/geo/src/algorithm/map_coords.rs
+++ b/geo/src/algorithm/map_coords.rs
@@ -645,16 +645,22 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
-    fn rect_inplace_panic() {
-        let mut rect = Rect::new((10, 10), (20, 20));
-        rect.map_coords_inplace(|&(x, y)| {
-            if x < 15 && y < 15 {
-                (x, y)
-            } else {
-                (x - 15, y - 15)
+    fn rect_inplace_normalized() {
+        let mut rect = Rect::new((2, 2), (3, 3));
+        // Rect's enforce that rect.min is up and left of p2.  Here we test that the points are
+        // normalized into a valid rect, regardless of the order they are mapped.
+        rect.map_coords_inplace(|&pt| {
+            match pt {
+                // old min point maps to new max point
+                (2, 2) => (4, 4),
+                // old max point maps to new min point
+                (3, 3) => (1, 1),
+                _ => panic!("unexpected point"),
             }
         });
+
+        assert_eq!(rect.min(), Coordinate { x: 1, y: 1 });
+        assert_eq!(rect.max(), Coordinate { x: 4, y: 4 });
     }
 
     #[test]
@@ -673,16 +679,23 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
-    fn rect_try_map_coords_panic() {
-        let rect = Rect::new((10, 10), (20, 20));
-        let _ = rect.try_map_coords(|&(x, y)| {
-            if x < 15 && y < 15 {
-                Ok((x, y))
-            } else {
-                Ok((x - 15, y - 15))
-            }
-        });
+    fn rect_try_map_coords_normalized() {
+        let rect = Rect::new((2, 2), (3, 3));
+        // Rect's enforce that rect.min is up and left of p2.  Here we test that the points are
+        // normalized into a valid rect, regardless of the order they are mapped.
+        let new_rect = rect
+            .try_map_coords(|&pt| {
+                match pt {
+                    // old min point maps to new max point
+                    (2, 2) => Ok((4, 4)),
+                    // old max point maps to new min point
+                    (3, 3) => Ok((1, 1)),
+                    _ => panic!("unexpected point"),
+                }
+            })
+            .unwrap();
+        assert_eq!(new_rect.min(), Coordinate { x: 1, y: 1 });
+        assert_eq!(new_rect.max(), Coordinate { x: 4, y: 4 });
     }
 
     #[test]

--- a/geo/src/algorithm/winding_order.rs
+++ b/geo/src/algorithm/winding_order.rs
@@ -40,9 +40,7 @@ where
     let mut tmp = T::zero();
     for line in linestring.lines() {
         use crate::algorithm::map_coords::MapCoords;
-        let line = line.map_coords(|&(x, y)| {
-            (x - shift.x, y - shift.y)
-        });
+        let line = line.map_coords(|&(x, y)| (x - shift.x, y - shift.y));
         tmp = tmp + line.determinant();
     }
 
@@ -201,7 +199,9 @@ mod test {
         let ccw_line = LineString::from(vec![a.0, b.0, c.0, a.0]);
 
         // Verify open linestrings return None
-        assert!(LineString::from(vec![a.0, b.0, c.0]).winding_order().is_none());
+        assert!(LineString::from(vec![a.0, b.0, c.0])
+            .winding_order()
+            .is_none());
 
         assert_eq!(cw_line.winding_order(), Some(WindingOrder::Clockwise));
         assert_eq!(cw_line.is_cw(), true);


### PR DESCRIPTION
Rect's, which are defined by two points, maintain the invariant that `min` is up and left of `max`, else we panic.

#490, as I understand it, makes the point that there is no reason to assume that mapping the min point (e.g. via `map_coords`) will output a point which is still the min, so normalizes the output to produce a valid rect.

However, there were two tests explicitly checking for the old failing behavior. This updates those tests.