### PR TITLE
Robust ExtremePoint trait

### DIFF
--- a/geo-types/src/coordinate.rs
+++ b/geo-types/src/coordinate.rs
@@ -76,17 +76,9 @@ where
     pub fn x_y(&self) -> (T, T) {
         (self.x, self.y)
     }
-
-    /// Scale the coordinates by a scalar value.
-    pub fn scale_by(&self, scale: T) -> Self {
-        Coordinate {
-            x: scale * self.x,
-            y: scale * self.y,
-        }
-    }
 }
 
-use std::ops::{Add, Neg, Sub};
+use std::ops::{Add, Neg, Sub, Mul, Div};
 impl<T> Neg for Coordinate<T>
 where
     T: CoordinateType + Neg<Output = T>,
@@ -158,6 +150,54 @@ where
     /// ```
     fn sub(self, rhs: Coordinate<T>) -> Coordinate<T> {
         (self.x - rhs.x, self.y - rhs.y).into()
+    }
+}
+
+impl<T> Mul<T> for Coordinate<T>
+where
+    T: CoordinateType,
+{
+    type Output = Coordinate<T>;
+
+    /// Add a point to the given point.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use geo_types::Coordinate;
+    ///
+    /// let p: Coordinate<_> = (1.25, 2.5).into();
+    /// let q: Coordinate<_> = p * 4.;
+    ///
+    /// assert_eq!(q.x, 5.0);
+    /// assert_eq!(q.y, 10.0);
+    /// ```
+    fn mul(self, rhs: T) -> Coordinate<T> {
+        (self.x * rhs, self.y * rhs).into()
+    }
+}
+
+impl<T> Div<T> for Coordinate<T>
+where
+    T: CoordinateType,
+{
+    type Output = Coordinate<T>;
+
+    /// Add a point to the given point.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use geo_types::Coordinate;
+    ///
+    /// let p: Coordinate<_> = (5., 10.).into();
+    /// let q: Coordinate<_> = p / 4.;
+    ///
+    /// assert_eq!(q.x, 1.25);
+    /// assert_eq!(q.y, 2.5);
+    /// ```
+    fn div(self, rhs: T) -> Coordinate<T> {
+        (self.x / rhs, self.y / rhs).into()
     }
 }
 

--- a/geo-types/src/coordinate.rs
+++ b/geo-types/src/coordinate.rs
@@ -10,10 +10,9 @@ use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 /// information), a `Coordinate` only contains ordinate values and accessor
 /// methods.
 ///
-/// This type obeys the typical [vector space] structure:
-/// implements the [`Add`], [`Sub`], [`Neg`], [`Zero`]
-/// traits and allows [`scaling`][`Coordinate::scale_by`] by
-/// a scalar.
+/// This type implements the [vector space] operations:
+/// [`Add`], [`Sub`], [`Neg`], [`Zero`],
+/// [`Mul<T>`][`Mul`], and [`Div<T>`][`Div`] traits.
 ///
 /// [vector space]: //en.wikipedia.org/wiki/Vector_space
 #[derive(Eq, PartialEq, Clone, Copy, Debug, Hash)]
@@ -79,129 +78,143 @@ where
 }
 
 use std::ops::{Add, Neg, Sub, Mul, Div};
+
+/// Negate a coordinate.
+///
+/// # Examples
+///
+/// ```
+/// use geo_types::Coordinate;
+///
+/// let p: Coordinate<_> = (1.25, 2.5).into();
+/// let q = -p;
+///
+/// assert_eq!(q.x, -p.x);
+/// assert_eq!(q.y, -p.y);
+/// ```
 impl<T> Neg for Coordinate<T>
 where
     T: CoordinateType + Neg<Output = T>,
 {
     type Output = Coordinate<T>;
 
-    /// Returns a coordinate with the x and y components negated.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use geo_types::Coordinate;
-    ///
-    /// let p: Coordinate<_> = (-1.25, 2.5).into();
-    /// let p = -p;
-    ///
-    /// assert_eq!(p.x, 1.25);
-    /// assert_eq!(p.y, -2.5);
-    /// ```
     fn neg(self) -> Coordinate<T> {
         (-self.x, -self.y).into()
     }
 }
 
+/// Add two coordinates.
+///
+/// # Examples
+///
+/// ```
+/// use geo_types::Coordinate;
+///
+/// let p: Coordinate<_> = (1.25, 2.5).into();
+/// let q: Coordinate<_> = (1.5, 2.5).into();
+/// let sum = p + q;
+///
+/// assert_eq!(sum.x, 2.75);
+/// assert_eq!(sum.y, 5.0);
+/// ```
 impl<T> Add for Coordinate<T>
 where
     T: CoordinateType,
 {
     type Output = Coordinate<T>;
 
-    /// Add a point to the given point.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use geo_types::Coordinate;
-    ///
-    /// let p: Coordinate<_> = (1.25, 2.5).into();
-    /// let q: Coordinate<_> = (1.5, 2.5).into();
-    /// let sum = p + q;
-    ///
-    /// assert_eq!(sum.x, 2.75);
-    /// assert_eq!(sum.y, 5.0);
-    /// ```
     fn add(self, rhs: Coordinate<T>) -> Coordinate<T> {
         (self.x + rhs.x, self.y + rhs.y).into()
     }
 }
 
+/// Subtract a coordinate from another.
+///
+/// # Examples
+///
+/// ```
+/// use geo_types::Coordinate;
+///
+/// let p: Coordinate<_> = (1.5, 2.5).into();
+/// let q: Coordinate<_> = (1.25, 2.5).into();
+/// let diff = p - q;
+///
+/// assert_eq!(diff.x, 0.25);
+/// assert_eq!(diff.y, 0.);
+/// ```
 impl<T> Sub for Coordinate<T>
 where
     T: CoordinateType,
 {
     type Output = Coordinate<T>;
 
-    /// Subtract a point from the given point.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use geo_types::Coordinate;
-    ///
-    /// let p: Coordinate<_> = (1.5, 2.5).into();
-    /// let q: Coordinate<_> = (1.25, 2.5).into();
-    /// let diff = p - q;
-    ///
-    /// assert_eq!(diff.x, 0.25);
-    /// assert_eq!(diff.y, 0.);
-    /// ```
     fn sub(self, rhs: Coordinate<T>) -> Coordinate<T> {
         (self.x - rhs.x, self.y - rhs.y).into()
     }
 }
 
