### PR TITLE
Fix Haversine formulas yet again

### DIFF
--- a/geo/src/algorithm/haversine_destination.rs
+++ b/geo/src/algorithm/haversine_destination.rs
@@ -2,7 +2,9 @@ use crate::{Point, MEAN_EARTH_RADIUS};
 use num_traits::{Float, FromPrimitive};
 
 /// Returns a new Point using the distance to the existing Point and a bearing for the direction
-
+///
+/// *Note*: this implementation uses a mean earth radius of 6371.088 km, based on the [recommendation of
+/// the IUGG](ftp://athena.fsv.cvut.cz/ZFG/grs80-Moritz.pdf)
 pub trait HaversineDestination<T: Float> {
     /// Returns a new Point using distance to the existing Point and a bearing for the direction
     ///
@@ -19,7 +21,7 @@ pub trait HaversineDestination<T: Float> {
     ///
     /// let p_1 = Point::<f64>::new(9.177789688110352, 48.776781529534965);
     /// let p_2 = p_1.haversine_destination(45., 10000.);
-    /// assert_eq!(p_2, Point::<f64>::new(9.274410083250379, 48.84033282787534))
+    /// assert_eq!(p_2, Point::<f64>::new(9.274409949623548, 48.84033274015048))
     /// ```
     fn haversine_destination(&self, bearing: T, distance: T) -> Point<T>;
 }
@@ -56,7 +58,7 @@ mod test {
     fn returns_a_new_point() {
         let p_1 = Point::<f64>::new(9.177789688110352, 48.776781529534965);
         let p_2 = p_1.haversine_destination(45., 10000.);
-        assert_eq!(p_2, Point::<f64>::new(9.274410083250379, 48.84033282787534));
+        assert_eq!(p_2, Point::<f64>::new(9.274409949623548, 48.84033274015048));
         let distance = p_1.haversine_distance(&p_2);
         assert_relative_eq!(distance, 10000., epsilon = 1.0e-6)
     }

--- a/geo/src/algorithm/haversine_distance.rs
+++ b/geo/src/algorithm/haversine_distance.rs
@@ -4,6 +4,9 @@ use num_traits::{Float, FromPrimitive};
 /// Determine the distance between two geometries using the [haversine formula].
 ///
 /// [haversine formula]: https://en.wikipedia.org/wiki/Haversine_formula
+///
+/// *Note*: this implementation uses a mean earth radius of 6371.088 km, based on the [recommendation of
+/// the IUGG](ftp://athena.fsv.cvut.cz/ZFG/grs80-Moritz.pdf)
 pub trait HaversineDistance<T, Rhs = Self> {
     /// Determine the distance between two geometries using the [haversine
     /// formula].
@@ -27,7 +30,7 @@ pub trait HaversineDistance<T, Rhs = Self> {
     /// let distance = p1.haversine_distance(&p2);
     ///
     /// assert_eq!(
-    ///     5_570_222., // meters
+    ///     5_570_230., // meters
     ///     distance.round()
     /// );
     /// ```
@@ -64,7 +67,7 @@ mod test {
         let b = Point::<f64>::new(1., 0.);
         assert_relative_eq!(
             a.haversine_distance(&b),
-            111194.92664455874_f64,
+            111195.0802335329_f64,
             epsilon = 1.0e-6
         );
     }
@@ -75,7 +78,7 @@ mod test {
         let b = Point::new(72.1260, 70.612);
         assert_relative_eq!(
             a.haversine_distance(&b),
-            7130570.458772508_f64,
+            7130580.307935911_f64,
             epsilon = 1.0e-6
         );
     }
@@ -87,7 +90,7 @@ mod test {
         let b = Point::<f64>::new(-77.009080, 38.889825);
         assert_relative_eq!(
             a.haversine_distance(&b),
-            2526.820014113592_f64,
+            2526.823504306046_f64,
             epsilon = 1.0e-6
         );
     }
@@ -97,6 +100,6 @@ mod test {
         // this input comes from issue #100
         let a = Point::<f32>::new(-77.036585, 38.897448);
         let b = Point::<f32>::new(-77.009080, 38.889825);
-        assert_relative_eq!(a.haversine_distance(&b), 2526.8318_f32, epsilon = 1.0e-6);
+        assert_relative_eq!(a.haversine_distance(&b), 2526.8354_f32, epsilon = 1.0e-6);
     }
 }

--- a/geo/src/algorithm/haversine_length.rs
+++ b/geo/src/algorithm/haversine_length.rs
@@ -6,6 +6,9 @@ use crate::{Line, LineString, MultiLineString};
 /// Determine the length of a geometry using the [haversine formula].
 ///
 /// [haversine formula]: https://en.wikipedia.org/wiki/Haversine_formula
+///
+/// *Note*: this implementation uses a mean earth radius of 6371.088 km, based on the [recommendation of
+/// the IUGG](ftp://athena.fsv.cvut.cz/ZFG/grs80-Moritz.pdf)
 pub trait HaversineLength<T, RHS = Self> {
     /// Determine the length of a geometry using the [haversine formula].
     ///
@@ -29,7 +32,7 @@ pub trait HaversineLength<T, RHS = Self> {
     /// let length = linestring.haversine_length();
     ///
     /// assert_eq!(
-    ///     5_570_222., // meters
+    ///     5_570_230., // meters
     ///     length.round()
     /// );
     /// ```

--- a/geo/src/lib.rs
+++ b/geo/src/lib.rs
@@ -65,7 +65,7 @@ mod utils;
 extern crate approx;
 
 // Mean radius of Earth in meters
-const MEAN_EARTH_RADIUS: f64 = 6_371_000.0;
+const MEAN_EARTH_RADIUS: f64 = 6371008.8;
 
 // Radius of Earth at the equator in meters (derived from the WGS-84 ellipsoid)
 const EQUATORIAL_EARTH_RADIUS: f64 = 6_378_137.0;

--- a/geo/src/lib.rs
+++ b/geo/src/lib.rs
@@ -64,7 +64,13 @@ mod utils;
 #[macro_use]
 extern crate approx;
 
-// Mean radius of Earth in meters
+/// Mean radius of Earth in meters
+/// This is the value recommended by the IUGG:
+/// Moritz, H. (2000). Geodetic Reference System 1980. Journal of Geodesy, 74(1), 128–133. doi:10.1007/s001900050278 
+/// "Derived Geometric Constants: mean radius" (p133)
+/// https://link.springer.com/article/10.1007%2Fs001900050278
+/// https://sci-hub.se/https://doi.org/10.1007/s001900050278
+/// https://en.wikipedia.org/wiki/Earth_radius#Mean_radius
 const MEAN_EARTH_RADIUS: f64 = 6371008.8;
 
 // Radius of Earth at the equator in meters (derived from the WGS-84 ellipsoid)


### PR DESCRIPTION
We were slightly off with our mean earth radius constant.
The IUGG defines it as 6,371.0088 km (https://doi.org/10.1007%2Fs001900050278)