### PR TITLE
proj network feature

### DIFF
--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -29,6 +29,7 @@ robust = { version = "0.2.2" }
 [features]
 default = []
 use-proj = ["proj"]
+proj-network = ["use-proj", "proj/network"]
 use-serde = ["serde", "geo-types/serde"]
 
 [dev-dependencies]

--- a/geo/src/lib.rs
+++ b/geo/src/lib.rs
@@ -25,6 +25,10 @@
 //! ## Optional Features (these can be activated in your `cargo.toml`)
 //! The following optional features are available:
 //! - `use-proj`: enable coordinate conversion and transformation of `Point` geometries using the [`proj`](https://docs.rs/proj) crate
+//! - `proj-network`: enables functionality for `proj` crate's network grid. After enabling
+//! this feature, some [further
+//! configuration](https://docs.rs/proj/0.20.5/proj/#grid-file-download) is
+//! required to actually use the network grid.
 //! - `use-serde`: enable serialisation of geometries using `serde`.
 //!
 //! ## GeoJSON


### PR DESCRIPTION
Once https://github.com/georust/proj/pull/39 is merged, if someone opts into the `proj` feature, we'll no longer build the recently added network/grid stuff (it has a lot of deps).

This new flag let's them opt-in to that.

To be clear, the default build doesn't include proj - this is only relevant to folks who want to use the optional proj features.