### PR TITLE
Robust Intersect and Contains

### DIFF
--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## Master (not released)
+
+* Add vector-space operations to `Coordinate` and `Point`
+  * <https://github.com/georust/geo/pull/505>
+
 ## 0.6.0
 
 * Remove `COORD_PRECISION` which was an arbitrary constant of 0.1m

--- a/geo-types/src/coordinate.rs
+++ b/geo-types/src/coordinate.rs
@@ -77,7 +77,7 @@ where
     }
 }
 
-use std::ops::{Add, Neg, Sub, Mul, Div};
+use std::ops::{Add, Div, Mul, Neg, Sub};
 
 /// Negate a coordinate.
 ///

--- a/geo-types/src/line.rs
+++ b/geo-types/src/line.rs
@@ -1,7 +1,7 @@
 use crate::{Coordinate, CoordinateType, Point};
 
 /// A line segment made up of exactly two
-/// [`Point`s](struct.Point.html). The interior and
+/// [`Coordinate`s](struct.Coordinate.html). The interior and
 /// boundaries are defined as with a `LineString` with the
 /// two end points.
 #[derive(Eq, PartialEq, Clone, Copy, Debug, Hash)]

--- a/geo-types/src/line.rs
+++ b/geo-types/src/line.rs
@@ -1,6 +1,9 @@
 use crate::{Coordinate, CoordinateType, Point};
 
-/// A line segment made up of exactly two [`Point`s](struct.Point.html).
+/// A line segment made up of exactly two
+/// [`Point`s](struct.Point.html). The interior and
+/// boundaries are defined as with a `LineString` with the
+/// two end points.
 #[derive(Eq, PartialEq, Clone, Copy, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Line<T>

--- a/geo-types/src/line.rs
+++ b/geo-types/src/line.rs
@@ -37,6 +37,11 @@ where
         }
     }
 
+    /// Calculate the difference in coordinates (Δx, Δy).
+    pub fn delta(&self) -> Coordinate<T> {
+        self.end - self.start
+    }
+
     /// Calculate the difference in ‘x’ components (Δx).
     ///
     /// Equivalent to:
@@ -53,7 +58,7 @@ where
     /// # );
     /// ```
     pub fn dx(&self) -> T {
-        self.end.x - self.start.x
+        self.delta().x
     }
 
     /// Calculate the difference in ‘y’ components (Δy).
@@ -72,7 +77,7 @@ where
     /// # );
     /// ```
     pub fn dy(&self) -> T {
-        self.end.y - self.start.y
+        self.delta().y
     }
 
     /// Calculate the slope (Δy/Δx).

--- a/geo-types/src/line_string.rs
+++ b/geo-types/src/line_string.rs
@@ -15,9 +15,9 @@ use std::ops::{Index, IndexMut};
 ///
 /// # Validity
 ///
-/// A `LineString` is valid if it does not self-intersect
-/// except possibly at the end points, and is either empty
-/// or contains 2 or more coordinates. Note that the
+/// A `LineString` is valid if it is either empty or
+/// contains 2 or more coordinates. Further, a closed
+/// `LineString` must not self intersect. Note that the
 /// validity is not enforced, and the operations and
 /// predicates are undefined on invalid linestrings.
 ///

--- a/geo-types/src/line_string.rs
+++ b/geo-types/src/line_string.rs
@@ -2,8 +2,24 @@ use crate::{Coordinate, CoordinateType, Line, Point, Triangle};
 use std::iter::FromIterator;
 use std::ops::{Index, IndexMut};
 
-/// An ordered collection of two or more [`Coordinate`s](struct.Coordinate.html), representing a
+/// An ordered collection of two or more
+/// [`Coordinate`s](struct.Coordinate.html), representing a
 /// path between locations.
+///
+/// A `LineString` is _closed_ if it is empty, or if the
+/// first and last coordinates are the same. The _boundary_
+/// of a `LineString` is empty if closed, and otherwise the
+/// end points. The interior is the (infinite) set of all
+/// points along the linestring _not including_ the
+/// boundary.
+///
+/// # Validity
+///
+/// A `LineString` is valid if it does not self-intersect
+/// except possibly at the end points, and is either empty
+/// or contains 2 or more coordinates. Note that the
+/// validity is not enforced, and the operations and
+/// predicates are undefined on invalid linestrings.
 ///
 /// # Examples
 ///
@@ -180,11 +196,9 @@ impl<T: CoordinateType> LineString<T> {
         self.0.len()
     }
 
-    /// Checks if the linestring is closed; i.e. the first
-    /// and last points have the same coords. Note that a
-    /// single point is considered closed, but the output on
-    /// an empty linestring is _unspecified_ and must not be
-    /// relied upon.
+    /// Checks if the linestring is closed; i.e. it is
+    /// either empty or, the first and last points are the
+    /// same.
     ///
     /// # Examples
     ///

--- a/geo-types/src/multi_line_string.rs
+++ b/geo-types/src/multi_line_string.rs
@@ -1,11 +1,16 @@
 use crate::{CoordinateType, LineString};
 use std::iter::FromIterator;
 
-/// A collection of [`LineString`s](line_string/struct.LineString.html).
+/// A collection of
+/// [`LineString`s](line_string/struct.LineString.html). The
+/// interior and the boundary are the union of the interior
+/// or the boundary of the constituent line strings.
 ///
-/// Can be created from a `Vec` of `LineString`s, or from an Iterator which yields `LineString`s.
+/// Can be created from a `Vec` of `LineString`s, or from an
+/// Iterator which yields `LineString`s.
 ///
-/// Iterating over this objects, yields the component `LineString`s.
+/// Iterating over this objects, yields the component
+/// `LineString`s.
 #[derive(Eq, PartialEq, Clone, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct MultiLineString<T>(pub Vec<LineString<T>>)

--- a/geo-types/src/multi_point.rs
+++ b/geo-types/src/multi_point.rs
@@ -1,7 +1,9 @@
 use crate::{CoordinateType, Point};
 use std::iter::FromIterator;
 
-/// A collection of [`Point`s](struct.Point.html).
+/// A collection of [`Point`s](struct.Point.html). The
+/// interior and the boundary are the union of the interior
+/// or the boundary of the constituent points.
 ///
 /// # Examples
 ///

--- a/geo-types/src/multi_polygon.rs
+++ b/geo-types/src/multi_polygon.rs
@@ -1,7 +1,9 @@
 use crate::{CoordinateType, Polygon};
 use std::iter::FromIterator;
 
-/// A collection of [`Polygon`s](struct.Polygon.html).
+/// A collection of [`Polygon`s](struct.Polygon.html). The
+/// interior and the boundary are the union of the interior
+/// or the boundary of the constituent polygons.
 ///
 /// Can be created from a `Vec` of `Polygon`s, or `collect`ed from an Iterator which yields `Polygon`s.
 ///

--- a/geo-types/src/point.rs
+++ b/geo-types/src/point.rs
@@ -9,6 +9,10 @@ use std::ops::{Add, Div, Mul, Neg, Sub};
 /// tuples, or arrays – see the `From` impl section for a
 /// complete list.
 ///
+/// A point is _valid_ iff neither coordinate is `NaN`. The
+/// _interior_ of the point is itself (a singleton set), and
+/// its _boundary_ is empty.
+///
 /// # Examples
 ///
 /// ```

--- a/geo-types/src/polygon.rs
+++ b/geo-types/src/polygon.rs
@@ -387,7 +387,10 @@ where
     // The polygon is convex if the z-components of the cross products are either
     // all positive or all negative. Otherwise, the polygon is non-convex.
     // see: http://stackoverflow.com/a/1881201/416626
-    #[deprecated(since = "0.6.1", note = "Please use `geo::is_convex` on `poly.exterior()` instead")]
+    #[deprecated(
+        since = "0.6.1",
+        note = "Please use `geo::is_convex` on `poly.exterior()` instead"
+    )]
     pub fn is_convex(&self) -> bool {
         let convex = self
             .exterior

--- a/geo-types/src/polygon.rs
+++ b/geo-types/src/polygon.rs
@@ -7,6 +7,11 @@ use num_traits::{Float, Signed};
 /// [`LineString`]. It may contain zero or more holes (_interior rings_), also
 /// represented by `LineString`s.
 ///
+/// The _boundary_ of the polygon is the union of the
+/// boundaries of the exterior and interiors. The interior
+/// is all the points inside the polygon (not on the
+/// boundary).
+///
 /// The `Polygon` structure guarantees that all exterior and interior rings will
 /// be _closed_, such that the first and last `Coordinate` of each ring has
 /// the same value.

--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -1,5 +1,15 @@
 # Changes
 
+## Master (not released)
+
+* Add robust predicates
+  * <https://github.com/georust/geo/pull/511>
+  * <https://github.com/georust/geo/pull/505>
+  * <https://github.com/georust/geo/pull/504>
+  * <https://github.com/georust/geo/pull/502>
+* Improve numerical stability in centroid computation
+  * <https://github.com/georust/geo/pull/510>
+
 ## 0.14.2
 
 * Bump proj version to 0.20.3

--- a/geo/src/algorithm/closest_point.rs
+++ b/geo/src/algorithm/closest_point.rs
@@ -1,4 +1,5 @@
 use crate::prelude::*;
+use crate::kernels::*;
 use crate::{Closest, Line, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon};
 use num_traits::Float;
 use std::iter;
@@ -47,7 +48,7 @@ impl<F: Float> ClosestPoint<F> for Point<F> {
     }
 }
 
