### PR TITLE
Round up Intersects implementations

### DIFF
--- a/geo-types/src/coordinate.rs
+++ b/geo-types/src/coordinate.rs
@@ -14,6 +14,13 @@ use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 /// [`Add`], [`Sub`], [`Neg`], [`Zero`],
 /// [`Mul<T>`][`Mul`], and [`Div<T>`][`Div`] traits.
 ///
+/// # Semantics
+///
+/// This type does not represent any geospatial primitive,
+/// but is used in their definitions. The only requirement
+/// is that the coordinates it contains are valid numbers
+/// (for eg. not `f64::NAN`).
+///
 /// [vector space]: //en.wikipedia.org/wiki/Vector_space
 #[derive(Eq, PartialEq, Clone, Copy, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/geo-types/src/geometry_collection.rs
+++ b/geo-types/src/geometry_collection.rs
@@ -6,10 +6,13 @@ use std::ops::{Index, IndexMut};
 ///
 /// It can be created from a `Vec` of Geometries, or from an Iterator which yields Geometries.
 ///
-/// Looping over this object yields its component **Geometry enum members** (_not_ the underlying geometry primitives),
-/// and it supports iteration and indexing
-/// as well as the various [`MapCoords`](algorithm/map_coords/index.html) functions, which _are_ directly
-/// applied to the underlying geometry primitives.
+/// Looping over this object yields its component **Geometry
+/// enum members** (_not_ the underlying geometry
+/// primitives), and it supports iteration and indexing as
+/// well as the various
+/// [`MapCoords`](algorithm/map_coords/index.html)
+/// functions, which _are_ directly applied to the
+/// underlying geometry primitives.
 ///
 /// # Examples
 /// ## Looping

--- a/geo-types/src/lib.rs
+++ b/geo-types/src/lib.rs
@@ -6,6 +6,17 @@
 //! with other `GeoRust` crates. Otherwise, the [`geo`](https://crates.io/crates/geo) crate re-exports these types and
 //! provides geospatial algorithms, while the [`geojson`](https://crates.io/crates/geojson) crate allows serialising
 //! and de-serialising `geo-types` primitives to GeoJSON.
+//!
+//! # Semantics
+//!
+//! The geospatial types provided here aim to adhere to the
+//! [OpenGIS Simple feature access][OGC-SFA] standards.
+//! Thus, the types here are inter-operable with other
+//! implementations of the standards: [JTS], [geos], etc.
+//!
+//! [OGC-SFA]: //www.ogc.org/standards/sfa
+//! [JTS]: //github.com/locationtech/jts
+//! [geos]: //trac.osgeo.org/geos
 extern crate num_traits;
 use num_traits::{Num, NumCast};
 
@@ -21,8 +32,9 @@ extern crate approx;
 
 /// The type of an x or y value of a point/coordinate.
 ///
-/// Floats (`f32` and `f64`) and Integers (`u8`, `i32` etc.) implement this. Many algorithms only
-/// make sense for Float types (like area, or length calculations).
+/// Floats (`f32` and `f64`) and Integers (`u8`, `i32` etc.)
+/// implement this. Many algorithms only make sense for
+/// Float types (like area, or length calculations).
 pub trait CoordinateType: Num + Copy + NumCast + PartialOrd {}
 // Little bit of a hack to make to make this work
 impl<T: Num + Copy + NumCast + PartialOrd> CoordinateType for T {}

--- a/geo-types/src/line.rs
+++ b/geo-types/src/line.rs
@@ -1,9 +1,12 @@
 use crate::{Coordinate, CoordinateType, Point};
 
 /// A line segment made up of exactly two
-/// [`Coordinate`s](struct.Coordinate.html). The interior and
-/// boundaries are defined as with a `LineString` with the
-/// two end points.
+/// [`Coordinate`s](struct.Coordinate.html).
+///
+/// # Semantics
+///
+/// The _interior_ and _boundary_ are defined as with a
+/// `LineString` with the two end points.
 #[derive(Eq, PartialEq, Clone, Copy, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Line<T>

--- a/geo-types/src/line_string.rs
+++ b/geo-types/src/line_string.rs
@@ -6,12 +6,18 @@ use std::ops::{Index, IndexMut};
 /// [`Coordinate`s](struct.Coordinate.html), representing a
 /// path between locations.
 ///
+/// # Semantics
+///
 /// A `LineString` is _closed_ if it is empty, or if the
 /// first and last coordinates are the same. The _boundary_
 /// of a `LineString` is empty if closed, and otherwise the
-/// end points. The interior is the (infinite) set of all
+/// end points. The _interior_ is the (infinite) set of all
 /// points along the linestring _not including_ the
