### PR TITLE
Fix bench compiler error; use black_box in more places.

### DIFF
--- a/geo/benches/area.rs
+++ b/geo/benches/area.rs
@@ -12,9 +12,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         let polygon = Polygon::new(LineString::<f32>::from(points), vec![]);
 
         bencher.iter(|| {
-            criterion::black_box(|| {
-                polygon.signed_area();
-            });
+            criterion::black_box(criterion::black_box(&polygon).signed_area());
         });
     });
 }

--- a/geo/benches/concave_hull.rs
+++ b/geo/benches/concave_hull.rs
@@ -16,7 +16,7 @@ pub fn uniform_points_in_range<S: CoordinateType + SampleUniform + Signed, R: Rn
     rng: &mut R,
 ) -> Vec<Coordinate<S>> {
     (0..size)
-        .map(|_| (rng.gen_range(-range, range), rng.gen_range(-range, range)).into())
+        .map(|_| (rng.gen_range(-range..=range), rng.gen_range(-range..=range)).into())
         .collect()
 }
 
@@ -26,7 +26,9 @@ fn criterion_benchmark(c: &mut Criterion) {
         let line_string = LineString::<f32>::from(points);
 
         bencher.iter(|| {
-            line_string.concave_hull(2.0);
+            criterion::black_box(
+                criterion::black_box(&line_string).concave_hull(criterion::black_box(2.0)),
+            );
         });
     });
 
@@ -35,7 +37,9 @@ fn criterion_benchmark(c: &mut Criterion) {
         let line_string = LineString::<f64>::from(points);
 
         bencher.iter(|| {
-            line_string.concave_hull(2.0);
+            criterion::black_box(
+                criterion::black_box(&line_string).concave_hull(criterion::black_box(2.0)),
+            );
         });
     });
 }

--- a/geo/benches/contains.rs
+++ b/geo/benches/contains.rs
@@ -17,7 +17,9 @@ fn criterion_benchmark(c: &mut Criterion) {
         ];
         let in_candidate = geo::Point::new(0.5, 0.1);
         bencher.iter(|| {
-            polygon.contains(&in_candidate);
+            criterion::black_box(
+                criterion::black_box(&polygon).contains(criterion::black_box(&in_candidate)),
+            );
         });
     });
 
@@ -30,7 +32,9 @@ fn criterion_benchmark(c: &mut Criterion) {
         ];
         let out_candidate = geo::Point::new(2.0, 2.0);
         bencher.iter(|| {
-            polygon.contains(&out_candidate);
+            criterion::black_box(
+                criterion::black_box(&polygon).contains(criterion::black_box(&out_candidate)),
+            );
         });
     });
 }

--- a/geo/benches/convex_hull.rs
+++ b/geo/benches/convex_hull.rs
@@ -15,7 +15,7 @@ pub fn uniform_points_in_range<S: CoordinateType + SampleUniform + Signed, R: Rn
     rng: &mut R,
 ) -> Vec<Coordinate<S>> {
     (0..size)
-        .map(|_| (rng.gen_range(-range, range), rng.gen_range(-range, range)).into())
+        .map(|_| (rng.gen_range(-range..=range), rng.gen_range(-range..=range)).into())
         .collect()
 }
 
@@ -25,7 +25,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         let line_string = LineString::<f32>::from(points);
 
         bencher.iter(|| {
-            line_string.convex_hull();
+            criterion::black_box(criterion::black_box(&line_string).convex_hull());
         });
     });
 
@@ -34,7 +34,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         let line_string = LineString::<f64>::from(points);
 
         bencher.iter(|| {
-            line_string.convex_hull();
+            criterion::black_box(criterion::black_box(&line_string).convex_hull());
         });
     });
 
@@ -42,7 +42,10 @@ fn criterion_benchmark(c: &mut Criterion) {
         let mut points = uniform_points_in_range(10_000_i64, 1_000_000, &mut rand::thread_rng());
         use geo::algorithm::convex_hull::graham_hull;
         bencher.iter(|| {
-            graham_hull(&mut points, true);
+            criterion::black_box(graham_hull(
+                criterion::black_box(&mut points),
+                criterion::black_box(true),
+            ));
         });
     });
 }

--- a/geo/benches/euclidean_distance.rs
+++ b/geo/benches/euclidean_distance.rs
@@ -40,7 +40,9 @@ fn criterion_benchmark(c: &mut criterion::Criterion) {
             (x: -6.064453, y: 68.49604),
         ];
         bencher.iter(|| {
-            let _ = poly1.euclidean_distance(&poly2);
+            criterion::black_box(
+                criterion::black_box(&poly1).euclidean_distance(criterion::black_box(&poly2)),
+            );
         });
     });
 
@@ -82,7 +84,9 @@ fn criterion_benchmark(c: &mut criterion::Criterion) {
             ]
             .convex_hull();
             bencher.iter(|| {
-                let _ = poly1.euclidean_distance(&poly2);
+                criterion::black_box(
+                    criterion::black_box(&poly1).euclidean_distance(criterion::black_box(&poly2)),
+                );
             });
         },
     );

--- a/geo/benches/extremes.rs
+++ b/geo/benches/extremes.rs
@@ -12,7 +12,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         let polygon = Polygon::new(LineString::<f32>::from(points), vec![]);
 
         bencher.iter(|| {
-            polygon.extreme_points();
+            criterion::black_box(criterion::black_box(&polygon).extreme_points());
         });
     });
 
