### PR TITLE
Switch to the Robust crate for predicate checks

### DIFF
--- a/geo-types/Cargo.toml
+++ b/geo-types/Cargo.toml
@@ -15,6 +15,7 @@ approx = "0.3"
 num-traits = "0.2"
 serde = { version = "1", optional = true, features = ["derive"] }
 rstar = { version = "0.8", optional = true }
+robust = "0.2.2"
 
 [dev-dependencies]
 approx = "0.3"

--- a/geo-types/src/point.rs
+++ b/geo-types/src/point.rs
@@ -1,6 +1,6 @@
 use crate::{Coordinate, CoordinateType};
-use num_traits::NumCast;
 use num_traits::Float;
+use num_traits::NumCast;
 use robust::{orient2d, Coord};
 use std::ops::Add;
 use std::ops::Neg;
@@ -244,6 +244,20 @@ where
     /// assert_eq!(cross, 2.0)
     /// ```
     pub fn cross_prod(self, point_b: Point<T>, point_c: Point<T>) -> T {
+        (point_b.x() - self.x()) * (point_c.y() - self.y())
+            - (point_b.y() - self.y()) * (point_c.x() - self.x())
+    }
+}
+
+impl<T> Point<T>
+where
+    T: Float,
+{
+    /// Returns a positive value if the coordinates `pa`, `pb`, and `pc` occur in counterclockwise order
+    /// (pc lies to the **left** of the directed line defined by coordinates pa and pb).  
+    /// Returns a negative value if they occur in clockwise order (`pc` lies to the **right** of the directed line `pa, pb`).  
+    /// Returns `0` if they are **collinear**.  
+    pub fn orient2d(self, point_b: Point<T>, point_c: Point<T>) -> T {
         let pa: Coord<f64> = Coord {
             x: NumCast::from(self.x()).unwrap(),
             y: NumCast::from(self.y()).unwrap(),

--- a/geo-types/src/point.rs
+++ b/geo-types/src/point.rs
@@ -1,5 +1,7 @@
 use crate::{Coordinate, CoordinateType};
+use num_traits::NumCast;
 use num_traits::Float;
+use robust::{orient2d, Coord};
 use std::ops::Add;
 use std::ops::Neg;
 use std::ops::Sub;
@@ -242,8 +244,19 @@ where
     /// assert_eq!(cross, 2.0)
     /// ```
     pub fn cross_prod(self, point_b: Point<T>, point_c: Point<T>) -> T {
-        (point_b.x() - self.x()) * (point_c.y() - self.y())
-            - (point_b.y() - self.y()) * (point_c.x() - self.x())
+        let pa: Coord<f64> = Coord {
+            x: NumCast::from(self.x()).unwrap(),
+            y: NumCast::from(self.y()).unwrap(),
+        };
+        let pb: Coord<f64> = Coord {
+            x: NumCast::from(point_b.x()).unwrap(),
+            y: NumCast::from(point_b.y()).unwrap(),
+        };
+        let pc: Coord<f64> = Coord {
+            x: NumCast::from(point_c.x()).unwrap(),
+            y: NumCast::from(point_c.y()).unwrap(),
+        };
+        T::from(orient2d(pa, pb, pc)).unwrap()
     }
 }
 


### PR DESCRIPTION
We're currently always up-converting to `f64`, but I couldn't see a clean way of making `CoordinateType` and `Into<f64>` interact, so any feedback is welcome.