-/// boundary.
+/// boundary. A `LineString` is _simple_ if it does not
+/// intersect except possibly at the first and last
+/// coordinates. A simple and closed `LineString` is a
+/// `LinearRing` as defined in the OGC-SFA (but is not a
+/// separate type here).
 ///
 /// # Validity
 ///

--- a/geo-types/src/multi_line_string.rs
+++ b/geo-types/src/multi_line_string.rs
@@ -5,7 +5,7 @@ use std::iter::FromIterator;
 /// [`LineString`s](line_string/struct.LineString.html). Can
 /// be created from a `Vec` of `LineString`s, or from an
 /// Iterator which yields `LineString`s. Iterating over this
-/// objects, yields the component `LineString`s.
+/// object yields the component `LineString`s.
 ///
 /// # Semantics
 ///

--- a/geo-types/src/multi_line_string.rs
+++ b/geo-types/src/multi_line_string.rs
@@ -2,15 +2,32 @@ use crate::{CoordinateType, LineString};
 use std::iter::FromIterator;
 
 /// A collection of
-/// [`LineString`s](line_string/struct.LineString.html). The
-/// interior and the boundary are the union of the interior
-/// or the boundary of the constituent line strings.
+/// [`LineString`s](line_string/struct.LineString.html). Can
+/// be created from a `Vec` of `LineString`s, or from an
+/// Iterator which yields `LineString`s. Iterating over this
+/// objects, yields the component `LineString`s.
 ///
-/// Can be created from a `Vec` of `LineString`s, or from an
-/// Iterator which yields `LineString`s.
+/// # Semantics
 ///
-/// Iterating over this objects, yields the component
-/// `LineString`s.
+/// The _boundary_ of a `MultiLineString` is obtained by
+/// applying the “mod 2” union rule: A `Point` is in the
+/// boundary of a `MultiLineString` if it is in the
+/// boundaries of an odd number of elements of the
+/// `MultiLineString`.
+///
+/// The _interior_ of a `MultiLineString` is the union of
+/// the interior, and boundary of the constituent
+/// `LineString`s, _except_ for the boundary as defined
+/// above. In other words, it is the set difference of the
+/// boundary from the union of the interior and boundary of
+/// the constituents.
+///
+/// A `MultiLineString` is _simple_ if and only if all of
+/// its elements are simple and the only intersections
+/// between any two elements occur at `Point`s that are on
+/// the boundaries of both elements. A `MultiLineString` is
+/// _closed_ if all of its elements are closed. The boundary
+/// of a closed `MultiLineString` is always empty.
 #[derive(Eq, PartialEq, Clone, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct MultiLineString<T>(pub Vec<LineString<T>>)

--- a/geo-types/src/multi_point.rs
+++ b/geo-types/src/multi_point.rs
@@ -1,9 +1,17 @@
 use crate::{CoordinateType, Point};
 use std::iter::FromIterator;
 
-/// A collection of [`Point`s](struct.Point.html). The
-/// interior and the boundary are the union of the interior
-/// or the boundary of the constituent points.
+/// A collection of [`Point`s](struct.Point.html). Can
+/// be created from a `Vec` of `Point`s, or from an
+/// Iterator which yields `Point`s. Iterating over this
+/// objects, yields the component `Point`s.
+///
+/// # Semantics
+///
+/// The _interior_ and the _boundary_ are the union of the
+/// interior and the boundary of the constituent points. In
+/// particular, the boundary of a a `MultiPoint` is always
+/// empty.
 ///
 /// # Examples
 ///

--- a/geo-types/src/multi_point.rs
+++ b/geo-types/src/multi_point.rs
@@ -4,13 +4,13 @@ use std::iter::FromIterator;
 /// A collection of [`Point`s](struct.Point.html). Can
 /// be created from a `Vec` of `Point`s, or from an
 /// Iterator which yields `Point`s. Iterating over this
-/// objects, yields the component `Point`s.
+/// object yields the component `Point`s.
 ///
 /// # Semantics
 ///
 /// The _interior_ and the _boundary_ are the union of the
 /// interior and the boundary of the constituent points. In
-/// particular, the boundary of a a `MultiPoint` is always
+/// particular, the boundary of a `MultiPoint` is always
 /// empty.
 ///
 /// # Examples

--- a/geo-types/src/multi_polygon.rs
+++ b/geo-types/src/multi_polygon.rs
@@ -1,13 +1,27 @@
 use crate::{CoordinateType, Polygon};
 use std::iter::FromIterator;
 
-/// A collection of [`Polygon`s](struct.Polygon.html). The
-/// interior and the boundary are the union of the interior
-/// or the boundary of the constituent polygons.
+/// A collection of [`Polygon`s](struct.Polygon.html). Can
+/// be created from a `Vec` of `Polygon`s, or from an
+/// Iterator which yields `Polygon`s. Iterating over this
+/// objects, yields the component `Polygon`s.
 ///
