### PR TITLE
fix ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       run:
         working-directory: geo-types
     container:
-      image: georust/geo-ci:088c49bece4afbb8381019cba17f230710de4040
+      image: georust/geo-ci
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -25,7 +25,7 @@ jobs:
       run:
         working-directory: geo
     container:
-      image: georust/geo-ci:088c49bece4afbb8381019cba17f230710de4040
+      image: georust/geo-ci
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -41,7 +41,7 @@ jobs:
       run:
         working-directory: geo-postgis
     container:
-      image: georust/geo-ci:088c49bece4afbb8381019cba17f230710de4040
+      image: georust/geo-ci
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     container:
-      image: georust/geo-ci:088c49bece4afbb8381019cba17f230710de4040
+      image: georust/geo-ci
       options: --security-opt seccomp=unconfined
     steps:
       - name: Checkout repository

--- a/geo/src/algorithm/centroid.rs
+++ b/geo/src/algorithm/centroid.rs
@@ -82,7 +82,10 @@ where
             )
         });
     let six = T::from_i32(6).unwrap();
-    Some(Point::new(sum_x / (six * area) + shift.x, sum_y / (six * area) + shift.y))
+    Some(Point::new(
+        sum_x / (six * area) + shift.x,
+        sum_y / (six * area) + shift.y,
+    ))
 }
 
 impl<T> Centroid for Line<T>
@@ -499,7 +502,9 @@ mod test {
         use crate::map_coords::MapCoords;
         let polygon = polygon.map_coords(|&(x, y)| (x + shift_x, y + shift_y));
 
-        let new_centroid = polygon.centroid().unwrap()
+        let new_centroid = polygon
+            .centroid()
+            .unwrap()
             .map_coords(|&(x, y)| (x - shift_x, y - shift_y));
         eprintln!("centroid {:?}", centroid.0);
         eprintln!("new_centroid {:?}", new_centroid.0);


### PR DESCRIPTION
We recently did some shuffling around of docker containers to facilitate some changes in docker, and the result was that the `--features proj` build for geo was failing.

Fixing that required two steps:

1. I fixed the automatic docker-hub container builds, which I'd inadvertently broken: https://github.com/georust/docker-images/commit/2464e6740e65f9b7d19013fa5a5a636d28ba9cf5

2. This PR, which updates to use the latest available geo-ci container rather than a hardcoded one.





