### PR TITLE
add missing `iter`, `iter_mut`, and `IntoIter<&'a mut, T>` methods

### DIFF
--- a/geo-types/src/multi_line_string.rs
+++ b/geo-types/src/multi_line_string.rs
@@ -57,7 +57,7 @@ impl<T: CoordinateType> MultiLineString<T> {
     /// ```
     pub fn is_closed(&self) -> bool {
         // Note: Unlike JTS et al, we consider an empty MultiLineString as closed.
-        self.0.iter().all(LineString::is_closed)
+        self.iter().all(LineString::is_closed)
     }
 }
 

--- a/geo-types/src/multi_point.rs
+++ b/geo-types/src/multi_point.rs
@@ -62,3 +62,88 @@ impl<T: CoordinateType> IntoIterator for MultiPoint<T> {
         self.0.into_iter()
     }
 }
+
+impl<'a, T: CoordinateType> IntoIterator for &'a MultiPoint<T> {
+    type Item = &'a Point<T>;
+    type IntoIter = ::std::slice::Iter<'a, Point<T>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        (&self.0).into_iter()
+    }
+}
+
+impl<'a, T: CoordinateType> IntoIterator for &'a mut MultiPoint<T> {
+    type Item = &'a mut Point<T>;
+    type IntoIter = ::std::slice::IterMut<'a, Point<T>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        (&mut self.0).iter_mut()
+    }
+}
+
+impl<T: CoordinateType> MultiPoint<T> {
+    pub fn iter(&self) -> impl Iterator<Item = &Point<T>> {
+        self.0.iter()
+    }
+
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Point<T>> {
+        self.0.iter_mut()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::point;
+
+    #[test]
+    fn test_iter() {
+        let multi = MultiPoint(vec![point![x: 0, y: 0], point![x: 10, y: 10]]);
+
+        let mut first = true;
+        for p in &multi {
+            if first {
+                assert_eq!(p, &point![x: 0, y: 0]);
+                first = false;
+            } else {
+                assert_eq!(p, &point![x: 10, y: 10]);
+            }
+        }
+
+        // Do it again to prove that `multi` wasn't `moved`.
+        first = true;
+        for p in &multi {
+            if first {
+                assert_eq!(p, &point![x: 0, y: 0]);
+                first = false;
+            } else {
+                assert_eq!(p, &point![x: 10, y: 10]);
+            }
+        }
+    }
+
+    #[test]
+    fn test_iter_mut() {
+        let mut multi = MultiPoint(vec![point![x: 0, y: 0], point![x: 10, y: 10]]);
+
+        for point in &mut multi {
+            point.0.x += 1;
+            point.0.y += 1;
+        }
+
+        for point in multi.iter_mut() {
+            point.0.x += 1;
+            point.0.y += 1;
+        }
+
+        let mut first = true;
+        for p in &multi {
+            if first {
+                assert_eq!(p, &point![x: 2, y: 2]);
+                first = false;
+            } else {
+                assert_eq!(p, &point![x: 12, y: 12]);
+            }
+        }
+    }
+}

--- a/geo/src/algorithm/bounding_rect.rs
+++ b/geo/src/algorithm/bounding_rect.rs
@@ -99,7 +99,7 @@ where
     ///
     /// Return the BoundingRect for a MultiLineString
     fn bounding_rect(&self) -> Self::Output {
-        get_bounding_rect(self.0.iter().flat_map(|line| line.0.iter().cloned()))
+        get_bounding_rect(self.iter().flat_map(|line| line.0.iter().cloned()))
     }
 }
 
@@ -127,8 +127,7 @@ where
     /// Return the BoundingRect for a MultiPolygon
     fn bounding_rect(&self) -> Self::Output {
         get_bounding_rect(
-            self.0
-                .iter()
+            self.iter()
                 .flat_map(|poly| poly.exterior().0.iter().cloned()),
         )
     }