-/// Can be created from a `Vec` of `Polygon`s, or `collect`ed from an Iterator which yields `Polygon`s.
+/// # Semantics
 ///
-/// Iterating over this object yields the component Polygons.
+/// The _interior_ and the _boundary_ are the union of the
+/// interior and the boundary of the constituent polygons.
+///
+/// # Validity
+///
+/// - The interiors of no two constituent polygons may intersect.
+///
+/// - The boundaries of two (distinct) constituent polygons
+/// may only intersect at finitely many points.
+///
+/// Refer section 6.1.14 of the OGC-SFA for a formal
+/// definition of validity. Note that the validity is not
+/// enforced, but expected by the operations and
+/// predicates that operate on it.
 #[derive(Eq, PartialEq, Clone, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct MultiPolygon<T>(pub Vec<Polygon<T>>)

--- a/geo-types/src/multi_polygon.rs
+++ b/geo-types/src/multi_polygon.rs
@@ -4,7 +4,7 @@ use std::iter::FromIterator;
 /// A collection of [`Polygon`s](struct.Polygon.html). Can
 /// be created from a `Vec` of `Polygon`s, or from an
 /// Iterator which yields `Polygon`s. Iterating over this
-/// objects, yields the component `Polygon`s.
+/// object yields the component `Polygon`s.
 ///
 /// # Semantics
 ///
@@ -18,7 +18,7 @@ use std::iter::FromIterator;
 /// - The boundaries of two (distinct) constituent polygons
 /// may only intersect at finitely many points.
 ///
-/// Refer section 6.1.14 of the OGC-SFA for a formal
+/// Refer to section 6.1.14 of the OGC-SFA for a formal
 /// definition of validity. Note that the validity is not
 /// enforced, but expected by the operations and
 /// predicates that operate on it.

--- a/geo-types/src/point.rs
+++ b/geo-types/src/point.rs
@@ -9,9 +9,11 @@ use std::ops::{Add, Div, Mul, Neg, Sub};
 /// tuples, or arrays – see the `From` impl section for a
 /// complete list.
 ///
-/// A point is _valid_ iff neither coordinate is `NaN`. The
-/// _interior_ of the point is itself (a singleton set), and
-/// its _boundary_ is empty.
+/// # Semantics
+///
+/// The _interior_ of the point is itself (a singleton set),
+/// and its _boundary_ is empty. A point is _valid_ if and
+/// only if the `Coordinate` is valid.
 ///
 /// # Examples
 ///

--- a/geo-types/src/polygon.rs
+++ b/geo-types/src/polygon.rs
@@ -7,6 +7,8 @@ use num_traits::{Float, Signed};
 /// [`LineString`]. It may contain zero or more holes (_interior rings_), also
 /// represented by `LineString`s.
 ///
+/// # Semantics
+///
 /// The _boundary_ of the polygon is the union of the
 /// boundaries of the exterior and interiors. The interior
 /// is all the points inside the polygon (not on the
@@ -18,8 +20,29 @@ use num_traits::{Float, Signed};
 ///
 /// # Validity
 ///
-/// Besides the closed `LineString` rings guarantee, the `Polygon` structure
-/// does not enforce validity at this time. For example, it is possible to
+/// - The exterior and interior rings must be valid
+/// `LinearRing`s (see [`LineString`]).
+///
+/// - No two rings in the boundary may cross, and may
+/// intersect at a `Point` only as a tangent. In other
+/// words, the rings must be distinct, and for every pair of
+/// common points in two of the rings, there must be a
+/// neighborhood (a topological open set) around one that
+/// does not contain the other point.
+///
+/// - The closure of the interior of the `Polygon` must
+/// equal the `Polygon` itself. For instance, the exterior
+/// may not contain a spike.
+///
+/// - The interior of the polygon must be a connected
+/// point-set. That is, any two distinct points in the
+/// interior must admit a curve between these two that lies
+/// in the interior.
+///
+/// Refer section 6.1.11.1 of the OGC-SFA for a formal
+/// definition of validity. Besides the closed `LineString`
+/// guarantee, the `Polygon` structure does not enforce
+/// validity at this time. For example, it is possible to
 /// construct a `Polygon` that has:
 ///
 /// - fewer than 3 coordinates per `LineString` ring

--- a/geo-types/src/polygon.rs
+++ b/geo-types/src/polygon.rs
@@ -39,7 +39,7 @@ use num_traits::{Float, Signed};
 /// interior must admit a curve between these two that lies
 /// in the interior.
 ///
