### PR TITLE
more forgiving rect constructor

### DIFF
--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## 0.6.2
+
+* `Rect::new` automatically determines min/max points
+
 ## 0.6.1
 
 * Add documentation on semantics (based on OGC-SFA)

--- a/geo-types/Cargo.toml
+++ b/geo-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geo-types"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Corey Farwell <coreyf@rwell.org>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/georust/geo"

--- a/geo-types/src/rect.rs
+++ b/geo-types/src/rect.rs
@@ -64,27 +64,37 @@ impl<T: CoordinateType> Rect<T> {
     ///     Coordinate { x: 10., y: 20. }
     /// );
     /// ```
-    pub fn new<C>(min: C, max: C) -> Rect<T>
+    pub fn new<C>(c1: C, c2: C) -> Rect<T>
     where
         C: Into<Coordinate<T>>,
     {
-        Rect::try_new(min, max).unwrap()
+        let c1 = c1.into();
+        let c2 = c2.into();
+        let (min_x, max_x) = if c1.x < c2.x {
+            (c1.x, c2.x)
+        } else {
+            (c2.x, c1.x)
+        };
+        let (min_y, max_y) = if c1.y < c2.y {
+            (c1.y, c2.y)
+        } else {
+            (c2.y, c1.y)
+        };
+        Rect {
+            min: Coordinate { x: min_x, y: min_y },
+            max: Coordinate { x: max_x, y: max_y },
+        }
     }
 
-    pub fn try_new<C>(min: C, max: C) -> Result<Rect<T>, InvalidRectCoordinatesError>
+    #[deprecated(
+        since = "0.6.2",
+        note = "Use `Rect::new` instead, since `Rect::try_new` will never Error"
+    )]
+    pub fn try_new<C>(c1: C, c2: C) -> Result<Rect<T>, InvalidRectCoordinatesError>
     where
         C: Into<Coordinate<T>>,
     {
-        let rect = Rect {
-            min: min.into(),
-            max: max.into(),
-        };
-
-        if rect.has_valid_bounds() {
-            Ok(rect)
-        } else {
-            Err(InvalidRectCoordinatesError)
-        }
+        Ok(Rect::new(c1, c2))
     }
 
     /// Returns the minimum `Coordinate` (bottom-left corner) of the `Rect`.
@@ -280,12 +290,14 @@ mod test {
         let rect = Rect::new((10, 10), (20, 20));
         assert_eq!(rect.min, Coordinate { x: 10, y: 10 });
         assert_eq!(rect.max, Coordinate { x: 20, y: 20 });
-    }
 
-    #[test]
-    #[should_panic]
-    fn rect_panic() {
-        let _ = Rect::new((10, 20), (20, 10));
+        let rect = Rect::new((20, 20), (10, 10));
+        assert_eq!(rect.min, Coordinate { x: 10, y: 10 });
+        assert_eq!(rect.max, Coordinate { x: 20, y: 20 });
+
+        let rect = Rect::new((10, 20), (20, 10));
+        assert_eq!(rect.min, Coordinate { x: 10, y: 10 });
+        assert_eq!(rect.max, Coordinate { x: 20, y: 20 });
     }
 
     #[test]

--- a/geo/src/algorithm/bounding_rect.rs
+++ b/geo/src/algorithm/bounding_rect.rs
@@ -4,7 +4,6 @@ use crate::{
     MultiPoint, MultiPolygon, Point, Polygon, Rect, Triangle,
 };
 use geo_types::private_utils::{get_bounding_rect, line_string_bounding_rect};
-use geo_types::InvalidRectCoordinatesError;
 
 /// Calculation of the bounding rectangle of a geometry.
 pub trait BoundingRect<T: CoordinateType> {
@@ -192,18 +191,15 @@ where
             match (acc, next_bounding_rect) {
                 (None, None) => None,
                 (Some(r), None) | (None, Some(r)) => Some(r),
-                (Some(r1), Some(r2)) => bounding_rect_merge(r1, r2).ok(),
+                (Some(r1), Some(r2)) => Some(bounding_rect_merge(r1, r2)),
             }
         })
     }
 }
 
 // Return a new rectangle that encompasses the provided rectangles
-fn bounding_rect_merge<T: CoordinateType>(
-    a: Rect<T>,
-    b: Rect<T>,
-) -> Result<Rect<T>, InvalidRectCoordinatesError> {
-    Rect::try_new(
+fn bounding_rect_merge<T: CoordinateType>(a: Rect<T>, b: Rect<T>) -> Rect<T> {
+    Rect::new(
         Coordinate {
             x: partial_min(a.min().x, b.min().x),
             y: partial_min(a.min().y, b.min().y),
@@ -324,10 +320,7 @@ mod test {
                 Rect::new(Coordinate { x: 0., y: 0. }, Coordinate { x: 1., y: 1. }),
                 Rect::new(Coordinate { x: 1., y: 1. }, Coordinate { x: 2., y: 2. }),
             ),
-            Ok(Rect::new(
-                Coordinate { x: 0., y: 0. },
-                Coordinate { x: 2., y: 2. }
-            )),
+            Rect::new(Coordinate { x: 0., y: 0. }, Coordinate { x: 2., y: 2. }),
         );
     }
 


### PR DESCRIPTION
Is there a reason for our constructor to be so brutal?

Rather than force the programmer to order points by min/max, let the computer do it.