@@ -21,7 +21,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         let polygon = Polygon::new(LineString::<f32>::from(points), vec![]);
 
         bencher.iter(|| {
-            polygon.extreme_points();
+            criterion::black_box(criterion::black_box(&polygon).extreme_points());
         });
     });
 }

--- a/geo/benches/frechet_distance.rs
+++ b/geo/benches/frechet_distance.rs
@@ -22,7 +22,9 @@ fn criterion_benchmark(c: &mut criterion::Criterion) {
         );
 
         bencher.iter(|| {
-            let _ = ls_a.frechet_distance(&ls_b);
+            criterion::black_box(
+                criterion::black_box(&ls_a).frechet_distance(criterion::black_box(&ls_b)),
+            );
         });
     });
 
@@ -43,7 +45,9 @@ fn criterion_benchmark(c: &mut criterion::Criterion) {
         );
 
         bencher.iter(|| {
-            let _ = ls_a.frechet_distance(&ls_b);
+            criterion::black_box(
+                criterion::black_box(&ls_a).frechet_distance(criterion::black_box(&ls_b)),
+            );
         });
     });
 }

--- a/geo/benches/geodesic_distance.rs
+++ b/geo/benches/geodesic_distance.rs
@@ -10,7 +10,9 @@ fn criterion_benchmark(c: &mut criterion::Criterion) {
         let b = geo::Point::<f64>::new(16.372477, 48.208810);
 
         bencher.iter(|| {
-            let _ = a.geodesic_distance(&b);
+            criterion::black_box(
+                criterion::black_box(&a).geodesic_distance(criterion::black_box(&b)),
+            );
         });
     });
 }

--- a/geo/benches/rotate.rs
+++ b/geo/benches/rotate.rs
@@ -12,7 +12,9 @@ fn criterion_benchmark(c: &mut Criterion) {
         let line_string = LineString::<f32>::from(points);
 
         bencher.iter(|| {
-            line_string.rotate(180.);
+            criterion::black_box(
+                criterion::black_box(&line_string).rotate(criterion::black_box(180.)),
+            );
         });
     });
 
@@ -21,7 +23,9 @@ fn criterion_benchmark(c: &mut Criterion) {
         let line_string = LineString::<f64>::from(points);
 
         bencher.iter(|| {
-            line_string.rotate(180.);
+            criterion::black_box(
+                criterion::black_box(&line_string).rotate(criterion::black_box(180.)),
+            );
         });
     });
 }

--- a/geo/benches/simplify.rs
+++ b/geo/benches/simplify.rs
@@ -12,7 +12,9 @@ fn criterion_benchmark(c: &mut Criterion) {
         let points = include!("../src/algorithm/test_fixtures/louisiana.rs");
         let ls: LineString<f32> = points.into();
         bencher.iter(|| {
-            let _ = ls.simplifyvw(&0.0005);
+            criterion::black_box(
+                criterion::black_box(&ls).simplifyvw(criterion::black_box(&0.0005)),
+            );
         });
     });
 
@@ -20,7 +22,9 @@ fn criterion_benchmark(c: &mut Criterion) {
         let points = include!("../src/algorithm/test_fixtures/louisiana.rs");
         let ls: LineString<f64> = points.into();
         bencher.iter(|| {
-            let _ = ls.simplifyvw(&0.0005);
+            criterion::black_box(
+                criterion::black_box(&ls).simplifyvw(criterion::black_box(&0.0005)),
+            );
         });
     });
 
@@ -28,7 +32,9 @@ fn criterion_benchmark(c: &mut Criterion) {
         let points = include!("../src/algorithm/test_fixtures/louisiana.rs");
         let ls: LineString<f32> = points.into();
         bencher.iter(|| {
-            let _ = ls.simplifyvw_preserve(&0.0005);
+            criterion::black_box(
+                criterion::black_box(&ls).simplifyvw_preserve(criterion::black_box(&0.0005)),
+            );
         });
     });
 
@@ -36,7 +42,9 @@ fn criterion_benchmark(c: &mut Criterion) {
         let points = include!("../src/algorithm/test_fixtures/louisiana.rs");
         let ls: LineString<f32> = points.into();
         bencher.iter(|| {
-            let _ = ls.simplifyvw_preserve(&0.0005);
+            criterion::black_box(
+                criterion::black_box(&ls).simplifyvw_preserve(criterion::black_box(&0.0005)),
+            );
         });
     });
 }

--- a/geo/benches/vincenty_distance.rs
+++ b/geo/benches/vincenty_distance.rs
@@ -10,7 +10,9 @@ fn criterion_benchmark(c: &mut criterion::Criterion) {
         let b = geo::Point::<f32>::new(16.372477, 48.208810);
 
         bencher.iter(|| {
-            let _ = a.vincenty_distance(&b);
+            let _ = criterion::black_box(
+                criterion::black_box(&a).vincenty_distance(criterion::black_box(&b))
+            );
         });
     });
 
@@ -19,7 +21,9 @@ fn criterion_benchmark(c: &mut criterion::Criterion) {
         let b = geo::Point::<f64>::new(16.372477, 48.208810);
 
         bencher.iter(|| {
-            let _ = a.vincenty_distance(&b);
+            let _ = criterion::black_box(
+                criterion::black_box(&a).vincenty_distance(criterion::black_box(&b))
+            );
         });
     });
 }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Fix a couple lines that were causing compiler errors. And extended `black_box` to be used on all parameters and return values. I'm not sure if we need to use it on the return value (see https://github.com/rust-lang/rust/issues/80480)