-/// Refer section 6.1.11.1 of the OGC-SFA for a formal
+/// Refer to section 6.1.11.1 of the OGC-SFA for a formal
 /// definition of validity. Besides the closed `LineString`
 /// guarantee, the `Polygon` structure does not enforce
 /// validity at this time. For example, it is possible to

--- a/geo-types/src/triangle.rs
+++ b/geo-types/src/triangle.rs
@@ -3,7 +3,7 @@ use crate::{polygon, Coordinate, CoordinateType, Line, Polygon};
 /// A bounded 2D area whose three vertices are defined by
 /// `Coordinate`s. The semantics and validity are that of
 /// the equivalent [`Polygon`]; in addition, the three
-/// vertices must be collinear (and distinct).
+/// vertices must not be collinear and they must be distinct.
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Triangle<T: CoordinateType>(pub Coordinate<T>, pub Coordinate<T>, pub Coordinate<T>);

--- a/geo-types/src/triangle.rs
+++ b/geo-types/src/triangle.rs
@@ -1,6 +1,9 @@
 use crate::{polygon, Coordinate, CoordinateType, Line, Polygon};
 
-/// A bounded 2D area whose three vertices are defined by `Coordinate`s.
+/// A bounded 2D area whose three vertices are defined by
+/// `Coordinate`s. The semantics and validity are that of
+/// the equivalent [`Polygon`]; in addition, the three
+/// vertices must be collinear (and distinct).
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Triangle<T: CoordinateType>(pub Coordinate<T>, pub Coordinate<T>, pub Coordinate<T>);

--- a/geo/src/algorithm/intersects/collections.rs
+++ b/geo/src/algorithm/intersects/collections.rs
@@ -1,0 +1,49 @@
+use super::Intersects;
+use crate::*;
+
+impl<T, G> Intersects<G> for Geometry<T>
+where
+    T: CoordinateType,
+    Point<T>: Intersects<G>,
+    MultiPoint<T>: Intersects<G>,
+    Line<T>: Intersects<G>,
+    LineString<T>: Intersects<G>,
+    MultiLineString<T>: Intersects<G>,
+    Triangle<T>: Intersects<G>,
+    Rect<T>: Intersects<G>,
+    Polygon<T>: Intersects<G>,
+    MultiPolygon<T>: Intersects<G>,
+{
+    fn intersects(&self, rhs: &G) -> bool {
+        match self {
+            Geometry::Point(geom) => geom.intersects(rhs),
+            Geometry::MultiPoint(geom) => geom.intersects(rhs),
+            Geometry::Line(geom) => geom.intersects(rhs),
+            Geometry::LineString(geom) => geom.intersects(rhs),
+            Geometry::MultiLineString(geom) => geom.intersects(rhs),
+            Geometry::Triangle(geom) => geom.intersects(rhs),
+            Geometry::Rect(geom) => geom.intersects(rhs),
+            Geometry::Polygon(geom) => geom.intersects(rhs),
+            Geometry::MultiPolygon(geom) => geom.intersects(rhs),
+            Geometry::GeometryCollection(geom) => geom.intersects(rhs),
+        }
+    }
+}
+symmetric_intersects_impl!(Coordinate<T>, Geometry<T>);
+symmetric_intersects_impl!(Line<T>, Geometry<T>);
+symmetric_intersects_impl!(Rect<T>, Geometry<T>);
+symmetric_intersects_impl!(Polygon<T>, Geometry<T>);
+
+impl<T, G> Intersects<G> for GeometryCollection<T>
+where
+    T: CoordinateType,
+    Geometry<T>: Intersects<G>,
+{
+    fn intersects(&self, rhs: &G) -> bool {
+        self.0.iter().any(|geom| geom.intersects(rhs))
+    }
+}
+symmetric_intersects_impl!(Coordinate<T>, GeometryCollection<T>);
+symmetric_intersects_impl!(Line<T>, GeometryCollection<T>);
+symmetric_intersects_impl!(Rect<T>, GeometryCollection<T>);
+symmetric_intersects_impl!(Polygon<T>, GeometryCollection<T>);

--- a/geo/src/algorithm/intersects/coordinate.rs
+++ b/geo/src/algorithm/intersects/coordinate.rs
@@ -9,3 +9,6 @@ where
         self == rhs
     }
 }
+
+// The other side of this is handled via a blanket impl.
+rhs_pt_from_coord_intersects_impl!(Coordinate<T>);

--- a/geo/src/algorithm/intersects/coordinate.rs
+++ b/geo/src/algorithm/intersects/coordinate.rs
@@ -11,4 +11,11 @@ where
 }
 
 // The other side of this is handled via a blanket impl.
