### PR TITLE
#533 Add Debug for implementations for all structs

### DIFF
--- a/geo-postgis/src/lib.rs
+++ b/geo-postgis/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_debug_implementations)]
 //! Conversion between [`geo-types`] and [`postgis`] types.
 //!
 //! # Examples

--- a/geo-types/src/geometry_collection.rs
+++ b/geo-types/src/geometry_collection.rs
@@ -118,6 +118,7 @@ impl<T: CoordinateType> IndexMut<usize> for GeometryCollection<T> {
 }
 
 // structure helper for consuming iterator
+#[derive(Debug)]
 pub struct IntoIteratorHelper<T: CoordinateType> {
     iter: ::std::vec::IntoIter<Geometry<T>>,
 }
@@ -147,6 +148,7 @@ impl<T: CoordinateType> Iterator for IntoIteratorHelper<T> {
 }
 
 // structure helper for non-consuming iterator
+#[derive(Debug)]
 pub struct IterHelper<'a, T: CoordinateType> {
     iter: ::std::slice::Iter<'a, Geometry<T>>,
 }
@@ -176,6 +178,7 @@ impl<'a, T: CoordinateType> Iterator for IterHelper<'a, T> {
 }
 
 // structure helper for mutable non-consuming iterator
+#[derive(Debug)]
 pub struct IterMutHelper<'a, T: CoordinateType> {
     iter: ::std::slice::IterMut<'a, Geometry<T>>,
 }

--- a/geo-types/src/lib.rs
+++ b/geo-types/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_debug_implementations)]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/georust/meta/master/logo/logo.png")]
 //! The `geo-types` library provides geospatial primitive types and traits to the [`GeoRust`](https://github.com/georust)
 //! crate ecosystem.

--- a/geo-types/src/line_string.rs
+++ b/geo-types/src/line_string.rs
@@ -102,6 +102,7 @@ where
     T: CoordinateType;
 
 /// A `Point` iterator returned by the `points_iter` method
+#[derive(Debug)]
 pub struct PointsIter<'a, T: CoordinateType + 'a>(::std::slice::Iter<'a, Coordinate<T>>);
 
 impl<'a, T: CoordinateType> Iterator for PointsIter<'a, T> {

--- a/geo/src/algorithm/coords_iter.rs
+++ b/geo/src/algorithm/coords_iter.rs
@@ -2,6 +2,7 @@ use crate::{
     Coordinate, CoordinateType, Geometry, GeometryCollection, Line, LineString, MultiLineString,
     MultiPoint, MultiPolygon, Point, Polygon, Rect, Triangle,
 };
+use std::fmt;
 use std::{iter, marker, slice};
 
 /// Iterate over geometry coordinates.
@@ -212,6 +213,7 @@ impl<'a, T: CoordinateType + 'a> CoordsIter<'a, T> for Geometry<T> {
 
 // Utility to transform Iterator<CoordsIter> into Iterator<Iterator<Coordinate>>
 #[doc(hidden)]
+#[derive(Debug)]
 pub struct MapCoordsIter<
     'a,
     T: 'a + CoordinateType,
@@ -274,6 +276,35 @@ impl<'a, T: CoordinateType> Iterator for GeometryCoordsIter<'a, T> {
             GeometryCoordsIter::GeometryCollection(g) => g.size_hint(),
             GeometryCoordsIter::Rect(g) => g.size_hint(),
             GeometryCoordsIter::Triangle(g) => g.size_hint(),
+        }
+    }
+}
+
+impl<'a, T: CoordinateType> fmt::Debug for GeometryCoordsIter<'a, T> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            GeometryCoordsIter::Point(_) => write!(fmt, "GeometryCoordsIter::Point() Iterator"),
+            GeometryCoordsIter::Line(_) => write!(fmt, "GeometryCoordsIter::Line() Iterator"),
+            GeometryCoordsIter::LineString(_) => {
+                write!(fmt, "GeometryCoordsIter::LineString() Iterator")
+            }
+            GeometryCoordsIter::Polygon(_) => write!(fmt, "GeometryCoordsIter::Polygon() Iterator"),
+            GeometryCoordsIter::MultiPoint(_) => {
+                write!(fmt, "GeometryCoordsIter::MultiPoint() Iterator")
+            }
+            GeometryCoordsIter::MultiLineString(_) => {
+                write!(fmt, "GeometryCoordsIter::MultiLine() Iterator")
+            }
+            GeometryCoordsIter::MultiPolygon(_) => {
+                write!(fmt, "GeometryCoordsIter::MultiPolygon() Iterator")
+            }
+            GeometryCoordsIter::GeometryCollection(_) => {
+                write!(fmt, "GeometryCoordsIter::GeometryCollection() Iterator")
+            }
+            GeometryCoordsIter::Rect(_) => write!(fmt, "GeometryCoordsIter::Rect() Iterator"),
+            GeometryCoordsIter::Triangle(_) => {
+                write!(fmt, "GeometryCoordsIter::Triangle() Iterator")
+            }
         }
     }
 }