--- a/geo/src/algorithm/centroid.rs
+++ b/geo/src/algorithm/centroid.rs
@@ -147,7 +147,7 @@ where
     /// The Centroid of a MultiLineString is the mean of the centroids of all the constituent linestrings,
     /// weighted by the length of each linestring
     fn centroid(&self) -> Self::Output {
-        if self.0.is_empty() || self.0.iter().all(|ls| ls.0.is_empty()) {
+        if self.0.is_empty() || self.iter().all(|ls| ls.0.is_empty()) {
             return None;
         }
         if self.0.len() == 1 {
@@ -341,7 +341,7 @@ where
         if self.0.is_empty() {
             return None;
         }
-        let sum = self.0.iter().fold(
+        let sum = self.iter().fold(
             Point::new(T::zero(), T::zero()),
             |a: Point<T>, b: &Point<T>| Point::new(a.x() + b.x(), a.y() + b.y()),
         );

--- a/geo/src/algorithm/closest_point.rs
+++ b/geo/src/algorithm/closest_point.rs
@@ -122,19 +122,19 @@ impl<F: Float + HasKernel> ClosestPoint<F> for Polygon<F> {
 
 impl<F: Float + HasKernel> ClosestPoint<F> for MultiPolygon<F> {
     fn closest_point(&self, p: &Point<F>) -> Closest<F> {
-        closest_of(self.0.iter(), *p)
+        closest_of(self.iter(), *p)
     }
 }
 
 impl<F: Float> ClosestPoint<F> for MultiPoint<F> {
     fn closest_point(&self, p: &Point<F>) -> Closest<F> {
-        closest_of(self.0.iter(), *p)
+        closest_of(self.iter(), *p)
     }
 }
 
 impl<F: Float + HasKernel> ClosestPoint<F> for MultiLineString<F> {
     fn closest_point(&self, p: &Point<F>) -> Closest<F> {
-        closest_of(self.0.iter(), *p)
+        closest_of(self.iter(), *p)
     }
 }
 

--- a/geo/src/algorithm/concave_hull.rs
+++ b/geo/src/algorithm/concave_hull.rs
@@ -92,7 +92,7 @@ where
     type Scalar = T;
     fn concave_hull(&self, concavity: T) -> Polygon<T> {
         let mut aggregated: Vec<Coordinate<T>> =
-            self.0.iter().flat_map(|elem| elem.0.clone()).collect();
+            self.iter().flat_map(|elem| elem.0.clone()).collect();
         Polygon::new(concave_hull(&mut aggregated, concavity), vec![])
     }
 }
@@ -103,7 +103,7 @@ where
 {
     type Scalar = T;
     fn concave_hull(&self, concavity: T) -> Polygon<T> {
-        let mut coordinates: Vec<Coordinate<T>> = self.0.iter().map(|point| point.0).collect();
+        let mut coordinates: Vec<Coordinate<T>> = self.iter().map(|point| point.0).collect();
         Polygon::new(concave_hull(&mut coordinates, concavity), vec![])
     }
 }

--- a/geo/src/algorithm/contains/geometry.rs
+++ b/geo/src/algorithm/contains/geometry.rs
@@ -44,7 +44,7 @@ where
     T: HasKernel,
 {
     fn contains(&self, coord: &Coordinate<T>) -> bool {
-        self.0.iter().any(|geometry| geometry.contains(coord))
+        self.iter().any(|geometry| geometry.contains(coord))
     }
 }
 

--- a/geo/src/algorithm/contains/line_string.rs
+++ b/geo/src/algorithm/contains/line_string.rs
@@ -123,6 +123,6 @@ where
     LineString<T>: Contains<G>,
 {
     fn contains(&self, rhs: &G) -> bool {
-        self.0.iter().any(|p| p.contains(rhs))
+        self.iter().any(|p| p.contains(rhs))
     }
 }

--- a/geo/src/algorithm/contains/point.rs
+++ b/geo/src/algorithm/contains/point.rs
@@ -32,6 +32,6 @@ where
     Point<T>: Contains<G>,
 {
     fn contains(&self, rhs: &G) -> bool {
-        self.0.iter().any(|p| p.contains(rhs))
+        self.iter().any(|p| p.contains(rhs))
     }
 }

--- a/geo/src/algorithm/contains/polygon.rs
+++ b/geo/src/algorithm/contains/polygon.rs
@@ -87,6 +87,6 @@ where
     Polygon<T>: Contains<G>,
 {
     fn contains(&self, rhs: &G) -> bool {
-        self.0.iter().any(|p| p.contains(rhs))
+        self.iter().any(|p| p.contains(rhs))
     }
 }

--- a/geo/src/algorithm/convex_hull/mod.rs
+++ b/geo/src/algorithm/convex_hull/mod.rs
@@ -83,7 +83,7 @@ where
 {
     type Scalar = T;
     fn convex_hull(&self) -> Polygon<T> {
-        let mut aggregated: Vec<_> = self.0.iter().flat_map(|elem| elem.clone().0).collect();
+        let mut aggregated: Vec<_> = self.iter().flat_map(|elem| elem.clone().0).collect();
         Polygon::new(quick_hull(&mut aggregated), vec![])
     }
 }
@@ -94,7 +94,7 @@ where
 {
     type Scalar = T;
     fn convex_hull(&self) -> Polygon<T> {
-        let mut aggregated: Vec<_> = self.0.iter().map(|p| p.0).collect();
+        let mut aggregated: Vec<_> = self.iter().map(|p| p.0).collect();
         Polygon::new(quick_hull(&mut aggregated), vec![])
     }
 }

--- a/geo/src/algorithm/dimensions.rs
+++ b/geo/src/algorithm/dimensions.rs
@@ -293,7 +293,7 @@ impl<C: CoordinateType> HasDimensions for MultiPoint<C> {
 
 impl<C: CoordinateType> HasDimensions for MultiLineString<C> {
     fn is_empty(&self) -> bool {
-        self.0.iter().all(LineString::is_empty)
+        self.iter().all(LineString::is_empty)
     }
 
     fn dimensions(&self) -> Dimensions {
@@ -328,7 +328,7 @@ impl<C: CoordinateType> HasDimensions for MultiLineString<C> {
 
 impl<C: CoordinateType> HasDimensions for MultiPolygon<C> {
     fn is_empty(&self) -> bool {
-        self.0.iter().all(Polygon::is_empty)
+        self.iter().all(Polygon::is_empty)
     }
 
     fn dimensions(&self) -> Dimensions {
@@ -353,7 +353,7 @@ impl<C: CoordinateType> HasDimensions for GeometryCollection<C> {
         if self.0.is_empty() {
             true
         } else {
-            self.0.iter().all(Geometry::is_empty)
+            self.iter().all(Geometry::is_empty)
         }
     }
 

--- a/geo/src/algorithm/intersects/collections.rs
+++ b/geo/src/algorithm/intersects/collections.rs
@@ -40,7 +40,7 @@ where
     Geometry<T>: Intersects<G>,
 {
     fn intersects(&self, rhs: &G) -> bool {
-        self.0.iter().any(|geom| geom.intersects(rhs))
+        self.iter().any(|geom| geom.intersects(rhs))
     }
 }
 symmetric_intersects_impl!(Coordinate<T>, GeometryCollection<T>);

--- a/geo/src/algorithm/intersects/line_string.rs
+++ b/geo/src/algorithm/intersects/line_string.rs
@@ -21,6 +21,6 @@ where
     LineString<T>: Intersects<G>,
 {
     fn intersects(&self, rhs: &G) -> bool {
-        self.0.iter().any(|p| p.intersects(rhs))
+        self.iter().any(|p| p.intersects(rhs))
     }
 }

--- a/geo/src/algorithm/intersects/point.rs
+++ b/geo/src/algorithm/intersects/point.rs
@@ -19,7 +19,7 @@ where
     Point<T>: Intersects<G>,
 {
     fn intersects(&self, rhs: &G) -> bool {
-        self.0.iter().any(|p| p.intersects(rhs))
+        self.iter().any(|p| p.intersects(rhs))
     }
 }
 

--- a/geo/src/algorithm/intersects/polygon.rs
+++ b/geo/src/algorithm/intersects/polygon.rs
@@ -64,7 +64,7 @@ where
     Polygon<T>: Intersects<G>,
 {
     fn intersects(&self, rhs: &G) -> bool {
-        self.0.iter().any(|p| p.intersects(rhs))
+        self.iter().any(|p| p.intersects(rhs))
     }
 }
 

--- a/geo/src/algorithm/map_coords.rs
+++ b/geo/src/algorithm/map_coords.rs
@@ -311,7 +311,7 @@ impl<T: CoordinateType, NT: CoordinateType> MapCoords<T, NT> for MultiPoint<T> {
     type Output = MultiPoint<NT>;
 
     fn map_coords(&self, func: impl Fn(&(T, T)) -> (NT, NT) + Copy) -> Self::Output {
-        MultiPoint(self.0.iter().map(|p| p.map_coords(func)).collect())
+        MultiPoint(self.iter().map(|p| p.map_coords(func)).collect())
     }
 }
 
@@ -343,7 +343,7 @@ impl<T: CoordinateType, NT: CoordinateType> MapCoords<T, NT> for MultiLineString
     type Output = MultiLineString<NT>;
 
     fn map_coords(&self, func: impl Fn(&(T, T)) -> (NT, NT) + Copy) -> Self::Output {
-        MultiLineString(self.0.iter().map(|l| l.map_coords(func)).collect())
+        MultiLineString(self.iter().map(|l| l.map_coords(func)).collect())
     }
 }
 
@@ -375,7 +375,7 @@ impl<T: CoordinateType, NT: CoordinateType> MapCoords<T, NT> for MultiPolygon<T>
     type Output = MultiPolygon<NT>;
 
     fn map_coords(&self, func: impl Fn(&(T, T)) -> (NT, NT) + Copy) -> Self::Output {
-        MultiPolygon(self.0.iter().map(|p| p.map_coords(func)).collect())
+        MultiPolygon(self.iter().map(|p| p.map_coords(func)).collect())
     }
 }
 
@@ -469,7 +469,7 @@ impl<T: CoordinateType, NT: CoordinateType> MapCoords<T, NT> for GeometryCollect
     type Output = GeometryCollection<NT>;
 
     fn map_coords(&self, func: impl Fn(&(T, T)) -> (NT, NT) + Copy) -> Self::Output {
-        GeometryCollection(self.0.iter().map(|g| g.map_coords(func)).collect())
+        GeometryCollection(self.iter().map(|g| g.map_coords(func)).collect())
     }
 }
 

--- a/geo/src/algorithm/orient.rs
+++ b/geo/src/algorithm/orient.rs
@@ -80,7 +80,7 @@ where
     T: HasKernel,
 {
     fn orient(&self, direction: Direction) -> MultiPolygon<T> {
-        MultiPolygon(self.0.iter().map(|poly| poly.orient(direction)).collect())
+        MultiPolygon(self.iter().map(|poly| poly.orient(direction)).collect())
     }
 }
 

--- a/geo/src/algorithm/rotate.rs
+++ b/geo/src/algorithm/rotate.rs
@@ -193,7 +193,7 @@ where
 {
     /// Rotate the contained Polygons about their centroids by the given number of degrees
     fn rotate(&self, angle: T) -> Self {
-        MultiPolygon(self.0.iter().map(|poly| poly.rotate(angle)).collect())
+        MultiPolygon(self.iter().map(|poly| poly.rotate(angle)).collect())
     }
 }
 
@@ -203,7 +203,7 @@ where
 {
     /// Rotate the contained LineStrings about their centroids by the given number of degrees
     fn rotate(&self, angle: T) -> Self {
-        MultiLineString(self.0.iter().map(|ls| ls.rotate(angle)).collect())
+        MultiLineString(self.iter().map(|ls| ls.rotate(angle)).collect())
     }
 }
 
@@ -213,7 +213,7 @@ where
 {
     /// Rotate the contained Points about their centroids by the given number of degrees
     fn rotate(&self, angle: T) -> Self {
-        MultiPoint(self.0.iter().map(|p| p.rotate(angle)).collect())
+        MultiPoint(self.iter().map(|p| p.rotate(angle)).collect())
     }
 }
 

--- a/geo/src/algorithm/simplify.rs
+++ b/geo/src/algorithm/simplify.rs
@@ -187,7 +187,7 @@ where
     T: Float,
 {
     fn simplify(&self, epsilon: &T) -> Self {
-        MultiLineString(self.0.iter().map(|l| l.simplify(epsilon)).collect())
+        MultiLineString(self.iter().map(|l| l.simplify(epsilon)).collect())
     }
 }
 
@@ -211,7 +211,7 @@ where
     T: Float,
 {
     fn simplify(&self, epsilon: &T) -> Self {
-        MultiPolygon(self.0.iter().map(|p| p.simplify(epsilon)).collect())
+        MultiPolygon(self.iter().map(|p| p.simplify(epsilon)).collect())
     }
 }
 

--- a/geo/src/algorithm/simplifyvw.rs
+++ b/geo/src/algorithm/simplifyvw.rs
@@ -639,7 +639,7 @@ where
     T: Float,
 {
     fn simplifyvw(&self, epsilon: &T) -> MultiLineString<T> {
-        MultiLineString(self.0.iter().map(|l| l.simplifyvw(epsilon)).collect())
+        MultiLineString(self.iter().map(|l| l.simplifyvw(epsilon)).collect())
     }
 }
 
@@ -663,7 +663,7 @@ where
     T: Float,
 {
     fn simplifyvw(&self, epsilon: &T) -> MultiPolygon<T> {
-        MultiPolygon(self.0.iter().map(|p| p.simplifyvw(epsilon)).collect())
+        MultiPolygon(self.iter().map(|p| p.simplifyvw(epsilon)).collect())
     }
 }
 


### PR DESCRIPTION
This is just a small quality of life thing - you can see its application in the final "apply" commit.

GeometryCollection had the full suite of iterator methods, but although MultiLineString, MultiPolygon, and MultiPoint had the consuming `IntoIter<T>` trait, they did *not* have the  conventional `iter()`, `iter_mut()` methods nor the non-consuming IntoIter methods.