-rhs_pt_from_coord_intersects_impl!(Coordinate<T>);
+impl<T> Intersects<Point<T>> for Coordinate<T>
+where
+    T: CoordinateType,
+{
+    fn intersects(&self, rhs: &Point<T>) -> bool {
+        self == &rhs.0
+    }
+}

--- a/geo/src/algorithm/intersects/line.rs
+++ b/geo/src/algorithm/intersects/line.rs
@@ -7,43 +7,58 @@ where
     T: HasKernel,
 {
     fn intersects(&self, rhs: &Coordinate<T>) -> bool {
+        // First we check if the point is collinear with the line.
         T::Ker::orient2d(self.start, self.end, *rhs) == Orientation::Collinear
+        // In addition, the point must have _both_ coordinates
+        // within the start and end bounds.
             && point_in_rect(*rhs, self.start, self.end)
     }
 }
-symmetric_intersects_impl!(Coordinate<T>, Line<T>, HasKernel);
-
-impl<T> Intersects<Point<T>> for Line<T>
-where
-    T: HasKernel,
-{
-    fn intersects(&self, p: &Point<T>) -> bool {
-        self.intersects(&p.0)
-    }
-}
-symmetric_intersects_impl!(Point<T>, Line<T>, HasKernel);
+symmetric_intersects_impl!(Coordinate<T>, Line<T>);
+symmetric_intersects_impl!(Line<T>, Point<T>);
 
 impl<T> Intersects<Line<T>> for Line<T>
 where
     T: HasKernel,
 {
     fn intersects(&self, line: &Line<T>) -> bool {
+        // Special case: self is equiv. to a point.
         if self.start == self.end {
             return line.intersects(&self.start);
         }
+
+        // Precondition: start and end are distinct.
+
+        // Check if orientation of rhs.{start,end} are different
+        // with respect to self.{start,end}.
         let check_1_1 = T::Ker::orient2d(self.start, self.end, line.start);
         let check_1_2 = T::Ker::orient2d(self.start, self.end, line.end);
 
         if check_1_1 != check_1_2 {
+            // Since the checks are different,
+            // rhs.{start,end} are distinct, and rhs is not
+            // collinear with self. Thus, there is exactly
+            // one point on the infinite extensions of rhs,
+            // that is collinear with self.
+
+            // By continuity, this point is not on the
+            // exterior of rhs. Now, check the same with
+            // self, rhs swapped.
+
             let check_2_1 = T::Ker::orient2d(line.start, line.end, self.start);
             let check_2_2 = T::Ker::orient2d(line.start, line.end, self.end);
 
+            // By similar argument, there is (exactly) one
+            // point on self, collinear with rhs. Thus,
+            // those two have to be same, and lies (interior
+            // or boundary, but not exterior) on both lines.
             check_2_1 != check_2_2
+
         } else if check_1_1 == Orientation::Collinear {
             // Special case: collinear line segments.
 
-            // Equivalent to the point-line intersection
-            // impl., but removes the calls to the kernel
+            // Equivalent to 4 point-line intersection
+            // checks, but removes the calls to the kernel
             // predicates.
             point_in_rect(line.start, self.start, self.end)
                 || point_in_rect(line.end, self.start, self.end)

--- a/geo/src/algorithm/intersects/line_string.rs
+++ b/geo/src/algorithm/intersects/line_string.rs
@@ -1,53 +1,32 @@
 use super::Intersects;
-use crate::kernels::*;
 use crate::*;
 
-impl<T> Intersects<Coordinate<T>> for LineString<T>
+// Blanket implementation using self.lines().any().
+impl<T, G> Intersects<G> for LineString<T>
 where
-    T: HasKernel,
+    T: CoordinateType,
+    Line<T>: Intersects<G>,
 {
-    fn intersects(&self, coord: &Coordinate<T>) -> bool {
-        self.lines().any(|l| coord.intersects(&l))
-    }
-}
-symmetric_intersects_impl!(Coordinate<T>, LineString<T>, HasKernel);
-
-impl<T> Intersects<Point<T>> for LineString<T>
-where
-    T: HasKernel,
-{
-    fn intersects(&self, point: &Point<T>) -> bool {
-        self.intersects(&point.0)
-    }
-}
-symmetric_intersects_impl!(Point<T>, LineString<T>, HasKernel);
-
-impl<T> Intersects<Line<T>> for LineString<T>
-where
-    T: HasKernel,
-{
-    fn intersects(&self, line: &Line<T>) -> bool {
-        self.lines().any(|l| line.intersects(&l))
-    }
-}
-symmetric_intersects_impl!(Line<T>, LineString<T>, HasKernel);
-
-impl<T> Intersects<LineString<T>> for LineString<T>
-where
-    T: HasKernel,
-{
-    fn intersects(&self, linestring: &LineString<T>) -> bool {
-        if self.0.is_empty() || linestring.0.is_empty() {
-            return false;
+    fn intersects(&self, geom: &G) -> bool {
+        // No need to loop if either self or rhs is empty.
+        if self.0.is_empty() {
+            false
+        } else {
+            self.lines().any(|l| l.intersects(geom))
         }
-        for a in self.lines() {
-            for b in linestring.lines() {
-                if a.intersects(&b) {
-                    return true;
-                }
-            }
-        }
+    }
+}
+symmetric_intersects_impl!(Coordinate<T>, LineString<T>);
+symmetric_intersects_impl!(Line<T>, LineString<T>);
 
-        false
+
+// Blanket implementation from LineString<T>
+impl<T, G> Intersects<G> for MultiLineString<T>
+where
+    T: CoordinateType,
+    LineString<T>: Intersects<G>,
+{
+    fn intersects(&self, rhs: &G) -> bool {
+        self.0.iter().any(|p| p.intersects(rhs))
     }
 }

--- a/geo/src/algorithm/intersects/line_string.rs
+++ b/geo/src/algorithm/intersects/line_string.rs
@@ -8,12 +8,7 @@ where
     Line<T>: Intersects<G>,
 {
     fn intersects(&self, geom: &G) -> bool {
-        // No need to loop if either self or rhs is empty.
-        if self.0.is_empty() {
-            false
-        } else {
-            self.lines().any(|l| l.intersects(geom))
-        }
+        self.lines().any(|l| l.intersects(geom))
     }
 }
 symmetric_intersects_impl!(Coordinate<T>, LineString<T>);

--- a/geo/src/algorithm/intersects/mod.rs
+++ b/geo/src/algorithm/intersects/mod.rs
@@ -65,31 +65,6 @@ macro_rules! symmetric_intersects_impl {
     };
 }
 
-// Macro to delegate implementation to field `0` of rhs.
-// Used for `Intersects<Point<T>>` from corresponding
-// `Coordinate<T>` impl. This cannot be a blanket impl.
-// because it would conflict with blanket impl. of Point<T>.
-#[macro_use]
-macro_rules! rhs_pt_from_coord_intersects_impl {
-    ($t:ty) => {
-        impl<T> $crate::algorithm::intersects::Intersects<Point<T>> for $t
-        where
-            T: CoordinateType,
-            $t: $crate::algorithm::intersects::Intersects<Coordinate<T>>
-        {
-            fn intersects(&self, rhs: &Point<T>) -> bool {
-                self.intersects(&rhs.0)
-            }
-
-        }
-    };
-}
-
-// Macro to delegate implementation to any() of an iterator.
-// Used for `LineString`, `Intersects<Point<T>>` from corresponding
-// `Coordinate<T>` impl. This cannot be a blanket impl.
-// because it would conflict with blanket impl. of Point<T>.
-
 mod coordinate;
 mod line;
 mod line_string;
@@ -97,6 +72,8 @@ mod point;
 mod polygon;
 mod rect;
 mod triangle;
+mod collections;
+
 
 // Helper function to check value lies between min and max.
 // Only makes sense if min <= max (or always false)

--- a/geo/src/algorithm/intersects/mod.rs
+++ b/geo/src/algorithm/intersects/mod.rs
@@ -113,7 +113,7 @@ where
 #[cfg(test)]
 mod test {
     use crate::algorithm::intersects::Intersects;
-    use crate::{line_string, polygon, Coordinate, Line, LineString, Point, Polygon, Rect};
+    use crate::{line_string, polygon, Geometry, Coordinate, Line, LineString, Point, Polygon, Rect};
 
     /// Tests: intersection LineString and LineString
     #[test]
@@ -566,5 +566,13 @@ mod test {
         );
         assert!(a.intersects(&b));
         assert!(b.intersects(&a));
+    }
+
+    #[test]
+    fn compile_test_geom_geom() {
+        // This test should check existance of all
+        // combinations of geometry types.
+        let geom: Geometry<_> = Line::from([(0.5, 0.5), (2., 1.)]).into();
+        assert!(geom.intersects(&geom));
     }
 }

--- a/geo/src/algorithm/intersects/point.rs
+++ b/geo/src/algorithm/intersects/point.rs
@@ -1,26 +1,18 @@
 use super::Intersects;
-use crate::kernels::*;
 use crate::*;
 
-impl<T> Intersects<Coordinate<T>> for Point<T>
+// Blanket implementation from Coordinate<T>
+impl<T, G> Intersects<G> for Point<T>
 where
     T: CoordinateType,
+    Coordinate<T>: Intersects<G>,
 {
-    fn intersects(&self, rhs: &Coordinate<T>) -> bool {
+    fn intersects(&self, rhs: &G) -> bool {
         self.0.intersects(rhs)
     }
 }
-symmetric_intersects_impl!(Coordinate<T>, Point<T>, CoordinateType);
 
-impl<T> Intersects<Point<T>> for Point<T>
-where
-    T: CoordinateType,
-{
-    fn intersects(&self, rhs: &Point<T>) -> bool {
-        self.intersects(&rhs.0)
-    }
-}
-
+// Blanket implementation from Point<T>
 impl<T, G> Intersects<G> for MultiPoint<T>
 where
     T: CoordinateType,
@@ -30,8 +22,7 @@ where
         self.0.iter().any(|p| p.intersects(rhs))
     }
 }
-symmetric_intersects_impl!(Coordinate<T>, MultiPoint<T>, CoordinateType);
-symmetric_intersects_impl!(Point<T>, MultiPoint<T>, CoordinateType);
-symmetric_intersects_impl!(Line<T>, MultiPoint<T>, HasKernel);
-symmetric_intersects_impl!(LineString<T>, MultiPoint<T>, HasKernel);
-symmetric_intersects_impl!(Polygon<T>, MultiPoint<T>, HasKernel);
+
+symmetric_intersects_impl!(Coordinate<T>, MultiPoint<T>);
+symmetric_intersects_impl!(Line<T>, MultiPoint<T>);
+symmetric_intersects_impl!(Polygon<T>, MultiPoint<T>);

--- a/geo/src/algorithm/intersects/polygon.rs
+++ b/geo/src/algorithm/intersects/polygon.rs
@@ -1,5 +1,4 @@
 use super::Intersects;
-use crate::contains::Contains;
 use crate::kernels::*;
 use crate::utils::{coord_pos_relative_to_ring, CoordPos};
 use crate::*;
@@ -16,17 +15,8 @@ where
                 .all(|int| coord_pos_relative_to_ring(*p, int) != CoordPos::Inside)
     }
 }
