### PR TITLE
intersects: implementation for MultiPolygon

### DIFF
--- a/geo/src/algorithm/intersects/polygon.rs
+++ b/geo/src/algorithm/intersects/polygon.rs
@@ -84,3 +84,21 @@ where
             polygon.intersects(self.exterior())
     }
 }
+
+// Implementations for MultiPolygon
+
+impl<G, T> Intersects<G> for MultiPolygon<T>
+where
+    T: HasKernel,
+    Polygon<T>: Intersects<G>,
+{
+    fn intersects(&self, rhs: &G) -> bool {
+        self.0.iter().any(|p| p.intersects(rhs))
+    }
+}
+
+symmetric_intersects_impl!(Point<T>, MultiPolygon<T>, HasKernel);
+symmetric_intersects_impl!(Line<T>, MultiPolygon<T>, HasKernel);
+symmetric_intersects_impl!(LineString<T>, MultiPolygon<T>, HasKernel);
+symmetric_intersects_impl!(Polygon<T>, MultiPolygon<T>, HasKernel);
+symmetric_intersects_impl!(Rect<T>, MultiPolygon<T>, HasKernel);


### PR DESCRIPTION
Implement `Intersects` for MultiPolygons together with any type that already implement it with Polygons.