### PR TITLE
Performance (and other) improvements to the Simplify algorithm.

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -8,6 +8,10 @@
   * <https://github.com/georust/geo/pull/561>
 * Add new `EuclideanDistance` implementations: `impl EuclideanDistance<Coordinate<T>> for Line`, `impl EuclideanDistance<Line> for Coordinate`, `impl EuclideanDistance<Coordinate> for Coordinate`
   * <https://github.com/georust/geo/pull/580>
+* Fix panic when `simplify` is given a negative epsilon
+  * <https://github.com/georust/geo/pull/584>
+* Performance improvements to `simplify`
+  * <https://github.com/georust/geo/pull/584>
 
 ## 0.16.0
 

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -78,5 +78,9 @@ name = "simplify"
 harness = false
 
 [[bench]]
+name = "simplifyvw"
+harness = false
+
+[[bench]]
 name = "frechet_distance"
 harness = false

--- a/geo/benches/simplify.rs
+++ b/geo/benches/simplify.rs
@@ -3,47 +3,26 @@ extern crate criterion;
 extern crate geo;
 
 use criterion::Criterion;
-use geo::prelude::*;
-use geo::simplifyvw::SimplifyVWPreserve;
+use geo::simplify::Simplify;
 use geo::LineString;
 
 fn criterion_benchmark(c: &mut Criterion) {
-    c.bench_function("simplify vw simple f32", |bencher| {
+    c.bench_function("simplify simple f32", |bencher| {
         let points = include!("../src/algorithm/test_fixtures/louisiana.rs");
         let ls: LineString<f32> = points.into();
         bencher.iter(|| {
             criterion::black_box(
-                criterion::black_box(&ls).simplifyvw(criterion::black_box(&0.0005)),
+                criterion::black_box(&ls).simplify(criterion::black_box(&0.0005)),
             );
         });
     });
 
-    c.bench_function("simplify vw simple f64", |bencher| {
+    c.bench_function("simplify simple f64", |bencher| {
         let points = include!("../src/algorithm/test_fixtures/louisiana.rs");
         let ls: LineString<f64> = points.into();
         bencher.iter(|| {
             criterion::black_box(
-                criterion::black_box(&ls).simplifyvw(criterion::black_box(&0.0005)),
-            );
-        });
-    });
-
-    c.bench_function("simplify vwp f32", |bencher| {
-        let points = include!("../src/algorithm/test_fixtures/louisiana.rs");
-        let ls: LineString<f32> = points.into();
-        bencher.iter(|| {
-            criterion::black_box(
-                criterion::black_box(&ls).simplifyvw_preserve(criterion::black_box(&0.0005)),
-            );
-        });
-    });
-
-    c.bench_function("simplify vwp f64", |bencher| {
-        let points = include!("../src/algorithm/test_fixtures/louisiana.rs");
-        let ls: LineString<f32> = points.into();
-        bencher.iter(|| {
-            criterion::black_box(
-                criterion::black_box(&ls).simplifyvw_preserve(criterion::black_box(&0.0005)),
+                criterion::black_box(&ls).simplify(criterion::black_box(&0.0005)),
             );
         });
     });

--- a/geo/benches/simplifyvw.rs
+++ b/geo/benches/simplifyvw.rs
@@ -1,0 +1,53 @@
+#[macro_use]
+extern crate criterion;
+extern crate geo;
+
+use criterion::Criterion;
+use geo::prelude::*;
+use geo::simplifyvw::SimplifyVWPreserve;
+use geo::LineString;
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("simplify vw simple f32", |bencher| {
+        let points = include!("../src/algorithm/test_fixtures/louisiana.rs");
+        let ls: LineString<f32> = points.into();
+        bencher.iter(|| {
+            criterion::black_box(
+                criterion::black_box(&ls).simplifyvw(criterion::black_box(&0.0005)),
+            );
+        });
+    });
+
+    c.bench_function("simplify vw simple f64", |bencher| {
+        let points = include!("../src/algorithm/test_fixtures/louisiana.rs");
+        let ls: LineString<f64> = points.into();
+        bencher.iter(|| {
+            criterion::black_box(
+                criterion::black_box(&ls).simplifyvw(criterion::black_box(&0.0005)),
+            );
+        });
+    });
+
+    c.bench_function("simplify vwp f32", |bencher| {
+        let points = include!("../src/algorithm/test_fixtures/louisiana.rs");
+        let ls: LineString<f32> = points.into();
+        bencher.iter(|| {
+            criterion::black_box(
+                criterion::black_box(&ls).simplifyvw_preserve(criterion::black_box(&0.0005)),
+            );
+        });
+    });
+
+    c.bench_function("simplify vwp f64", |bencher| {
+        let points = include!("../src/algorithm/test_fixtures/louisiana.rs");
+        let ls: LineString<f32> = points.into();
+        bencher.iter(|| {
+            criterion::black_box(
+                criterion::black_box(&ls).simplifyvw_preserve(criterion::black_box(&0.0005)),
+            );
+        });
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/geo/src/algorithm/simplify.rs
+++ b/geo/src/algorithm/simplify.rs
@@ -1,5 +1,6 @@
+use crate::algorithm::coords_iter::CoordsIter;
 use crate::algorithm::euclidean_distance::EuclideanDistance;
-use crate::{Line, LineString, MultiLineString, MultiPolygon, Point, Polygon};
+use crate::{Coordinate, Line, LineString, MultiLineString, MultiPolygon, Polygon};
 use num_traits::Float;
 
 // Because the RDP algorithm is recursive, we can't assign an index to a point inside the loop
@@ -11,41 +12,40 @@ where
     T: Float,
 {
     index: usize,
-    point: Point<T>,
+    coord: Coordinate<T>,
 }
 
 // Wrapper for the RDP algorithm, returning simplified points
-fn rdp<T>(points: &[Point<T>], epsilon: &T) -> Vec<Point<T>>
+fn rdp<T>(coords: impl Iterator<Item = Coordinate<T>>, epsilon: &T) -> Vec<Coordinate<T>>
 where
     T: Float,
 {
     // Epsilon must be greater than zero for any meaningful simplification to happen
     if *epsilon <= T::zero() {
-        points.to_vec();
+        return coords.collect::<Vec<Coordinate<T>>>();
     }
     compute_rdp(
-        &points
-            .iter()
+        &coords
             .enumerate()
-            .map(|(idx, point)| RdpIndex {
-                index: idx,
-                point: *point,
-            })
+            .map(|(idx, coord)| RdpIndex { index: idx, coord })
             .collect::<Vec<RdpIndex<T>>>(),
         epsilon,
     )
     .into_iter()
-    .map(|rdpindex| rdpindex.point)
-    .collect::<Vec<Point<T>>>()
+    .map(|rdpindex| rdpindex.coord)
+    .collect()
 }
 
 // Wrapper for the RDP algorithm, returning simplified point indices
-fn rdp_indices<T>(points: &[RdpIndex<T>], epsilon: &T) -> Vec<usize>
+fn calculate_rdp_indices<T>(rdp_indices: &[RdpIndex<T>], epsilon: &T) -> Vec<usize>
 where
     T: Float,
 {
-    compute_rdp(points, epsilon)
-        .iter()
+    if *epsilon <= T::zero() {
+        return rdp_indices.iter().map(|rdp_index| rdp_index.index).collect();
+    }
+    compute_rdp(rdp_indices, epsilon)
+        .into_iter()
         .map(|rdpindex| rdpindex.index)
         .collect::<Vec<usize>>()
 }
@@ -53,33 +53,47 @@ where
 // Ramer–Douglas-Peucker line simplification algorithm
 // This function returns both the retained points, and their indices in the original geometry,
 // for more flexible use by FFI implementers
-fn compute_rdp<T>(points: &[RdpIndex<T>], epsilon: &T) -> Vec<RdpIndex<T>>
+fn compute_rdp<T>(rdp_indices: &[RdpIndex<T>], epsilon: &T) -> Vec<RdpIndex<T>>
 where
     T: Float,
 {
-    if points.is_empty() {
-        return points.to_vec();
+    if rdp_indices.is_empty() {
+        return vec![];
     }
-    let mut dmax = T::zero();
-    let mut index: usize = 0;
-    let mut distance: T;
 
-    for (i, _) in points.iter().enumerate().take(points.len() - 1).skip(1) {
-        distance = points[i]
-            .point
-            .euclidean_distance(&Line::new(points[0].point, points.last().unwrap().point));
-        if distance > dmax {
-            index = i;
-            dmax = distance;
-        }
-    }
-    if dmax > *epsilon {
-        let mut intermediate = compute_rdp(&points[..=index], &*epsilon);
-        intermediate.pop();
-        intermediate.extend_from_slice(&compute_rdp(&points[index..], &*epsilon));
+    let first = rdp_indices[0];
+    let last = rdp_indices[rdp_indices.len() - 1];
+    let first_last_line = Line::new(first.coord, last.coord);
+
+    // Find the farthest `RdpIndex` from `first_last_line`
+    let (farthest_index, farthest_distance) = rdp_indices
+        .iter()
+        .enumerate()
+        .take(rdp_indices.len() - 1) // Don't include the last index
+        .skip(1) // Don't include the first index
+        .map(|(index, rdp_index)| (index, rdp_index.coord.euclidean_distance(&first_last_line)))
+        .fold(
+            (0usize, T::zero()),
+            |(farthest_index, farthest_distance), (index, distance)| {
+                if distance > farthest_distance {
+                    (index, distance)
+                } else {
+                    (farthest_index, farthest_distance)
+                }
+            },
+        );
+
+    if farthest_distance > *epsilon {
+        // The farthest index was larger than epsilon, so we will recursively simplify subsegments
+        // split by the farthest index.
+        let mut intermediate = compute_rdp(&rdp_indices[..=farthest_index], &*epsilon);
+        intermediate.pop(); // Don't include the farthest index twice
+        intermediate.extend_from_slice(&compute_rdp(&rdp_indices[farthest_index..], &*epsilon));
         intermediate
     } else {
-        vec![*points.first().unwrap(), *points.last().unwrap()]
+        // The farthest index was less than or equal to epsilon, so we will retain only the first
+        // and last indices, resulting in the indices inbetween getting culled.
+        vec![first, last]
     }
 }
 
@@ -170,7 +184,7 @@ where
     T: Float,
 {
     fn simplify(&self, epsilon: &T) -> Self {
-        LineString::from(rdp(&self.clone().into_points(), epsilon))
+        LineString::from(rdp(self.coords_iter(), epsilon))
     }
 }
 
@@ -179,11 +193,15 @@ where
     T: Float,
 {
     fn simplify_idx(&self, epsilon: &T) -> Vec<usize> {
-        rdp_indices(
+        calculate_rdp_indices(
             &self
-                .points_iter()
+                .0
+                .iter()
                 .enumerate()
-                .map(|(idx, point)| RdpIndex { index: idx, point })
+                .map(|(idx, coord)| RdpIndex {
+                    index: idx,
+                    coord: *coord,
+                })
                 .collect::<Vec<RdpIndex<T>>>(),
             epsilon,
         )
@@ -226,40 +244,44 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::polygon;
+    use crate::{line_string, polygon};
 
     #[test]
     fn rdp_test() {
-        let mut vec = Vec::new();
-        vec.push(Point::new(0.0, 0.0));
-        vec.push(Point::new(5.0, 4.0));
-        vec.push(Point::new(11.0, 5.5));
-        vec.push(Point::new(17.3, 3.2));
-        vec.push(Point::new(27.8, 0.1));
-        let mut compare = Vec::new();
-        compare.push(Point::new(0.0, 0.0));
-        compare.push(Point::new(5.0, 4.0));
-        compare.push(Point::new(11.0, 5.5));
-        compare.push(Point::new(27.8, 0.1));
-        let simplified = rdp(&vec, &1.0);
+        let vec = vec![
+            Coordinate { x: 0.0, y: 0.0 },
+            Coordinate { x: 5.0, y: 4.0 },
+            Coordinate { x: 11.0, y: 5.5 },
+            Coordinate { x: 17.3, y: 3.2 },
+            Coordinate { x: 27.8, y: 0.1 },
+        ];
+        let compare = vec![
+            Coordinate { x: 0.0, y: 0.0 },
+            Coordinate { x: 5.0, y: 4.0 },
+            Coordinate { x: 11.0, y: 5.5 },
+            Coordinate { x: 27.8, y: 0.1 },
+        ];
+        let simplified = rdp(vec.into_iter(), &1.0);
         assert_eq!(simplified, compare);
     }
     #[test]
     fn rdp_test_empty_linestring() {
         let vec = Vec::new();
         let compare = Vec::new();
-        let simplified = rdp(&vec, &1.0);
+        let simplified = rdp(vec.into_iter(), &1.0);
         assert_eq!(simplified, compare);
     }
     #[test]
     fn rdp_test_two_point_linestring() {
-        let mut vec = Vec::new();
-        vec.push(Point::new(0.0, 0.0));
-        vec.push(Point::new(27.8, 0.1));
-        let mut compare = Vec::new();
-        compare.push(Point::new(0.0, 0.0));
-        compare.push(Point::new(27.8, 0.1));
-        let simplified = rdp(&vec, &1.0);
+        let vec = vec![
+            Coordinate { x: 0.0, y: 0.0 },
+            Coordinate { x: 27.8, y: 0.1 },
+        ];
+        let compare = vec![
+            Coordinate { x: 0.0, y: 0.0 },
+            Coordinate { x: 27.8, y: 0.1 },
+        ];
+        let simplified = rdp(vec.into_iter(), &1.0);
         assert_eq!(simplified, compare);
     }
 
@@ -334,5 +356,31 @@ mod test {
                 (x: 0., y: 0.)
             ]]),
         );
+    }
+
+    #[test]
+    fn simplify_negative_epsilon() {
+        let ls = line_string![
+            (x: 0., y: 0.),
+            (x: 0., y: 10.),
+            (x: 5., y: 11.),
+            (x: 10., y: 10.),
+            (x: 10., y: 0.),
+        ];
+        let simplified = ls.simplify(&-1.0);
+        assert_eq!(ls, simplified);
+    }
+
+    #[test]
+    fn simplify_idx_negative_epsilon() {
+        let ls = line_string![
+            (x: 0., y: 0.),
+            (x: 0., y: 10.),
+            (x: 5., y: 11.),
+            (x: 10., y: 10.),
+            (x: 10., y: 0.),
+        ];
+        let indices = ls.simplify_idx(&-1.0);
+        assert_eq!(vec![0usize, 1, 2, 3, 4], indices);
     }
 }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

- Create a new benchmark for `Simplify` (previously we just had `SimplifyVw`)
- Add code comments to `Simplify` and `SimplifyIdx` implementations
- Remove an unnecessary clone in `LineString::simplify`
- Short circuit if the user passes a negative epsilon, and add regression tests
- Minor refactoring