-symmetric_intersects_impl!(Coordinate<T>, Polygon<T>, HasKernel);
-
-impl<T> Intersects<Point<T>> for Polygon<T>
-where
-    T: HasKernel,
-{
-    fn intersects(&self, p: &Point<T>) -> bool {
-        self.intersects(&p.0)
-    }
-}
-symmetric_intersects_impl!(Point<T>, Polygon<T>, HasKernel);
+symmetric_intersects_impl!(Coordinate<T>, Polygon<T>);
+symmetric_intersects_impl!(Polygon<T>, Point<T>);
 
 impl<T> Intersects<Line<T>> for Polygon<T>
 where
@@ -35,32 +25,13 @@ where
     fn intersects(&self, line: &Line<T>) -> bool {
         self.exterior().intersects(line)
             || self.interiors().iter().any(|inner| inner.intersects(line))
-            || self.contains(&line.start)
-            || self.contains(&line.end)
+            || self.intersects(&line.start)
+            || self.intersects(&line.end)
     }
 }
-symmetric_intersects_impl!(Line<T>, Polygon<T>, HasKernel);
-
-impl<T> Intersects<LineString<T>> for Polygon<T>
-where
-    T: HasKernel,
-{
-    fn intersects(&self, linestring: &LineString<T>) -> bool {
-        // line intersects inner or outer polygon edge
-        if self.exterior().intersects(linestring)
-            || self
-                .interiors()
-                .iter()
-                .any(|inner| inner.intersects(linestring))
-        {
-            true
-        } else {
-            // or if it's contained in the polygon
-            linestring.0.iter().any(|c| self.contains(c))
-        }
-    }
-}
-symmetric_intersects_impl!(LineString<T>, Polygon<T>, HasKernel);
+symmetric_intersects_impl!(Line<T>, Polygon<T>);
+symmetric_intersects_impl!(Polygon<T>, LineString<T>);
+symmetric_intersects_impl!(Polygon<T>, MultiLineString<T>);
 
 impl<T> Intersects<Rect<T>> for Polygon<T>
 where
