### PR TITLE
relative_eq()

### DIFF
--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -4,6 +4,8 @@
 
 * `geo_types::LineString::num_coords` has been deprecated in favor of `geo::algorithm::coords_iter::CoordsIter::coords_count`
   * <https://github.com/georust/geo/pull/563>
+* Introduce `use-rstar` feature rather than `rstar` so that `approx` dependency can be optional
+  * <https://github.com/georust/geo/pull/567>
 
 ## 0.6.2
 

--- a/geo-types/Cargo.toml
+++ b/geo-types/Cargo.toml
@@ -11,13 +11,23 @@ description = "Geospatial primitive data types"
 edition = "2018"
 
 [features]
-relative_eq = []
+use-rstar = ["rstar", "approx"]
 
 [dependencies]
-approx = "0.4.0"
+approx = { version = "0.4.0", optional = true }
 num-traits = "0.2"
 serde = { version = "1", optional = true, features = ["derive"] }
+# Prefer `use-rstar` feature rather than enabling rstar directly.
+# rstar integration relies on the optional approx crate, but implicit features cannot yet enable other features.
+# See: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#namespaced-features
 rstar = { version = "0.8", optional = true }
 
 [dev-dependencies]
 approx = "0.4.0"
+
+[package.metadata.cargo-all-features]
+
+skip_feature_sets = [
+    # must be enabled via use-rstar
+    ["rstar"],
+]

--- a/geo-types/Cargo.toml
+++ b/geo-types/Cargo.toml
@@ -10,6 +10,9 @@ keywords = ["gis", "geo", "geography", "geospatial"]
 description = "Geospatial primitive data types"
 edition = "2018"
 
+[features]
+relative_eq = []
+
 [dependencies]
 approx = "0.4.0"
 num-traits = "0.2"

--- a/geo-types/src/coordinate.rs
+++ b/geo-types/src/coordinate.rs
@@ -1,6 +1,6 @@
 use crate::{CoordinateType, Point};
 
-#[cfg(any(test, feature = "relative_eq"))]
+#[cfg(any(feature = "relative_eq", test))]
 use approx::{AbsDiffEq, RelativeEq};
 
 #[cfg(test)]
@@ -243,7 +243,7 @@ impl<T: CoordinateType> Zero for Coordinate<T> {
     }
 }
 
-#[cfg(any(test, feature = "relative_eq"))]
+#[cfg(feature = "relative_eq")]
 impl<T: CoordinateType + AbsDiffEq> AbsDiffEq for Coordinate<T>
 where
     T::Epsilon: Copy,
@@ -261,7 +261,7 @@ where
     }
 }
 
-#[cfg(any(test, feature = "relative_eq"))]
+#[cfg(feature = "relative_eq")]
 impl<T: CoordinateType + RelativeEq> RelativeEq for Coordinate<T>
 where
     T::Epsilon: Copy,

--- a/geo-types/src/coordinate.rs
+++ b/geo-types/src/coordinate.rs
@@ -1,7 +1,10 @@
 use crate::{CoordinateType, Point};
-#[cfg(test)]
-use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 
+#[cfg(any(test, feature = "relative_eq"))]
+use approx::{AbsDiffEq, RelativeEq};
+
+#[cfg(test)]
+use approx::UlpsEq;
 /// A lightweight struct used to store coordinates on the 2-dimensional
 /// Cartesian plane.
 ///
@@ -240,7 +243,7 @@ impl<T: CoordinateType> Zero for Coordinate<T> {
     }
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "relative_eq"))]
 impl<T: CoordinateType + AbsDiffEq> AbsDiffEq for Coordinate<T>
 where
     T::Epsilon: Copy,
@@ -258,7 +261,7 @@ where
     }
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "relative_eq"))]
 impl<T: CoordinateType + RelativeEq> RelativeEq for Coordinate<T>
 where
     T::Epsilon: Copy,

--- a/geo-types/src/coordinate.rs
+++ b/geo-types/src/coordinate.rs
@@ -1,10 +1,8 @@
 use crate::{CoordinateType, Point};
 
-#[cfg(any(feature = "relative_eq", test))]
-use approx::{AbsDiffEq, RelativeEq};
+#[cfg(any(feature = "approx", test))]
+use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 
-#[cfg(test)]
-use approx::UlpsEq;
 /// A lightweight struct used to store coordinates on the 2-dimensional
 /// Cartesian plane.
 ///
@@ -243,7 +241,7 @@ impl<T: CoordinateType> Zero for Coordinate<T> {
     }
 }
 
-#[cfg(feature = "relative_eq")]
+#[cfg(any(feature = "approx", test))]
 impl<T: CoordinateType + AbsDiffEq> AbsDiffEq for Coordinate<T>
 where
     T::Epsilon: Copy,
@@ -261,7 +259,7 @@ where
     }
 }
 
-#[cfg(feature = "relative_eq")]
+#[cfg(any(feature = "approx", test))]
 impl<T: CoordinateType + RelativeEq> RelativeEq for Coordinate<T>
 where
     T::Epsilon: Copy,
@@ -278,7 +276,7 @@ where
     }
 }
 
-#[cfg(test)]
+#[cfg(any(feature = "approx", test))]
 impl<T: CoordinateType + UlpsEq> UlpsEq for Coordinate<T>
 where
     T::Epsilon: Copy,