+/// Multiply coordinate wise by a scalar.
+///
+/// # Examples
+///
+/// ```
+/// use geo_types::Coordinate;
+///
+/// let p: Coordinate<_> = (1.25, 2.5).into();
+/// let q: Coordinate<_> = p * 4.;
+///
+/// assert_eq!(q.x, 5.0);
+/// assert_eq!(q.y, 10.0);
+/// ```
 impl<T> Mul<T> for Coordinate<T>
 where
     T: CoordinateType,
 {
     type Output = Coordinate<T>;
 
-    /// Add a point to the given point.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use geo_types::Coordinate;
-    ///
-    /// let p: Coordinate<_> = (1.25, 2.5).into();
-    /// let q: Coordinate<_> = p * 4.;
-    ///
-    /// assert_eq!(q.x, 5.0);
-    /// assert_eq!(q.y, 10.0);
-    /// ```
     fn mul(self, rhs: T) -> Coordinate<T> {
         (self.x * rhs, self.y * rhs).into()
     }
 }
 
+/// Divide coordinate wise by a scalar.
+///
+/// # Examples
+///
+/// ```
+/// use geo_types::Coordinate;
+///
+/// let p: Coordinate<_> = (5., 10.).into();
+/// let q: Coordinate<_> = p / 4.;
+///
+/// assert_eq!(q.x, 1.25);
+/// assert_eq!(q.y, 2.5);
+/// ```
 impl<T> Div<T> for Coordinate<T>
 where
     T: CoordinateType,
 {
     type Output = Coordinate<T>;
 
-    /// Add a point to the given point.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use geo_types::Coordinate;
-    ///
-    /// let p: Coordinate<_> = (5., 10.).into();
-    /// let q: Coordinate<_> = p / 4.;
-    ///
-    /// assert_eq!(q.x, 1.25);
-    /// assert_eq!(q.y, 2.5);
-    /// ```
     fn div(self, rhs: T) -> Coordinate<T> {
         (self.x / rhs, self.y / rhs).into()
     }
 }
 
 use num_traits::Zero;