@@ -70,7 +41,7 @@ where
         self.intersects(&rect.clone().to_polygon())
     }
 }
-symmetric_intersects_impl!(Rect<T>, Polygon<T>, HasKernel);
+symmetric_intersects_impl!(Rect<T>, Polygon<T>);
 
 impl<T> Intersects<Polygon<T>> for Polygon<T>
 where
@@ -97,8 +68,7 @@ where
     }
 }
 
-symmetric_intersects_impl!(Point<T>, MultiPolygon<T>, HasKernel);
-symmetric_intersects_impl!(Line<T>, MultiPolygon<T>, HasKernel);
-symmetric_intersects_impl!(LineString<T>, MultiPolygon<T>, HasKernel);
-symmetric_intersects_impl!(Polygon<T>, MultiPolygon<T>, HasKernel);
-symmetric_intersects_impl!(Rect<T>, MultiPolygon<T>, HasKernel);
+symmetric_intersects_impl!(Point<T>, MultiPolygon<T>);
+symmetric_intersects_impl!(Line<T>, MultiPolygon<T>);
+symmetric_intersects_impl!(Rect<T>, MultiPolygon<T>);
+symmetric_intersects_impl!(Polygon<T>, MultiPolygon<T>);

--- a/geo/src/algorithm/intersects/rect.rs
+++ b/geo/src/algorithm/intersects/rect.rs
@@ -1,5 +1,23 @@
 use super::{value_in_range, Intersects};