--- a/geo/src/algorithm/coords_iter.rs
+++ b/geo/src/algorithm/coords_iter.rs
@@ -1,10 +1,12 @@
+use std::fmt::Debug;
+
 use crate::{
     Coordinate, CoordinateType, Geometry, GeometryCollection, Line, LineString, MultiLineString,
     MultiPoint, MultiPolygon, Point, Polygon, Rect, Triangle,
 };
+
 use std::fmt;
 use std::{iter, marker, slice};
-
 /// Iterate over geometry coordinates.
 pub trait CoordsIter<'a, T: CoordinateType> {
     type Iter: Iterator<Item = Coordinate<T>>;
@@ -280,31 +282,25 @@ impl<'a, T: CoordinateType> Iterator for GeometryCoordsIter<'a, T> {
     }
 }
 
-impl<'a, T: CoordinateType> fmt::Debug for GeometryCoordsIter<'a, T> {
+impl<'a, T: CoordinateType + Debug> fmt::Debug for GeometryCoordsIter<'a, T> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            GeometryCoordsIter::Point(_) => write!(fmt, "GeometryCoordsIter::Point() Iterator"),
-            GeometryCoordsIter::Line(_) => write!(fmt, "GeometryCoordsIter::Line() Iterator"),
-            GeometryCoordsIter::LineString(_) => {
-                write!(fmt, "GeometryCoordsIter::LineString() Iterator")
+            GeometryCoordsIter::Point(i) => fmt.debug_tuple("Point").field(i).finish(),
+            GeometryCoordsIter::Line(i) => fmt.debug_tuple("Line").field(i).finish(),
+            GeometryCoordsIter::LineString(i) => fmt.debug_tuple("LineString").field(i).finish(),
+            GeometryCoordsIter::Polygon(i) => fmt.debug_tuple("Polygon").field(i).finish(),
+            GeometryCoordsIter::MultiPoint(i) => fmt.debug_tuple("MultiPoint").field(i).finish(),
+            GeometryCoordsIter::MultiLineString(i) => {
+                fmt.debug_tuple("MultiLineString").field(i).finish()
             }
-            GeometryCoordsIter::Polygon(_) => write!(fmt, "GeometryCoordsIter::Polygon() Iterator"),
-            GeometryCoordsIter::MultiPoint(_) => {
-                write!(fmt, "GeometryCoordsIter::MultiPoint() Iterator")
-            }
-            GeometryCoordsIter::MultiLineString(_) => {
-                write!(fmt, "GeometryCoordsIter::MultiLine() Iterator")
-            }
-            GeometryCoordsIter::MultiPolygon(_) => {
-                write!(fmt, "GeometryCoordsIter::MultiPolygon() Iterator")
+            GeometryCoordsIter::MultiPolygon(i) => {
+                fmt.debug_tuple("MultiPolygon").field(i).finish()
             }
             GeometryCoordsIter::GeometryCollection(_) => {
-                write!(fmt, "GeometryCoordsIter::GeometryCollection() Iterator")
+                write!(fmt, "GeometryCollection Iterator")
             }
-            GeometryCoordsIter::Rect(_) => write!(fmt, "GeometryCoordsIter::Rect() Iterator"),
-            GeometryCoordsIter::Triangle(_) => {
-                write!(fmt, "GeometryCoordsIter::Triangle() Iterator")
-            }
+            GeometryCoordsIter::Rect(i) => fmt.debug_tuple("Rect").field(i).finish(),
+            GeometryCoordsIter::Triangle(i) => fmt.debug_tuple("Triangle").field(i).finish(),
         }
     }
 }

--- a/geo/src/algorithm/coords_iter.rs
+++ b/geo/src/algorithm/coords_iter.rs
@@ -5,7 +5,7 @@ use crate::{
     MultiPoint, MultiPolygon, Point, Polygon, Rect, Triangle,
 };
 
-use std::{fmt iter, marker, slice};
+use std::{fmt, iter, marker, slice};
 
 type CoordinateChainOnce<T> = iter::Chain<iter::Once<Coordinate<T>>, iter::Once<Coordinate<T>>>;
 
