### PR TITLE
only use "rotating calipers" distance calculation when both polygons are convex

### DIFF
--- a/geo/src/algorithm/euclidean_distance.rs
+++ b/geo/src/algorithm/euclidean_distance.rs
@@ -455,11 +455,11 @@ where
             }
             return mindist;
         }
-        if poly2.is_convex() || !self.is_convex() {
+        if poly2.is_convex() && self.is_convex() {
+            min_poly_dist(self, poly2)
+        } else {
             // fall back to R* nearest neighbour method
             nearest_neighbour_distance(&self.exterior(), &poly2.exterior())
-        } else {
-            min_poly_dist(self, poly2)
         }
     }
 }


### PR DESCRIPTION
follow up to [@rmanoka comment](https://github.com/georust/geo/pull/505#issuecomment-688592143) 

I haven't read the paper, but indeed the section "distance between to convex polygons" implies that this check was incorrect.

https://escholarship.mcgill.ca/concern/file_sets/3x816p60j?locale=en

Doing a little git archeology, seems like a typo in the initial implementation: 6cf04ee22a14b242888edd11ae94824aaa775d76:

```
+        if !(self.is_convex() && !poly2.is_convex()) {
+            // fall back to R* nearest neighbour method
+            nearest_neighbour_distance(&self.exterior, &poly2.exterior)
+        } else {
+            min_poly_dist(self, poly2)
+        }
```

Which was refactored by a clippy suggestion here: 764e7c527

I'd like to add a good test to capture this before merging.