+use crate::kernels::*;
 use crate::*;
+
+impl<T> Intersects<Coordinate<T>> for Rect<T>
+where
+    T: CoordinateType,
+{
+    fn intersects(&self, rhs: &Coordinate<T>) -> bool {
+        // Funnily, we don't use point_in_rect, as we know
+        // self.min <= self.max.
+        let bound_1 = self.min();
+        let bound_2 = self.max();
+        value_in_range(rhs.x, bound_1.x, bound_2.x)
+            && value_in_range(rhs.y, bound_1.y, bound_2.y)
+    }
+}
+symmetric_intersects_impl!(Coordinate<T>, Rect<T>);
+symmetric_intersects_impl!(Rect<T>, Point<T>);
+symmetric_intersects_impl!(Rect<T>, MultiPoint<T>);
 
 impl<T> Intersects<Rect<T>> for Rect<T>
 where
@@ -13,5 +31,26 @@ where
             || value_in_range(other.min().y, self.min().y, self.max().y);
 
         x_overlap && y_overlap
+    }
+}
+
+// Same logic as Polygon<T>: Intersects<Line<T>>, but avoid
+// an allocation.
+impl<T> Intersects<Line<T>> for Rect<T>
+where
+    T: HasKernel,
+{
+    fn intersects(&self, rhs: &Line<T>) -> bool {
+        let lt = self.min();
+        let rb = self.max();
+        let lb = Coordinate::from((lt.x, rb.y));
+        let rt = Coordinate::from((rb.x, lt.y));
+        // If either rhs.{start,end} lies inside Rect, then true
+        self.intersects(&rhs.start)
+            || self.intersects(&rhs.end)
+            || Line::new(lt, rt).intersects(rhs)
+            || Line::new(rt, rb).intersects(rhs)
+            || Line::new(lb, rb).intersects(rhs)
+            || Line::new(lt, lb).intersects(rhs)
     }
 }

--- a/geo/src/algorithm/intersects/rect.rs
+++ b/geo/src/algorithm/intersects/rect.rs
@@ -54,3 +54,4 @@ where
             || Line::new(lt, lb).intersects(rhs)
     }
 }
+symmetric_intersects_impl!(Line<T>, Rect<T>);

--- a/geo/src/algorithm/intersects/triangle.rs
+++ b/geo/src/algorithm/intersects/triangle.rs
@@ -1,5 +1,4 @@
 use super::Intersects;
-use crate::kernels::*;
 use crate::*;
 
 impl<T, G> Intersects<G> for Triangle<T>
@@ -11,8 +10,7 @@ where
         self.clone().to_polygon().intersects(rhs)
     }
 }
-symmetric_intersects_impl!(Coordinate<T>, Triangle<T>, HasKernel);
-symmetric_intersects_impl!(Point<T>, Triangle<T>, HasKernel);
-symmetric_intersects_impl!(Line<T>, Triangle<T>, HasKernel);
-symmetric_intersects_impl!(LineString<T>, Triangle<T>, HasKernel);
-symmetric_intersects_impl!(Polygon<T>, Triangle<T>, HasKernel);
+symmetric_intersects_impl!(Coordinate<T>, Triangle<T>);
+symmetric_intersects_impl!(Line<T>, Triangle<T>);
+symmetric_intersects_impl!(Rect<T>, Triangle<T>);
+symmetric_intersects_impl!(Polygon<T>, Triangle<T>);


### PR DESCRIPTION
This PR completes the `Intersects` implementation for all pairs of current geo-types (discounting possible bugs)!

+ Add OGC-SA descriptions to geo-types docs
+ Verify existing implementations
+ Add implementations for containers: `Geometry`, `GeometryCollection`

See [here](//georust.github.io/geo/support/intersects.html) for table describing the implementation status / map.

Interestingly, we didn't need geom-graph for this trait (presumably because this trait doesn't distinguish between interior and boundary).  I also removed any usage of `Contains` trait in this trait for easier verification of correctness.