### PR TITLE
Fix ray-tracing algorithm when ray passes through a vertex

### DIFF
--- a/geo/src/algorithm/contains/mod.rs
+++ b/geo/src/algorithm/contains/mod.rs
@@ -186,6 +186,17 @@ mod test {
     #[test]
     fn point_in_polygon_with_ray_passing_through_a_vertex_test() {
         let linestring = LineString::from(vec![
+            (1., 0.),
+            (0., 1.),
+            (-1., 0.),
+            (0., -1.),
+        ]);
+        let poly = Polygon::new(linestring, Vec::new());
+        assert!(poly.contains(&Point::new(0., 0.)));
+    }
+    #[test]
+    fn point_in_polygon_with_ray_passing_through_a_vertex_and_not_crossing() {
+        let linestring = LineString::from(vec![
             (0., 0.),
             (2., 0.),
             (3., 1.),

--- a/geo/src/algorithm/contains/mod.rs
+++ b/geo/src/algorithm/contains/mod.rs
@@ -184,6 +184,20 @@ mod test {
         assert!(poly.contains(&Point::new(1., 1.)));
     }
     #[test]
+    fn point_in_polygon_with_ray_passing_through_a_vertex_test() {
+        let linestring = LineString::from(vec![
+            (0., 0.),
+            (2., 0.),
+            (3., 1.),
+            (4., 0.),
+            (4., 2.),
+            (0., 2.),
+            (0., 0.),
+        ]);
+        let poly = Polygon::new(linestring, Vec::new());
+        assert!(poly.contains(&Point::new(1., 1.)));
+    }
+    #[test]
     fn point_out_polygon_test() {
         let linestring = LineString::from(vec![(0., 0.), (2., 0.), (2., 2.), (0., 2.), (0., 0.)]);
         let poly = Polygon::new(linestring, Vec::new());

--- a/geo/src/utils.rs
+++ b/geo/src/utils.rs
@@ -144,6 +144,12 @@ where
         // the line lies below the ray. This is to
         // prevent a double counting when the ray passes
         // through a vertex of the polygon.
+        //
+        // The below logic handles two cases:
+        //   1. if the ray enters/exits the polygon
+        //      at the point of intersection
+        //   2. if the ray touches a vertex,
+        //      but doesn't enter/exit at that point
         if (line.start.y == coord.y && line.end.y < coord.y)
             || (line.end.y == coord.y && line.start.y < coord.y)
         {

--- a/geo/src/utils.rs
+++ b/geo/src/utils.rs
@@ -140,10 +140,13 @@ where
         }
 
         // Ignore if the intersection of the line is
-        // possibly at the beginning of the line. This is to
+        // possibly at the beginning/end of the line, and
+        // the line lies below the ray. This is to
         // prevent a double counting when the ray passes
-        // through a vertex of the plygon
-        if line.start.y == coord.y {
+        // through a vertex of the polygon.
+        if (line.start.y == coord.y && line.end.y < coord.y)
+            || (line.end.y == coord.y && line.start.y < coord.y)
+        {
             continue;
         }
 


### PR DESCRIPTION
The ray casting algorithm introduced in #511 that implements `coord_pos_relative_to_ring` does not handle correctly the case when the ray passes through a vertex.

In the following situation, the number of crossings to be counted should 1 or 3, definitely not 2:
<img src="https://user-images.githubusercontent.com/4726554/98441277-95626380-20fd-11eb-8367-3adbe91f3ac7.png" width="500px">

To prevent a double counting in the general case when the ray intersects the line at one end, this PR suggests to ignore the line only if it lies below the ray.