-impl<F: Float> ClosestPoint<F> for Line<F> {
+impl<F: Float + HasKernel> ClosestPoint<F> for Line<F> {
     fn closest_point(&self, p: &Point<F>) -> Closest<F> {
         let line_length = self.euclidean_length();
         if line_length == F::zero() {
@@ -106,20 +107,20 @@ where
     best
 }
 
-impl<F: Float> ClosestPoint<F> for LineString<F> {
+impl<F: Float + HasKernel> ClosestPoint<F> for LineString<F> {
     fn closest_point(&self, p: &Point<F>) -> Closest<F> {
         closest_of(self.lines(), *p)
     }
 }
 
-impl<F: Float> ClosestPoint<F> for Polygon<F> {
+impl<F: Float + HasKernel> ClosestPoint<F> for Polygon<F> {
     fn closest_point(&self, p: &Point<F>) -> Closest<F> {
         let prospectives = self.interiors().iter().chain(iter::once(self.exterior()));
         closest_of(prospectives, *p)
     }
 }
 
-impl<F: Float> ClosestPoint<F> for MultiPolygon<F> {
+impl<F: Float + HasKernel> ClosestPoint<F> for MultiPolygon<F> {
     fn closest_point(&self, p: &Point<F>) -> Closest<F> {
         closest_of(self.0.iter(), *p)
     }
@@ -131,7 +132,7 @@ impl<F: Float> ClosestPoint<F> for MultiPoint<F> {
     }
 }
 
-impl<F: Float> ClosestPoint<F> for MultiLineString<F> {
+impl<F: Float + HasKernel> ClosestPoint<F> for MultiLineString<F> {
     fn closest_point(&self, p: &Point<F>) -> Closest<F> {
         closest_of(self.0.iter(), *p)
     }

--- a/geo/src/algorithm/closest_point.rs
+++ b/geo/src/algorithm/closest_point.rs
@@ -1,5 +1,5 @@
-use crate::prelude::*;
 use crate::kernels::*;
+use crate::prelude::*;
 use crate::{Closest, Line, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon};
 use num_traits::Float;
 use std::iter;

--- a/geo/src/algorithm/closest_point.rs
+++ b/geo/src/algorithm/closest_point.rs
@@ -78,7 +78,7 @@ impl<F: Float + HasKernel> ClosestPoint<F> for Line<F> {
         let y = direction_vector.y();
         let c = Point(self.start + (t * x, t * y).into());
 
-        if self.contains(p) {
+        if self.intersects(p) {
             Closest::Intersection(c)
         } else {
             Closest::SinglePoint(c)

--- a/geo/src/algorithm/contains/geometry.rs
+++ b/geo/src/algorithm/contains/geometry.rs
@@ -1,6 +1,6 @@
 use super::Contains;
-use crate::*;
 use crate::kernels::*;
+use crate::*;
 
 // ┌──────────────────────────────┐
 // │ Implementations for Geometry │

--- a/geo/src/algorithm/contains/geometry.rs
+++ b/geo/src/algorithm/contains/geometry.rs
@@ -1,0 +1,58 @@
+use super::Contains;
+use crate::*;
+use crate::kernels::*;
+
+// ┌──────────────────────────────┐
+// │ Implementations for Geometry │
+// └──────────────────────────────┘
+
+impl<T> Contains<Coordinate<T>> for Geometry<T>
+where
+    T: HasKernel,
+{
+    fn contains(&self, coord: &Coordinate<T>) -> bool {
+        match self {
+            Geometry::Point(g) => g.contains(coord),
+            Geometry::Line(g) => g.contains(coord),
+            Geometry::LineString(g) => g.contains(coord),
+            Geometry::Polygon(g) => g.contains(coord),
+            Geometry::MultiPoint(g) => g.contains(coord),
+            Geometry::MultiLineString(g) => g.contains(coord),
+            Geometry::MultiPolygon(g) => g.contains(coord),
+            Geometry::GeometryCollection(g) => g.contains(coord),
+            Geometry::Rect(g) => g.contains(coord),
+            Geometry::Triangle(g) => g.contains(coord),
+        }
+    }
+}
+
+impl<T> Contains<Point<T>> for Geometry<T>
+where
+    T: HasKernel,
+{
+    fn contains(&self, point: &Point<T>) -> bool {
+        self.contains(&point.0)
+    }
+}
+
+// ┌────────────────────────────────────────┐
+// │ Implementations for GeometryCollection │
+// └────────────────────────────────────────┘
+
+impl<T> Contains<Coordinate<T>> for GeometryCollection<T>
+where
+    T: HasKernel,
+{
+    fn contains(&self, coord: &Coordinate<T>) -> bool {
+        self.0.iter().any(|geometry| geometry.contains(coord))
+    }
+}
+
+impl<T> Contains<Point<T>> for GeometryCollection<T>
+where
+    T: HasKernel,
+{
+    fn contains(&self, point: &Point<T>) -> bool {
+        self.contains(&point.0)
+    }
+}

--- a/geo/src/algorithm/contains/line.rs
+++ b/geo/src/algorithm/contains/line.rs
@@ -53,13 +53,32 @@ where
             return false;
         }
 
-        // A closed linestring contains the start point in
-        // its interior and hence, must be within the line
-        // too.
-        if linestring.is_closed() && !self.contains(&linestring.0[0]) {
-            return false;
-        }
+        // The interior of the linestring should have some
+        // intersection with the interior of self. Two cases
+        // arise:
+        //
+        // 1. There are at least two distinct points in the
+        // linestring. Then, if both intersect, the interior
+        // between these two must have non-empty intersection.
+        //
+        // 2. Otherwise, all the points on the linestring
+        // are the same. In this case, the interior is this
+        // specific point, and it should be contained in the
+        // line.
+        let first = linestring.0.first().unwrap();
+        let mut all_equal = true;
 
-        linestring.0.iter().all(|c| self.intersects(c))
+        // If all the vertices of the linestring intersect
+        // self, then the interior or boundary of the
+        // linestring cannot have non-empty intersection
+        // with the exterior.
+        let all_intersects = linestring.0.iter().all(|c| {
+            if c != first {
+                all_equal = false;
+            }
+            self.intersects(c)
+        });
+
+        all_intersects && (!all_equal || self.contains(first))
     }
 }

--- a/geo/src/algorithm/contains/line.rs
+++ b/geo/src/algorithm/contains/line.rs
@@ -12,7 +12,11 @@ where
     T: HasKernel,
 {
     fn contains(&self, coord: &Coordinate<T>) -> bool {
-        self.intersects(coord)
+        if self.start == self.end {
+            &self.start == coord
+        } else {
+            coord != &self.start && coord != &self.end && self.intersects(coord)
+        }
     }
 }
 
@@ -30,7 +34,11 @@ where
     T: HasKernel,
 {
     fn contains(&self, line: &Line<T>) -> bool {
-        self.contains(&line.start) && self.contains(&line.end)
+        if line.start == line.end {
+            self.contains(&line.start)
+        } else {
+            self.intersects(&line.start) && self.intersects(&line.end)
+        }
     }
 }
 
@@ -39,6 +47,19 @@ where
     T: HasKernel,
 {
     fn contains(&self, linestring: &LineString<T>) -> bool {
-        linestring.0.iter().all(|c| self.contains(c))
+        // Empty linestring has no interior, and not
+        // contained in anything.
+        if linestring.0.is_empty() {
+            return false;
+        }
+
+        // A closed linestring contains the start point in
+        // its interior and hence, must be within the line
+        // too.
+        if linestring.is_closed() && !self.contains(&linestring.0[0]) {
+            return false;
+        }
+
+        linestring.0.iter().all(|c| self.intersects(c))
     }
 }

--- a/geo/src/algorithm/contains/line.rs
+++ b/geo/src/algorithm/contains/line.rs
@@ -1,0 +1,44 @@
+use super::Contains;
+use crate::*;
+use crate::kernels::*;
+use crate::intersects::Intersects;
+
+// ┌──────────────────────────┐
+// │ Implementations for Line │
+// └──────────────────────────┘
+
+impl<T> Contains<Coordinate<T>> for Line<T>
+where
+    T: HasKernel,
+{
+    fn contains(&self, coord: &Coordinate<T>) -> bool {
+        self.intersects(coord)
+    }
+}
+
+impl<T> Contains<Point<T>> for Line<T>
+where
+    T: HasKernel,
+{
+    fn contains(&self, p: &Point<T>) -> bool {
+        self.contains(&p.0)
+    }
+}
+
+impl<T> Contains<Line<T>> for Line<T>
+where
+    T: HasKernel,
+{
+    fn contains(&self, line: &Line<T>) -> bool {
+        self.contains(&line.start) && self.contains(&line.end)
+    }
+}
+
+impl<T> Contains<LineString<T>> for Line<T>
+where
+    T: HasKernel,
+{
+    fn contains(&self, linestring: &LineString<T>) -> bool {
+        linestring.0.iter().all(|c| self.contains(c))
+    }
+}

--- a/geo/src/algorithm/contains/line.rs
+++ b/geo/src/algorithm/contains/line.rs
@@ -1,7 +1,7 @@
 use super::Contains;
-use crate::*;
-use crate::kernels::*;
 use crate::intersects::Intersects;
+use crate::kernels::*;
+use crate::*;
 
 // ┌──────────────────────────┐
 // │ Implementations for Line │

--- a/geo/src/algorithm/contains/line_string.rs
+++ b/geo/src/algorithm/contains/line_string.rs
@@ -1,6 +1,7 @@
 use super::Contains;
 use crate::kernels::*;
 use crate::*;
+use intersects::Intersects;
 
 // ┌────────────────────────────────┐
 // │ Implementations for LineString │
@@ -11,7 +12,17 @@ where
     T: HasKernel,
 {
     fn contains(&self, coord: &Coordinate<T>) -> bool {
-        self.lines().any(|line| line.contains(coord))
+        if self.0.is_empty() {
+            return false;
+        }
+
+        if self.is_closed() && coord == &self.0[0] {
+            return true;
+        }
+
+        self.lines()
+            .enumerate()
+            .any(|(i, line)| line.contains(coord) || (i > 0 && coord == &line.start))
     }
 }
 
@@ -20,7 +31,7 @@ where
     T: HasKernel,
 {
     fn contains(&self, p: &Point<T>) -> bool {
-        self.lines().any(|line| line.contains(p))
+        self.contains(&p.0)
     }
 }
 
@@ -29,52 +40,89 @@ where
     T: HasKernel,
 {
     fn contains(&self, line: &Line<T>) -> bool {
-        let (p0, p1) = line.points();
-        let mut look_for: Option<Point<T>> = None;
-        for segment in self.lines() {
-            if look_for.is_none() {
-                // If segment contains an endpoint of line, we mark the other endpoint as the
-                // one we are looking for.
-                if segment.contains(&p0) {
-                    look_for = Some(p1);
-                } else if segment.contains(&p1) {
-                    look_for = Some(p0);
+        if line.start == line.end {
+            return self.contains(&line.start);
+        }
+
+        // We copy the line as we may truncate the line as
+        // we find partial matches.
+        let mut line = *line;
+        let mut first_cut = None;
+
+        let lines_iter = self.lines();
+        let num_lines = lines_iter.len();
+
+        // We need to repeat the logic twice to handle cases
+        // where the linestring starts at the middle of the line.
+        for (i, segment) in self.lines().chain(lines_iter).enumerate() {
+            if i >= num_lines {
+                // The first loop was done. If we never cut
+                // the line, or at the cut segment again, we
+                // can exit now.
+                if let Some(upto_i) = first_cut {
+                    if i >= num_lines + upto_i {
+                        break;
+                    }
+                } else {
+                    break;
                 }
             }
-            if let Some(p) = look_for {
-                // If we are looking for an endpoint, we need to either find it, or show that we
-                // should continue to look for it
-                if segment.contains(&p) {
-                    // If the segment contains the endpoint we are looking for we are done
-                    return true;
-                } else if !line.contains(&segment.end_point()) {
-                    // If not, and the end of the segment is not on the line, we should stop
-                    // looking
-                    look_for = None
-                }
+            // Look for a segment that intersects at least
+            // one of the end points.
+            let other = if segment.intersects(&line.start) {
+                line.end
+            } else if segment.intersects(&line.end) {
+                line.start
+            } else {
+                continue;
+            };
+
+            // If the other end point also intersects this
+            // segment, then we are done.
+            let new_inside = if segment.intersects(&other) {
+                return true;
+            }
+            // otoh, if the line contains one of the ends of
+            // the segments, then we truncate the line to
+            // the part outside.
+            else if line.contains(&segment.start) {
+                segment.start
+            } else if line.contains(&segment.end) {
+                segment.end
+            } else {
+                continue;
+            };
+
+            first_cut = first_cut.or(Some(i));
+            if other == line.start {
+                line.end = new_inside;
+            } else {
+                line.start = new_inside;
             }
         }
+
         false
+    }
+}
+
+impl<T> Contains<LineString<T>> for LineString<T>
+where
+    T: HasKernel,
+{
+    fn contains(&self, rhs: &LineString<T>) -> bool {
+        rhs.lines().all(|l| self.contains(&l))
     }
 }
 
 // ┌─────────────────────────────────────┐
 // │ Implementations for MultiLineString │
 // └─────────────────────────────────────┘
-impl<T> Contains<Coordinate<T>> for MultiLineString<T>
+impl<G, T> Contains<G> for MultiLineString<T>
 where
-    T: HasKernel,
+    T: CoordinateType,
+    LineString<T>: Contains<G>,
 {
-    fn contains(&self, coord: &Coordinate<T>) -> bool {
-        self.0.iter().any(|line_string| line_string.contains(coord))
-    }
-}
-
-impl<T> Contains<Point<T>> for MultiLineString<T>
-where
-    T: HasKernel,
-{
-    fn contains(&self, point: &Point<T>) -> bool {
-        self.contains(&point.0)
+    fn contains(&self, rhs: &G) -> bool {
+        self.0.iter().any(|p| p.contains(rhs))
     }
 }

--- a/geo/src/algorithm/contains/line_string.rs
+++ b/geo/src/algorithm/contains/line_string.rs
@@ -1,7 +1,6 @@
 use super::Contains;
-use crate::*;
 use crate::kernels::*;
-
+use crate::*;
 
 // ┌────────────────────────────────┐
 // │ Implementations for LineString │

--- a/geo/src/algorithm/contains/line_string.rs
+++ b/geo/src/algorithm/contains/line_string.rs
@@ -1,0 +1,81 @@
+use super::Contains;
+use crate::*;
+use crate::kernels::*;
+
+
+// ┌────────────────────────────────┐
+// │ Implementations for LineString │
+// └────────────────────────────────┘
+
+impl<T> Contains<Coordinate<T>> for LineString<T>
+where
+    T: HasKernel,
+{
+    fn contains(&self, coord: &Coordinate<T>) -> bool {
+        self.lines().any(|line| line.contains(coord))
+    }
+}
+
+impl<T> Contains<Point<T>> for LineString<T>
+where
+    T: HasKernel,
+{
+    fn contains(&self, p: &Point<T>) -> bool {
+        self.lines().any(|line| line.contains(p))
+    }
+}
+
+impl<T> Contains<Line<T>> for LineString<T>
+where
+    T: HasKernel,
+{
+    fn contains(&self, line: &Line<T>) -> bool {
+        let (p0, p1) = line.points();
+        let mut look_for: Option<Point<T>> = None;
+        for segment in self.lines() {
+            if look_for.is_none() {
+                // If segment contains an endpoint of line, we mark the other endpoint as the
+                // one we are looking for.
+                if segment.contains(&p0) {
+                    look_for = Some(p1);
+                } else if segment.contains(&p1) {
+                    look_for = Some(p0);
+                }
+            }
+            if let Some(p) = look_for {
+                // If we are looking for an endpoint, we need to either find it, or show that we
+                // should continue to look for it
+                if segment.contains(&p) {
+                    // If the segment contains the endpoint we are looking for we are done
+                    return true;
+                } else if !line.contains(&segment.end_point()) {
+                    // If not, and the end of the segment is not on the line, we should stop
+                    // looking
+                    look_for = None
+                }
+            }
+        }
+        false
+    }
+}
+
+// ┌─────────────────────────────────────┐
+// │ Implementations for MultiLineString │
+// └─────────────────────────────────────┘
+impl<T> Contains<Coordinate<T>> for MultiLineString<T>
+where
+    T: HasKernel,
+{
+    fn contains(&self, coord: &Coordinate<T>) -> bool {
+        self.0.iter().any(|line_string| line_string.contains(coord))
+    }
+}
+
+impl<T> Contains<Point<T>> for MultiLineString<T>
+where
+    T: HasKernel,
+{
+    fn contains(&self, point: &Point<T>) -> bool {
+        self.contains(&point.0)
+    }
+}

--- a/geo/src/algorithm/contains/mod.rs
+++ b/geo/src/algorithm/contains/mod.rs
@@ -138,7 +138,11 @@ mod test {
     #[test]
     fn linestring_point_is_vertex_test() {
         let linestring = LineString::from(vec![(0., 0.), (2., 0.), (2., 2.)]);
-        assert!(linestring.contains(&Point::new(2., 2.)));
+        // Note: the end points of a linestring are not
+        // considered to be "contained"
+        assert!(linestring.contains(&Point::new(2., 0.)));
+        assert!(!linestring.contains(&Point::new(0., 0.)));
+        assert!(!linestring.contains(&Point::new(2., 2.)));
     }
     #[test]
     fn linestring_test() {
@@ -347,6 +351,32 @@ mod test {
         let poly1 = Polygon::new(linestring1, Vec::new());
         assert!(poly0.contains(&line));
         assert!(!poly1.contains(&line));
+    }
+    #[test]
+    #[ignore]
+    fn line_in_polygon_edgecases_test() {
+        // Some DE-9IM edge cases for checking line is
+        // inside polygon The end points of the line can be
+        // on the boundary of the polygon but we don't allow
+        // that yet.
+        let c = |x, y| Coordinate { x, y };
+        // A non-convex polygon
+        let linestring0 = line_string![c(0, 0), c(1, 1), c(1, -1), c(-1, -1), c(-1, 1)];
+        let poly = Polygon::new(linestring0, Vec::new());
+
+        assert!(poly.contains(&Line::new(c(0, 0), c(1, -1))));
+        assert!(poly.contains(&Line::new(c(-1, 1), c(1, -1))));
+        assert!(!poly.contains(&Line::new(c(-1, 1), c(1, 1))));
+    }
+    #[test]
+    fn line_in_linestring_edgecases() {
+        let c = |x, y| Coordinate { x, y };
+        use crate::line_string;
+        let mut ls = line_string![c(0, 0), c(1, 0), c(0, 1), c(-1, 0)];
+        assert!(!ls.contains(&Line::from([(0, 0), (0, 0)])));
+        ls.close();
+        assert!(ls.contains(&Line::from([(0, 0), (0, 0)])));
+        assert!(ls.contains(&Line::from([(-1, 0), (1, 0)])));
     }
     #[test]
     fn line_in_linestring_test() {

--- a/geo/src/algorithm/contains/mod.rs
+++ b/geo/src/algorithm/contains/mod.rs
@@ -1,4 +1,11 @@
 /// Checks if `rhs` is completely contained within `self`.
+/// More formally, the interior of `rhs` has non-empty
+/// (set-theoretic) intersection but neither the interior,
+/// nor the boundary of `rhs` intersects the exterior of
+/// `self`. In other words, the [DE-9IM] intersection matrix
+/// of `(rhs, self)` is `T*F**F***`.
+///
+/// [DE-9IM]: https://en.wikipedia.org/wiki/DE-9IM
 ///
 /// # Examples
 ///

--- a/geo/src/algorithm/contains/mod.rs
+++ b/geo/src/algorithm/contains/mod.rs
@@ -336,10 +336,16 @@ mod test {
         let linestring2 = LineString::from(vec![(01, 11), (10, 20), (40, 50)]);
         // no part of linestring3 is contained in line
         let linestring3 = LineString::from(vec![(11, 11), (20, 20), (25, 25)]);
+        // a linestring with singleton interior on the boundary of the line
+        let linestring4 = LineString::from(vec![(0, 10), (0, 10), (0, 10)]);
+        // a linestring with singleton interior that is contained in the line
+        let linestring5 = LineString::from(vec![(1, 11), (1, 11), (1, 11)]);
         assert!(line.contains(&linestring0));
         assert!(!line.contains(&linestring1));
         assert!(!line.contains(&linestring2));
         assert!(!line.contains(&linestring3));
+        assert!(!line.contains(&linestring4));
+        assert!(line.contains(&linestring5));
     }
     #[test]
     fn line_in_polygon_test() {

--- a/geo/src/algorithm/contains/mod.rs
+++ b/geo/src/algorithm/contains/mod.rs
@@ -382,17 +382,17 @@ mod test {
     }
 
     #[test]
-    fn triangle_contains_point_on_edge() {
+    fn triangle_not_contains_point_on_edge() {
         let t = Triangle::from([(0.0, 0.0), (2.0, 0.0), (2.0, 2.0)]);
         let p = Point::new(1.0, 0.0);
-        assert!(t.contains(&p));
+        assert!(!t.contains(&p));
     }
 
     #[test]
-    fn triangle_contains_point_on_vertex() {
+    fn triangle_not_contains_point_on_vertex() {
         let t = Triangle::from([(0.0, 0.0), (2.0, 0.0), (2.0, 2.0)]);
         let p = Point::new(2.0, 0.0);
-        assert!(t.contains(&p));
+        assert!(!t.contains(&p));
     }
 
     #[test]

--- a/geo/src/algorithm/contains/mod.rs
+++ b/geo/src/algorithm/contains/mod.rs
@@ -1,434 +1,41 @@
-use num_traits::Float;
-
-use crate::algorithm::intersects::Intersects;
-use crate::utils;
-use crate::{
-    Coordinate, CoordinateType, Geometry, GeometryCollection, Line, LineString, MultiLineString,
-    MultiPoint, MultiPolygon, Point, Polygon, Rect, Triangle,
-};
-
-///  Checks if the geometry A is completely inside the B geometry
+/// Checks if `rhs` is completely contained within `self`.
+///
+/// # Examples
+///
+/// ```
+/// use geo::algorithm::contains::Contains;
+/// use geo::{line_string, point, Polygon};
+///
+/// let line_string = line_string![
+///     (x: 0., y: 0.),
+///     (x: 2., y: 0.),
+///     (x: 2., y: 2.),
+///     (x: 0., y: 2.),
+///     (x: 0., y: 0.),
+/// ];
+///
+/// let polygon = Polygon::new(line_string.clone(), vec![]);
+///
+/// // Point in Point
+/// assert!(point!(x: 2., y: 0.).contains(&point!(x: 2., y: 0.)));
+///
+/// // Point in Linestring
+/// assert!(line_string.contains(&point!(x: 2., y: 0.)));
+///
+/// // Point in Polygon
+/// assert!(polygon.contains(&point!(x: 1., y: 1.)));
+/// ```
 pub trait Contains<Rhs = Self> {
-    /// Checks if `rhs` is completely contained within `self`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use geo::algorithm::contains::Contains;
-    /// use geo::{line_string, point, Polygon};
-    ///
-    /// let line_string = line_string![
-    ///     (x: 0., y: 0.),
-    ///     (x: 2., y: 0.),
-    ///     (x: 2., y: 2.),
-    ///     (x: 0., y: 2.),
-    ///     (x: 0., y: 0.),
-    /// ];
-    ///
-    /// let polygon = Polygon::new(line_string.clone(), vec![]);
-    ///
-    /// // Point in Point
-    /// assert!(point!(x: 2., y: 0.).contains(&point!(x: 2., y: 0.)));
-    ///
-    /// // Point in Linestring
-    /// assert!(line_string.contains(&point!(x: 2., y: 0.)));
-    ///
-    /// // Point in Polygon
-    /// assert!(polygon.contains(&point!(x: 1., y: 1.)));
-    /// ```
     fn contains(&self, rhs: &Rhs) -> bool;
 }
 
-// ┌───────────────────────────┐
-// │ Implementations for Point │
-// └───────────────────────────┘
-
-impl<T> Contains<Coordinate<T>> for Point<T>
-where
-    T: Float,
-{
-    fn contains(&self, coord: &Coordinate<T>) -> bool {
-        self.contains(&Point(*coord))
-    }
-}
-
-impl<T> Contains<Point<T>> for Point<T>
-where
-    T: Float,
-{
-    fn contains(&self, p: &Point<T>) -> bool {
-        ::geo_types::private_utils::point_contains_point(*self, *p)
-    }
-}
-
-// ┌────────────────────────────────┐
-// │ Implementations for MultiPoint │
-// └────────────────────────────────┘
-
-impl<T> Contains<Coordinate<T>> for MultiPoint<T>
-where
-    T: Float,
-{
-    fn contains(&self, coord: &Coordinate<T>) -> bool {
-        self.0.iter().any(|point| point.contains(coord))
-    }
-}
-
-impl<T> Contains<Point<T>> for MultiPoint<T>
-where
-    T: Float,
-{
-    fn contains(&self, point: &Point<T>) -> bool {
-        self.contains(&point.0)
-    }
-}
-
-// ┌──────────────────────────┐
-// │ Implementations for Line │
-// └──────────────────────────┘
-
-impl<T> Contains<Coordinate<T>> for Line<T>
-where
-    T: Float,
-{
-    fn contains(&self, coord: &Coordinate<T>) -> bool {
-        self.contains(&Point(*coord))
-    }
-}
-
-impl<T> Contains<Point<T>> for Line<T>
-where
-    T: Float,
-{
-    fn contains(&self, p: &Point<T>) -> bool {
-        self.intersects(p)
-    }
-}
-
-impl<T> Contains<Line<T>> for Line<T>
-where
-    T: Float,
-{
-    fn contains(&self, line: &Line<T>) -> bool {
-        self.contains(&line.start_point()) && self.contains(&line.end_point())
-    }
-}
-
-impl<T> Contains<LineString<T>> for Line<T>
-where
-    T: Float,
-{
-    fn contains(&self, linestring: &LineString<T>) -> bool {
-        linestring.points_iter().all(|pt| self.contains(&pt))
-    }
-}
-
-// ┌────────────────────────────────┐
-// │ Implementations for LineString │
-// └────────────────────────────────┘
-
-impl<T> Contains<Coordinate<T>> for LineString<T>
-where
-    T: Float,
-{
-    fn contains(&self, coord: &Coordinate<T>) -> bool {
-        self.contains(&Point(*coord))
-    }
-}
-
-impl<T> Contains<Point<T>> for LineString<T>
-where
-    T: Float,
-{
-    fn contains(&self, p: &Point<T>) -> bool {
-        self.lines().any(|line| line.contains(p))
-    }
-}
-
-impl<T> Contains<Line<T>> for LineString<T>
-where
-    T: Float,
-{
-    fn contains(&self, line: &Line<T>) -> bool {
-        let (p0, p1) = line.points();
-        let mut look_for: Option<Point<T>> = None;
-        for segment in self.lines() {
-            if look_for.is_none() {
-                // If segment contains an endpoint of line, we mark the other endpoint as the
-                // one we are looking for.
-                if segment.contains(&p0) {
-                    look_for = Some(p1);
-                } else if segment.contains(&p1) {
-                    look_for = Some(p0);
-                }
-            }
-            if let Some(p) = look_for {
-                // If we are looking for an endpoint, we need to either find it, or show that we
-                // should continue to look for it
-                if segment.contains(&p) {
-                    // If the segment contains the endpoint we are looking for we are done
-                    return true;
-                } else if !line.contains(&segment.end_point()) {
-                    // If not, and the end of the segment is not on the line, we should stop
-                    // looking
-                    look_for = None
-                }
-            }
-        }
-        false
-    }
-}
-
-// ┌─────────────────────────────────────┐
-// │ Implementations for MultiLineString │
-// └─────────────────────────────────────┘
-
-impl<T> Contains<Coordinate<T>> for MultiLineString<T>
-where
-    T: Float,
-{
-    fn contains(&self, coord: &Coordinate<T>) -> bool {
-        self.0.iter().any(|line_string| line_string.contains(coord))
-    }
-}
-
-impl<T> Contains<Point<T>> for MultiLineString<T>
-where
-    T: Float,
-{
-    fn contains(&self, point: &Point<T>) -> bool {
-        self.contains(&point.0)
-    }
-}
-
-// ┌─────────────────────────────┐
-// │ Implementations for Polygon │
-// └─────────────────────────────┘
-
-impl<T> Contains<Coordinate<T>> for Polygon<T>
-where
-    T: Float,
-{
-    fn contains(&self, coord: &Coordinate<T>) -> bool {
-        match utils::coord_pos_relative_to_line_string(*coord, &self.exterior()) {
-            utils::CoordPos::OnBoundary | utils::CoordPos::Outside => false,
-            _ => self.interiors().iter().all(|ls| {
-                utils::coord_pos_relative_to_line_string(*coord, ls) == utils::CoordPos::Outside
-            }),
-        }
-    }
-}
-
-impl<T> Contains<Point<T>> for Polygon<T>
-where
-    T: Float,
-{
-    fn contains(&self, p: &Point<T>) -> bool {
-        self.contains(&p.0)
-    }
-}
-
-impl<T> Contains<Line<T>> for Polygon<T>
-where
-    T: Float,
-{
-    fn contains(&self, line: &Line<T>) -> bool {
-        // both endpoints are contained in the polygon and the line
-        // does NOT intersect the exterior or any of the interior boundaries
-        self.contains(&line.start_point())
-            && self.contains(&line.end_point())
-            && !self.exterior().intersects(line)
-            && !self.interiors().iter().any(|inner| inner.intersects(line))
-    }
-}
-
-impl<T> Contains<Polygon<T>> for Polygon<T>
-where
-    T: Float,
-{
-    fn contains(&self, poly: &Polygon<T>) -> bool {
-        // decompose poly's exterior ring into Lines, and check each for containment
-        poly.exterior().lines().all(|line| self.contains(&line))
-    }
-}
-
-impl<T> Contains<LineString<T>> for Polygon<T>
-where
-    T: Float,
-{
-    fn contains(&self, linestring: &LineString<T>) -> bool {
-        // All LineString points must be inside the Polygon
-        if linestring.points_iter().all(|point| self.contains(&point)) {
-            // The Polygon interior is allowed to intersect with the LineString
-            // but the Polygon's rings are not
-            !self
-                .interiors()
-                .iter()
-                .any(|ring| ring.intersects(linestring))
-        } else {
-            false
-        }
-    }
-}
-
-// ┌──────────────────────────────────┐
-// │ Implementations for MultiPolygon │
-// └──────────────────────────────────┘
-
-impl<T> Contains<Coordinate<T>> for MultiPolygon<T>
-where
-    T: Float,
-{
-    fn contains(&self, coord: &Coordinate<T>) -> bool {
-        self.0.iter().any(|poly| poly.contains(coord))
-    }
-}
-
-impl<T> Contains<Point<T>> for MultiPolygon<T>
-where
-    T: Float,
-{
-    fn contains(&self, p: &Point<T>) -> bool {
-        self.contains(&p.0)
-    }
-}
-
-// ┌──────────────────────────┐
-// │ Implementations for Rect │
-// └──────────────────────────┘
-
-impl<T> Contains<Coordinate<T>> for Rect<T>
-where
-    T: CoordinateType,
-{
-    fn contains(&self, coord: &Coordinate<T>) -> bool {
-        coord.x >= self.min().x
-            && coord.x <= self.max().x
-            && coord.y >= self.min().y
-            && coord.y <= self.max().y
-    }
-}
-
-impl<T> Contains<Point<T>> for Rect<T>
-where
-    T: CoordinateType,
-{
-    fn contains(&self, p: &Point<T>) -> bool {
-        self.contains(&p.0)
-    }
-}
-
-impl<T> Contains<Rect<T>> for Rect<T>
-where
-    T: CoordinateType,
-{
-    fn contains(&self, bounding_rect: &Rect<T>) -> bool {
-        // All points of LineString must be in the polygon ?
-        self.min().x <= bounding_rect.min().x
-            && self.max().x >= bounding_rect.max().x
-            && self.min().y <= bounding_rect.min().y
-            && self.max().y >= bounding_rect.max().y
-    }
-}
-
-// ┌──────────────────────────────┐
-// │ Implementations for Triangle │
-// └──────────────────────────────┘
-
-impl<T> Contains<Coordinate<T>> for Triangle<T>
-where
-    T: CoordinateType,
-{
-    fn contains(&self, coord: &Coordinate<T>) -> bool {
-        let s = self.0.y * self.2.x - self.0.x * self.2.y
-            + (self.2.y - self.0.y) * coord.x
-            + (self.0.x - self.2.x) * coord.y;
-        let t = self.0.x * self.1.y - self.0.y * self.1.x
-            + (self.0.y - self.1.y) * coord.x
-            + (self.1.x - self.0.x) * coord.y;
-
-        if (s < T::zero()) != (t < T::zero()) {
-            return false;
-        }
-
-        let a = (T::zero() - self.1.y) * self.2.x
-            + self.0.y * (self.2.x - self.1.x)
-            + self.0.x * (self.1.y - self.2.y)
-            + self.1.x * self.2.y;
-
-        if a == T::zero() {
-            false
-        } else if a < T::zero() {
-            s <= T::zero() && s + t >= a
-        } else {
-            s >= T::zero() && s + t <= a
-        }
-    }
-}
-
-impl<T> Contains<Point<T>> for Triangle<T>
-where
-    T: CoordinateType,
-{
-    fn contains(&self, point: &Point<T>) -> bool {
-        self.contains(&point.0)
-    }
-}
-
-// ┌──────────────────────────────┐
-// │ Implementations for Geometry │
-// └──────────────────────────────┘
-
-impl<T> Contains<Coordinate<T>> for Geometry<T>
-where
-    T: Float,
-{
-    fn contains(&self, coord: &Coordinate<T>) -> bool {
-        match self {
-            Geometry::Point(g) => g.contains(coord),
-            Geometry::Line(g) => g.contains(coord),
-            Geometry::LineString(g) => g.contains(coord),
-            Geometry::Polygon(g) => g.contains(coord),
-            Geometry::MultiPoint(g) => g.contains(coord),
-            Geometry::MultiLineString(g) => g.contains(coord),
-            Geometry::MultiPolygon(g) => g.contains(coord),
-            Geometry::GeometryCollection(g) => g.contains(coord),
-            Geometry::Rect(g) => g.contains(coord),
-            Geometry::Triangle(g) => g.contains(coord),
-        }
-    }
-}
-
-impl<T> Contains<Point<T>> for Geometry<T>
-where
-    T: Float,
-{
-    fn contains(&self, point: &Point<T>) -> bool {
-        self.contains(&point.0)
-    }
-}
-
-// ┌────────────────────────────────────────┐
-// │ Implementations for GeometryCollection │
-// └────────────────────────────────────────┘
-
-impl<T> Contains<Coordinate<T>> for GeometryCollection<T>
-where
-    T: Float,
-{
-    fn contains(&self, coord: &Coordinate<T>) -> bool {
-        self.0.iter().any(|geometry| geometry.contains(coord))
-    }
-}
-
-impl<T> Contains<Point<T>> for GeometryCollection<T>
-where
-    T: Float,
-{
-    fn contains(&self, point: &Point<T>) -> bool {
-        self.contains(&point.0)
-    }
-}
+mod point;
+mod line;
+mod line_string;
+mod triangle;
+mod rect;
+mod polygon;
+mod geometry;
 
 // ┌───────┐
 // │ Tests │
@@ -709,15 +316,15 @@ mod test {
     }
     #[test]
     fn linestring_in_line_test() {
-        let line = Line::from([(0., 1.), (3., 4.)]);
+        let line = Line::from([(0, 10), (30, 40)]);
         // linestring0 in line
-        let linestring0 = LineString::from(vec![(0.1, 1.1), (1., 2.), (1.5, 2.5)]);
+        let linestring0 = LineString::from(vec![(01, 11), (10, 20), (15, 25)]);
         // linestring1 starts and ends in line, but wanders in the middle
-        let linestring1 = LineString::from(vec![(0.1, 1.1), (2., 2.), (1.5, 2.5)]);
+        let linestring1 = LineString::from(vec![(01, 11), (20, 20), (15, 25)]);
         // linestring2 is co-linear, but extends beyond line
-        let linestring2 = LineString::from(vec![(0.1, 1.1), (1., 2.), (4., 5.)]);
+        let linestring2 = LineString::from(vec![(01, 11), (10, 20), (40, 50)]);
         // no part of linestring3 is contained in line
-        let linestring3 = LineString::from(vec![(1.1, 1.1), (2., 2.), (2.5, 2.5)]);
+        let linestring3 = LineString::from(vec![(11, 11), (20, 20), (25, 25)]);
         assert!(line.contains(&linestring0));
         assert!(!line.contains(&linestring1));
         assert!(!line.contains(&linestring2));
@@ -726,10 +333,10 @@ mod test {
     #[test]
     fn line_in_polygon_test() {
         let c = |x, y| Coordinate { x, y };
-        let line = Line::new(c(0., 1.), c(3., 4.));
-        let linestring0 = line_string![c(-1., 0.), c(5., 0.), c(5., 5.), c(0., 5.), c(-1., 0.)];
+        let line = Line::new(c(0, 10), c(30, 40));
+        let linestring0 = line_string![c(-10, 0), c(50, 0), c(50, 50), c(0, 50), c(-10, 0)];
         let poly0 = Polygon::new(linestring0, Vec::new());
-        let linestring1 = line_string![c(0., 0.), c(0., 2.), c(2., 2.), c(2., 0.), c(0., 0.)];
+        let linestring1 = line_string![c(0, 0), c(0, 20), c(20, 20), c(20, 0), c(0, 0)];
         let poly1 = Polygon::new(linestring1, Vec::new());
         assert!(poly0.contains(&line));
         assert!(!poly1.contains(&line));

--- a/geo/src/algorithm/contains/mod.rs
+++ b/geo/src/algorithm/contains/mod.rs
@@ -29,13 +29,13 @@ pub trait Contains<Rhs = Self> {
     fn contains(&self, rhs: &Rhs) -> bool;
 }
 
-mod point;
+mod geometry;
 mod line;
 mod line_string;
-mod triangle;
-mod rect;
+mod point;
 mod polygon;
-mod geometry;
+mod rect;
+mod triangle;
 
 // ┌───────┐
 // │ Tests │

--- a/geo/src/algorithm/contains/point.rs
+++ b/geo/src/algorithm/contains/point.rs
@@ -1,0 +1,46 @@
+use super::Contains;
+use crate::*;
+
+// ┌────────────────────────────────┐
+// │ Implementations for Point      │
+// └────────────────────────────────┘
+
+impl<T> Contains<Coordinate<T>> for Point<T>
+where
+    T: CoordinateType,
+{
+    fn contains(&self, coord: &Coordinate<T>) -> bool {
+        &self.0 == coord
+    }
+}
+
+impl<T> Contains<Point<T>> for Point<T>
+where
+    T: CoordinateType,
+{
+    fn contains(&self, p: &Point<T>) -> bool {
+        self.contains(&p.0)
+    }
+}
+
+// ┌────────────────────────────────┐
+// │ Implementations for MultiPoint │
+// └────────────────────────────────┘
+
+impl<T> Contains<Coordinate<T>> for MultiPoint<T>
+where
+    T: CoordinateType,
+{
+    fn contains(&self, coord: &Coordinate<T>) -> bool {
+        self.0.iter().any(|point| point.contains(coord))
+    }
+}
+
+impl<T> Contains<Point<T>> for MultiPoint<T>
+where
+    T: CoordinateType,
+{
+    fn contains(&self, point: &Point<T>) -> bool {
+        self.contains(&point.0)
+    }
+}

--- a/geo/src/algorithm/contains/point.rs
+++ b/geo/src/algorithm/contains/point.rs
@@ -26,21 +26,12 @@ where
 // ┌────────────────────────────────┐
 // │ Implementations for MultiPoint │
 // └────────────────────────────────┘
-
-impl<T> Contains<Coordinate<T>> for MultiPoint<T>
+impl<G, T> Contains<G> for MultiPoint<T>
 where
     T: CoordinateType,
+    Point<T>: Contains<G>,
 {
-    fn contains(&self, coord: &Coordinate<T>) -> bool {
-        self.0.iter().any(|point| point.contains(coord))
-    }
-}
-
-impl<T> Contains<Point<T>> for MultiPoint<T>
-where
-    T: CoordinateType,
-{
-    fn contains(&self, point: &Point<T>) -> bool {
-        self.contains(&point.0)
+    fn contains(&self, rhs: &G) -> bool {
+        self.0.iter().any(|p| p.contains(rhs))
     }
 }

--- a/geo/src/algorithm/contains/polygon.rs
+++ b/geo/src/algorithm/contains/polygon.rs
@@ -1,7 +1,7 @@
 use super::Contains;
-use crate::*;
-use crate::kernels::*;
 use crate::intersects::Intersects;
+use crate::kernels::*;
+use crate::*;
 
 // ┌─────────────────────────────┐
 // │ Implementations for Polygon │

--- a/geo/src/algorithm/contains/polygon.rs
+++ b/geo/src/algorithm/contains/polygon.rs
@@ -30,6 +30,8 @@ where
     }
 }
 
+// TODO: ensure DE-9IM compliance: esp., when
+// line.start and line.end is on the boundaries
 impl<T> Contains<Line<T>> for Polygon<T>
 where
     T: HasKernel,
@@ -44,6 +46,7 @@ where
     }
 }
 
+// TODO: also check interiors
 impl<T> Contains<Polygon<T>> for Polygon<T>
 where
     T: HasKernel,
@@ -54,6 +57,7 @@ where
     }
 }
 
+// TODO: ensure DE-9IM compliance
 impl<T> Contains<LineString<T>> for Polygon<T>
 where
     T: HasKernel,
@@ -76,21 +80,12 @@ where
 // ┌──────────────────────────────────┐
 // │ Implementations for MultiPolygon │
 // └──────────────────────────────────┘
-
-impl<T> Contains<Coordinate<T>> for MultiPolygon<T>
+impl<G, T> Contains<G> for MultiPolygon<T>
 where
-    T: HasKernel,
+    T: CoordinateType,
+    Polygon<T>: Contains<G>,
 {
-    fn contains(&self, coord: &Coordinate<T>) -> bool {
-        self.0.iter().any(|poly| poly.contains(coord))
-    }
-}
-
-impl<T> Contains<Point<T>> for MultiPolygon<T>
-where
-    T: HasKernel,
-{
-    fn contains(&self, p: &Point<T>) -> bool {
-        self.contains(&p.0)
+    fn contains(&self, rhs: &G) -> bool {
+        self.0.iter().any(|p| p.contains(rhs))
     }
 }

--- a/geo/src/algorithm/contains/polygon.rs
+++ b/geo/src/algorithm/contains/polygon.rs
@@ -1,0 +1,96 @@
+use super::Contains;
+use crate::*;
+use crate::kernels::*;
+use crate::intersects::Intersects;
+
+// ┌─────────────────────────────┐
+// │ Implementations for Polygon │
+// └─────────────────────────────┘
+
+impl<T> Contains<Coordinate<T>> for Polygon<T>
+where
+    T: HasKernel,
+{
+    fn contains(&self, coord: &Coordinate<T>) -> bool {
+        match utils::coord_pos_relative_to_ring(*coord, &self.exterior()) {
+            utils::CoordPos::OnBoundary | utils::CoordPos::Outside => false,
+            _ => self.interiors().iter().all(|ls| {
+                utils::coord_pos_relative_to_ring(*coord, ls) == utils::CoordPos::Outside
+            }),
+        }
+    }
+}
+
+impl<T> Contains<Point<T>> for Polygon<T>
+where
+    T: HasKernel,
+{
+    fn contains(&self, p: &Point<T>) -> bool {
+        self.contains(&p.0)
+    }
+}
+
+impl<T> Contains<Line<T>> for Polygon<T>
+where
+    T: HasKernel,
+{
+    fn contains(&self, line: &Line<T>) -> bool {
+        // both endpoints are contained in the polygon and the line
+        // does NOT intersect the exterior or any of the interior boundaries
+        self.contains(&line.start_point())
+            && self.contains(&line.end_point())
+            && !self.exterior().intersects(line)
+            && !self.interiors().iter().any(|inner| inner.intersects(line))
+    }
+}
+
+impl<T> Contains<Polygon<T>> for Polygon<T>
+where
+    T: HasKernel,
+{
+    fn contains(&self, poly: &Polygon<T>) -> bool {
+        // decompose poly's exterior ring into Lines, and check each for containment
+        poly.exterior().lines().all(|line| self.contains(&line))
+    }
+}
+
+impl<T> Contains<LineString<T>> for Polygon<T>
+where
+    T: HasKernel,
+{
+    fn contains(&self, linestring: &LineString<T>) -> bool {
+        // All LineString points must be inside the Polygon
+        if linestring.points_iter().all(|point| self.contains(&point)) {
+            // The Polygon interior is allowed to intersect with the LineString
+            // but the Polygon's rings are not
+            !self
+                .interiors()
+                .iter()
+                .any(|ring| ring.intersects(linestring))
+        } else {
+            false
+        }
+    }
+}
+
+// ┌──────────────────────────────────┐
+// │ Implementations for MultiPolygon │
+// └──────────────────────────────────┘
+
+impl<T> Contains<Coordinate<T>> for MultiPolygon<T>
+where
+    T: HasKernel,
+{
+    fn contains(&self, coord: &Coordinate<T>) -> bool {
+        self.0.iter().any(|poly| poly.contains(coord))
+    }
+}
+
+impl<T> Contains<Point<T>> for MultiPolygon<T>
+where
+    T: HasKernel,
+{
+    fn contains(&self, p: &Point<T>) -> bool {
+        self.contains(&p.0)
+    }
+}

--- a/geo/src/algorithm/contains/polygon.rs
+++ b/geo/src/algorithm/contains/polygon.rs
@@ -37,8 +37,8 @@ where
     fn contains(&self, line: &Line<T>) -> bool {
         // both endpoints are contained in the polygon and the line
         // does NOT intersect the exterior or any of the interior boundaries
-        self.contains(&line.start_point())
-            && self.contains(&line.end_point())
+        self.contains(&line.start)
+            && self.contains(&line.end)
             && !self.exterior().intersects(line)
             && !self.interiors().iter().any(|inner| inner.intersects(line))
     }

--- a/geo/src/algorithm/contains/polygon.rs
+++ b/geo/src/algorithm/contains/polygon.rs
@@ -80,6 +80,7 @@ where
 // ┌──────────────────────────────────┐
 // │ Implementations for MultiPolygon │
 // └──────────────────────────────────┘
+// TODO: ensure DE-9IM compliance
 impl<G, T> Contains<G> for MultiPolygon<T>
 where
     T: CoordinateType,

--- a/geo/src/algorithm/contains/rect.rs
+++ b/geo/src/algorithm/contains/rect.rs
@@ -10,10 +10,10 @@ where
     T: CoordinateType,
 {
     fn contains(&self, coord: &Coordinate<T>) -> bool {
-        coord.x >= self.min().x
-            && coord.x <= self.max().x
-            && coord.y >= self.min().y
-            && coord.y <= self.max().y
+        coord.x > self.min().x
+            && coord.x < self.max().x
+            && coord.y > self.min().y
+            && coord.y < self.max().y
     }
 }
 

--- a/geo/src/algorithm/contains/rect.rs
+++ b/geo/src/algorithm/contains/rect.rs
@@ -30,11 +30,12 @@ impl<T> Contains<Rect<T>> for Rect<T>
 where
     T: CoordinateType,
 {
-    fn contains(&self, bounding_rect: &Rect<T>) -> bool {
+    fn contains(&self, other: &Rect<T>) -> bool {
+        // TODO: check for degenerate rectangle (which is a line or a point)
         // All points of LineString must be in the polygon ?
-        self.min().x <= bounding_rect.min().x
-            && self.max().x >= bounding_rect.max().x
-            && self.min().y <= bounding_rect.min().y
-            && self.max().y >= bounding_rect.max().y
+        self.min().x <= other.min().x
+            && self.max().x >= other.max().x
+            && self.min().y <= other.min().y
+            && self.max().y >= other.max().y
     }
 }

--- a/geo/src/algorithm/contains/rect.rs
+++ b/geo/src/algorithm/contains/rect.rs
@@ -1,0 +1,40 @@
+use super::Contains;
+use crate::*;
+
+// ┌──────────────────────────┐
+// │ Implementations for Rect │
+// └──────────────────────────┘
+
+impl<T> Contains<Coordinate<T>> for Rect<T>
+where
+    T: CoordinateType,
+{
+    fn contains(&self, coord: &Coordinate<T>) -> bool {
+        coord.x >= self.min().x
+            && coord.x <= self.max().x
+            && coord.y >= self.min().y
+            && coord.y <= self.max().y
+    }
+}
+
+impl<T> Contains<Point<T>> for Rect<T>
+where
+    T: CoordinateType,
+{
+    fn contains(&self, p: &Point<T>) -> bool {
+        self.contains(&p.0)
+    }
+}
+
+impl<T> Contains<Rect<T>> for Rect<T>
+where
+    T: CoordinateType,
+{
+    fn contains(&self, bounding_rect: &Rect<T>) -> bool {
+        // All points of LineString must be in the polygon ?
+        self.min().x <= bounding_rect.min().x
+            && self.max().x >= bounding_rect.max().x
+            && self.min().y <= bounding_rect.min().y
+            && self.max().y >= bounding_rect.max().y
+    }
+}

--- a/geo/src/algorithm/contains/triangle.rs
+++ b/geo/src/algorithm/contains/triangle.rs
@@ -11,9 +11,9 @@ where
     T: HasKernel,
 {
     fn contains(&self, coord: &Coordinate<T>) -> bool {
-        let ls = LineString(vec![self.0, self.1, self.2]);
+        let ls = LineString(vec![self.0, self.1, self.2, self.0]);
         use utils::*;
-        coord_pos_relative_to_ring(*coord, &ls) != CoordPos::Outside
+        coord_pos_relative_to_ring(*coord, &ls) == CoordPos::Inside
     }
 }
 

--- a/geo/src/algorithm/contains/triangle.rs
+++ b/geo/src/algorithm/contains/triangle.rs
@@ -1,0 +1,27 @@
+use super::Contains;
+use crate::kernels::*;
+use crate::*;
+
+// ┌──────────────────────────────┐
+// │ Implementations for Triangle │
+// └──────────────────────────────┘
+
+impl<T> Contains<Coordinate<T>> for Triangle<T>
+where
+    T: HasKernel,
+{
+    fn contains(&self, coord: &Coordinate<T>) -> bool {
+        let ls = LineString(vec![self.0, self.1, self.2]);
+        use utils::*;
+        coord_pos_relative_to_ring(*coord, &ls) != CoordPos::Outside
+    }
+}
+
+impl<T> Contains<Point<T>> for Triangle<T>
+where
+    T: HasKernel,
+{
+    fn contains(&self, point: &Point<T>) -> bool {
+        self.contains(&point.0)
+    }
+}

--- a/geo/src/algorithm/convex_hull/graham.rs
+++ b/geo/src/algorithm/convex_hull/graham.rs
@@ -89,9 +89,8 @@ where
 mod test {
     use super::*;
     use crate::algorithm::is_convex::IsConvex;
-    use geo_types::CoordinateType;
     use std::fmt::Debug;
-    fn test_convexity<T: CoordinateType + HasKernel + Debug>(initial: &[(T, T)]) {
+    fn test_convexity<T: HasKernel + Debug>(initial: &[(T, T)]) {
         let mut v: Vec<_> = initial
             .iter()
             .map(|e| Coordinate::from((e.0, e.1)))

--- a/geo/src/algorithm/convex_hull/graham.rs
+++ b/geo/src/algorithm/convex_hull/graham.rs
@@ -96,12 +96,6 @@ mod test {
             .map(|e| Coordinate::from((e.0, e.1)))
             .collect();
         let hull = graham_hull(&mut v, false);
-        eprintln!("Strict hull");
-        for v in hull.0.iter() {
-            eprintln!("{:?}", v);
-        }
-        eprintln!("{}", hull.is_closed());
-        eprintln!("{:?}", hull.convex_orientation(true, None));
         assert!(hull.is_strictly_ccw_convex());
         let hull = graham_hull(&mut v, true);
         assert!(hull.is_ccw_convex());

--- a/geo/src/algorithm/convex_hull/mod.rs
+++ b/geo/src/algorithm/convex_hull/mod.rs
@@ -117,10 +117,17 @@ where
 
     // Remove repeated points unless collinear points
     // are to be included.
-    let mut ls: LineString<T> = points.iter().copied().collect();
+    let mut ls: Vec<Coordinate<T>> = points.iter().copied().collect();
     if !include_on_hull {
-        ls.0.dedup();
+        ls.dedup();
     }
+
+    // A linestring with a single point is invalid.
+    if ls.len() == 1 {
+        ls.push(ls[0]);
+    }
+
+    let mut ls = LineString(ls);
     ls.close();
 
     // Maintain the CCW invariance

--- a/geo/src/algorithm/extremes.rs
+++ b/geo/src/algorithm/extremes.rs
@@ -1,20 +1,7 @@
 use super::kernels::*;
 use crate::prelude::*;
 use crate::*;
-use num_traits::{Signed, Zero};
-
-/// Compute the sign of the dot product of `u` and `v` using
-/// robust predicates. The output is `CounterClockwise` if
-/// the sign is positive, `Clockwise` if negative, and
-/// `Collinear` if zero.
-fn dot_product_sign<T>(u: Coordinate<T>, v: Coordinate<T>) -> Orientation
-where
-    T: CoordinateType + Signed + HasKernel,
-{
-    let zero = Coordinate::zero();
-    let vdash = Coordinate { x: -v.y, y: v.x };
-    T::Ker::orient2d(zero, u, vdash)
-}
+use num_traits::Signed;
 
 // Useful direction vectors, aligned with x and y axes:
 // 1., 0. = largest x
@@ -28,7 +15,7 @@ fn above<T>(u: Coordinate<T>, vi: Coordinate<T>, vj: Coordinate<T>) -> bool
 where
     T: CoordinateType + Signed + HasKernel,
 {
-    dot_product_sign(u, vi - vj) == Orientation::CounterClockwise
+    T::Ker::dot_product_sign(u, vi - vj) == Orientation::CounterClockwise
 }
 
 /// Predicate that returns `true` if `vi` is (strictly) below `vj`
@@ -38,13 +25,13 @@ fn below<T>(u: Coordinate<T>, vi: Coordinate<T>, vj: Coordinate<T>) -> bool
 where
     T: CoordinateType + Signed + HasKernel,
 {
-    dot_product_sign(u, vi - vj) == Orientation::Clockwise
+    T::Ker::dot_product_sign(u, vi - vj) == Orientation::Clockwise
 }
 
 // wrapper for extreme-finding function
 fn find_extreme_indices<T, F>(func: F, polygon: &Polygon<T>) -> Result<Extremes, ()>
 where
-    T: CoordinateType + HasKernel + Signed,
+    T: HasKernel + Signed,
     F: Fn(Coordinate<T>, &Polygon<T>) -> Result<usize, ()>,
 {
     use crate::is_convex::IsConvex;
@@ -68,7 +55,7 @@ where
 // u: a direction vector. We're using a point to represent this, which is a hack but works fine
 fn polymax_naive_indices<T>(u: Coordinate<T>, poly: &Polygon<T>) -> Result<usize, ()>
 where
-    T: CoordinateType + HasKernel + Signed,
+    T: HasKernel + Signed,
 {
     let vertices = &poly.exterior().0;
     let mut max: usize = 0;

--- a/geo/src/algorithm/extremes.rs
+++ b/geo/src/algorithm/extremes.rs
@@ -34,7 +34,6 @@ where
     T: HasKernel + Signed,
     F: Fn(Coordinate<T>, &Polygon<T>) -> Result<usize, ()>,
 {
-    use crate::is_convex::IsConvex;
     if !polygon.exterior().is_convex() {
         return Err(());
     }

--- a/geo/src/algorithm/intersects/coordinate.rs
+++ b/geo/src/algorithm/intersects/coordinate.rs
@@ -1,0 +1,11 @@
+use super::Intersects;
+use crate::*;
+
+impl<T> Intersects<Coordinate<T>> for Coordinate<T>
+where
+    T: CoordinateType,
+{
+    fn intersects(&self, rhs: &Coordinate<T>) -> bool {
+        self == rhs
+    }
+}

--- a/geo/src/algorithm/intersects/line.rs
+++ b/geo/src/algorithm/intersects/line.rs
@@ -1,0 +1,54 @@
+use super::{point_in_rect, Intersects};
+use crate::kernels::*;
+use crate::*;
+
+impl<T> Intersects<Coordinate<T>> for Line<T>
+where
+    T: HasKernel,
+{
+    fn intersects(&self, rhs: &Coordinate<T>) -> bool {
+        T::Ker::orient2d(self.start, self.end, *rhs) == Orientation::Collinear
+            && point_in_rect(*rhs, self.start, self.end)
+    }
+}
+
+impl<T> Intersects<Point<T>> for Line<T>
+where
+    T: HasKernel,
+{
+    fn intersects(&self, p: &Point<T>) -> bool {
+        self.intersects(&p.0)
+    }
+}
+
+impl<T> Intersects<Line<T>> for Line<T>
+where
+    T: HasKernel,
+{
+    fn intersects(&self, line: &Line<T>) -> bool {
+        if self.start == self.end {
+            return line.intersects(&self.start);
+        }
+        let check_1_1 = T::Ker::orient2d(self.start, self.end, line.start);
+        let check_1_2 = T::Ker::orient2d(self.start, self.end, line.end);
+
+        if check_1_1 != check_1_2 {
+            let check_2_1 = T::Ker::orient2d(line.start, line.end, self.start);
+            let check_2_2 = T::Ker::orient2d(line.start, line.end, self.end);
+
+            check_2_1 != check_2_2
+        } else if check_1_1 == Orientation::Collinear {
+            // Special case: collinear line segments.
+
+            // Equivalent to the point-line intersection
+            // impl., but removes the calls to the kernel
+            // predicates.
+            point_in_rect(line.start, self.start, self.end)
+                || point_in_rect(line.end, self.start, self.end)
+                || point_in_rect(self.end, line.start, line.end)
+                || point_in_rect(self.end, line.start, line.end)
+        } else {
+            false
+        }
+    }
+}

--- a/geo/src/algorithm/intersects/line.rs
+++ b/geo/src/algorithm/intersects/line.rs
@@ -11,6 +11,7 @@ where
             && point_in_rect(*rhs, self.start, self.end)
     }
 }
+symmetric_intersects_impl!(Coordinate<T>, Line<T>, HasKernel);
 
 impl<T> Intersects<Point<T>> for Line<T>
 where
@@ -20,6 +21,7 @@ where
         self.intersects(&p.0)
     }
 }
+symmetric_intersects_impl!(Point<T>, Line<T>, HasKernel);
 
 impl<T> Intersects<Line<T>> for Line<T>
 where

--- a/geo/src/algorithm/intersects/line_string.rs
+++ b/geo/src/algorithm/intersects/line_string.rs
@@ -1,0 +1,32 @@
+use super::Intersects;
+use crate::kernels::*;
+use crate::*;
+
+impl<T> Intersects<Line<T>> for LineString<T>
+where
+    T: HasKernel,
+{
+    fn intersects(&self, line: &Line<T>) -> bool {
+        self.lines().any(|l| line.intersects(&l))
+    }
+}
+
+impl<T> Intersects<LineString<T>> for LineString<T>
+where
+    T: HasKernel,
+{
+    fn intersects(&self, linestring: &LineString<T>) -> bool {
+        if self.0.is_empty() || linestring.0.is_empty() {
+            return false;
+        }
+        for a in self.lines() {
+            for b in linestring.lines() {
+                if a.intersects(&b) {
+                    return true;
+                }
+            }
+        }
+
+        false
+    }
+}

--- a/geo/src/algorithm/intersects/line_string.rs
+++ b/geo/src/algorithm/intersects/line_string.rs
@@ -2,6 +2,26 @@ use super::Intersects;
 use crate::kernels::*;
 use crate::*;
 
+impl<T> Intersects<Coordinate<T>> for LineString<T>
+where
+    T: HasKernel,
+{
+    fn intersects(&self, coord: &Coordinate<T>) -> bool {
+        self.lines().any(|l| coord.intersects(&l))
+    }
+}
+symmetric_intersects_impl!(Coordinate<T>, LineString<T>, HasKernel);
+
+impl<T> Intersects<Point<T>> for LineString<T>
+where
+    T: HasKernel,
+{
+    fn intersects(&self, point: &Point<T>) -> bool {
+        self.intersects(&point.0)
+    }
+}
+symmetric_intersects_impl!(Point<T>, LineString<T>, HasKernel);
+
 impl<T> Intersects<Line<T>> for LineString<T>
 where
     T: HasKernel,

--- a/geo/src/algorithm/intersects/line_string.rs
+++ b/geo/src/algorithm/intersects/line_string.rs
@@ -10,6 +10,7 @@ where
         self.lines().any(|l| line.intersects(&l))
     }
 }
+symmetric_intersects_impl!(Line<T>, LineString<T>, HasKernel);
 
 impl<T> Intersects<LineString<T>> for LineString<T>
 where

--- a/geo/src/algorithm/intersects/mod.rs
+++ b/geo/src/algorithm/intersects/mod.rs
@@ -64,6 +64,7 @@ mod line_string;
 mod point;
 mod polygon;
 mod rect;
+mod triangle;
 
 // Helper function to check value lies between min and max.
 // Only makes sense if min <= max (or always false)

--- a/geo/src/algorithm/intersects/mod.rs
+++ b/geo/src/algorithm/intersects/mod.rs
@@ -34,9 +34,8 @@ mod coordinate;
 mod line;
 mod line_string;
 mod point;
-mod rect;
 mod polygon;
-
+mod rect;
 
 // Since `Intersects` is symmetric, we use a macro to
 // implement `T: Intersects<S>` if `S: Intersects<T>` is
@@ -105,8 +104,6 @@ where
     value_in_between(value.x, bound_1.x, bound_2.x)
         && value_in_between(value.y, bound_1.y, bound_2.y)
 }
-
-
 
 #[cfg(test)]
 mod test {

--- a/geo/src/algorithm/intersects/mod.rs
+++ b/geo/src/algorithm/intersects/mod.rs
@@ -534,7 +534,6 @@ mod test {
     #[test]
     // See https://github.com/georust/geo/issues/419
     fn rect_test_419() {
-
         let a = Rect::new(
             Coordinate {
                 x: 9.228515625,

--- a/geo/src/algorithm/intersects/mod.rs
+++ b/geo/src/algorithm/intersects/mod.rs
@@ -1,6 +1,12 @@
 use crate::*;
 
-/// Checks if the geometry A intersects the geometry B.
+/// Checks if the geometry A intersects the geometry B. More
+/// formally, either boundary or interior of A has non-empty
+/// (set-theoretic) intersection with the boundary or
+/// interior of B. In other words, the [DE-9IM] intersection
+/// matrix for (A, B) is _not_ `FF*FF****`.
+///
+/// [DE-9IM]: https://en.wikipedia.org/wiki/DE-9IM
 ///
 /// # Examples
 ///

--- a/geo/src/algorithm/intersects/mod.rs
+++ b/geo/src/algorithm/intersects/mod.rs
@@ -1,10 +1,13 @@
 use crate::*;
 
-/// Checks if the geometry A intersects the geometry B. More
-/// formally, either boundary or interior of A has non-empty
-/// (set-theoretic) intersection with the boundary or
-/// interior of B. In other words, the [DE-9IM] intersection
-/// matrix for (A, B) is _not_ `FF*FF****`.
+/// Checks if the geometry Self intersects the geometry Rhs.
+/// More formally, either boundary or interior of Self has
+/// non-empty (set-theoretic) intersection with the boundary
+/// or interior of Rhs. In other words, the [DE-9IM]
+/// intersection matrix for (Self, Rhs) is _not_ `FF*FF****`.
+///
+/// This predicate is symmetric: `a.intersects(b)` iff
+/// `b.intersects(a)`.
 ///
 /// [DE-9IM]: https://en.wikipedia.org/wiki/DE-9IM
 ///
@@ -36,13 +39,6 @@ pub trait Intersects<Rhs = Self> {
     fn intersects(&self, rhs: &Rhs) -> bool;
 }
 
-mod coordinate;
-mod line;
-mod line_string;
-mod point;
-mod polygon;
-mod rect;
-
 // Since `Intersects` is symmetric, we use a macro to
 // implement `T: Intersects<S>` if `S: Intersects<T>` is
 // available. As a convention, we provide explicit impl.
@@ -62,19 +58,12 @@ macro_rules! symmetric_intersects_impl {
     };
 }
 
-use crate::kernels::HasKernel;
-
-symmetric_intersects_impl!(Coordinate<T>, Point<T>, CoordinateType);
-symmetric_intersects_impl!(Coordinate<T>, Line<T>, HasKernel);
-
-symmetric_intersects_impl!(Point<T>, Line<T>, HasKernel);
-
-symmetric_intersects_impl!(Line<T>, LineString<T>, HasKernel);
-symmetric_intersects_impl!(Line<T>, Polygon<T>, HasKernel);
-
-symmetric_intersects_impl!(LineString<T>, Polygon<T>, HasKernel);
-
-symmetric_intersects_impl!(Rect<T>, Polygon<T>, HasKernel);
+mod coordinate;
+mod line;
+mod line_string;
+mod point;
+mod polygon;
+mod rect;
 
 // Helper function to check value lies between min and max.
 // Only makes sense if min <= max (or always false)
@@ -545,6 +534,7 @@ mod test {
     #[test]
     // See https://github.com/georust/geo/issues/419
     fn rect_test_419() {
+
         let a = Rect::new(
             Coordinate {
                 x: 9.228515625,

--- a/geo/src/algorithm/intersects/point.rs
+++ b/geo/src/algorithm/intersects/point.rs
@@ -1,0 +1,20 @@
+use super::Intersects;
+use crate::*;
+
+impl<T> Intersects<Coordinate<T>> for Point<T>
+where
+    T: CoordinateType,
+{
+    fn intersects(&self, rhs: &Coordinate<T>) -> bool {
+        &self.0 == rhs
+    }
+}
+
+impl<T> Intersects<Point<T>> for Point<T>
+where
+    T: CoordinateType,
+{
+    fn intersects(&self, rhs: &Point<T>) -> bool {
+        self == rhs
+    }
+}

--- a/geo/src/algorithm/intersects/point.rs
+++ b/geo/src/algorithm/intersects/point.rs
@@ -9,6 +9,7 @@ where
         &self.0 == rhs
     }
 }
+symmetric_intersects_impl!(Coordinate<T>, Point<T>, CoordinateType);
 
 impl<T> Intersects<Point<T>> for Point<T>
 where

--- a/geo/src/algorithm/intersects/point.rs
+++ b/geo/src/algorithm/intersects/point.rs
@@ -1,4 +1,5 @@
 use super::Intersects;
+use crate::kernels::*;
 use crate::*;
 
 impl<T> Intersects<Coordinate<T>> for Point<T>
@@ -6,7 +7,7 @@ where
     T: CoordinateType,
 {
     fn intersects(&self, rhs: &Coordinate<T>) -> bool {
-        &self.0 == rhs
+        self.0.intersects(rhs)
     }
 }
 symmetric_intersects_impl!(Coordinate<T>, Point<T>, CoordinateType);
@@ -16,6 +17,21 @@ where
     T: CoordinateType,
 {
     fn intersects(&self, rhs: &Point<T>) -> bool {
-        self == rhs
+        self.intersects(&rhs.0)
     }
 }
+
+impl<T, G> Intersects<G> for MultiPoint<T>
+where
+    T: CoordinateType,
+    Point<T>: Intersects<G>,
+{
+    fn intersects(&self, rhs: &G) -> bool {
+        self.0.iter().any(|p| p.intersects(rhs))
+    }
+}
+symmetric_intersects_impl!(Coordinate<T>, MultiPoint<T>, CoordinateType);
+symmetric_intersects_impl!(Point<T>, MultiPoint<T>, CoordinateType);
+symmetric_intersects_impl!(Line<T>, MultiPoint<T>, HasKernel);
+symmetric_intersects_impl!(LineString<T>, MultiPoint<T>, HasKernel);
+symmetric_intersects_impl!(Polygon<T>, MultiPoint<T>, HasKernel);

--- a/geo/src/algorithm/intersects/polygon.rs
+++ b/geo/src/algorithm/intersects/polygon.rs
@@ -1,7 +1,7 @@
 use super::Intersects;
+use crate::contains::Contains;
 use crate::kernels::*;
 use crate::*;
-use crate::contains::Contains;
 
 impl<T> Intersects<Line<T>> for Polygon<T>
 where

--- a/geo/src/algorithm/intersects/polygon.rs
+++ b/geo/src/algorithm/intersects/polygon.rs
@@ -67,17 +67,7 @@ where
     T: HasKernel,
 {
     fn intersects(&self, rect: &Rect<T>) -> bool {
-        let p = Polygon::new(
-            LineString::from(vec![
-                (rect.min().x, rect.min().y),
-                (rect.min().x, rect.max().y),
-                (rect.max().x, rect.max().y),
-                (rect.max().x, rect.min().y),
-                (rect.min().x, rect.min().y),
-            ]),
-            vec![],
-        );
-        self.intersects(&p)
+        self.intersects(&rect.clone().to_polygon())
     }
 }
 symmetric_intersects_impl!(Rect<T>, Polygon<T>, HasKernel);

--- a/geo/src/algorithm/intersects/polygon.rs
+++ b/geo/src/algorithm/intersects/polygon.rs
@@ -16,6 +16,7 @@ where
                 .all(|int| coord_pos_relative_to_ring(*p, int) != CoordPos::Inside)
     }
 }
+symmetric_intersects_impl!(Coordinate<T>, Polygon<T>, HasKernel);
 
 impl<T> Intersects<Point<T>> for Polygon<T>
 where
@@ -25,18 +26,20 @@ where
         self.intersects(&p.0)
     }
 }
+symmetric_intersects_impl!(Point<T>, Polygon<T>, HasKernel);
 
 impl<T> Intersects<Line<T>> for Polygon<T>
 where
     T: HasKernel,
 {
-    fn intersects(&self, p: &Line<T>) -> bool {
-        self.exterior().intersects(p)
-            || self.interiors().iter().any(|inner| inner.intersects(p))
-            || self.contains(&p.start)
-            || self.contains(&p.end)
+    fn intersects(&self, line: &Line<T>) -> bool {
+        self.exterior().intersects(line)
+            || self.interiors().iter().any(|inner| inner.intersects(line))
+            || self.contains(&line.start)
+            || self.contains(&line.end)
     }
 }
+symmetric_intersects_impl!(Line<T>, Polygon<T>, HasKernel);
 
 impl<T> Intersects<LineString<T>> for Polygon<T>
 where
@@ -53,10 +56,11 @@ where
             true
         } else {
             // or if it's contained in the polygon
-            linestring.points_iter().any(|point| self.contains(&point))
+            linestring.0.iter().any(|c| self.contains(c))
         }
     }
 }
+symmetric_intersects_impl!(LineString<T>, Polygon<T>, HasKernel);
 
 impl<T> Intersects<Rect<T>> for Polygon<T>
 where
@@ -76,6 +80,7 @@ where
         self.intersects(&p)
     }
 }
+symmetric_intersects_impl!(Rect<T>, Polygon<T>, HasKernel);
 
 impl<T> Intersects<Polygon<T>> for Polygon<T>
 where

--- a/geo/src/algorithm/intersects/polygon.rs
+++ b/geo/src/algorithm/intersects/polygon.rs
@@ -1,0 +1,68 @@
+use super::Intersects;
+use crate::kernels::*;
+use crate::*;
+use crate::contains::Contains;
+
+impl<T> Intersects<Line<T>> for Polygon<T>
+where
+    T: HasKernel,
+{
+    fn intersects(&self, p: &Line<T>) -> bool {
+        self.exterior().intersects(p)
+            || self.interiors().iter().any(|inner| inner.intersects(p))
+            || self.contains(&p.start)
+            || self.contains(&p.end)
+    }
+}
+
+impl<T> Intersects<LineString<T>> for Polygon<T>
+where
+    T: HasKernel,
+{
+    fn intersects(&self, linestring: &LineString<T>) -> bool {
+        // line intersects inner or outer polygon edge
+        if self.exterior().intersects(linestring)
+            || self
+                .interiors()
+                .iter()
+                .any(|inner| inner.intersects(linestring))
+        {
+            true
+        } else {
+            // or if it's contained in the polygon
+            linestring.points_iter().any(|point| self.contains(&point))
+        }
+    }
+}
+
+impl<T> Intersects<Rect<T>> for Polygon<T>
+where
+    T: HasKernel,
+{
+    fn intersects(&self, rect: &Rect<T>) -> bool {
+        let p = Polygon::new(
+            LineString::from(vec![
+                (rect.min().x, rect.min().y),
+                (rect.min().x, rect.max().y),
+                (rect.max().x, rect.max().y),
+                (rect.max().x, rect.min().y),
+                (rect.min().x, rect.min().y),
+            ]),
+            vec![],
+        );
+        self.intersects(&p)
+    }
+}
+
+impl<T> Intersects<Polygon<T>> for Polygon<T>
+where
+    T: HasKernel,
+{
+    fn intersects(&self, polygon: &Polygon<T>) -> bool {
+        // self intersects (or contains) any line in polygon
+        self.intersects(polygon.exterior()) ||
+            polygon.interiors().iter().any(|inner_line_string| self.intersects(inner_line_string)) ||
+            // self is contained inside polygon
+            polygon.intersects(self.exterior())
+    }
+}

--- a/geo/src/algorithm/intersects/polygon.rs
+++ b/geo/src/algorithm/intersects/polygon.rs
@@ -2,6 +2,29 @@ use super::Intersects;
 use crate::contains::Contains;
 use crate::kernels::*;
 use crate::*;
+use crate::utils::{coord_pos_relative_to_ring, CoordPos};
+
+impl<T> Intersects<Coordinate<T>> for Polygon<T>
+where
+    T: HasKernel,
+{
+    fn intersects(&self, p: &Coordinate<T>) -> bool {
+        coord_pos_relative_to_ring(*p, &self.exterior()) != CoordPos::Outside
+            && self.interiors().iter().all(
+                |int| coord_pos_relative_to_ring(*p, int) != CoordPos::Inside
+            )
+    }
+}
+
+impl<T> Intersects<Point<T>> for Polygon<T>
+where
+    T: HasKernel,
+{
+    fn intersects(&self, p: &Point<T>) -> bool {
+        self.intersects(&p.0)
+    }
+}
+
 
 impl<T> Intersects<Line<T>> for Polygon<T>
 where

--- a/geo/src/algorithm/intersects/polygon.rs
+++ b/geo/src/algorithm/intersects/polygon.rs
@@ -1,8 +1,8 @@
 use super::Intersects;
 use crate::contains::Contains;
 use crate::kernels::*;
-use crate::*;
 use crate::utils::{coord_pos_relative_to_ring, CoordPos};
+use crate::*;
 
 impl<T> Intersects<Coordinate<T>> for Polygon<T>
 where
@@ -10,9 +10,10 @@ where
 {
     fn intersects(&self, p: &Coordinate<T>) -> bool {
         coord_pos_relative_to_ring(*p, &self.exterior()) != CoordPos::Outside
-            && self.interiors().iter().all(
-                |int| coord_pos_relative_to_ring(*p, int) != CoordPos::Inside
-            )
+            && self
+                .interiors()
+                .iter()
+                .all(|int| coord_pos_relative_to_ring(*p, int) != CoordPos::Inside)
     }
 }
 
@@ -24,7 +25,6 @@ where
         self.intersects(&p.0)
     }
 }
-
 
 impl<T> Intersects<Line<T>> for Polygon<T>
 where

--- a/geo/src/algorithm/intersects/rect.rs
+++ b/geo/src/algorithm/intersects/rect.rs
@@ -1,4 +1,4 @@
-use super::{Intersects, value_in_range};
+use super::{value_in_range, Intersects};
 use crate::*;
 
 impl<T> Intersects<Rect<T>> for Rect<T>

--- a/geo/src/algorithm/intersects/rect.rs
+++ b/geo/src/algorithm/intersects/rect.rs
@@ -1,0 +1,17 @@
+use super::{Intersects, value_in_range};
+use crate::*;
+
+impl<T> Intersects<Rect<T>> for Rect<T>
+where
+    T: CoordinateType,
+{
+    fn intersects(&self, other: &Rect<T>) -> bool {
+        let x_overlap = value_in_range(self.min().x, other.min().x, other.max().x)
+            || value_in_range(other.min().x, self.min().x, self.max().x);
+
+        let y_overlap = value_in_range(self.min().y, other.min().y, other.max().y)
+            || value_in_range(other.min().y, self.min().y, self.max().y);
+
+        x_overlap && y_overlap
+    }
+}

--- a/geo/src/algorithm/intersects/triangle.rs
+++ b/geo/src/algorithm/intersects/triangle.rs
@@ -1,0 +1,18 @@
+use super::Intersects;
+use crate::kernels::*;
+use crate::*;
+
+impl<T, G> Intersects<G> for Triangle<T>
+where
+    T: CoordinateType,
+    Polygon<T>: Intersects<G>,
+{
+    fn intersects(&self, rhs: &G) -> bool {
+        self.clone().to_polygon().intersects(rhs)
+    }
+}
+symmetric_intersects_impl!(Coordinate<T>, Triangle<T>, HasKernel);
+symmetric_intersects_impl!(Point<T>, Triangle<T>, HasKernel);
+symmetric_intersects_impl!(Line<T>, Triangle<T>, HasKernel);
+symmetric_intersects_impl!(LineString<T>, Triangle<T>, HasKernel);
+symmetric_intersects_impl!(Polygon<T>, Triangle<T>, HasKernel);

--- a/geo/src/algorithm/is_convex.rs
+++ b/geo/src/algorithm/is_convex.rs
@@ -1,5 +1,5 @@
 use crate::kernels::*;
-use crate::{Coordinate, CoordinateType, LineString};
+use crate::{Coordinate, LineString};
 
 /// Predicates to test the convexity of a [ `LineString` ].
 /// A closed `LineString` is said to be _convex_ if it
@@ -108,7 +108,7 @@ pub trait IsConvex {
     fn is_collinear(&self) -> bool;
 }
 
-impl<T: CoordinateType + HasKernel> IsConvex for LineString<T> {
+impl<T: HasKernel> IsConvex for LineString<T> {
     fn convex_orientation(
         &self,
         allow_collinear: bool,
@@ -140,7 +140,7 @@ fn is_convex_shaped<T>(
     specific_orientation: Option<Orientation>,
 ) -> Option<Orientation>
 where
-    T: CoordinateType + HasKernel,
+    T: HasKernel,
 {
     let n = coords.len();
 

--- a/geo/src/algorithm/kernels/mod.rs
+++ b/geo/src/algorithm/kernels/mod.rs
@@ -1,4 +1,5 @@
 use crate::{Coordinate, CoordinateType};
+use num_traits::Zero;
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
 pub enum Orientation {
@@ -20,7 +21,6 @@ pub trait Kernel {
         r: Coordinate<Self::Scalar>,
     ) -> Orientation {
         let res = (q.x - p.x) * (r.y - q.y) - (q.y - p.y) * (r.x - q.x);
-        use num_traits::Zero;
         if res > Zero::zero() {
             Orientation::CounterClockwise
         } else if res < Zero::zero() {
@@ -35,6 +35,16 @@ pub trait Kernel {
         q: Coordinate<Self::Scalar>,
     ) -> Self::Scalar {
         (p.x - q.x) * (p.x - q.x) + (p.y - q.y) * (p.y - q.y)
+    }
+
+    /// Compute the sign of the dot product of `u` and `v` using
+    /// robust predicates. The output is `CounterClockwise` if
+    /// the sign is positive, `Clockwise` if negative, and
+    /// `Collinear` if zero.
+    fn dot_product_sign(u: Coordinate<Self::Scalar>, v: Coordinate<Self::Scalar>) -> Orientation {
+        let zero = Coordinate::zero();
+        let vdash = Coordinate { x: Self::Scalar::zero() - v.y, y: v.x };
+        Self::orient2d(zero, u, vdash)
     }
 }
 

--- a/geo/src/algorithm/kernels/mod.rs
+++ b/geo/src/algorithm/kernels/mod.rs
@@ -43,7 +43,10 @@ pub trait Kernel {
     /// `Collinear` if zero.
     fn dot_product_sign(u: Coordinate<Self::Scalar>, v: Coordinate<Self::Scalar>) -> Orientation {
         let zero = Coordinate::zero();
-        let vdash = Coordinate { x: Self::Scalar::zero() - v.y, y: v.x };
+        let vdash = Coordinate {
+            x: Self::Scalar::zero() - v.y,
+            y: v.x,
+        };
         Self::orient2d(zero, u, vdash)
     }
 }

--- a/geo/src/algorithm/kernels/mod.rs
+++ b/geo/src/algorithm/kernels/mod.rs
@@ -10,16 +10,10 @@ pub enum Orientation {
 
 /// Kernel trait to provide predicates to operate on
 /// different scalar types.
-pub trait Kernel {
-    type Scalar: CoordinateType;
-
+pub trait Kernel<T: CoordinateType> {
     /// Gives the orientation of 3 2-dimensional points:
     /// ccw, cw or collinear (None)
-    fn orient2d(
-        p: Coordinate<Self::Scalar>,
-        q: Coordinate<Self::Scalar>,
-        r: Coordinate<Self::Scalar>,
-    ) -> Orientation {
+    fn orient2d(p: Coordinate<T>, q: Coordinate<T>, r: Coordinate<T>) -> Orientation {
         let res = (q.x - p.x) * (r.y - q.y) - (q.y - p.y) * (r.x - q.x);
         if res > Zero::zero() {
             Orientation::CounterClockwise
@@ -30,10 +24,7 @@ pub trait Kernel {
         }
     }
 
-    fn square_euclidean_distance(
-        p: Coordinate<Self::Scalar>,
-        q: Coordinate<Self::Scalar>,
-    ) -> Self::Scalar {
+    fn square_euclidean_distance(p: Coordinate<T>, q: Coordinate<T>) -> T {
         (p.x - q.x) * (p.x - q.x) + (p.y - q.y) * (p.y - q.y)
     }
 
@@ -41,10 +32,10 @@ pub trait Kernel {
     /// robust predicates. The output is `CounterClockwise` if
     /// the sign is positive, `Clockwise` if negative, and
     /// `Collinear` if zero.
-    fn dot_product_sign(u: Coordinate<Self::Scalar>, v: Coordinate<Self::Scalar>) -> Orientation {
+    fn dot_product_sign(u: Coordinate<T>, v: Coordinate<T>) -> Orientation {
         let zero = Coordinate::zero();
         let vdash = Coordinate {
-            x: Self::Scalar::zero() - v.y,
+            x: T::zero() - v.y,
             y: v.x,
         };
         Self::orient2d(zero, u, vdash)
@@ -53,7 +44,7 @@ pub trait Kernel {
 
 /// Marker trait to assign Kernel for scalars
 pub trait HasKernel: CoordinateType {
-    type Ker: Kernel<Scalar = Self>;
+    type Ker: Kernel<Self>;
 }
 
 // Helper macro to implement `HasKernel` on a a scalar type
@@ -64,7 +55,7 @@ pub trait HasKernel: CoordinateType {
 macro_rules! has_kernel {
     ($t:ident, $k:ident) => {
         impl $crate::algorithm::kernels::HasKernel for $t {
-            type Ker = $k<$t>;
+            type Ker = $k;
         }
     };
 }

--- a/geo/src/algorithm/kernels/robust.rs
+++ b/geo/src/algorithm/kernels/robust.rs
@@ -1,6 +1,5 @@
 use super::{Kernel, Orientation};
 use crate::Coordinate;
-use std::marker::PhantomData;
 
 /// Robust kernel that uses [fast robust
 /// predicates](//www.cs.cmu.edu/~quake/robust.html) to
@@ -8,17 +7,11 @@ use std::marker::PhantomData;
 /// used with types that can _always_ be casted to `f64`
 /// _without loss in precision_.
 #[derive(Default)]
-pub struct RobustKernel<T>(PhantomData<T>);
+pub struct RobustKernel;
 
 use num_traits::{Float, NumCast};
-impl<T: Float> Kernel for RobustKernel<T> {
-    type Scalar = T;
-
-    fn orient2d(
-        p: Coordinate<Self::Scalar>,
-        q: Coordinate<Self::Scalar>,
-        r: Coordinate<Self::Scalar>,
-    ) -> Orientation {
+impl<T: Float> Kernel<T> for RobustKernel {
+    fn orient2d(p: Coordinate<T>, q: Coordinate<T>, r: Coordinate<T>) -> Orientation {
         use robust::{orient2d, Coord};
 
         let orientation = orient2d(

--- a/geo/src/algorithm/kernels/simple.rs
+++ b/geo/src/algorithm/kernels/simple.rs
@@ -1,13 +1,10 @@
 use super::Kernel;
 use crate::CoordinateType;
-use std::marker::PhantomData;
 
 /// Simple kernel provides the direct implementation of the
 /// predicates. These are meant to be used with exact
 /// arithmetic signed tpyes (eg. i32, i64).
 #[derive(Default)]
-pub struct SimpleKernel<T>(PhantomData<T>);
+pub struct SimpleKernel;
 
-impl<T: CoordinateType> Kernel for SimpleKernel<T> {
-    type Scalar = T;
-}
+impl<T: CoordinateType> Kernel<T> for SimpleKernel {}

--- a/geo/src/algorithm/orient.rs
+++ b/geo/src/algorithm/orient.rs
@@ -1,5 +1,5 @@
 use super::kernels::*;
-use crate::{CoordinateType, MultiPolygon, Polygon};
+use crate::{MultiPolygon, Polygon};
 
 use crate::algorithm::winding_order::{Winding, WindingOrder};
 
@@ -68,7 +68,7 @@ pub trait Orient {
 
 impl<T> Orient for Polygon<T>
 where
-    T: CoordinateType + HasKernel,
+    T: HasKernel,
 {
     fn orient(&self, direction: Direction) -> Polygon<T> {
         orient(self, direction)
@@ -77,7 +77,7 @@ where
 
 impl<T> Orient for MultiPolygon<T>
 where
-    T: CoordinateType + HasKernel,
+    T: HasKernel,
 {
     fn orient(&self, direction: Direction) -> MultiPolygon<T> {
         MultiPolygon(self.0.iter().map(|poly| poly.orient(direction)).collect())
@@ -100,7 +100,7 @@ pub enum Direction {
 // and the interior ring(s) will be oriented clockwise
 fn orient<T>(poly: &Polygon<T>, direction: Direction) -> Polygon<T>
 where
-    T: CoordinateType + HasKernel,
+    T: HasKernel,
 {
     let interiors = poly
         .interiors()

--- a/geo/src/algorithm/winding_order.rs
+++ b/geo/src/algorithm/winding_order.rs
@@ -92,7 +92,7 @@ pub trait Winding {
 impl<T, K> Winding for LineString<T>
 where
     T: HasKernel<Ker = K>,
-    K: Kernel<Scalar = T>,
+    K: Kernel<T>,
 {
     type Scalar = T;
 

--- a/geo/src/algorithm/winding_order.rs
+++ b/geo/src/algorithm/winding_order.rs
@@ -91,7 +91,7 @@ pub trait Winding {
 
 impl<T, K> Winding for LineString<T>
 where
-    T: CoordinateType + HasKernel<Ker = K>,
+    T: HasKernel<Ker = K>,
     K: Kernel<Scalar = T>,
 {
     type Scalar = T;

--- a/geo/src/lib.rs
+++ b/geo/src/lib.rs
@@ -105,6 +105,7 @@ pub mod prelude {
     pub use crate::algorithm::haversine_intermediate::HaversineIntermediate;
     pub use crate::algorithm::haversine_length::HaversineLength;
     pub use crate::algorithm::intersects::Intersects;
+    pub use crate::algorithm::is_convex::IsConvex;
     pub use crate::algorithm::map_coords::MapCoords;
     pub use crate::algorithm::orient::Orient;
     #[cfg(feature = "use-proj")]

--- a/geo/src/utils.rs
+++ b/geo/src/utils.rs
@@ -143,14 +143,20 @@ where
         // possibly at the beginning of the line. This is to
         // prevent a double counting when the ray passes
         // through a vertex of the plygon
-        if line.start.y == coord.y  {
+        if line.start.y == coord.y {
             continue;
         }
 
         // Otherwise, check if ray intersects the line
         // segment. Enough to consider ray upto the max_x
         // coordinate of the current segment.
-        let ray = Line::new(coord, Coordinate {x: max_x, y: coord.y});
+        let ray = Line::new(
+            coord,
+            Coordinate {
+                x: max_x,
+                y: coord.y,
+            },
+        );
         if ray.intersects(&line) {
             crossings += 1;
         }

--- a/geo/src/utils.rs
+++ b/geo/src/utils.rs
@@ -115,7 +115,7 @@ where
     }
 
     let mut crossings = 0;
-    for (i, line) in linestring.lines().enumerate() {
+    for line in linestring.lines() {
         // Check if coord lies on the line
         if line.intersects(&coord) {
             return CoordPos::OnBoundary;
@@ -160,7 +160,6 @@ where
         if ray.intersects(&line) {
             crossings += 1;
         }
-        eprintln!("current crossing @ iter {} = {}", i, crossings);
     }
     if crossings % 2 == 1 {
         CoordPos::Inside


### PR DESCRIPTION
Use robust predicates in Intersects and Contains traits

+ use robust preds (doesn't need Float anymore)
+ define interior, boundary, and exterior of geometry types (similar to geos/jts)
+ define Intersect and Contains using DE-9IM model
+ fix contains logic in a few corner cases

Future work:

The polygon contains line / polygon logic is not yet fully correct.   I've added a few TODO comments, and an ignored test for cases where our predicate doesn't match the DE-9IM definition.  Unfortunately, it doesn't seem to be a simple change to fix these corner cases.  For instance, geos seems to use a concept called `GeometryGraph` for these cases which I'm yet to understand.