+/// Create a coordinate at the origin.
+///
+/// # Examples
+///
+/// ```
+/// use geo_types::Coordinate;
+/// use num_traits::Zero;
+///
+/// let p: Coordinate<f64> = Zero::zero();
+///
+/// assert_eq!(p.x, 0.);
+/// assert_eq!(p.y, 0.);
+/// ```
 impl<T: CoordinateType> Zero for Coordinate<T> {
     fn zero() -> Self {
         Coordinate {

--- a/geo-types/src/line_string.rs
+++ b/geo-types/src/line_string.rs
@@ -160,7 +160,7 @@ impl<T: CoordinateType> LineString<T> {
     /// and the value of the first coordinate does not equal the value of the last coordinate, then
     /// a new coordinate is added to the end with the value of the first coordinate.
     pub fn close(&mut self) {
-        if !self.is_closed() && !self.0.is_empty() {
+        if !self.is_closed() {
             self.0.push(self.0[0]);
         }
     }
@@ -182,7 +182,9 @@ impl<T: CoordinateType> LineString<T> {
 
     /// Checks if the linestring is closed; i.e. the first
     /// and last points have the same coords. Note that a
-    /// single point is considered closed.
+    /// single point is considered closed, but the output on
+    /// an empty linestring is _unspecified_ and must not be
+    /// relied upon.
     ///
     /// # Examples
     ///
@@ -194,7 +196,7 @@ impl<T: CoordinateType> LineString<T> {
     /// assert!(line_string.is_closed());
     /// ```
     pub fn is_closed(&self) -> bool {
-        !self.0.is_empty() && self.0.first() == self.0.last()
+        self.0.first() == self.0.last()
     }
 }
 

--- a/geo-types/src/point.rs
+++ b/geo-types/src/point.rs
@@ -307,7 +307,7 @@ where
     /// assert_eq!(p.y(), -2.5);
     /// ```
     fn neg(self) -> Point<T> {
-        Point::new(-self.x(), -self.y())
+        Point(-self.0)
     }
 }
 
@@ -330,7 +330,7 @@ where
     /// assert_eq!(p.y(), 5.0);
     /// ```
     fn add(self, rhs: Point<T>) -> Point<T> {
-        Point::new(self.x() + rhs.x(), self.y() + rhs.y())
+        Point(self.0 + rhs.0)
     }
 }
 
@@ -353,7 +353,7 @@ where
     /// assert_eq!(p.y(), 0.5);
     /// ```
     fn sub(self, rhs: Point<T>) -> Point<T> {
-        Point::new(self.x() - rhs.x(), self.y() - rhs.y())
+        Point(self.0 - rhs.0)
     }
 }
 

--- a/geo-types/src/point.rs
+++ b/geo-types/src/point.rs
@@ -374,7 +374,7 @@ where
     /// assert_eq!(p.y(), 6.0);
     /// ```
     fn mul(self, rhs: T) -> Point<T> {
-        Point::new(self.x() * rhs, self.y() * rhs)
+        Point(self.0 * rhs)
     }
 }
 
@@ -397,7 +397,7 @@ where
     /// assert_eq!(p.y(), 1.5);
     /// ```
     fn div(self, rhs: T) -> Point<T> {
-        Point::new(self.x() / rhs, self.y() / rhs)
+        Point(self.0 / rhs)
     }
 }
 

--- a/geo-types/src/point.rs
+++ b/geo-types/src/point.rs
@@ -4,8 +4,10 @@ use std::ops::{Add, Div, Mul, Neg, Sub};
 
 /// A single point in 2D space.
 ///
-/// Points can be created using the `new(x, y)` constructor, the `point!` macro, a `Coordinate`, or from
-/// two-element tuples or arrays – see the `From` impl section for a complete list.
+/// Points can be created using the `new(x, y)` constructor,
+/// the `point!` macro, or from a `Coordinate`, two-element
+/// tuples, or arrays – see the `From` impl section for a
+/// complete list.
 ///
 /// # Examples
 ///

--- a/geo-types/src/polygon.rs
+++ b/geo-types/src/polygon.rs
@@ -387,6 +387,7 @@ where
     // The polygon is convex if the z-components of the cross products are either
     // all positive or all negative. Otherwise, the polygon is non-convex.
     // see: http://stackoverflow.com/a/1881201/416626
+    #[deprecated(since = "0.6.1", note = "Please use `geo::is_convex` on `poly.exterior()` instead")]
     pub fn is_convex(&self) -> bool {
         let convex = self
             .exterior

--- a/geo/src/algorithm/closest_point.rs
+++ b/geo/src/algorithm/closest_point.rs
@@ -61,8 +61,8 @@ impl<F: Float> ClosestPoint<F> for Line<F> {
         //
         // Line equation: P = start + t * (end - start)
 
-        let direction_vector = Point(self.end) - Point(self.start);
-        let to_p = *p - Point(self.start);
+        let direction_vector = Point(self.end - self.start);
+        let to_p = Point(p.0 - self.start);
 
         let t = to_p.dot(direction_vector) / direction_vector.dot(direction_vector);
 
@@ -75,8 +75,7 @@ impl<F: Float> ClosestPoint<F> for Line<F> {
 
         let x = direction_vector.x();
         let y = direction_vector.y();
-        let displacement = Point::new(t * x, t * y);
-        let c = Point(self.start) + displacement;
+        let c = Point(self.start + (t * x, t * y).into());
 
         if self.contains(p) {
             Closest::Intersection(c)

--- a/geo/src/algorithm/convex_hull/graham.rs
+++ b/geo/src/algorithm/convex_hull/graham.rs
@@ -2,10 +2,22 @@ use super::{swap_remove_to_first, trivial_hull};
 use crate::algorithm::kernels::*;
 use crate::{Coordinate, LineString};
 
-/// Graham Scan: https://en.wikipedia.org/wiki/Graham_scan
-/// This algorithm also provides an option to obtain all
-/// points on the convex hull as opposed to only the
-/// strictly convex points.
+/// The [Graham's scan] algorithm to compute the convex hull
+/// of a collection of points. This algorithm is less
+/// performant than the quick hull, but allows computing all
+/// the points on the convex hull, as opposed to a strict
+/// convex hull that does not include collinear points.
+///
+/// # References
+///
+/// Graham, R.L. (1972). ["An Efficient Algorithm for
+/// Determining the Convex Hull of a Finite Planar
+/// Set"](http://www.math.ucsd.edu/~ronspubs/72_10_convex_hull.pdf)
+/// (PDF). \
+/// Information Processing Letters. 1 (4): 132–133.
+/// [doi:10.1016/0020-0190(72)90045-2](https://doi.org/10.1016%2F0020-0190%2872%2990045-2)
+///
+/// [Graham's scan]: //en.wikipedia.org/wiki/Graham_scan
 pub fn graham_hull<T>(mut points: &mut [Coordinate<T>], include_on_hull: bool) -> LineString<T>
 where
     T: HasKernel,
@@ -26,12 +38,12 @@ where
     output.push(*head);
 
     // Sort rest of the points by angle it makes with head
-    // point. If two points are colinear with head, we sort
+    // point. If two points are collinear with head, we sort
     // by distance. We use kernel predicates here.
     let cmp = |q: &Coordinate<T>, r: &Coordinate<T>| match T::Ker::orient2d(*q, *head, *r) {
         Orientation::CounterClockwise => Ordering::Greater,
         Orientation::Clockwise => Ordering::Less,
-        Orientation::Colinear => {
+        Orientation::Collinear => {
             let dist1 = T::Ker::square_euclidean_distance(*head, *q);
             let dist2 = T::Ker::square_euclidean_distance(*head, *r);
             dist1.partial_cmp(&dist2).unwrap()
@@ -49,7 +61,7 @@ where
                 Orientation::Clockwise => {
                     output.pop();
                 }
-                Orientation::Colinear => {
+                Orientation::Collinear => {
                     if include_on_hull {
                         break;
                     } else {
@@ -75,19 +87,25 @@ where
 
 #[cfg(test)]
 mod test {
-    use super::super::test::is_ccw_convex;
     use super::*;
+    use crate::algorithm::is_convex::IsConvex;
     use geo_types::CoordinateType;
-
-    fn test_convexity<T: CoordinateType + HasKernel>(initial: &[(T, T)]) {
+    use std::fmt::Debug;
+    fn test_convexity<T: CoordinateType + HasKernel + Debug>(initial: &[(T, T)]) {
         let mut v: Vec<_> = initial
             .iter()
             .map(|e| Coordinate::from((e.0, e.1)))
             .collect();
         let hull = graham_hull(&mut v, false);
-        assert!(is_ccw_convex(&hull.0, false));
+        eprintln!("Strict hull");
+        for v in hull.0.iter() {
+            eprintln!("{:?}", v);
+        }
+        eprintln!("{}", hull.is_closed());
+        eprintln!("{:?}", hull.convex_orientation(true, None));
+        assert!(hull.is_strictly_ccw_convex());
         let hull = graham_hull(&mut v, true);
-        assert!(is_ccw_convex(&hull.0, true));
+        assert!(hull.is_ccw_convex());
     }
 
     #[test]

--- a/geo/src/algorithm/convex_hull/mod.rs
+++ b/geo/src/algorithm/convex_hull/mod.rs
@@ -2,42 +2,42 @@ use super::kernels::*;
 use crate::*;
 
 pub trait ConvexHull {
-    /// Returns the convex hull of a Polygon. The hull is always oriented counter-clockwise.
-    ///
-    /// This implementation uses the QuickHull algorithm,
-    /// based on [Barber, C. Bradford; Dobkin, David P.; Huhdanpaa, Hannu (1 December 1996)](https://dx.doi.org/10.1145%2F235815.235821)
-    /// Original paper here: http://www.cs.princeton.edu/~dpd/Papers/BarberDobkinHuhdanpaa.pdf
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use geo::{line_string, polygon};
-    /// use geo::algorithm::convex_hull::ConvexHull;
-    ///
-    /// // an L shape
-    /// let poly = polygon![
-    ///     (x: 0.0, y: 0.0),
-    ///     (x: 4.0, y: 0.0),
-    ///     (x: 4.0, y: 1.0),
-    ///     (x: 1.0, y: 1.0),
-    ///     (x: 1.0, y: 4.0),
-    ///     (x: 0.0, y: 4.0),
-    ///     (x: 0.0, y: 0.0),
-    /// ];
-    ///
-    /// // The correct convex hull coordinates
-    /// let correct_hull = line_string![
-    ///     (x: 4.0, y: 0.0),
-    ///     (x: 4.0, y: 1.0),
-    ///     (x: 1.0, y: 4.0),
-    ///     (x: 0.0, y: 4.0),
-    ///     (x: 0.0, y: 0.0),
-    ///     (x: 4.0, y: 0.0),
-    /// ];
-    ///
-    /// let res = poly.convex_hull();
-    /// assert_eq!(res.exterior(), &correct_hull);
-    /// ```
+    //! Returns the convex hull of a Polygon. The hull is always oriented counter-clockwise.
+    //!
+    //! This implementation uses the QuickHull algorithm,
+    //! based on [Barber, C. Bradford; Dobkin, David P.; Huhdanpaa, Hannu (1 December 1996)](https://dx.doi.org/10.1145%2F235815.235821)
+    //! Original paper here: http://www.cs.princeton.edu/~dpd/Papers/BarberDobkinHuhdanpaa.pdf
+    //!
+    //! # Examples
+    //!
+    //! ```
+    //! use geo::{line_string, polygon};
+    //! use geo::algorithm::convex_hull::ConvexHull;
+    //!
+    //! // an L shape
+    //! let poly = polygon![
+    //!     (x: 0.0, y: 0.0),
+    //!     (x: 4.0, y: 0.0),
+    //!     (x: 4.0, y: 1.0),
+    //!     (x: 1.0, y: 1.0),
+    //!     (x: 1.0, y: 4.0),
+    //!     (x: 0.0, y: 4.0),
+    //!     (x: 0.0, y: 0.0),
+    //! ];
+    //!
+    //! // The correct convex hull coordinates
+    //! let correct_hull = line_string![
+    //!     (x: 4.0, y: 0.0),
+    //!     (x: 4.0, y: 1.0),
+    //!     (x: 1.0, y: 4.0),
+    //!     (x: 0.0, y: 4.0),
+    //!     (x: 0.0, y: 0.0),
+    //!     (x: 4.0, y: 0.0),
+    //! ];
+    //!
+    //! let res = poly.convex_hull();
+    //! assert_eq!(res.exterior(), &correct_hull);
+    //! ```
     type Scalar: CoordinateType;
     fn convex_hull(&self) -> Polygon<Self::Scalar>;
 }
@@ -115,7 +115,7 @@ where
 {
     assert!(points.len() < 4);
 
-    // Remove repeated points unless colinear points
+    // Remove repeated points unless collinear points
     // are to be included.
     let mut ls: LineString<T> = points.iter().copied().collect();
     if !include_on_hull {

--- a/geo/src/algorithm/convex_hull/mod.rs
+++ b/geo/src/algorithm/convex_hull/mod.rs
@@ -1,43 +1,43 @@
 use super::kernels::*;
 use crate::*;
 
+/// Returns the convex hull of a Polygon. The hull is always oriented counter-clockwise.
+///
+/// This implementation uses the QuickHull algorithm,
+/// based on [Barber, C. Bradford; Dobkin, David P.; Huhdanpaa, Hannu (1 December 1996)](https://dx.doi.org/10.1145%2F235815.235821)
+/// Original paper here: http://www.cs.princeton.edu/~dpd/Papers/BarberDobkinHuhdanpaa.pdf
+///
+/// # Examples
+///
+/// ```
+/// use geo::{line_string, polygon};
+/// use geo::algorithm::convex_hull::ConvexHull;
+///
+/// // an L shape
+/// let poly = polygon![
+///     (x: 0.0, y: 0.0),
+///     (x: 4.0, y: 0.0),
+///     (x: 4.0, y: 1.0),
+///     (x: 1.0, y: 1.0),
+///     (x: 1.0, y: 4.0),
+///     (x: 0.0, y: 4.0),
+///     (x: 0.0, y: 0.0),
+/// ];
+///
+/// // The correct convex hull coordinates
+/// let correct_hull = line_string![
+///     (x: 4.0, y: 0.0),
+///     (x: 4.0, y: 1.0),
+///     (x: 1.0, y: 4.0),
+///     (x: 0.0, y: 4.0),
+///     (x: 0.0, y: 0.0),
+///     (x: 4.0, y: 0.0),
+/// ];
+///
+/// let res = poly.convex_hull();
+/// assert_eq!(res.exterior(), &correct_hull);
+/// ```
 pub trait ConvexHull {
-    //! Returns the convex hull of a Polygon. The hull is always oriented counter-clockwise.
-    //!
-    //! This implementation uses the QuickHull algorithm,
-    //! based on [Barber, C. Bradford; Dobkin, David P.; Huhdanpaa, Hannu (1 December 1996)](https://dx.doi.org/10.1145%2F235815.235821)
-    //! Original paper here: http://www.cs.princeton.edu/~dpd/Papers/BarberDobkinHuhdanpaa.pdf
-    //!
-    //! # Examples
-    //!
-    //! ```
-    //! use geo::{line_string, polygon};
-    //! use geo::algorithm::convex_hull::ConvexHull;
-    //!
-    //! // an L shape
-    //! let poly = polygon![
-    //!     (x: 0.0, y: 0.0),
-    //!     (x: 4.0, y: 0.0),
-    //!     (x: 4.0, y: 1.0),
-    //!     (x: 1.0, y: 1.0),
-    //!     (x: 1.0, y: 4.0),
-    //!     (x: 0.0, y: 4.0),
-    //!     (x: 0.0, y: 0.0),
-    //! ];
-    //!
-    //! // The correct convex hull coordinates
-    //! let correct_hull = line_string![
-    //!     (x: 4.0, y: 0.0),
-    //!     (x: 4.0, y: 1.0),
-    //!     (x: 1.0, y: 4.0),
-    //!     (x: 0.0, y: 4.0),
-    //!     (x: 0.0, y: 0.0),
-    //!     (x: 4.0, y: 0.0),
-    //! ];
-    //!
-    //! let res = poly.convex_hull();
-    //! assert_eq!(res.exterior(), &correct_hull);
-    //! ```
     type Scalar: CoordinateType;
     fn convex_hull(&self) -> Polygon<Self::Scalar>;
 }

--- a/geo/src/algorithm/convex_hull/qhull.rs
+++ b/geo/src/algorithm/convex_hull/qhull.rs
@@ -117,8 +117,8 @@ fn hull_set<T>(
 
 #[cfg(test)]
 mod test {
-    use super::super::test::is_ccw_convex;
     use super::*;
+    use crate::algorithm::is_convex::IsConvex;
 
     #[test]
     fn quick_hull_test1() {
@@ -132,7 +132,7 @@ mod test {
             Coordinate { x: 0.0, y: 0.0 },
         ];
         let res = quick_hull(&mut v);
-        assert!(is_ccw_convex(&res.0, false));
+        assert!(res.is_strictly_ccw_convex());
     }
 
     #[test]
@@ -201,7 +201,7 @@ mod test {
             .map(|e| Coordinate { x: e.0, y: e.1 })
             .collect();
         let res = quick_hull(&mut v);
-        assert!(is_ccw_convex(&res.0, false));
+        assert!(res.is_strictly_ccw_convex());
     }
 
     #[test]
@@ -228,11 +228,11 @@ mod test {
             .map(|e| Coordinate { x: e.0, y: e.1 })
             .collect();
         let res = quick_hull(&mut v);
-        assert!(is_ccw_convex(&res.0, false));
+        assert!(res.is_strictly_ccw_convex());
     }
 
     #[test]
-    fn quick_hull_test_colinear() {
+    fn quick_hull_test_collinear() {
         // Initial input begins at min x, but not min y
         // There are three points with same x.
         // Output should not contain the middle point.
@@ -252,6 +252,6 @@ mod test {
             .map(|e| Coordinate { x: e.0, y: e.1 })
             .collect();
         let res = quick_hull(&mut v);
-        assert!(is_ccw_convex(&res.0, false));
+        assert!(res.is_strictly_ccw_convex());
     }
 }

--- a/geo/src/algorithm/convex_hull/test.rs
+++ b/geo/src/algorithm/convex_hull/test.rs
@@ -1,27 +1,5 @@
 use super::ConvexHull;
-use crate::algorithm::kernels::{HasKernel, Kernel, Orientation};
 use crate::*;
-
-// Utility function to test convex hull
-pub(super) fn is_ccw_convex<T: CoordinateType + HasKernel>(
-    mut ls: &[Coordinate<T>],
-    allow_collinear: bool,
-) -> bool {
-    if ls.len() > 1 && ls[0] == ls[ls.len() - 1] {
-        ls = &ls[1..];
-    }
-    let n = ls.len();
-    if n < 3 {
-        return true;
-    }
-
-    ls.iter().enumerate().all(|(i, coord)| {
-        let np = ls[(i + 1) % n];
-        let nnp = ls[(i + 2) % n];
-        let o = T::Ker::orient2d(*coord, np, nnp);
-        o == Orientation::CounterClockwise || (allow_collinear && o == Orientation::Colinear)
-    })
-}
 
 #[test]
 fn convex_hull_multipoint_test() {

--- a/geo/src/algorithm/euclidean_distance.rs
+++ b/geo/src/algorithm/euclidean_distance.rs
@@ -456,7 +456,8 @@ where
             }
             return mindist;
         }
-        if poly2.is_convex() || !self.is_convex() {
+        use super::is_convex::IsConvex;
+        if !poly2.exterior().is_convex() || !self.exterior().is_convex() {
             // fall back to R* nearest neighbour method
             nearest_neighbour_distance(&self.exterior(), &poly2.exterior())
         } else {

--- a/geo/src/algorithm/euclidean_distance.rs
+++ b/geo/src/algorithm/euclidean_distance.rs
@@ -2,6 +2,7 @@ use crate::algorithm::contains::Contains;
 use crate::algorithm::euclidean_length::EuclideanLength;
 use crate::algorithm::intersects::Intersects;
 use crate::algorithm::polygon_distance_fast_path::*;
+use crate::kernels::*;
 use crate::utils::{coord_pos_relative_to_line_string, CoordPos};
 use crate::{
     Line, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon, Triangle,
@@ -429,7 +430,7 @@ where
 // Polygon to Polygon distance
 impl<T> EuclideanDistance<T, Polygon<T>> for Polygon<T>
 where
-    T: Float + FloatConst + RTreeNum,
+    T: Float + FloatConst + RTreeNum + HasKernel,
 {
     /// This implementation has a "fast path" in cases where both input polygons are convex:
     /// it switches to an implementation of the "rotating calipers" method described in [Pirzadeh (1999), pp24—30](http://digitool.library.mcgill.ca/R/?func=dbin-jump-full&object_id=21623&local_base=GEN01-MCG02),

--- a/geo/src/algorithm/extremes.rs
+++ b/geo/src/algorithm/extremes.rs
@@ -44,10 +44,11 @@ where
 // wrapper for extreme-finding function
 fn find_extreme_indices<T, F>(func: F, polygon: &Polygon<T>) -> Result<Extremes, ()>
 where
-    T: Float + Signed,
+    T: CoordinateType + HasKernel + Signed,
     F: Fn(Coordinate<T>, &Polygon<T>) -> Result<usize, ()>,
 {
-    if !polygon.is_convex() {
+    use crate::is_convex::IsConvex;
+    if !polygon.exterior().is_convex() {
         return Err(());
     }
     let directions: Vec<Coordinate<_>> = vec![

--- a/geo/src/algorithm/is_convex.rs
+++ b/geo/src/algorithm/is_convex.rs
@@ -10,26 +10,26 @@ use crate::{Coordinate, CoordinateType, LineString};
 ///
 /// # Remarks
 ///
-/// 1. The convexity, and collinearity of an empty
+/// - The convexity, and collinearity of an empty
 /// `LineString` is _unspecified_ and must not be relied
 /// upon.
 ///
-/// 1. Collinearity does not require that the `LineString`
+/// - Collinearity does not require that the `LineString`
 /// be closed, but the rest of the predicates do.
 ///
-/// 1. A `LineString` with a single point is both strictly
+/// - A `LineString` with a single point is both strictly
 /// convex, and collinear.
 ///
-/// 1. A closed `LineString` with three vertices (where the
+/// - A closed `LineString` with three vertices (where the
 /// first and third coordinates are the same) is not strictly
 /// convex.  However, it is convex and collinear.
 ///
-/// 1. This definition is closely related to the notion
+/// - This definition is closely related to the notion
 /// of [convexity of polygons][convex set]. In particular, a
 /// [`Polygon`] is convex, if and only if its `exterior` is
 /// convex, and `interiors` is empty.
 ///
-/// 1. The [`ConvexHull`] algorithm always returns a
+/// - The [`ConvexHull`] algorithm always returns a
 /// strictly convex `LineString` unless the input is
 /// collinear. The [`graham_hull`] algorithm provides an
 /// option to include collinear points, producing a (possibly

--- a/geo/src/algorithm/is_convex.rs
+++ b/geo/src/algorithm/is_convex.rs
@@ -170,6 +170,7 @@ where
         match orientation {
             Orientation::Collinear => {
                 // Only happens if !allow_collinear
+                assert!(!allow_collinear);
                 return None;
             }
             _ => (i, orientation),

--- a/geo/src/algorithm/is_convex.rs
+++ b/geo/src/algorithm/is_convex.rs
@@ -1,0 +1,237 @@
+use crate::kernels::*;
+use crate::{Coordinate, CoordinateType, LineString};
+
+/// Predicates to test the convexity of a [ `LineString` ].
+/// A closed `LineString` is said to be _convex_ if it
+/// encloses a [convex set]. It is said to be _strictly
+/// convex_ if in addition, no three consecutive vertices
+/// are collinear. It is _collinear_ if all the vertices lie
+/// on the same line.
+///
+/// # Remarks
+///
+/// 1. The convexity, and collinearity of an empty
+/// `LineString` is _unspecified_ and must not be relied
+/// upon.
+///
+/// 1. Collinearity does not require that the `LineString`
+/// be closed, but the rest of the predicates do.
+///
+/// 1. A `LineString` with a single point is both strictly
+/// convex, and collinear.
+///
+/// 1. A closed `LineString` with three vertices (where the
+/// first and third coordinates are the same) is not strictly
+/// convex.  However, it is convex and collinear.
+///
+/// 1. This definition is closely related to the notion
+/// of [convexity of polygons][convex set]. In particular, a
+/// [`Polygon`] is convex, if and only if its `exterior` is
+/// convex, and `interiors` is empty.
+///
+/// 1. The [`ConvexHull`] algorithm always returns a
+/// strictly convex `LineString` unless the input is
+/// collinear. The [`graham_hull`] algorithm provides an
+/// option to include collinear points, producing a (possibly
+/// non-strict) convex `LineString`.
+///
+/// [convex combination]: //en.wikipedia.org/wiki/Convex_combination
+/// [convex set]: //en.wikipedia.org/wiki/Convex_set
+/// [`ConvexHull`]: crate::algorithm::convex_hull::ConvexHull
+/// [`graham_hull`]: crate::algorithm::convex_hull::graham_hull
+pub trait IsConvex {
+    /// Test and get the orientation if the shape is convex.
+    /// Tests for strict convexity if `allow_collinear`, and
+    /// only accepts a specific orientation if provided.
+    ///
+    /// The return value is `None` if either:
+    ///
+    /// 1. the shape is not convex
+    ///
+    /// 1. the shape is not strictly convex, and
+    ///    `allow_collinear` is false
+    ///
+    /// 1. an orientation is specified, and some three
+    ///    consecutive vertices where neither collinear, nor
+    ///    in the specified orientation.
+    ///
+    /// In all other cases, the return value is the
+    /// orientation of the shape, or `Orientation::Collinear`
+    /// if all the vertices are on the same line.
+    ///
+    /// **Note.** This predicate is not equivalent to
+    /// `is_collinear` as this requires that the input is
+    /// closed.
+    fn convex_orientation(
+        &self,
+        allow_collinear: bool,
+        specific_orientation: Option<Orientation>,
+    ) -> Option<Orientation>;
+
+    /// Test if the shape is convex.
+    fn is_convex(&self) -> bool {
+        self.convex_orientation(true, None).is_some()
+    }
+
+    /// Test if the shape is convex, and oriented
+    /// counter-clockwise.
+    fn is_ccw_convex(&self) -> bool {
+        self.convex_orientation(true, Some(Orientation::CounterClockwise))
+            .is_some()
+    }
+
+    /// Test if the shape is convex, and oriented clockwise.
+    fn is_cw_convex(&self) -> bool {
+        self.convex_orientation(true, Some(Orientation::Clockwise))
+            .is_some()
+    }
+
+    /// Test if the shape is strictly convex.
+    fn is_strictly_convex(&self) -> bool {
+        self.convex_orientation(false, None).is_some()
+    }
+
+    /// Test if the shape is strictly convex, and oriented
+    /// counter-clockwise.
+    fn is_strictly_ccw_convex(&self) -> bool {
+        self.convex_orientation(false, Some(Orientation::CounterClockwise))
+            == Some(Orientation::CounterClockwise)
+    }
+
+    /// Test if the shape is strictly convex, and oriented
+    /// clockwise.
+    fn is_strictly_cw_convex(&self) -> bool {
+        self.convex_orientation(false, Some(Orientation::Clockwise)) == Some(Orientation::Clockwise)
+    }
+
+    /// Test if the shape lies on a line.
+    fn is_collinear(&self) -> bool;
+}
+
+impl<T: CoordinateType + HasKernel> IsConvex for LineString<T> {
+    fn convex_orientation(
+        &self,
+        allow_collinear: bool,
+        specific_orientation: Option<Orientation>,
+    ) -> Option<Orientation> {
+        if !self.is_closed() {
+            None
+        } else {
+            is_convex_shaped(&self.0[1..], allow_collinear, specific_orientation)
+        }
+    }
+
+    fn is_collinear(&self) -> bool {
+        self.0.is_empty()
+            || is_convex_shaped(&self.0[1..], true, Some(Orientation::Collinear)).is_some()
+    }
+}
+
+/// A utility that tests convexity of a sequence of
+/// coordinates. It verifies that for all `0 <= i < n`, the
+/// vertices at positions `i`, `i+1`, `i+2` (mod `n`) have
+/// the same orientation, optionally accepting collinear
+/// triplets, and expecting a specific orientation. The
+/// output is `None` or the only non-collinear orientation,
+/// unless everything is collinear.
+fn is_convex_shaped<T>(
+    coords: &[Coordinate<T>],
+    allow_collinear: bool,
+    specific_orientation: Option<Orientation>,
+) -> Option<Orientation>
+where
+    T: CoordinateType + HasKernel,
+{
+    let n = coords.len();
+
+    let orientation_at = |i: usize| {
+        let coord = coords[i];
+        let next = coords[(i + 1) % n];
+        let nnext = coords[(i + 2) % n];
+        (i, T::Ker::orient2d(coord, next, nnext))
+    };
+
+    let find_first_non_collinear = (0..n).map(orientation_at).find_map(|(i, orientation)| {
+        match orientation {
+            Orientation::Collinear => {
+                // If collinear accepted, we skip, otherwise
+                // stop.
+                if allow_collinear {
+                    None
+                } else {
+                    Some((i, orientation))
+                }
+            }
+            _ => Some((i, orientation)),
+        }
+    });
+
+    let (i, first_non_collinear) = if let Some((i, orientation)) = find_first_non_collinear {
+        match orientation {
+            Orientation::Collinear => {
+                // Only happens if !allow_collinear
+                return None;
+            }
+            _ => (i, orientation),
+        }
+    } else {
+        // Empty or everything collinear, and allowed.
+        return Some(Orientation::Collinear);
+    };
+
+    // If a specific orientation is expected, accept only that.
+    if let Some(req_orientation) = specific_orientation {
+        if req_orientation != first_non_collinear {
+            return None;
+        }
+    }
+
+    // Now we have a fixed orientation expected at the rest
+    // of the coords. Loop to check everything matches it.
+    if ((i + 1)..n)
+        .map(orientation_at)
+        .find(|&(_, orientation)| match orientation {
+            Orientation::Collinear => !allow_collinear,
+            orientation => !(orientation == first_non_collinear),
+        })
+        .is_none()
+    {
+        Some(first_non_collinear)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use geo_types::line_string;
+
+    #[test]
+    fn test_corner_cases() {
+        // let empty: LineString<f64> = line_string!();
+        // assert!(empty.is_collinear());
+        // assert!(!empty.is_convex());
+        // assert!(!empty.is_strictly_ccw_convex());
+
+        // let one = line_string![(x: 0., y: 0.)];
+        // assert!(one.is_collinear());
+        // assert!(one.is_convex());
+        // assert!(one.is_cw_convex());
+        // assert!(one.is_ccw_convex());
+        // assert!(one.is_strictly_convex());
+        // assert!(!one.is_strictly_ccw_convex());
+        // assert!(!one.is_strictly_cw_convex());
+
+        // let mut two = line_string![(x: 0, y: 0), (x: 1, y: 1)];
+        // assert!(two.is_collinear());
+        // assert!(!two.is_convex());
+
+        // two.close();
+        // assert!(two.is_cw_convex());
+        // assert!(two.is_ccw_convex());
+        // assert!(two.is_strictly_convex());
+        // assert!(!two.is_strictly_ccw_convex());
+        // assert!(!two.is_strictly_cw_convex());
+    }
+}

--- a/geo/src/algorithm/kernels/mod.rs
+++ b/geo/src/algorithm/kernels/mod.rs
@@ -1,10 +1,10 @@
 use crate::{Coordinate, CoordinateType};
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
 pub enum Orientation {
     CounterClockwise,
     Clockwise,
-    Colinear,
+    Collinear,
 }
 
 /// Kernel trait to provide predicates to operate on
@@ -13,7 +13,7 @@ pub trait Kernel {
     type Scalar: CoordinateType;
 
     /// Gives the orientation of 3 2-dimensional points:
-    /// ccw, cw or colinear (None)
+    /// ccw, cw or collinear (None)
     fn orient2d(
         p: Coordinate<Self::Scalar>,
         q: Coordinate<Self::Scalar>,
@@ -26,7 +26,7 @@ pub trait Kernel {
         } else if res < Zero::zero() {
             Orientation::Clockwise
         } else {
-            Orientation::Colinear
+            Orientation::Collinear
         }
     }
 

--- a/geo/src/algorithm/kernels/robust.rs
+++ b/geo/src/algorithm/kernels/robust.rs
@@ -41,7 +41,7 @@ impl<T: Float> Kernel for RobustKernel<T> {
         } else if orientation > 0. {
             Orientation::CounterClockwise
         } else {
-            Orientation::Colinear
+            Orientation::Collinear
         }
     }
 }

--- a/geo/src/algorithm/mod.rs
+++ b/geo/src/algorithm/mod.rs
@@ -39,6 +39,8 @@ pub mod haversine_intermediate;
 pub mod haversine_length;
 /// Determine whether `Geometry` `A` intersects `Geometry` `B`.
 pub mod intersects;
+/// Determins whether a `LineString` is convex.
+pub mod is_convex;
 /// Interpolate a point along a `Line` or `LineString`.
 pub mod line_interpolate_point;
 /// Locate a point along a `Line` or `LineString`.

--- a/geo/src/algorithm/polygon_distance_fast_path.rs
+++ b/geo/src/algorithm/polygon_distance_fast_path.rs
@@ -1,4 +1,5 @@
 use crate::algorithm::extremes::ExtremeIndices;
+use crate::kernels::*;
 use crate::prelude::*;
 use crate::{Line, Point, Polygon, Triangle};
 use num_traits::float::FloatConst;
@@ -12,7 +13,7 @@ use num_traits::{Float, Signed};
 /// using the rotating calipers method
 pub(crate) fn min_poly_dist<T>(poly1: &Polygon<T>, poly2: &Polygon<T>) -> T
 where
-    T: Float + FloatConst + Signed,
+    T: Float + FloatConst + Signed + HasKernel,
 {
     let poly1_extremes = poly1.extreme_indices().unwrap();
     let poly2_extremes = poly2.extreme_indices().unwrap();

--- a/geo/src/algorithm/winding_order.rs
+++ b/geo/src/algorithm/winding_order.rs
@@ -30,12 +30,19 @@ pub enum WindingOrder {
 }
 
 pub trait Winding {
+    //! Determine and operate on how a [`LineString`] is
+    //! wound. This functionality, and our implementation is
+    //! based on [CGAL's Polygon_2::orientation].
+    //!
+    //! [CGAL's Polygon_2::orientation]: //doc.cgal.org/latest/Polygon/classCGAL_1_1Polygon__2.html#a4ce8b4b8395406243ac16c2a120ffc15
     type Scalar: CoordinateType;
 
-    /// Return the winding order of this object
+    /// Return the winding order of this object if it
+    /// contains at least three distinct coordinates, and
+    /// `None` otherwise.
     fn winding_order(&self) -> Option<WindingOrder>;
 
-    /// True iff this clockwise
+    /// True iff this is wound clockwise
     fn is_cw(&self) -> bool {
         self.winding_order() == Some(WindingOrder::Clockwise)
     }
@@ -90,15 +97,10 @@ where
     type Scalar = T;
 
     fn winding_order(&self) -> Option<WindingOrder> {
-        // If linestring has at most 2 points, it is either
-        // not closed, or is the same point. Either way, the
-        // WindingOrder is unspecified.
-        if self.num_coords() < 3 {
-            return None;
-        }
-
-        // Open linestrings do not have a winding order.
-        if !self.is_closed() {
+        // If linestring has at most 3 coords, it is either
+        // not closed, or is at most two distinct points.
+        // Either way, the WindingOrder is unspecified.
+        if self.num_coords() < 4 || !self.is_closed() {
             return None;
         }
 

--- a/geo/src/algorithm/winding_order.rs
+++ b/geo/src/algorithm/winding_order.rs
@@ -29,12 +29,12 @@ pub enum WindingOrder {
     CounterClockwise,
 }
 
+/// Determine and operate on how a [`LineString`] is
+/// wound. This functionality, and our implementation is
+/// based on [CGAL's Polygon_2::orientation].
+///
+/// [CGAL's Polygon_2::orientation]: //doc.cgal.org/latest/Polygon/classCGAL_1_1Polygon__2.html#a4ce8b4b8395406243ac16c2a120ffc15
 pub trait Winding {
-    //! Determine and operate on how a [`LineString`] is
-    //! wound. This functionality, and our implementation is
-    //! based on [CGAL's Polygon_2::orientation].
-    //!
-    //! [CGAL's Polygon_2::orientation]: //doc.cgal.org/latest/Polygon/classCGAL_1_1Polygon__2.html#a4ce8b4b8395406243ac16c2a120ffc15
     type Scalar: CoordinateType;
 
     /// Return the winding order of this object if it


### PR DESCRIPTION
This PR introduces `IsConvex` trait, and partially revamps the `ExtremePoint` trait.

1. add `IsConvex` trait and documentation of predicates.

1. add vector space ops in `Coordinate`. These were earlier
available in `Point`, but it makes more sense to be
available for `Coordinate` too.

1. many minor doc improvements:  explain corner cases,
better references, fix spellings (collinear).

1. make `ExtremePoint` robust
1. Remove unneeded trait generic parameter `T`, and requirement `T: Float`

Things to revamp / discuss in `ExtremePoint`

1. FIgure out what the trait is about.  Should we really compute `convex_hull` in the impl?
1. Replace `Result<Extremes, ()>` with `Option`
