### PR TITLE
Better handling of points/lines with NaN/Inf and zero length lines for LineLocatePoint and LineInterpolatePoint

### DIFF
--- a/geo/src/algorithm/line_interpolate_point.rs
+++ b/geo/src/algorithm/line_interpolate_point.rs
@@ -8,10 +8,12 @@ use crate::{
 /// Returns an option of the point that lies a given fraction along the line.
 ///
 /// If the given fraction is
-///  * less than zero (including negative infinity): returns a `Some` of the starting point
+///  * less than zero (including negative infinity): returns a `Some`
+///    of the starting point
 ///  * greater than one (including infinity): returns a `Some` of the ending point
 ///
-///  If either the fraction is NaN, or any coordinates of the line are not finite, returns `None`.
+///  If either the fraction is NaN, or any coordinates of the line are not
+///  finite, returns `None`.
 ///
 /// # Examples
 ///

--- a/geo/src/algorithm/line_interpolate_point.rs
+++ b/geo/src/algorithm/line_interpolate_point.rs
@@ -143,11 +143,11 @@ mod test {
         assert_eq!(line.line_interpolate_point(Float::nan()), None);
         assert_eq!(
             line.line_interpolate_point(Float::infinity()),
-            Some(line.end.into())
+            Some(line.end_point())
         );
         assert_eq!(
             line.line_interpolate_point(Float::neg_infinity()),
-            Some(line.start.into())
+            Some(line.start_point())
         );
 
         let line = Line::new(Coordinate { x: 0.0, y: 0.0 }, Coordinate { x: 1.0, y: 1.0 });

--- a/geo/src/algorithm/line_interpolate_point.rs
+++ b/geo/src/algorithm/line_interpolate_point.rs
@@ -84,7 +84,7 @@ where
                 let line_frac = (fractional_length - x.0) / x.2;
                 (x.3).line_interpolate_point(&line_frac)
             }
-            None => self.points_iter().last().unwrap(),
+            None => self.points_iter().last().unwrap_or(Point::new(T::nan(), T::nan())),
         }
     }
 }
@@ -134,10 +134,8 @@ mod test {
 
         let coords: Vec<Point<f64>> = Vec::new();
         let linestring: LineString<f64> = coords.into();
-        assert_eq!(
-            linestring.line_interpolate_point(&0.5),
-            point!(x: Float::nan(), y: Float::nan())
-        );
+        let pt = linestring.line_interpolate_point(&0.5);
+        assert!(pt.x().is_nan() & pt.y().is_nan());
 
     }
 