--- a/geo-types/src/coordinate.rs
+++ b/geo-types/src/coordinate.rs
@@ -247,10 +247,12 @@ where
 {
     type Epsilon = T::Epsilon;
 
+    #[inline]
     fn default_epsilon() -> T::Epsilon {
         T::default_epsilon()
     }
 
+    #[inline]
     fn abs_diff_eq(&self, other: &Self, epsilon: T::Epsilon) -> bool {
         T::abs_diff_eq(&self.x, &other.x, epsilon) && T::abs_diff_eq(&self.y, &other.y, epsilon)
     }
@@ -261,10 +263,12 @@ impl<T: CoordinateType + RelativeEq> RelativeEq for Coordinate<T>
 where
     T::Epsilon: Copy,
 {
+    #[inline]
     fn default_max_relative() -> T::Epsilon {
         T::default_max_relative()
     }
 
+    #[inline]
     fn relative_eq(&self, other: &Self, epsilon: T::Epsilon, max_relative: T::Epsilon) -> bool {
         T::relative_eq(&self.x, &other.x, epsilon, max_relative)
             && T::relative_eq(&self.y, &other.y, epsilon, max_relative)

--- a/geo-types/src/lib.rs
+++ b/geo-types/src/lib.rs
@@ -28,6 +28,7 @@ extern crate serde;
 #[cfg(feature = "rstar")]
 extern crate rstar;
 
+#[cfg(test)]
 #[macro_use]
 extern crate approx;
 
@@ -79,6 +80,7 @@ pub use crate::rect::{InvalidRectCoordinatesError, Rect};
 #[macro_use]
 mod macros;
 
+#[cfg(feature = "rstar")]
 #[doc(hidden)]
 pub mod private_utils;
 

--- a/geo-types/src/line.rs
+++ b/geo-types/src/line.rs
@@ -172,9 +172,8 @@ impl<T: CoordinateType> From<[(T, T); 2]> for Line<T> {
 #[cfg(test)]
 impl<T> RelativeEq for Line<T>
 where
-    T: AbsDiffEq<Epsilon = T> + CoordinateType + RelativeEq
+    T: AbsDiffEq<Epsilon = T> + CoordinateType + RelativeEq,
 {
-
     #[inline]
     fn default_max_relative() -> Self::Epsilon {
         T::default_max_relative()
@@ -187,11 +186,8 @@ where
         epsilon: Self::Epsilon,
         max_relative: Self::Epsilon,
     ) -> bool {
-        self.start
-            .relative_eq(&other.start, epsilon, max_relative)
-            && self
-                .end
-                .relative_eq(&other.end, epsilon, max_relative)
+        self.start.relative_eq(&other.start, epsilon, max_relative)
+            && self.end.relative_eq(&other.end, epsilon, max_relative)
     }
 }
 
@@ -206,9 +202,7 @@ impl<T: AbsDiffEq<Epsilon = T> + CoordinateType> AbsDiffEq for Line<T> {
 
     #[inline]
     fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
-        self.start
-            .abs_diff_eq(&other.start, epsilon)
-            && self.end.abs_diff_eq(&other.end, epsilon)
+        self.start.abs_diff_eq(&other.start, epsilon) && self.end.abs_diff_eq(&other.end, epsilon)
     }
 }
 

--- a/geo-types/src/line.rs
+++ b/geo-types/src/line.rs
@@ -1,7 +1,7 @@
 use crate::{Coordinate, CoordinateType, Point};
-#[cfg(any(feature = "relative_eq", test))]
+#[cfg(feature = "relative_eq")]
 use approx::AbsDiffEq;
-#[cfg(any(feature = "relative_eq", test))]
+#[cfg(feature = "relative_eq")]
 use approx::RelativeEq;
 
 /// A line segment made up of exactly two

--- a/geo-types/src/line.rs
+++ b/geo-types/src/line.rs
@@ -3,8 +3,7 @@ use crate::{Coordinate, CoordinateType, Point};
 use approx::AbsDiffEq;
 #[cfg(test)]
 use approx::RelativeEq;
-#[cfg(test)]
-use num_traits::Float;
+
 /// A line segment made up of exactly two
 /// [`Coordinate`s](struct.Coordinate.html).
 ///
@@ -173,18 +172,18 @@ impl<T: CoordinateType> From<[(T, T); 2]> for Line<T> {
 #[cfg(test)]
 impl<T> RelativeEq for Line<T>
 where
-    T: AbsDiffEq<Epsilon = T> + CoordinateType + Float + RelativeEq
+    T: AbsDiffEq<Epsilon = T> + CoordinateType + RelativeEq
 {
 
     #[inline]
     fn default_max_relative() -> Self::Epsilon {
-        T::epsilon()
+        T::default_max_relative()
     }
 
     #[inline]
     fn relative_eq(
         &self,
-        other: &Line<T>,
+        other: &Self,
         epsilon: Self::Epsilon,
         max_relative: Self::Epsilon,
     ) -> bool {
@@ -197,16 +196,16 @@ where
 }
 
 #[cfg(test)]
-impl<T: AbsDiffEq<Epsilon = T> + CoordinateType + Float> AbsDiffEq for Line<T> {
+impl<T: AbsDiffEq<Epsilon = T> + CoordinateType> AbsDiffEq for Line<T> {
     type Epsilon = T;
 
     #[inline]
     fn default_epsilon() -> Self::Epsilon {
-        T::epsilon()
+        T::default_epsilon()
     }
 
     #[inline]
-    fn abs_diff_eq(&self, other: &Line<T>, epsilon: Self::Epsilon) -> bool {
+    fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
         self.start
             .abs_diff_eq(&other.start, epsilon)
             && self.end.abs_diff_eq(&other.end, epsilon)

--- a/geo-types/src/line.rs
+++ b/geo-types/src/line.rs
@@ -197,7 +197,7 @@ where
 }
 
 #[cfg(test)]
-impl<T: AbsDiffEq + CoordinateType + Float> AbsDiffEq for Line<T> {
+impl<T: AbsDiffEq<Epsilon = T> + CoordinateType + Float> AbsDiffEq for Line<T> {
     type Epsilon = T;
 
     #[inline]
@@ -207,9 +207,9 @@ impl<T: AbsDiffEq + CoordinateType + Float> AbsDiffEq for Line<T> {
 
     #[inline]
     fn abs_diff_eq(&self, other: &Line<T>, epsilon: Self::Epsilon) -> bool {
-        self.start_point()
-            .abs_diff_eq(&other.start_point(), epsilon)
-            && self.end_point().abs_diff_eq(&other.end_point(), epsilon)
+        self.start
+            .abs_diff_eq(&other.start, epsilon)
+            && self.end.abs_diff_eq(&other.end, epsilon)
     }
 }
 

--- a/geo-types/src/line.rs
+++ b/geo-types/src/line.rs
@@ -1,7 +1,7 @@
 use crate::{Coordinate, CoordinateType, Point};
-#[cfg(test)]
+#[cfg(any(feature = "relative_eq", test))]
 use approx::AbsDiffEq;
-#[cfg(test)]
+#[cfg(any(feature = "relative_eq", test))]
 use approx::RelativeEq;
 
 /// A line segment made up of exactly two
@@ -168,8 +168,7 @@ impl<T: CoordinateType> From<[(T, T); 2]> for Line<T> {
         Line::new(coord[0], coord[1])
     }
 }
-
-#[cfg(test)]
+#[cfg(feature = "relative_eq")]
 impl<T> RelativeEq for Line<T>
 where
     T: AbsDiffEq<Epsilon = T> + CoordinateType + RelativeEq,
@@ -179,6 +178,18 @@ where
         T::default_max_relative()
     }
 
+    /// Equality assertion within a relative limit.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use geo_types::{Coordinate, Line};
+    ///
+    /// let a = Line::new(Coordinate { x: 0., y: 0. }, Coordinate { x: 1., y: 1. });
+    /// let b = Line::new(Coordinate { x: 0., y: 0. }, Coordinate { x: 1.001, y: 1. });
+    ///
+    /// approx::assert_relative_eq!(a, b, max_relative=0.1)
+    /// ```
     #[inline]
     fn relative_eq(
         &self,
@@ -191,7 +202,7 @@ where
     }
 }
 
-#[cfg(test)]
+#[cfg(feature = "relative_eq")]
 impl<T: AbsDiffEq<Epsilon = T> + CoordinateType> AbsDiffEq for Line<T> {
     type Epsilon = T;
 
@@ -200,6 +211,18 @@ impl<T: AbsDiffEq<Epsilon = T> + CoordinateType> AbsDiffEq for Line<T> {
         T::default_epsilon()
     }
 
+    /// Equality assertion within a relative limit.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use geo_types::{Coordinate, Line};
+    ///
+    /// let a = Line::new(Coordinate { x: 0., y: 0. }, Coordinate { x: 1., y: 1. });
+    /// let b = Line::new(Coordinate { x: 0., y: 0. }, Coordinate { x: 1.001, y: 1. });
+    ///
+    /// approx::assert_relative_eq!(a, b, epsilon=0.1)
+    /// ```
     #[inline]
     fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
         self.start.abs_diff_eq(&other.start, epsilon) && self.end.abs_diff_eq(&other.end, epsilon)
@@ -234,8 +257,6 @@ where
 mod test {
     use super::*;
 
-    use super::{Coordinate, Line, Point};
-    use approx::AbsDiffEq;
     #[test]
     fn test_abs_diff_eq() {
         let delta = 1e-6;

--- a/geo-types/src/line.rs
+++ b/geo-types/src/line.rs
@@ -1,8 +1,6 @@
 use crate::{Coordinate, CoordinateType, Point};
-#[cfg(feature = "relative_eq")]
-use approx::AbsDiffEq;
-#[cfg(feature = "relative_eq")]
-use approx::RelativeEq;
+#[cfg(any(feature = "approx", test))]
+use approx::{AbsDiffEq, RelativeEq};
 
 /// A line segment made up of exactly two
 /// [`Coordinate`s](struct.Coordinate.html).
@@ -168,7 +166,7 @@ impl<T: CoordinateType> From<[(T, T); 2]> for Line<T> {
         Line::new(coord[0], coord[1])
     }
 }
-#[cfg(feature = "relative_eq")]
+#[cfg(any(feature = "approx", test))]
 impl<T> RelativeEq for Line<T>
 where
     T: AbsDiffEq<Epsilon = T> + CoordinateType + RelativeEq,
@@ -202,7 +200,7 @@ where
     }
 }
 
-#[cfg(feature = "relative_eq")]
+#[cfg(any(feature = "approx", test))]
 impl<T: AbsDiffEq<Epsilon = T> + CoordinateType> AbsDiffEq for Line<T> {
     type Epsilon = T;
 

--- a/geo-types/src/line.rs
+++ b/geo-types/src/line.rs
@@ -188,7 +188,7 @@ where
     /// let a = Line::new(Coordinate { x: 0., y: 0. }, Coordinate { x: 1., y: 1. });
     /// let b = Line::new(Coordinate { x: 0., y: 0. }, Coordinate { x: 1.001, y: 1. });
     ///
-    /// approx::assert_relative_eq!(a, b, max_relative=0.1)
+    /// approx::assert_relative_eq!(a, b, max_relative=0.1);
     /// ```
     #[inline]
     fn relative_eq(
@@ -211,7 +211,7 @@ impl<T: AbsDiffEq<Epsilon = T> + CoordinateType> AbsDiffEq for Line<T> {
         T::default_epsilon()
     }
 
-    /// Equality assertion within a relative limit.
+    /// Equality assertion with a absolute limit.
     ///
     /// # Examples
     ///
@@ -221,7 +221,7 @@ impl<T: AbsDiffEq<Epsilon = T> + CoordinateType> AbsDiffEq for Line<T> {
     /// let a = Line::new(Coordinate { x: 0., y: 0. }, Coordinate { x: 1., y: 1. });
     /// let b = Line::new(Coordinate { x: 0., y: 0. }, Coordinate { x: 1.001, y: 1. });
     ///
-    /// approx::assert_relative_eq!(a, b, epsilon=0.1)
+    /// approx::assert_abs_diff_eq!(a, b, epsilon=0.1);
     /// ```
     #[inline]
     fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {

--- a/geo-types/src/line.rs
+++ b/geo-types/src/line.rs
@@ -173,7 +173,7 @@ impl<T: CoordinateType> From<[(T, T); 2]> for Line<T> {
 #[cfg(test)]
 impl<T> RelativeEq for Line<T>
 where
-    T: CoordinateType + Float + AbsDiffEq,
+    T: AbsDiffEq<Epsilon = T> + CoordinateType + Float + RelativeEq
 {
 
     #[inline]
@@ -188,11 +188,11 @@ where
         epsilon: Self::Epsilon,
         max_relative: Self::Epsilon,
     ) -> bool {
-        self.start_point()
-            .relative_eq(&other.start_point(), epsilon, max_relative)
+        self.start
+            .relative_eq(&other.start, epsilon, max_relative)
             && self
-                .end_point()
-                .relative_eq(&other.end_point(), epsilon, max_relative)
+                .end
+                .relative_eq(&other.end, epsilon, max_relative)
     }
 }
 

--- a/geo-types/src/line_string.rs
+++ b/geo-types/src/line_string.rs
@@ -1,6 +1,6 @@
-#[cfg(test)]
+#[cfg(feature = "relative_eq")]
 use approx::AbsDiffEq;
-#[cfg(test)]
+#[cfg(feature = "relative_eq")]
 use approx::RelativeEq;
 
 use crate::{Coordinate, CoordinateType, Line, Point, Triangle};
@@ -287,7 +287,7 @@ impl<T: CoordinateType> IndexMut<usize> for LineString<T> {
     }
 }
 
-#[cfg(test)]
+#[cfg(feature = "relative_eq")]
 impl<T> RelativeEq for LineString<T>
 where
     T: AbsDiffEq<Epsilon = T> + CoordinateType + RelativeEq,
@@ -297,6 +297,22 @@ where
         T::default_max_relative()
     }
 
+    /// Equality assertion within a relative limit.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use geo_types::LineString;
+    ///
+    /// let mut coords_a = vec![(0., 0.), (5., 0.), (7., 9.)];
+    /// let a: LineString<f32> = coords_a.into_iter().collect();
+    ///
+    /// let mut coords_b = vec![(0., 0.), (5., 0.), (7.001, 9.)];
+    /// let b: LineString<f32> = coords_b.into_iter().collect();
+    ///
+    /// approx::assert_relative_eq!(a, b, max_relative=0.1)
+    /// ```
+    ///
     fn relative_eq(
         &self,
         other: &Self,
@@ -318,7 +334,7 @@ where
     }
 }
 
-#[cfg(test)]
+#[cfg(feature = "relative_eq")]
 impl<T: AbsDiffEq<Epsilon = T> + CoordinateType> AbsDiffEq for LineString<T> {
     type Epsilon = T;
 
@@ -327,6 +343,21 @@ impl<T: AbsDiffEq<Epsilon = T> + CoordinateType> AbsDiffEq for LineString<T> {
         T::default_epsilon()
     }
 
+    /// Equality assertion within a relative limit.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use geo_types::LineString;
+    ///
+    /// let mut coords_a = vec![(0., 0.), (5., 0.), (7., 9.)];
+    /// let a: LineString<f32> = coords_a.into_iter().collect();
+    ///
+    /// let mut coords_b = vec![(0., 0.), (5., 0.), (7.001, 9.)];
+    /// let b: LineString<f32> = coords_b.into_iter().collect();
+    ///
+    /// approx::assert_relative_eq!(a, b, epsilon=0.1)
+    /// ```
     fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
         if self.num_coords() != other.num_coords() {
             return false;
@@ -374,12 +405,11 @@ where
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "relative_eq"))]
 mod test {
     use super::*;
 
     use approx::AbsDiffEq;
-    // use geo_types::LineString;
 
     #[test]
     fn test_abs_diff_eq() {

--- a/geo-types/src/line_string.rs
+++ b/geo-types/src/line_string.rs
@@ -294,8 +294,6 @@ impl<T> RelativeEq for LineString<T>
 where
     T: CoordinateType + Float + AbsDiffEq,
 {
-    // type Epsilon = T;
-
     #[inline]
     fn default_max_relative() -> Self::Epsilon {
         T::epsilon()

--- a/geo-types/src/line_string.rs
+++ b/geo-types/src/line_string.rs
@@ -2,8 +2,6 @@
 use approx::AbsDiffEq;
 #[cfg(test)]
 use approx::RelativeEq;
-#[cfg(test)]
-use num_traits::Float;
 
 use crate::{Coordinate, CoordinateType, Line, Point, Triangle};
 use std::iter::FromIterator;
@@ -292,16 +290,16 @@ impl<T: CoordinateType> IndexMut<usize> for LineString<T> {
 #[cfg(test)]
 impl<T> RelativeEq for LineString<T>
 where
-    T: AbsDiffEq<Epsilon = T> + CoordinateType + Float + RelativeEq
+    T: AbsDiffEq<Epsilon = T> + CoordinateType + RelativeEq
 {
     #[inline]
     fn default_max_relative() -> Self::Epsilon {
-        T::epsilon()
+        T::default_max_relative()
     }
 
     fn relative_eq(
         &self,
-        other: &LineString<T>,
+        other: &Self,
         epsilon: Self::Epsilon,
         max_relative: Self::Epsilon,
     ) -> bool {
@@ -321,15 +319,15 @@ where
 }
 
 #[cfg(test)]
-impl<T: AbsDiffEq + CoordinateType + Float> AbsDiffEq for LineString<T> {
+impl<T: AbsDiffEq<Epsilon = T> + CoordinateType > AbsDiffEq for LineString<T> {
     type Epsilon = T;
 
     #[inline]
     fn default_epsilon() -> Self::Epsilon {
-        T::epsilon()
+        T::default_epsilon()
     }
 
-    fn abs_diff_eq(&self, other: &LineString<T>, epsilon: Self::Epsilon) -> bool {
+    fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
         if self.num_coords() != other.num_coords() {
             return false;
         }

--- a/geo-types/src/line_string.rs
+++ b/geo-types/src/line_string.rs
@@ -319,7 +319,7 @@ where
         epsilon: Self::Epsilon,
         max_relative: Self::Epsilon,
     ) -> bool {
-        if self.num_coords() != other.num_coords() {
+        if self.0.len() != other.0.len() {
             return false;
         }
 
@@ -359,7 +359,7 @@ impl<T: AbsDiffEq<Epsilon = T> + CoordinateType> AbsDiffEq for LineString<T> {
     /// approx::assert_relative_eq!(a, b, epsilon=0.1)
     /// ```
     fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
-        if self.num_coords() != other.num_coords() {
+        if self.0.len() != other.0.len() {
             return false;
         }
         let mut points_zipper = self.points_iter().zip(other.points_iter());

--- a/geo-types/src/line_string.rs
+++ b/geo-types/src/line_string.rs
@@ -1,7 +1,5 @@
-#[cfg(feature = "relative_eq")]
-use approx::AbsDiffEq;
-#[cfg(feature = "relative_eq")]
-use approx::RelativeEq;
+#[cfg(any(feature = "approx", test))]
+use approx::{AbsDiffEq, RelativeEq};
 
 use crate::{Coordinate, CoordinateType, Line, Point, Triangle};
 use std::iter::FromIterator;
@@ -287,7 +285,7 @@ impl<T: CoordinateType> IndexMut<usize> for LineString<T> {
     }
 }
 
-#[cfg(feature = "relative_eq")]
+#[cfg(any(feature = "approx", test))]
 impl<T> RelativeEq for LineString<T>
 where
     T: AbsDiffEq<Epsilon = T> + CoordinateType + RelativeEq,
@@ -334,7 +332,7 @@ where
     }
 }
 
-#[cfg(feature = "relative_eq")]
+#[cfg(any(feature = "approx", test))]
 impl<T: AbsDiffEq<Epsilon = T> + CoordinateType> AbsDiffEq for LineString<T> {
     type Epsilon = T;
 

--- a/geo-types/src/line_string.rs
+++ b/geo-types/src/line_string.rs
@@ -292,7 +292,7 @@ impl<T: CoordinateType> IndexMut<usize> for LineString<T> {
 #[cfg(test)]
 impl<T> RelativeEq for LineString<T>
 where
-    T: CoordinateType + Float + AbsDiffEq,
+    T: AbsDiffEq<Epsilon = T> + CoordinateType + Float + RelativeEq
 {
     #[inline]
     fn default_max_relative() -> Self::Epsilon {

--- a/geo-types/src/line_string.rs
+++ b/geo-types/src/line_string.rs
@@ -290,7 +290,7 @@ impl<T: CoordinateType> IndexMut<usize> for LineString<T> {
 #[cfg(test)]
 impl<T> RelativeEq for LineString<T>
 where
-    T: AbsDiffEq<Epsilon = T> + CoordinateType + RelativeEq
+    T: AbsDiffEq<Epsilon = T> + CoordinateType + RelativeEq,
 {
     #[inline]
     fn default_max_relative() -> Self::Epsilon {
@@ -319,7 +319,7 @@ where
 }
 
 #[cfg(test)]
-impl<T: AbsDiffEq<Epsilon = T> + CoordinateType > AbsDiffEq for LineString<T> {
+impl<T: AbsDiffEq<Epsilon = T> + CoordinateType> AbsDiffEq for LineString<T> {
     type Epsilon = T;
 
     #[inline]

--- a/geo-types/src/line_string.rs
+++ b/geo-types/src/line_string.rs
@@ -405,7 +405,7 @@ where
     }
 }
 
-#[cfg(all(test, feature = "relative_eq"))]
+#[cfg(test)]
 mod test {
     use super::*;
 

--- a/geo-types/src/line_string.rs
+++ b/geo-types/src/line_string.rs
@@ -299,7 +299,6 @@ where
         T::epsilon()
     }
 
-    #[inline]
     fn relative_eq(
         &self,
         other: &LineString<T>,
@@ -330,8 +329,10 @@ impl<T: AbsDiffEq + CoordinateType + Float> AbsDiffEq for LineString<T> {
         T::epsilon()
     }
 
-    #[inline]
     fn abs_diff_eq(&self, other: &LineString<T>, epsilon: Self::Epsilon) -> bool {
+        if self.num_coords() != other.num_coords() {
+            return false;
+        }
         let mut points_zipper = self.points_iter().zip(other.points_iter());
         points_zipper.all(|(lhs, rhs)| lhs.abs_diff_eq(&rhs, epsilon))
     }
@@ -398,6 +399,16 @@ mod test {
         let ls_y: LineString<f32> = coords_y.into_iter().collect();
         assert!(ls.abs_diff_eq(&ls_y, 1e-2));
         assert!(ls.abs_diff_ne(&ls_y, 1e-12));
+
+        // Undersized, but otherwise equal.
+        let coords_x = vec![(0., 0.), (5., 0.)];
+        let ls_under: LineString<f32> = coords_x.into_iter().collect();
+        assert!(ls.abs_diff_ne(&ls_under, 1.));
+
+        // Oversized, but otherwise equal.
+        let coords_x = vec![(0., 0.), (5., 0.), (10., 10.), (10., 100.)];
+        let ls_oversized: LineString<f32> = coords_x.into_iter().collect();
+        assert!(ls.abs_diff_ne(&ls_oversized, 1.));
     }
 
     #[test]

--- a/geo-types/src/line_string.rs
+++ b/geo-types/src/line_string.rs
@@ -343,7 +343,7 @@ impl<T: AbsDiffEq<Epsilon = T> + CoordinateType> AbsDiffEq for LineString<T> {
         T::default_epsilon()
     }
 
-    /// Equality assertion within a relative limit.
+    /// Equality assertion with a absolute limit.
     ///
     /// # Examples
     ///

--- a/geo-types/src/line_string.rs
+++ b/geo-types/src/line_string.rs
@@ -332,13 +332,8 @@ impl<T: AbsDiffEq + CoordinateType + Float> AbsDiffEq for LineString<T> {
 
     #[inline]
     fn abs_diff_eq(&self, other: &LineString<T>, epsilon: Self::Epsilon) -> bool {
-        let points_zipper = self.points_iter().zip(other.points_iter());
-        for (lhs, rhs) in points_zipper {
-            if lhs.abs_diff_ne(&rhs, epsilon) {
-                return false;
-            }
-        }
-        true
+        let mut points_zipper = self.points_iter().zip(other.points_iter());
+        points_zipper.all(|(lhs, rhs)| lhs.abs_diff_eq(&rhs, epsilon))
     }
 }
 

--- a/geo-types/src/multi_point.rs
+++ b/geo-types/src/multi_point.rs
@@ -3,8 +3,6 @@ use crate::{CoordinateType, Point};
 use approx::AbsDiffEq;
 #[cfg(test)]
 use approx::RelativeEq;
-#[cfg(test)]
-use num_traits::float::Float;
 
 use std::iter::FromIterator;
 
@@ -118,17 +116,17 @@ impl<T: CoordinateType> MultiPoint<T> {
 #[cfg(test)]
 impl<T> RelativeEq for MultiPoint<T>
 where
-    T: AbsDiffEq<Epsilon = T> + CoordinateType + Float + RelativeEq
+    T: AbsDiffEq<Epsilon = T> + CoordinateType + RelativeEq
 {
     #[inline]
     fn default_max_relative() -> Self::Epsilon {
-        T::epsilon()
+        T::default_max_relative()
     }
 
     #[inline]
     fn relative_eq(
         &self,
-        other: &MultiPoint<T>,
+        other: &Self,
         epsilon: Self::Epsilon,
         max_relative: Self::Epsilon,
     ) -> bool {
@@ -144,17 +142,18 @@ where
 #[cfg(test)]
 impl<T> AbsDiffEq for MultiPoint<T>
 where
-    T: CoordinateType + Float,
+    T: AbsDiffEq<Epsilon = T> + CoordinateType,
+    T::Epsilon: Copy,
 {
     type Epsilon = T;
 
     #[inline]
     fn default_epsilon() -> Self::Epsilon {
-        T::epsilon()
+        T::default_epsilon()
     }
 
     #[inline]
-    fn abs_diff_eq(&self, other: &MultiPoint<T>, epsilon: Self::Epsilon) -> bool {
+    fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
         if self.num_coords() != other.num_coords() {
             return false;
         }

--- a/geo-types/src/multi_point.rs
+++ b/geo-types/src/multi_point.rs
@@ -118,7 +118,7 @@ impl<T: CoordinateType> MultiPoint<T> {
 #[cfg(test)]
 impl<T> RelativeEq for MultiPoint<T>
 where
-    T: CoordinateType + Float + AbsDiffEq,
+    T: AbsDiffEq<Epsilon = T> + CoordinateType + Float + RelativeEq
 {
     #[inline]
     fn default_max_relative() -> Self::Epsilon {

--- a/geo-types/src/multi_point.rs
+++ b/geo-types/src/multi_point.rs
@@ -1,7 +1,7 @@
 use crate::{CoordinateType, Point};
-#[cfg(test)]
+#[cfg(any(feature = "relative_eq"))]
 use approx::AbsDiffEq;
-#[cfg(test)]
+#[cfg(feature = "relative_eq")]
 use approx::RelativeEq;
 
 use std::iter::FromIterator;
@@ -113,7 +113,7 @@ impl<T: CoordinateType> MultiPoint<T> {
     }
 }
 
-#[cfg(test)]
+#[cfg(feature = "relative_eq")]
 impl<T> RelativeEq for MultiPoint<T>
 where
     T: AbsDiffEq<Epsilon = T> + CoordinateType + RelativeEq,
@@ -123,6 +123,19 @@ where
         T::default_max_relative()
     }
 
+    /// Equality assertion within a relative limit.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use geo_types::MultiPoint;
+    /// use geo_types::point;
+    ///
+    /// let a = MultiPoint(vec![point![x: 0., y: 0.], point![x: 10., y: 10.]]);
+    /// let b = MultiPoint(vec![point![x: 0., y: 0.], point![x: 10.001, y: 10.]]);
+    ///
+    /// approx::assert_relative_eq!(a, b, max_relative=0.1)
+    /// ```
     #[inline]
     fn relative_eq(
         &self,
@@ -139,7 +152,7 @@ where
     }
 }
 
-#[cfg(test)]
+#[cfg(feature = "relative_eq")]
 impl<T> AbsDiffEq for MultiPoint<T>
 where
     T: AbsDiffEq<Epsilon = T> + CoordinateType,
@@ -152,6 +165,19 @@ where
         T::default_epsilon()
     }
 
+    /// Equality assertion within a absolute limit.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use geo_types::MultiPoint;
+    /// use geo_types::point;
+    ///
+    /// let a = MultiPoint(vec![point![x: 0., y: 0.], point![x: 10., y: 10.]]);
+    /// let b = MultiPoint(vec![point![x: 0., y: 0.], point![x: 10.001, y: 10.]]);
+    ///
+    /// approx::assert_relative_eq!(a, b, epsilon=0.1)
+    /// ```
     #[inline]
     fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
         if self.num_coords() != other.num_coords() {

--- a/geo-types/src/multi_point.rs
+++ b/geo-types/src/multi_point.rs
@@ -155,6 +155,10 @@ where
 
     #[inline]
     fn abs_diff_eq(&self, other: &MultiPoint<T>, epsilon: Self::Epsilon) -> bool {
+        if self.num_coords() != other.num_coords() {
+            return false;
+        }
+
         let mut mp_zipper = self.into_iter().zip(other.into_iter());
         mp_zipper.all(|(lhs, rhs)| lhs.abs_diff_eq(&rhs, epsilon))
     }
@@ -242,4 +246,32 @@ mod test {
         ]);
         assert!(multi.relative_ne(&multi_oversized, 1., 1.));
     }
+
+    #[test]
+    fn test_abs_diff_eq() {
+        let delta = 1e-6;
+
+        let multi = MultiPoint(vec![point![x: 0., y: 0.], point![x: 10., y: 10.]]);
+
+        let multi_x = MultiPoint(vec![point![x: 0., y: 0.], point![x: 10.+delta, y: 10.]]);
+        assert!(multi.abs_diff_eq(&multi_x, 1e-2));
+        assert!(multi.abs_diff_ne(&multi_x, 1e-12));
+
+        let multi_y = MultiPoint(vec![point![x: 0., y: 0.], point![x: 10., y: 10.+delta]]);
+        assert!(multi.abs_diff_eq(&multi_y, 1e-2));
+        assert!(multi.abs_diff_ne(&multi_y, 1e-12));
+
+        // Under-sized but otherwise equal.
+        let multi_undersized = MultiPoint(vec![point![x: 0., y: 0.]]);
+        assert!(multi.abs_diff_ne(&multi_undersized, 1.));
+
+        // Over-sized but otherwise equal.
+        let multi_oversized = MultiPoint(vec![
+            point![x: 0., y: 0.],
+            point![x: 10., y: 10.],
+            point![x: 10., y:100.],
+        ]);
+        assert!(multi.abs_diff_ne(&multi_oversized, 1.));
+    }
+
 }

--- a/geo-types/src/multi_point.rs
+++ b/geo-types/src/multi_point.rs
@@ -136,13 +136,8 @@ where
             return false;
         }
 
-        let mp_zipper = self.iter().zip(other.iter());
-        for (lhs, rhs) in mp_zipper {
-            if lhs.relative_ne(&rhs, epsilon, max_relative) {
-                return false;
-            }
-        }
-        true
+        let mut mp_zipper = self.iter().zip(other.iter());
+        mp_zipper.all(|(lhs, rhs)| lhs.relative_eq(&rhs, epsilon, max_relative))
     }
 }
 
@@ -160,13 +155,8 @@ where
 
     #[inline]
     fn abs_diff_eq(&self, other: &MultiPoint<T>, epsilon: Self::Epsilon) -> bool {
-        let mp_zipper = self.into_iter().zip(other.into_iter());
-        for (lhs, rhs) in mp_zipper {
-            if lhs.abs_diff_ne(&rhs, epsilon) {
-                return false;
-            }
-        }
-        true
+        let mut mp_zipper = self.into_iter().zip(other.into_iter());
+        mp_zipper.all(|(lhs, rhs)| lhs.abs_diff_eq(&rhs, epsilon))
     }
 }
 

--- a/geo-types/src/multi_point.rs
+++ b/geo-types/src/multi_point.rs
@@ -1,8 +1,7 @@
 use crate::{CoordinateType, Point};
-#[cfg(feature = "relative_eq")]
-use approx::AbsDiffEq;
-#[cfg(feature = "relative_eq")]
-use approx::RelativeEq;
+
+#[cfg(any(feature = "approx", test))]
+use approx::{AbsDiffEq, RelativeEq};
 
 use std::iter::FromIterator;
 
@@ -96,7 +95,7 @@ impl<T: CoordinateType> MultiPoint<T> {
     }
 }
 
-#[cfg(feature = "relative_eq")]
+#[cfg(any(feature = "approx", test))]
 impl<T> RelativeEq for MultiPoint<T>
 where
     T: AbsDiffEq<Epsilon = T> + CoordinateType + RelativeEq,
@@ -135,7 +134,7 @@ where
     }
 }
 
-#[cfg(feature = "relative_eq")]
+#[cfg(any(feature = "approx", test))]
 impl<T> AbsDiffEq for MultiPoint<T>
 where
     T: AbsDiffEq<Epsilon = T> + CoordinateType,

--- a/geo-types/src/multi_point.rs
+++ b/geo-types/src/multi_point.rs
@@ -116,7 +116,7 @@ impl<T: CoordinateType> MultiPoint<T> {
 #[cfg(test)]
 impl<T> RelativeEq for MultiPoint<T>
 where
-    T: AbsDiffEq<Epsilon = T> + CoordinateType + RelativeEq
+    T: AbsDiffEq<Epsilon = T> + CoordinateType + RelativeEq,
 {
     #[inline]
     fn default_max_relative() -> Self::Epsilon {
@@ -272,5 +272,4 @@ mod test {
         ]);
         assert!(multi.abs_diff_ne(&multi_oversized, 1.));
     }
-
 }

--- a/geo-types/src/multi_point.rs
+++ b/geo-types/src/multi_point.rs
@@ -1,5 +1,5 @@
 use crate::{CoordinateType, Point};
-#[cfg(any(feature = "relative_eq"))]
+#[cfg(feature = "relative_eq")]
 use approx::AbsDiffEq;
 #[cfg(feature = "relative_eq")]
 use approx::RelativeEq;

--- a/geo-types/src/multi_point.rs
+++ b/geo-types/src/multi_point.rs
@@ -96,23 +96,6 @@ impl<T: CoordinateType> MultiPoint<T> {
     }
 }
 
-impl<T: CoordinateType> MultiPoint<T> {
-    /// Return the number of coordinates in the `MultiPoint`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use geo_types::MultiPoint;
-    ///
-    /// let mut coords = vec![(0., 0.), (5., 0.), (7., 9.)];
-    /// let multi_point: MultiPoint<f32> = coords.into_iter().collect();
-    /// assert_eq!(3, multi_point.num_coords());
-    /// ```
-    pub fn num_coords(&self) -> usize {
-        self.0.len()
-    }
-}
-
 #[cfg(feature = "relative_eq")]
 impl<T> RelativeEq for MultiPoint<T>
 where
@@ -143,7 +126,7 @@ where
         epsilon: Self::Epsilon,
         max_relative: Self::Epsilon,
     ) -> bool {
-        if self.num_coords() != other.num_coords() {
+        if self.0.len() != other.0.len() {
             return false;
         }
 
@@ -165,7 +148,7 @@ where
         T::default_epsilon()
     }
 
-    /// Equality assertion within a absolute limit.
+    /// Equality assertion with a absolute limit.
     ///
     /// # Examples
     ///
@@ -176,11 +159,11 @@ where
     /// let a = MultiPoint(vec![point![x: 0., y: 0.], point![x: 10., y: 10.]]);
     /// let b = MultiPoint(vec![point![x: 0., y: 0.], point![x: 10.001, y: 10.]]);
     ///
-    /// approx::assert_relative_eq!(a, b, epsilon=0.1)
+    /// approx::abs_diff_eq!(a, b, epsilon=0.1);
     /// ```
     #[inline]
     fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
-        if self.num_coords() != other.num_coords() {
+        if self.0.len() != other.0.len() {
             return false;
         }
 

--- a/geo-types/src/point.rs
+++ b/geo-types/src/point.rs
@@ -1,8 +1,7 @@
 use crate::{Coordinate, CoordinateType};
 
-use approx::AbsDiffEq;
-#[cfg(feature = "relative_eq")]
-use approx::RelativeEq;
+#[cfg(any(feature = "approx", test))]
+use approx::{AbsDiffEq, RelativeEq};
 
 use num_traits::Float;
 use std::ops::{Add, Div, Mul, Neg, Sub};
@@ -414,7 +413,7 @@ where
     }
 }
 
-#[cfg(feature = "relative_eq")]
+#[cfg(any(feature = "approx", test))]
 impl<T> RelativeEq for Point<T>
 where
     T: AbsDiffEq<Epsilon = T> + CoordinateType + RelativeEq,
@@ -446,7 +445,8 @@ where
         self.0.relative_eq(&other.0, epsilon, max_relative)
     }
 }
-#[cfg(feature = "relative_eq")]
+
+#[cfg(any(feature = "approx", test))]
 impl<T> AbsDiffEq for Point<T>
 where
     T: AbsDiffEq<Epsilon = T> + CoordinateType,

--- a/geo-types/src/point.rs
+++ b/geo-types/src/point.rs
@@ -419,8 +419,6 @@ impl<T> RelativeEq for Point<T>
 where
     T: CoordinateType + Float,
 {
-    // type Epsilon = T;
-
     #[inline]
     fn default_max_relative() -> Self::Epsilon {
         T::epsilon()

--- a/geo-types/src/point.rs
+++ b/geo-types/src/point.rs
@@ -449,7 +449,7 @@ where
         let diff_x = self.x() - other.x();
         let diff_y = self.y() - other.y();
         let abs_diff = (diff_x * diff_x + diff_y * diff_y).sqrt();
-        println!("compute largest");
+
         // For when the numbers are really close together.
         if abs_diff <= epsilon {
             return true;

--- a/geo-types/src/point.rs
+++ b/geo-types/src/point.rs
@@ -417,7 +417,7 @@ where
 #[cfg(test)]
 impl<T> RelativeEq for Point<T>
 where
-    T: CoordinateType + Float,
+    T: AbsDiffEq<Epsilon = T> + CoordinateType + Float + RelativeEq
 {
     #[inline]
     fn default_max_relative() -> Self::Epsilon {
@@ -431,39 +431,7 @@ where
         epsilon: Self::Epsilon,
         max_relative: Self::Epsilon,
     ) -> bool {
-        // Handle same infinities.
-        if self == other {
-            return true;
-        }
-
-        if self.x().is_infinite()
-            || self.y().is_infinite()
-            || other.x().is_infinite()
-            || other.y().is_infinite()
-        {
-            return false;
-        }
-
-        let diff_x = self.x() - other.x();
-        let diff_y = self.y() - other.y();
-        let abs_diff = (diff_x * diff_x + diff_y * diff_y).sqrt();
-
-        // For when the numbers are really close together.
-        if abs_diff <= epsilon {
-            return true;
-        }
-
-        let abs_self = (self.x() * self.x() + self.y() + self.y()).sqrt();
-        let abs_other = (other.x() * other.x() + other.y() * other.y()).sqrt();
-
-        let largest = if abs_other > abs_self {
-            abs_other
-        } else {
-            abs_self
-        };
-
-        // Use a relative difference comparison.
-        abs_diff <= largest * max_relative
+        self.0.relative_eq(&other.0, epsilon, max_relative)
     }
 }
 

--- a/geo-types/src/point.rs
+++ b/geo-types/src/point.rs
@@ -459,11 +459,11 @@ where
         T::default_epsilon()
     }
 
-    /// Equality assertion within a absolute limit.
+    /// Equality assertion with a absolute limit.
     ///
     /// # Examples
     ///
-    /// ```relative_eq
+    /// ```
     /// use geo_types::Point;
     ///
     /// let a = Point::new(2.0, 3.0);

--- a/geo-types/src/point.rs
+++ b/geo-types/src/point.rs
@@ -417,17 +417,17 @@ where
 #[cfg(test)]
 impl<T> RelativeEq for Point<T>
 where
-    T: AbsDiffEq<Epsilon = T> + CoordinateType + Float + RelativeEq
+    T: AbsDiffEq<Epsilon = T> + CoordinateType + RelativeEq
 {
     #[inline]
     fn default_max_relative() -> Self::Epsilon {
-        T::epsilon()
+        T::default_max_relative()
     }
 
     #[inline]
     fn relative_eq(
         &self,
-        other: &Point<T>,
+        other: &Self,
         epsilon: Self::Epsilon,
         max_relative: Self::Epsilon,
     ) -> bool {
@@ -438,18 +438,19 @@ where
 #[cfg(test)]
 impl<T> AbsDiffEq for Point<T>
 where
-    T: CoordinateType + Float,
+    T: AbsDiffEq<Epsilon = T> + CoordinateType,
+    T::Epsilon: Copy
 {
-    type Epsilon = T;
+    type Epsilon = T::Epsilon;
 
     #[inline]
     fn default_epsilon() -> Self::Epsilon {
-        T::epsilon()
+        T::default_epsilon()
     }
 
     #[inline]
-    fn abs_diff_eq(&self, other: &Point<T>, epsilon: Self::Epsilon) -> bool {
-        (self.x() - other.x()).abs() < epsilon && (self.y() - other.y()).abs() < epsilon
+    fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
+        self.0.abs_diff_eq(&other.0, epsilon)
     }
 }
 

--- a/geo-types/src/point.rs
+++ b/geo-types/src/point.rs
@@ -417,7 +417,7 @@ where
 #[cfg(test)]
 impl<T> RelativeEq for Point<T>
 where
-    T: AbsDiffEq<Epsilon = T> + CoordinateType + RelativeEq
+    T: AbsDiffEq<Epsilon = T> + CoordinateType + RelativeEq,
 {
     #[inline]
     fn default_max_relative() -> Self::Epsilon {
@@ -439,7 +439,7 @@ where
 impl<T> AbsDiffEq for Point<T>
 where
     T: AbsDiffEq<Epsilon = T> + CoordinateType,
-    T::Epsilon: Copy
+    T::Epsilon: Copy,
 {
     type Epsilon = T::Epsilon;
 

--- a/geo-types/src/point.rs
+++ b/geo-types/src/point.rs
@@ -1,7 +1,7 @@
 use crate::{Coordinate, CoordinateType};
-#[cfg(test)]
+
 use approx::AbsDiffEq;
-#[cfg(test)]
+#[cfg(feature = "relative_eq")]
 use approx::RelativeEq;
 
 use num_traits::Float;
@@ -414,7 +414,7 @@ where
     }
 }
 
-#[cfg(test)]
+#[cfg(feature = "relative_eq")]
 impl<T> RelativeEq for Point<T>
 where
     T: AbsDiffEq<Epsilon = T> + CoordinateType + RelativeEq,
@@ -424,6 +424,18 @@ where
         T::default_max_relative()
     }
 
+    /// Equality assertion within a relative limit.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use geo_types::Point;
+    ///
+    /// let a = Point::new(2.0, 3.0);
+    /// let b = Point::new(2.0, 3.01);
+    ///
+    /// approx::assert_relative_eq!(a, b, max_relative=0.1)
+    /// ```
     #[inline]
     fn relative_eq(
         &self,
@@ -434,8 +446,7 @@ where
         self.0.relative_eq(&other.0, epsilon, max_relative)
     }
 }
-
-#[cfg(test)]
+#[cfg(feature = "relative_eq")]
 impl<T> AbsDiffEq for Point<T>
 where
     T: AbsDiffEq<Epsilon = T> + CoordinateType,
@@ -448,6 +459,18 @@ where
         T::default_epsilon()
     }
 
+    /// Equality assertion within a absolute limit.
+    ///
+    /// # Examples
+    ///
+    /// ```relative_eq
+    /// use geo_types::Point;
+    ///
+    /// let a = Point::new(2.0, 3.0);
+    /// let b = Point::new(2.0, 3.0000001);
+    ///
+    /// approx::assert_relative_eq!(a, b, epsilon=0.1)
+    /// ```
     #[inline]
     fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
         self.0.abs_diff_eq(&other.0, epsilon)

--- a/geo-types/src/private_utils.rs
+++ b/geo-types/src/private_utils.rs
@@ -127,7 +127,7 @@ where
     T: Float,
 {
     let distance = line_euclidean_length(Line::new(p1, p2)).to_f32().unwrap();
-    relative_eq!(distance, 0.0)
+    approx::relative_eq!(distance, 0.0)
 }
 
 pub fn line_string_contains_point<T>(line_string: &LineString<T>, point: Point<T>) -> bool

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -22,8 +22,8 @@ geographiclib-rs = { version = "0.2" }
 
 proj = { version = "0.20.3", optional = true }
 
-geo-types = { version = "0.6.2", path = "../geo-types", features = ["rstar"] }
-
+geo-types = { version = "0.6.2", path = "../geo-types", features = ["relative_eq", "rstar"] }
+approx= { version = "0.4.0", optional = true }
 robust = { version = "0.2.2" }
 
 [features]
@@ -31,6 +31,7 @@ default = []
 use-proj = ["proj"]
 proj-network = ["use-proj", "proj/network"]
 use-serde = ["serde", "geo-types/serde"]
+relative_eq = ["approx"]
 
 [dev-dependencies]
 approx = "0.4.0"

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -22,20 +22,20 @@ geographiclib-rs = { version = "0.2" }
 
 proj = { version = "0.20.3", optional = true }
 
-geo-types = { version = "0.6.2", path = "../geo-types", features = ["relative_eq", "rstar"] }
-approx= { version = "0.4.0", optional = true }
+geo-types = { version = "0.6.2", optional = true, path = "../geo-types", features = ["rstar"] }
+
 robust = { version = "0.2.2" }
 
 [features]
-default = []
+default = ["geo-types"]
 use-proj = ["proj"]
 proj-network = ["use-proj", "proj/network"]
 use-serde = ["serde", "geo-types/serde"]
-relative_eq = ["approx"]
 
 [dev-dependencies]
 approx = "0.4.0"
 criterion = { version = "0.3" }
+geo-types = { version = "0.6.2", path = "../geo-types", features = ["relative_eq", "rstar"] }
 rand = "0.8.0"
 
 [[bench]]

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -22,12 +22,11 @@ geographiclib-rs = { version = "0.2" }
 
 proj = { version = "0.20.3", optional = true }
 
-geo-types = { version = "0.6.2", optional = true, path = "../geo-types", features = ["rstar"] }
+geo-types = { version = "0.6.2", path = "../geo-types", features = ["approx", "use-rstar"] }
 
 robust = { version = "0.2.2" }
 
 [features]
-default = ["geo-types"]
 use-proj = ["proj"]
 proj-network = ["use-proj", "proj/network"]
 use-serde = ["serde", "geo-types/serde"]
@@ -35,7 +34,6 @@ use-serde = ["serde", "geo-types/serde"]
 [dev-dependencies]
 approx = "0.4.0"
 criterion = { version = "0.3" }
-geo-types = { version = "0.6.2", path = "../geo-types", features = ["relative_eq", "rstar"] }
 rand = "0.8.0"
 
 [[bench]]

--- a/geo/src/algorithm/rotate.rs
+++ b/geo/src/algorithm/rotate.rs
@@ -221,6 +221,7 @@ where
 mod test {
     use super::*;
     use crate::{line_string, point, polygon, Coordinate, Point};
+    use approx::assert_relative_eq;
 
     #[test]
     fn test_rotate_around_point() {
@@ -334,16 +335,13 @@ mod test {
     #[test]
     fn test_rotate_line() {
         let line0 = Line::from([(0., 0.), (0., 2.)]);
-        let line1 = Line::from([(1., 0.9999999999999999), (-1., 1.)]);
-        assert_eq!(line0.rotate(90.), line1);
+        let line1 = Line::from([(1., 1.), (-1., 1.)]);
+        assert_relative_eq!(line0.rotate(90.0), line1);
     }
     #[test]
     fn test_rotate_line_around_point() {
         let line0 = Line::new(Point::new(0., 0.), Point::new(0., 2.));
-        let line1 = Line::new(
-            Point::new(0., 0.),
-            Point::new(-2., 0.00000000000000012246467991473532),
-        );
-        assert_eq!(line0.rotate_around_point(90., Point::new(0., 0.)), line1);
+        let line1 = Line::new(Point::new(0., 0.), Point::new(-2., 0.));
+        assert_relative_eq!(line0.rotate_around_point(90., Point::new(0., 0.)), line1);
     }
 }


### PR DESCRIPTION
Added num_coords() method to MultiPoint. To Point, Line, LineString and MultiPoint test helpers and associated tests were added to assert that two structs were relatively equal. That is identical within the limits of numerical rounding accuracy.

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