@@ -295,8 +295,13 @@ impl<'a, T: CoordinateType + Debug> fmt::Debug for GeometryCoordsIter<'a, T> {
             GeometryCoordsIter::MultiPolygon(i) => {
                 fmt.debug_tuple("MultiPolygon").field(i).finish()
             }
-            GeometryCoordsIter::GeometryCollection(_) => {
-                write!(fmt, "GeometryCollection Iterator")
+            GeometryCoordsIter::GeometryCollection(i) => {                
+                let dynamicIter: Box<dyn CoordsIter<T, Iter=Box<dyn Iterator<Item = dyn CoordsIter<T, Iter=Box<dyn CoordsIter<T, Iter=dyn Iterator<Item = Coordinate<T>>>>>>>>> = Box::new(i);                
+                let mut debug_tuple = fmt.debug_tuple("GeometryCollection");
+                for geometry in dynamicIter.into_iter() {
+                    debug_tuple.field(&geometry);
+                }
+                debug_tuple.finish()
             }
             GeometryCoordsIter::Rect(i) => fmt.debug_tuple("Rect").field(i).finish(),
             GeometryCoordsIter::Triangle(i) => fmt.debug_tuple("Triangle").field(i).finish(),

--- a/geo/src/algorithm/coords_iter.rs
+++ b/geo/src/algorithm/coords_iter.rs
@@ -295,14 +295,10 @@ impl<'a, T: CoordinateType + Debug> fmt::Debug for GeometryCoordsIter<'a, T> {
             GeometryCoordsIter::MultiPolygon(i) => {
                 fmt.debug_tuple("MultiPolygon").field(i).finish()
             }
-            GeometryCoordsIter::GeometryCollection(i) => {                
-                let dynamicIter: Box<dyn CoordsIter<T, Iter=Box<dyn Iterator<Item = dyn CoordsIter<T, Iter=Box<dyn CoordsIter<T, Iter=dyn Iterator<Item = Coordinate<T>>>>>>>>> = Box::new(i);                
-                let mut debug_tuple = fmt.debug_tuple("GeometryCollection");
-                for geometry in dynamicIter.into_iter() {
-                    debug_tuple.field(&geometry);
-                }
-                debug_tuple.finish()
-            }
+            GeometryCoordsIter::GeometryCollection(_) => fmt
+                .debug_tuple("GeometryCollection")
+                .field(&String::from("..."))
+                .finish(),
             GeometryCoordsIter::Rect(i) => fmt.debug_tuple("Rect").field(i).finish(),
             GeometryCoordsIter::Triangle(i) => fmt.debug_tuple("Triangle").field(i).finish(),
         }

--- a/geo/src/algorithm/kernels/robust.rs
+++ b/geo/src/algorithm/kernels/robust.rs
@@ -6,7 +6,7 @@ use crate::Coordinate;
 /// provide robust floating point predicates. Should only be
 /// used with types that can _always_ be casted to `f64`
 /// _without loss in precision_.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct RobustKernel;
 
 use num_traits::{Float, NumCast};

--- a/geo/src/algorithm/kernels/simple.rs
+++ b/geo/src/algorithm/kernels/simple.rs
@@ -4,7 +4,7 @@ use crate::CoordinateType;
 /// Simple kernel provides the direct implementation of the
 /// predicates. These are meant to be used with exact
 /// arithmetic signed tpyes (eg. i32, i64).
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct SimpleKernel;
 
 impl<T: CoordinateType> Kernel<T> for SimpleKernel {}

--- a/geo/src/algorithm/winding_order.rs
+++ b/geo/src/algorithm/winding_order.rs
@@ -5,6 +5,7 @@ use geo_types::PointsIter;
 use std::iter::Rev;
 
 /// Iterates through a list of `Point`s
+#[allow(missing_debug_implementations)]
 pub struct Points<'a, T>(
     pub(crate) EitherIter<Point<T>, PointsIter<'a, T>, Rev<PointsIter<'a, T>>>,
 )

--- a/geo/src/lib.rs
+++ b/geo/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_debug_implementations)]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/georust/meta/master/logo/logo.png")]
 //! The `geo` crate provides geospatial primitive types such as `Coordinate`, `Point`, `LineString`, and `Polygon` as
 //! well as their `Multi–` equivalents, and provides algorithms and operations such as:


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Where appropriate, I have added 

`#[derive(Debug)]`

It is more complicated for the enumeration

GeometryCoordsIter

For this iterator thing I think it would be useful to just output a string to effect that 

this is a Iterator for type x, y or z

So Debug::fmt() just outputs string of the type ""GeometryCoordsIter::Point() Iterator"

For other iterators,  my response has just been to individually allow "No Debug" as I think that is  valid.

PS 
This is my first PR here, so I will be responsive to reviews as I may have done something awkward 