--- a/geo/src/algorithm/line_interpolate_point.rs
+++ b/geo/src/algorithm/line_interpolate_point.rs
@@ -1,4 +1,4 @@
-use num_traits::{Float, One, Zero};
+use num_traits::Float;
 use std::{
     cmp::Ordering,
     ops::AddAssign
@@ -44,7 +44,7 @@ pub trait LineInterpolatePoint<F: Float> {
 
 impl<T> LineInterpolatePoint<T> for Line<T>
 where
-    T: CoordinateType + Float + Zero + One,
+    T: CoordinateType + Float,
 {
     type Output = Option<Point<T>>;
 
@@ -73,7 +73,7 @@ where
 
 impl<T> LineInterpolatePoint<T> for LineString<T>
 where
-    T: CoordinateType + Float + Zero + AddAssign + One,
+    T: CoordinateType + Float + AddAssign,
     Line<T>: EuclideanLength<T>,
     LineString<T>: EuclideanLength<T>,
 {

--- a/geo/src/algorithm/line_interpolate_point.rs
+++ b/geo/src/algorithm/line_interpolate_point.rs
@@ -131,6 +131,14 @@ mod test {
             linestring.line_interpolate_point(&1.5),
             point!(x: 0.0, y: 1.0)
         );
+
+        let coords: Vec<Point<f64>> = Vec::new();
+        let linestring: LineString<f64> = coords.into();
+        assert_eq!(
+            linestring.line_interpolate_point(&0.5),
+            point!(x: Float::nan(), y: Float::nan())
+        );
+
     }
 
     #[test]

--- a/geo/src/algorithm/line_interpolate_point.rs
+++ b/geo/src/algorithm/line_interpolate_point.rs
@@ -1,5 +1,8 @@
 use num_traits::{Float, One, Zero};
-use std::ops::AddAssign;
+use std::{
+    cmp::Ordering,
+    ops::AddAssign
+};
 
 use crate::{
     algorithm::euclidean_length::EuclideanLength, Coordinate, CoordinateType, Line, LineString,
@@ -9,8 +12,10 @@ use crate::{
 /// Returns the point that lies a given fraction along the line.
 ///
 /// If the given fraction is
-///  * less than zero: returns the starting point
-///  * greater than one: returns the end point
+///  * less than zero (including negative infinity): returns a `Some` of the starting point
+///  * greater than one (including infinity): returns a `Some` of the ending point
+///
+///  If either the fraction is NaN, or any coordinates of the line are not finite, returns `None`.
 ///
 /// # Examples
 ///
@@ -24,11 +29,11 @@ use crate::{
 ///     [0.0, 1.0]
 /// ].into();
 ///
-/// assert_eq!(linestring.line_interpolate_point(&-1.0), point!(x: -1.0, y: 0.0));
-/// assert_eq!(linestring.line_interpolate_point(&0.25), point!(x: -0.5, y: 0.0));
-/// assert_eq!(linestring.line_interpolate_point(&0.5), point!(x: 0.0, y: 0.0));
-/// assert_eq!(linestring.line_interpolate_point(&0.75), point!(x: 0.0, y: 0.5));
-/// assert_eq!(linestring.line_interpolate_point(&2.0), point!(x: 0.0, y: 1.0));
+/// assert_eq!(linestring.line_interpolate_point(&-1.0), Some(point!(x: -1.0, y: 0.0)));
+/// assert_eq!(linestring.line_interpolate_point(&0.25), Some(point!(x: -0.5, y: 0.0)));
+/// assert_eq!(linestring.line_interpolate_point(&0.5), Some(point!(x: 0.0, y: 0.0)));
+/// assert_eq!(linestring.line_interpolate_point(&0.75), Some(point!(x: 0.0, y: 0.5)));
+/// assert_eq!(linestring.line_interpolate_point(&2.0), Some(point!(x: 0.0, y: 1.0)));
 /// ```
 pub trait LineInterpolatePoint<F: Float> {
     type Output;
@@ -36,23 +41,39 @@ pub trait LineInterpolatePoint<F: Float> {
     fn line_interpolate_point(&self, fraction: &F) -> Self::Output;
 }
 
+
 impl<T> LineInterpolatePoint<T> for Line<T>
 where
     T: CoordinateType + Float + Zero + One,
 {
-    type Output = Point<T>;
+    type Output = Option<Point<T>>;
 
     fn line_interpolate_point(&self, fraction: &T) -> Self::Output {
-        if fraction < &T::zero() {
-            return self.start.into();
-        };
-        if fraction > &T::one() {
-            return self.end.into();
+        match fraction.partial_cmp(&T::zero()) {
+            Some(o) => match o {
+                Ordering::Less => return Some(self.start.into()),
+                Ordering::Equal => return Some(self.start.into()),
+                Ordering::Greater => {
+                    match fraction.partial_cmp(&T::one()) {
+                        Some(p) => match p {
+                            Ordering::Greater => return Some(self.end.into()),
+                            Ordering::Equal => return Some(self.end.into()),
+                            Ordering::Less => {}
+                        },
+                        None => return None
+                    }
+                }
+            },
+            None => return None
         };
         let s = [self.start.x, self.start.y];
         let v = [self.end.x - self.start.x, self.end.y - self.start.y];
         let r = [*fraction * v[0] + s[0], *fraction * v[1] + s[1]];
-        Coordinate { x: r[0], y: r[1] }.into()
+        if r[0].is_finite() & r[1].is_finite() {
+            return Some(Coordinate { x: r[0], y: r[1] }.into())
+        } else {
+            return None
+        }
     }
 }
 
@@ -62,7 +83,7 @@ where
     Line<T>: EuclideanLength<T>,
     LineString<T>: EuclideanLength<T>,
 {
-    type Output = Point<T>;
+    type Output = Option<Point<T>>;
 
     fn line_interpolate_point(&self, fraction: &T) -> Self::Output {
         let total_length = self.euclidean_length();
@@ -71,21 +92,21 @@ where
         let mut queue = Vec::new();
         for line in self.lines() {
             let length = line.euclidean_length();
-            queue.push((
-                cum_length.clone(),
-                cum_length.clone() + length.clone(),
-                length.clone(),
-                line.clone(),
-            ));
+            let entry = (cum_length.clone() + length.clone()).partial_cmp(&fractional_length)
+                .map(|o| (cum_length.clone(), o, length.clone(), line.clone()));
+            queue.push(entry);
             cum_length += length;
         }
-        match queue.iter().find(|x| x.1 >= fractional_length) {
-            Some(x) => {
-                let line_frac = (fractional_length - x.0) / x.2;
-                (x.3).line_interpolate_point(&line_frac)
-            }
-            None => self.points_iter().last().unwrap_or(Point::new(T::nan(), T::nan())),
-        }
+        queue.into_iter()
+            .collect::<Option<Vec<_>>>()
+            .map(|q| q.iter()
+                // the first line segment who ends after tracing `fractional_length`
+                .find(|x| x.1 != Ordering::Less)
+                .map(|x| {let line_frac = (fractional_length - x.0) / x.2;
+                        (x.3).line_interpolate_point(&line_frac)})
+                // Nothing found, return the last point
+                .unwrap_or(self.points_iter().last()))
+            .flatten()
     }
 }
 
@@ -103,53 +124,98 @@ mod test {
             Coordinate { x: -1.0, y: 0.0 },
             Coordinate { x: 1.0, y: 0.0 },
         );
-        assert_eq!(line.line_interpolate_point(&-1.0), point!(x: -1.0, y: 0.0));
-        assert_eq!(line.line_interpolate_point(&0.5), point!(x: 0.0, y: 0.0));
-        assert_eq!(line.line_interpolate_point(&0.75), point!(x: 0.5, y: 0.0));
-        assert_eq!(line.line_interpolate_point(&0.0), point!(x: -1.0, y: 0.0));
-        assert_eq!(line.line_interpolate_point(&1.0), point!(x: 1.0, y: 0.0));
-        assert_eq!(line.line_interpolate_point(&2.0), point!(x: 1.0, y: 0.0));
+        // some finite examples
+        assert_eq!(line.line_interpolate_point(&-1.0), Some(point!(x: -1.0, y: 0.0)));
+        assert_eq!(line.line_interpolate_point(&0.5), Some(point!(x: 0.0, y: 0.0)));
+        assert_eq!(line.line_interpolate_point(&0.75), Some(point!(x: 0.5, y: 0.0)));
+        assert_eq!(line.line_interpolate_point(&0.0), Some(point!(x: -1.0, y: 0.0)));
+        assert_eq!(line.line_interpolate_point(&1.0), Some(point!(x: 1.0, y: 0.0)));
+        assert_eq!(line.line_interpolate_point(&2.0), Some(point!(x: 1.0, y: 0.0)));
+
+        // fraction is nan or inf
+        assert_eq!(line.line_interpolate_point(&Float::nan()), None);
+        assert_eq!(line.line_interpolate_point(&Float::infinity()), Some(line.end.into()));
+        assert_eq!(line.line_interpolate_point(&Float::neg_infinity()), Some(line.start.into()));
 
         let line = Line::new(Coordinate { x: 0.0, y: 0.0 }, Coordinate { x: 1.0, y: 1.0 });
-        assert_eq!(line.line_interpolate_point(&0.5), point!(x: 0.5, y: 0.5));
+        assert_eq!(line.line_interpolate_point(&0.5), Some(point!(x: 0.5, y: 0.5)));
+
+        // line contains nans or infs
+        let line = Line::new(Coordinate { x: Float::nan(), y: 0.0}, Coordinate { x:1.0, y: 1.0});
+        assert_eq!(line.line_interpolate_point(&0.5), None);
+
+        let line = Line::new(Coordinate { x: Float::infinity(), y: 0.0}, Coordinate { x:1.0, y: 1.0});
+        assert_eq!(line.line_interpolate_point(&0.5), None);
+
+        let line = Line::new(Coordinate { x: 0.0, y: 0.0}, Coordinate { x:1.0, y: Float::infinity()});
+        assert_eq!(line.line_interpolate_point(&0.5), None);
+
+        let line = Line::new(Coordinate { x: Float::neg_infinity(), y: 0.0}, Coordinate { x:1.0, y: 1.0});
+        assert_eq!(line.line_interpolate_point(&0.5), None);
+
+        let line = Line::new(Coordinate { x: 0.0, y: 0.0}, Coordinate { x:1.0, y: Float::neg_infinity()});
+        assert_eq!(line.line_interpolate_point(&0.5), None);
     }
 
     #[test]
     fn test_line_interpolate_point_linestring() {
+        // some finite examples
         let linestring: LineString<f64> = vec![[-1.0, 0.0], [0.0, 0.0], [1.0, 0.0]].into();
         assert_eq!(
             linestring.line_interpolate_point(&0.5),
-            point!(x: 0.0, y: 0.0)
+            Some(point!(x: 0.0, y: 0.0))
         );
         assert_eq!(
             linestring.line_interpolate_point(&1.0),
-            point!(x: 1.0, y: 0.0)
+            Some(point!(x: 1.0, y: 0.0))
         );
+
+        // fraction is nan or inf
+        assert_eq!(
+            linestring.line_interpolate_point(&Float::infinity()),
+            linestring.points_iter().last()
+        );
+        assert_eq!(
+            linestring.line_interpolate_point(&Float::neg_infinity()),
+            linestring.points_iter().next()
+        );
+        assert_eq!(linestring.line_interpolate_point(&Float::nan()), None);
 
         let linestring: LineString<f64> = vec![[-1.0, 0.0], [0.0, 0.0], [0.0, 1.0]].into();
         assert_eq!(
             linestring.line_interpolate_point(&1.5),
-            point!(x: 0.0, y: 1.0)
+            Some(point!(x: 0.0, y: 1.0))
         );
 
+        // linestrings with nans/infs
+        let linestring: LineString<f64> = vec![[-1.0, 0.0], [0.0, Float::nan()], [0.0, 1.0]].into();
+        assert_eq!(linestring.line_interpolate_point(&0.5), None);
+
+        let linestring: LineString<f64> = vec![[-1.0, 0.0], [0.0, Float::infinity()], [0.0, 1.0]].into();
+        assert_eq!(linestring.line_interpolate_point(&0.5), None);
+
+        let linestring: LineString<f64> = vec![[-1.0, 0.0], [0.0, Float::neg_infinity()], [0.0, 1.0]].into();
+        assert_eq!(linestring.line_interpolate_point(&0.5), None);
+
+        // Empty line
         let coords: Vec<Point<f64>> = Vec::new();
         let linestring: LineString<f64> = coords.into();
-        let pt = linestring.line_interpolate_point(&0.5);
-        assert!(pt.x().is_nan() & pt.y().is_nan());
-
+        assert_eq!(linestring.line_interpolate_point(&0.5), None);
     }
 
     #[test]
     fn test_matches_closest_point() {
+        // line_locate_point should return the fraction to the closest point,
+        // so interpolating the line with that fraction should yield the closest point
         let linestring: LineString<f64> = vec![[-1.0, 0.0], [0.5, 1.0], [1.0, 2.0]].into();
         let pt = point!(x: 0.7, y: 0.7);
-        let frac = linestring.line_locate_point(&pt);
+        let frac = linestring.line_locate_point(&pt).expect("Should result in fraction between 0 and 1");
         println!("{:?}", &frac);
-        let interpolated_point = linestring.line_interpolate_point(&frac);
+        let interpolated_point = linestring.line_interpolate_point(&frac).expect("Shouldn't return None");
         let closest_point = linestring.closest_point(&pt);
         match closest_point {
             crate::Closest::SinglePoint(p) => assert_eq!(interpolated_point, p),
-            _ => panic!("The closest point should be a SinglePoint"),
+            _ => panic!("The closest point should be a SinglePoint"), // example chosen to not be an intersection
         };
     }
 }

--- a/geo/src/algorithm/line_interpolate_point.rs
+++ b/geo/src/algorithm/line_interpolate_point.rs
@@ -49,23 +49,17 @@ where
     type Output = Option<Point<T>>;
 
     fn line_interpolate_point(&self, fraction: &T) -> Self::Output {
-        match fraction.partial_cmp(&T::zero()) {
-            Some(o) => match o {
-                Ordering::Less => return Some(self.start.into()),
-                Ordering::Equal => return Some(self.start.into()),
-                Ordering::Greater => {
-                    match fraction.partial_cmp(&T::one()) {
-                        Some(p) => match p {
-                            Ordering::Greater => return Some(self.end.into()),
-                            Ordering::Equal => return Some(self.end.into()),
-                            Ordering::Less => {}
-                        },
-                        None => return None
-                    }
+        match fraction.partial_cmp(&T::zero())? {
+            Ordering::Less => return Some(self.start.into()),
+            Ordering::Equal => return Some(self.start.into()),
+            Ordering::Greater => {
+                match fraction.partial_cmp(&T::one())? {
+                    Ordering::Greater => return Some(self.end.into()),
+                    Ordering::Equal => return Some(self.end.into()),
+                    Ordering::Less => {}
                 }
-            },
-            None => return None
-        };
+            }
+        }
         let s = [self.start.x, self.start.y];
         let v = [self.end.x - self.start.x, self.end.y - self.start.y];
         let r = [*fraction * v[0] + s[0], *fraction * v[1] + s[1]];

--- a/geo/src/algorithm/line_locate_point.rs
+++ b/geo/src/algorithm/line_locate_point.rs
@@ -94,14 +94,15 @@ where
             // linestring has zero legnth, return zero
             return T::zero();
         } else {
-            let first = queue.pop();
+            let first = queue.first().map(|x| x.clone());
             let opt_l = queue
                 .iter()
                 .fold(first, |l, y| { 
                     match l.map(|x| (x.2).partial_cmp(&y.2)).flatten() {
                         Some(o) => match o {
                             Ordering::Less => l,
-                            _ => Some(*y)
+                            Ordering::Equal => l,
+                            Ordering::Greater => Some(*y)
                         },
                         None => None
                     }});
@@ -177,6 +178,13 @@ mod test {
 
         let pt = point!(x: 10.0, y: 1.0);
         assert_eq!(ring.line_locate_point(&pt), 0.0);
+
+        let line: LineString<f64> = LineString(vec![(0.0, 0.0).into(),
+                                                    (1.0, 0.0).into(),
+                                                    (1.0, 1.0).into(),
+                                                    (0.0, 1.0).into()]);
+        let pt = point!(x: 0.0, y: 0.5);
+        assert_eq!(line.line_locate_point(&pt), 0.0);
 
         let line: LineString<f64> = LineString(vec![(1.0, 1.0).into(),
                                                     (1.0, 1.0).into(),

--- a/geo/src/algorithm/line_locate_point.rs
+++ b/geo/src/algorithm/line_locate_point.rs
@@ -2,10 +2,7 @@ use crate::{
     algorithm::{euclidean_distance::EuclideanDistance, euclidean_length::EuclideanLength},
     CoordinateType, Line, LineString, Point,
 };
-use num_traits::{
-    identities::{One, Zero},
-    Float,
-};
+use num_traits::Float;
 use std::{
     ops::AddAssign,
     cmp::Ordering
@@ -46,7 +43,7 @@ pub trait LineLocatePoint<T, Rhs> {
 
 impl<T> LineLocatePoint<T, Point<T>> for Line<T>
 where
-    T: CoordinateType + Float + Zero + One,
+    T: CoordinateType + Float,
 {
     type Output = Option<T>;
     type Rhs = Point<T>;
@@ -83,7 +80,7 @@ where
 
 impl<T> LineLocatePoint<T, Point<T>> for LineString<T>
 where
-    T: CoordinateType + Float + Zero + One + PartialOrd + AddAssign,
+    T: CoordinateType + Float + AddAssign,
     Line<T>: EuclideanDistance<T, Point<T>> + EuclideanLength<T>,
 {
     type Output = Option<T>;

--- a/geo/src/algorithm/line_locate_point.rs
+++ b/geo/src/algorithm/line_locate_point.rs
@@ -6,12 +6,13 @@ use num_traits::Float;
 use std::ops::AddAssign;
 
 /// Returns a (option of the) fraction of the line's total length
-/// representing the location
-/// of the closest point on the line to the given point.
+/// representing the location of the closest point on the line to
+/// the given point.
 ///
 /// If the line has zero length the fraction returned is zero.
 ///
-/// If either the point's coordinates or any coordinates of the line are not finite, returns `None`
+/// If either the point's coordinates or any coordinates of the line
+/// are not finite, returns `None`.
 ///
 /// # Examples
 ///

--- a/geo/src/algorithm/line_locate_point.rs
+++ b/geo/src/algorithm/line_locate_point.rs
@@ -53,7 +53,7 @@ where
         // $l$ along the line to $p$ is perpendicular to $v$.a
 
         // vector $p - s$
-        let sp: Point<_> = (*p - self.start_point()).into();
+        let sp: Point<_> = *p - self.start_point();
 
         // direction vector of line, $v$
         let v: Point<_> = (self.end - self.start).into();

--- a/geo/src/algorithm/line_locate_point.rs
+++ b/geo/src/algorithm/line_locate_point.rs
@@ -12,6 +12,8 @@ use std::ops::AddAssign;
 /// representing the location
 /// of the closest point on the line to the given point.
 ///
+/// If the line has zero length the fraction returned is zero.
+///
 /// # Examples
 ///
 /// ```
@@ -85,12 +87,17 @@ where
             ));
             total_length += length;
         }
-        let l = queue
-            .iter()
-            .min_by(|x, y| (x.2).partial_cmp(&y.2).unwrap())
-            .unwrap();
+        if total_length == T::zero() {
+            // linestring has zero legnth, return zero
+            return T::zero();
+        } else {
+            let l = queue
+                .iter()
+                .min_by(|x, y| (x.2).partial_cmp(&y.2).unwrap())
+                .unwrap();
 
-        (l.0 + l.1 * (l.3).line_locate_point(p)) / total_length
+            return (l.0 + l.1 * (l.3).line_locate_point(p)) / total_length
+        }
     }
 }
 

--- a/geo/src/algorithm/line_locate_point.rs
+++ b/geo/src/algorithm/line_locate_point.rs
@@ -52,7 +52,7 @@ where
         // $l$ along the line to $p$ is perpendicular to $v$.a
 
         // vector $p - s$
-        let sp: Point<_> = (*p - self.start.into()).into();
+        let sp: Point<_> = (*p - self.start_point()).into();
 
         // direction vector of line, $v$
         let v: Point<_> = (self.end - self.start).into();

--- a/geo/src/algorithm/line_locate_point.rs
+++ b/geo/src/algorithm/line_locate_point.rs
@@ -6,7 +6,10 @@ use num_traits::{
     identities::{One, Zero},
     Float,
 };
-use std::ops::AddAssign;
+use std::{
+    ops::AddAssign,
+    cmp::Ordering
+};
 
 /// Returns a fraction of the line's total length
 /// representing the location
@@ -91,12 +94,22 @@ where
             // linestring has zero legnth, return zero
             return T::zero();
         } else {
-            let l = queue
+            let first = queue.pop();
+            let opt_l = queue
                 .iter()
-                .min_by(|x, y| (x.2).partial_cmp(&y.2).unwrap())
-                .unwrap();
+                .fold(first, |l, y| { 
+                    match l.map(|x| (x.2).partial_cmp(&y.2)).flatten() {
+                        Some(o) => match o {
+                            Ordering::Less => l,
+                            _ => Some(*y)
+                        },
+                        None => None
+                    }});
 
-            return (l.0 + l.1 * (l.3).line_locate_point(p)) / total_length
+            match opt_l {
+                Some(l) => (l.0 + l.1 * (l.3).line_locate_point(p)) / total_length,
+                None => T::nan()
+            }
         }
     }
 }

--- a/geo/src/algorithm/line_locate_point.rs
+++ b/geo/src/algorithm/line_locate_point.rs
@@ -139,6 +139,11 @@ mod test {
         );
         let point = Point::new(1000.0, 1000.0);
         assert!(line.line_locate_point(&point).is_nan());
+
+        let line: Line<f64> = Line::new(Coordinate { x: 1.0, y: 1.0},
+                                        Coordinate { x: 1.0, y: 1.0});
+        let pt = point!(x: 2.0, y: 2.0);
+        assert_eq!(line.line_locate_point(&pt), 0.0);
     }
 
     #[test]
@@ -152,5 +157,11 @@ mod test {
 
         let pt = point!(x: 10.0, y: 1.0);
         assert_eq!(ring.line_locate_point(&pt), 0.0);
+
+        let line: LineString<f64> = LineString(vec![(1.0, 1.0).into(),
+                                                    (1.0, 1.0).into(),
+                                                    (1.0, 1.0).into()]);
+        let pt = point!(x: 2.0, y: 2.0);
+        assert_eq!(line.line_locate_point(&pt), 0.0);
     }
 }

--- a/geo/src/algorithm/line_locate_point.rs
+++ b/geo/src/algorithm/line_locate_point.rs
@@ -52,19 +52,19 @@ where
         // $l$ along the line to $p$ is perpendicular to $v$.a
 
         // vector $p - s$
-        let sp = [p.x() - self.start.x, p.y() - self.start.y];
+        let sp: Point<_> = (*p - self.start.into()).into();
 
         // direction vector of line, $v$
-        let v = [self.end.x - self.start.x, self.end.y - self.start.y];
+        let v: Point<_> = (self.end - self.start).into();
 
         // $v \cdot v$
-        let v_sq = v[0] * v[0] + v[1] * v[1];
+        let v_sq = v.dot(v);
         if v_sq == T::zero() {
             // The line has zero length, return zero
             return Some(T::zero());
         } else {
             // $v \cdot (p - s)$
-            let v_dot_sp = v[0] * sp[0] + v[1] * sp[1];
+            let v_dot_sp = v.dot(sp);
             let l = v_dot_sp / v_sq;
             if l.is_finite() {
                 return Some(l.max(T::zero()).min(T::one()));

--- a/geo/src/algorithm/line_locate_point.rs
+++ b/geo/src/algorithm/line_locate_point.rs
@@ -170,5 +170,11 @@ mod test {
                                                     (1.0, 1.0).into()]);
         let pt = point!(x: 2.0, y: 2.0);
         assert_eq!(line.line_locate_point(&pt), 0.0);
+
+        let line: LineString<f64> = LineString(vec![Coordinate { x: 1.0, y: 1.0 },
+                                                    Coordinate { x: f64::NAN, y: 1.0},
+                                                    Coordinate { x: 0.0, y:0.0 }]);
+        let pt = point!(x: 2.0, y: 2.0);
+        assert!(line.line_locate_point(&pt).is_nan())
     }
 }


### PR DESCRIPTION
This started out as a quick PR to address the inconsistency I mentioned in #520, but I've also removed some `unwrap` calls I should have been more careful about last time.

Both `LineLocatePoint` and `LineInterpolatePoint` now return NAN or points of NAN where appropriate instead of panicking. 