### PR TITLE
Rewrite Extremes algorithm to iteratively find the extreme coordinates using CoordsIter

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -21,7 +21,7 @@
   * <https://github.com/georust/geo/pull/593>
 * Add `CoordsIter::exterior_coords_iter` method to iterate over exterior coordinates of a geometry
   * <https://github.com/georust/geo/pull/594>
-
+* The `ExtremeIndices` and `ExtremePoints` traits have been combined into a new `Extremes` trait containing an `extremes` method. The output of the `extremes` method contains both indices and coordinates. The new implementation is based on `CoordsIter` instead of `ConvexHull`, and now runs 6x faster.
 
 ## 0.16.0
 

--- a/geo/benches/extremes.rs
+++ b/geo/benches/extremes.rs
@@ -12,7 +12,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         let polygon = Polygon::new(LineString::<f32>::from(points), vec![]);
 
         bencher.iter(|| {
-            criterion::black_box(criterion::black_box(&polygon).extreme_points());
+            criterion::black_box(criterion::black_box(&polygon).extremes());
         });
     });
 
@@ -21,7 +21,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         let polygon = Polygon::new(LineString::<f32>::from(points), vec![]);
 
         bencher.iter(|| {
-            criterion::black_box(criterion::black_box(&polygon).extreme_points());
+            criterion::black_box(criterion::black_box(&polygon).extremes());
         });
     });
 }

--- a/geo/src/algorithm/extremes.rs
+++ b/geo/src/algorithm/extremes.rs
@@ -28,11 +28,13 @@ pub trait Extremes<'a, T: CoordinateType> {
     fn extremes(&'a self) -> Option<Outcome<T>>;
 }
 
+#[derive(Debug, PartialEq)]
 pub struct Extreme<T: CoordinateType> {
     pub index: usize,
     pub coord: Coordinate<T>,
 }
 
+#[derive(Debug, PartialEq)]
 pub struct Outcome<T: CoordinateType> {
     pub x_min: Extreme<T>,
     pub y_min: Extreme<T>,
@@ -80,102 +82,50 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{point, polygon};
+    use crate::{MultiPoint, polygon};
 
-    /*
     #[test]
-    fn test_polygon_extreme_x() {
+    fn polygon() {
         // a diamond shape
-        let poly1 = polygon![
+        let polygon = polygon![
             (x: 1.0, y: 0.0),
             (x: 2.0, y: 1.0),
             (x: 1.0, y: 2.0),
             (x: 0.0, y: 1.0),
-            (x: 1.0, y: 0.0)
-        ];
-        let min_x = polymax_naive_indices(Coordinate { x: -1., y: 0. }, &poly1).unwrap();
-        let correct = 3_usize;
-        assert_eq!(min_x, correct);
-    }
-    #[test]
-    #[should_panic]
-    fn test_extreme_indices_bad_polygon() {
-        // non-convex, with a bump on the top-right edge
-        let poly1 = polygon![
             (x: 1.0, y: 0.0),
-            (x: 1.3, y: 1.),
-            (x: 2.0, y: 1.0),
-            (x: 1.75, y: 1.75),
-            (x: 1.0, y: 2.0),
-            (x: 0.0, y: 1.0),
-            (x: 1.0, y: 0.0)
         ];
-        let extremes = find_extreme_indices(polymax_naive_indices, &poly1).unwrap();
-        let correct = Extremes {
-            ymin: 0,
-            xmax: 1,
-            ymax: 3,
-            xmin: 4,
-        };
-        assert_eq!(extremes, correct);
-    }
-    #[test]
-    fn test_extreme_indices_good_polygon() {
-        // non-convex, with a bump on the top-right edge
-        let poly1 = polygon![
-            (x: 1.0, y: 0.0),
-            (x: 1.3, y: 1.),
-            (x: 2.0, y: 1.0),
-            (x: 1.75, y: 1.75),
-            (x: 1.0, y: 2.0),
-            (x: 0.0, y: 1.0),
-            (x: 1.0, y: 0.0)
-        ];
-        let extremes = find_extreme_indices(polymax_naive_indices, &poly1.convex_hull()).unwrap();
-        let correct = Extremes {
-            ymin: 0,
-            xmax: 1,
-            ymax: 3,
-            xmin: 4,
-        };
-        assert_eq!(extremes, correct);
-    }
-    #[test]
-    fn test_polygon_extreme_wrapper_convex() {
-        // convex, with a bump on the top-right edge
-        let poly1 = polygon![
-            (x: 1.0, y: 0.0),
-            (x: 2.0, y: 1.0),
-            (x: 1.75, y: 1.75),
-            (x: 1.0, y: 2.0),
-            (x: 0.0, y: 1.0),
-            (x: 1.0, y: 0.0)
-        ];
-        let extremes = find_extreme_indices(polymax_naive_indices, &poly1.convex_hull()).unwrap();
-        let correct = Extremes {
-            ymin: 0,
-            xmax: 1,
-            ymax: 3,
-            xmin: 4,
-        };
-        assert_eq!(extremes, correct);
-    }
-    */
 
-    /*
-    #[test]
-    fn test_polygon_extreme_point_x() {
-        // a diamond shape
-        let poly1 = polygon![
-            (x: 1.0, y: 0.0),
-            (x: 2.0, y: 1.0),
-            (x: 1.0, y: 2.0),
-            (x: 0.0, y: 1.0),
-            (x: 1.0, y: 0.0)
-        ];
-        let extremes = poly1.extreme_points();
-        let correct = point!(x: 0.0, y: 1.0);
-        assert_eq!(extremes.xmin, correct);
+        let actual = polygon.extremes();
+
+        assert_eq!(
+            Some(Outcome {
+                x_min: Extreme {
+                    index: 3,
+                    coord: Coordinate { x: 0.0, y: 1.0 }
+                },
+                y_min: Extreme {
+                    index: 0,
+                    coord: Coordinate { x: 1.0, y: 0.0 }
+                },
+                x_max: Extreme {
+                    index: 1,
+                    coord: Coordinate { x: 2.0, y: 1.0 }
+                },
+                y_max: Extreme {
+                    index: 2,
+                    coord: Coordinate { x: 1.0, y: 2.0 }
+                }
+            }),
+            actual
+        );
     }
-    */
+
+    #[test]
+    fn empty() {
+        let multi_point: MultiPoint<f32> = MultiPoint(vec![]);
+
+        let actual = multi_point.extremes();
+
+        assert!(actual.is_none());
+    }
 }

--- a/geo/src/algorithm/extremes.rs
+++ b/geo/src/algorithm/extremes.rs
@@ -46,7 +46,7 @@ where
     T: CoordinateType,
 {
     fn extremes(&'a self) -> Option<Outcome<T>> {
-        let mut iter = self.coords_iter().enumerate();
+        let mut iter = self.exterior_coords_iter().enumerate();
 
         let mut outcome = iter.next().map(|(index, coord)| Outcome {
             x_min: Extreme { index, coord },

--- a/geo/src/algorithm/extremes.rs
+++ b/geo/src/algorithm/extremes.rs
@@ -22,7 +22,7 @@ use crate::{Coordinate, CoordinateType};
 ///
 /// assert_eq!(extremes.y_max.index, 2);
 /// assert_eq!(extremes.y_max.coord.x, 1.);
-/// assert_eq!(extremes.y_max.coord.x, 2.);
+/// assert_eq!(extremes.y_max.coord.y, 2.);
 /// ```
 pub trait Extremes<'a, T: CoordinateType> {
     fn extremes(&'a self) -> Option<Outcome<T>>;

--- a/geo/src/algorithm/extremes.rs
+++ b/geo/src/algorithm/extremes.rs
@@ -7,7 +7,7 @@ use crate::{Coordinate, CoordinateType};
 ///
 /// ```
 /// use geo::extremes::Extremes;
-/// use geo::{Coordinate, polygon};
+/// use geo::polygon;
 ///
 /// // a diamond shape
 /// let polygon = polygon![
@@ -21,7 +21,8 @@ use crate::{Coordinate, CoordinateType};
 /// let extremes = polygon.extremes().unwrap();
 ///
 /// assert_eq!(extremes.y_max.index, 2);
-/// assert_eq!(extremes.y_max.coord, geo::Coordinate { x: 1., y: 2. });
+/// assert_eq!(extremes.y_max.coord.x, 1.);
+/// assert_eq!(extremes.y_max.coord.x, 2.);
 /// ```
 pub trait Extremes<'a, T: CoordinateType> {
     fn extremes(&'a self) -> Option<Outcome<T>>;

--- a/geo/src/algorithm/extremes.rs
+++ b/geo/src/algorithm/extremes.rs
@@ -1,73 +1,7 @@
-use super::kernels::*;
-use crate::prelude::*;
-use crate::*;
-use num_traits::Signed;
+use crate::algorithm::coords_iter::CoordsIter;
+use crate::{Coordinate, CoordinateType};
 
-// Useful direction vectors, aligned with x and y axes:
-// 1., 0. = largest x
-// 0., 1. = largest y
-// 0., -1. = smallest y
-// -1, 0. = smallest x
-
-/// Predicate that returns `true` if `vi` is (strictly) above `vj`
-/// along the direction of `u`
-fn above<T>(u: Coordinate<T>, vi: Coordinate<T>, vj: Coordinate<T>) -> bool
-where
-    T: CoordinateType + Signed + HasKernel,
-{
-    T::Ker::dot_product_sign(u, vi - vj) == Orientation::CounterClockwise
-}
-
-/// Predicate that returns `true` if `vi` is (strictly) below `vj`
-/// along the direction of `u`
-#[allow(dead_code)]
-fn below<T>(u: Coordinate<T>, vi: Coordinate<T>, vj: Coordinate<T>) -> bool
-where
-    T: CoordinateType + Signed + HasKernel,
-{
-    T::Ker::dot_product_sign(u, vi - vj) == Orientation::Clockwise
-}
-
-// wrapper for extreme-finding function
-fn find_extreme_indices<T, F>(func: F, polygon: &Polygon<T>) -> Result<Extremes, ()>
-where
-    T: HasKernel + Signed,
-    F: Fn(Coordinate<T>, &Polygon<T>) -> Result<usize, ()>,
-{
-    if !polygon.exterior().is_convex() {
-        return Err(());
-    }
-    let directions: Vec<Coordinate<_>> = vec![
-        (T::zero(), -T::one()).into(),
-        (T::one(), T::zero()).into(),
-        (T::zero(), T::one()).into(),
-        (-T::one(), T::zero()).into(),
-    ];
-    Ok(directions
-        .into_iter()
-        .map(|p| func(p, polygon).unwrap())
-        .collect::<Vec<usize>>()
-        .into())
-}
-
-// find a convex, counter-clockwise oriented polygon's maximum vertex in a specified direction
-// u: a direction vector. We're using a point to represent this, which is a hack but works fine
-fn polymax_naive_indices<T>(u: Coordinate<T>, poly: &Polygon<T>) -> Result<usize, ()>
-where
-    T: HasKernel + Signed,
-{
-    let vertices = &poly.exterior().0;
-    let mut max: usize = 0;
-    for (i, _) in vertices.iter().enumerate() {
-        // if vertices[i] is above prior vertices[max]
-        if above(u, vertices[i], vertices[max]) {
-            max = i;
-        }
-    }
-    Ok(max)
-}
-
-pub trait ExtremeIndices {
+pub trait Extremes<'a, T: CoordinateType> {
     /// Find the extreme `x` and `y` _indices_ of a convex Polygon
     ///
     /// The polygon **must be convex and properly (ccw) oriented**.
@@ -95,82 +29,59 @@ pub trait ExtremeIndices {
     /// assert_eq!(extremes.ymax, 2);
     /// assert_eq!(extremes.xmin, 3);
     /// ```
-    fn extreme_indices(&self) -> Result<Extremes, ()>;
+    fn extremes(&'a self) -> Option<Outcome<T>>;
 }
 
-impl<T> ExtremeIndices for Polygon<T>
+pub struct Extreme<T: CoordinateType> {
+    pub index: usize,
+    pub coord: Coordinate<T>,
+}
+
+pub struct Outcome<T: CoordinateType> {
+    pub x_min: Extreme<T>,
+    pub y_min: Extreme<T>,
+    pub x_max: Extreme<T>,
+    pub y_max: Extreme<T>,
+}
+
+impl<'a, T, G> Extremes<'a, T> for G
 where
-    T: Signed + HasKernel,
+    G: CoordsIter<'a, Scalar = T>,
+    T: CoordinateType,
 {
-    fn extreme_indices(&self) -> Result<Extremes, ()> {
-        find_extreme_indices(polymax_naive_indices, self)
-    }
-}
+    fn extremes(&'a self) -> Option<Outcome<T>> {
+        let mut iter = self.coords_iter().enumerate();
 
-impl<T> ExtremeIndices for MultiPolygon<T>
-where
-    T: Signed + HasKernel,
-{
-    fn extreme_indices(&self) -> Result<Extremes, ()> {
-        find_extreme_indices(polymax_naive_indices, &self.convex_hull())
-    }
-}
+        let mut outcome = iter.next().map(|(index, coord)| Outcome {
+            x_min: Extreme { index, coord },
+            y_min: Extreme { index, coord },
+            x_max: Extreme { index, coord },
+            y_max: Extreme { index, coord },
+        })?;
 
-impl<T> ExtremeIndices for MultiPoint<T>
-where
-    T: Signed + HasKernel,
-{
-    fn extreme_indices(&self) -> Result<Extremes, ()> {
-        find_extreme_indices(polymax_naive_indices, &self.convex_hull())
-    }
-}
+        for (i, coord) in iter {
+            if coord.x < outcome.x_min.coord.x {
+                outcome.x_min.index = i;
+                outcome.x_min.coord = coord;
+            }
 
-pub trait ExtremePoints {
-    type Scalar: CoordinateType;
-    /// Find the extreme `x` and `y` `Point`s of a Geometry
-    ///
-    /// This trait is available to any struct implementing both `ConvexHull` amd `ExtremeIndices`
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use geo::extremes::ExtremePoints;
-    /// use geo::{point, polygon};
-    ///
-    /// // a diamond shape
-    /// let polygon = polygon![
-    ///     (x: 1.0, y: 0.0),
-    ///     (x: 2.0, y: 1.0),
-    ///     (x: 1.0, y: 2.0),
-    ///     (x: 0.0, y: 1.0),
-    ///     (x: 1.0, y: 0.0),
-    /// ];
-    ///
-    /// let extremes = polygon.extreme_points();
-    ///
-    /// assert_eq!(extremes.xmin, point!(x: 0., y: 1.));
-    /// ```
-    fn extreme_points(&self) -> ExtremePoint<Self::Scalar>;
-}
+            if coord.y < outcome.y_min.coord.y {
+                outcome.y_min.index = i;
+                outcome.y_min.coord = coord;
+            }
 
-impl<T, G> ExtremePoints for G
-where
-    T: Signed + HasKernel,
-    G: ConvexHull<Scalar = T> + ExtremeIndices,
-{
-    type Scalar = T;
+            if coord.x > outcome.x_max.coord.x {
+                outcome.x_max.index = i;
+                outcome.x_max.coord = coord;
+            }
 
-    // Any Geometry implementing `ConvexHull` and `ExtremeIndices` gets this automatically
-    fn extreme_points(&self) -> ExtremePoint<T> {
-        let ch = self.convex_hull();
-        // safe to unwrap, since we're guaranteeing the polygon's convexity
-        let indices = ch.extreme_indices().unwrap();
-        ExtremePoint {
-            ymin: Point(ch.exterior().0[indices.ymin]),
-            xmax: Point(ch.exterior().0[indices.xmax]),
-            ymax: Point(ch.exterior().0[indices.ymax]),
-            xmin: Point(ch.exterior().0[indices.xmin]),
+            if coord.y > outcome.y_max.coord.y {
+                outcome.y_max.index = i;
+                outcome.y_max.coord = coord;
+            }
         }
+
+        Some(outcome)
     }
 }
 
@@ -179,6 +90,7 @@ mod test {
     use super::*;
     use crate::{point, polygon};
 
+    /*
     #[test]
     fn test_polygon_extreme_x() {
         // a diamond shape
@@ -256,7 +168,9 @@ mod test {
         };
         assert_eq!(extremes, correct);
     }
+    */
 
+    /*
     #[test]
     fn test_polygon_extreme_point_x() {
         // a diamond shape
@@ -271,4 +185,5 @@ mod test {
         let correct = point!(x: 0.0, y: 1.0);
         assert_eq!(extremes.xmin, correct);
     }
+    */
 }

--- a/geo/src/algorithm/extremes.rs
+++ b/geo/src/algorithm/extremes.rs
@@ -9,8 +9,8 @@ pub trait Extremes<'a, T: CoordinateType> {
     /// # Examples
     ///
     /// ```
-    /// use geo::extremes::ExtremeIndices;
-    /// use geo::polygon;
+    /// use geo::extremes::Extremes;
+    /// use geo::{Coordinate, polygon};
     ///
     /// // a diamond shape
     /// let polygon = polygon![
@@ -22,12 +22,10 @@ pub trait Extremes<'a, T: CoordinateType> {
     /// ];
     ///
     /// // Polygon is both convex and oriented counter-clockwise
-    /// let extremes = polygon.extreme_indices().unwrap();
+    /// let extremes = polygon.extremes().unwrap();
     ///
-    /// assert_eq!(extremes.ymin, 0);
-    /// assert_eq!(extremes.xmax, 1);
-    /// assert_eq!(extremes.ymax, 2);
-    /// assert_eq!(extremes.xmin, 3);
+    /// assert_eq!(extremes.y_max.index, 2);
+    /// assert_eq!(extremes.y_max.coord, geo::Coordinate { x: 1., y: 2. });
     /// ```
     fn extremes(&'a self) -> Option<Outcome<T>>;
 }

--- a/geo/src/algorithm/extremes.rs
+++ b/geo/src/algorithm/extremes.rs
@@ -1,32 +1,29 @@
 use crate::algorithm::coords_iter::CoordsIter;
 use crate::{Coordinate, CoordinateType};
 
+/// Find the extreme coordinates and indices of a geometry.
+///
+/// # Examples
+///
+/// ```
+/// use geo::extremes::Extremes;
+/// use geo::{Coordinate, polygon};
+///
+/// // a diamond shape
+/// let polygon = polygon![
+///     (x: 1.0, y: 0.0),
+///     (x: 2.0, y: 1.0),
+///     (x: 1.0, y: 2.0),
+///     (x: 0.0, y: 1.0),
+///     (x: 1.0, y: 0.0),
+/// ];
+///
+/// let extremes = polygon.extremes().unwrap();
+///
+/// assert_eq!(extremes.y_max.index, 2);
+/// assert_eq!(extremes.y_max.coord, geo::Coordinate { x: 1., y: 2. });
+/// ```
 pub trait Extremes<'a, T: CoordinateType> {
-    /// Find the extreme `x` and `y` _indices_ of a convex Polygon
-    ///
-    /// The polygon **must be convex and properly (ccw) oriented**.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use geo::extremes::Extremes;
-    /// use geo::{Coordinate, polygon};
-    ///
-    /// // a diamond shape
-    /// let polygon = polygon![
-    ///     (x: 1.0, y: 0.0),
-    ///     (x: 2.0, y: 1.0),
-    ///     (x: 1.0, y: 2.0),
-    ///     (x: 0.0, y: 1.0),
-    ///     (x: 1.0, y: 0.0),
-    /// ];
-    ///
-    /// // Polygon is both convex and oriented counter-clockwise
-    /// let extremes = polygon.extremes().unwrap();
-    ///
-    /// assert_eq!(extremes.y_max.index, 2);
-    /// assert_eq!(extremes.y_max.coord, geo::Coordinate { x: 1., y: 2. });
-    /// ```
     fn extremes(&'a self) -> Option<Outcome<T>>;
 }
 

--- a/geo/src/algorithm/extremes.rs
+++ b/geo/src/algorithm/extremes.rs
@@ -55,25 +55,21 @@ where
             y_max: Extreme { index, coord },
         })?;
 
-        for (i, coord) in iter {
+        for (index, coord) in iter {
             if coord.x < outcome.x_min.coord.x {
-                outcome.x_min.index = i;
-                outcome.x_min.coord = coord;
+                outcome.x_min = Extreme { coord, index };
             }
 
             if coord.y < outcome.y_min.coord.y {
-                outcome.y_min.index = i;
-                outcome.y_min.coord = coord;
+                outcome.y_min = Extreme { coord, index };
             }
 
             if coord.x > outcome.x_max.coord.x {
-                outcome.x_max.index = i;
-                outcome.x_max.coord = coord;
+                outcome.x_max = Extreme { coord, index };
             }
 
             if coord.y > outcome.y_max.coord.y {
-                outcome.y_max.index = i;
-                outcome.y_max.coord = coord;
+                outcome.y_max = Extreme { coord, index };
             }
         }
 

--- a/geo/src/algorithm/mod.rs
+++ b/geo/src/algorithm/mod.rs
@@ -29,7 +29,7 @@ pub mod dimensions;
 pub mod euclidean_distance;
 /// Calculate the length of a planar line between two `Geometries`.
 pub mod euclidean_length;
-/// Calculate the extreme indices of a `Polygon`, `MultiPolygon`, or `MultiPoint`.
+/// Calculate the extreme coordinates and indices of a geometry.
 pub mod extremes;
 /// Calculate the Frechet distance between two `LineStrings`.
 pub mod frechet_distance;

--- a/geo/src/algorithm/polygon_distance_fast_path.rs
+++ b/geo/src/algorithm/polygon_distance_fast_path.rs
@@ -1,4 +1,4 @@
-use crate::algorithm::extremes::ExtremeIndices;
+use crate::algorithm::extremes::Extremes;
 use crate::kernels::*;
 use crate::prelude::*;
 use crate::{Line, Point, Polygon, Triangle};
@@ -15,10 +15,10 @@ pub(crate) fn min_poly_dist<T>(poly1: &Polygon<T>, poly2: &Polygon<T>) -> T
 where
     T: Float + FloatConst + Signed + HasKernel,
 {
-    let poly1_extremes = poly1.extreme_indices().unwrap();
-    let poly2_extremes = poly2.extreme_indices().unwrap();
-    let ymin1 = Point(poly1.exterior().0[poly1_extremes.ymin]);
-    let ymax2 = Point(poly2.exterior().0[poly2_extremes.ymax]);
+    let poly1_extremes = poly1.extremes().unwrap();
+    let poly2_extremes = poly2.extremes().unwrap();
+    let ymin1 = Point(poly1.exterior().0[poly1_extremes.y_min.index]);
+    let ymax2 = Point(poly2.exterior().0[poly2_extremes.y_max.index]);
 
     let mut state = Polydist {
         poly1,
@@ -27,9 +27,9 @@ where
         ymin1,
         ymax2,
         // initial polygon 1 min y idx
-        p1_idx: poly1_extremes.ymin,
+        p1_idx: poly1_extremes.y_min.index,
         // initial polygon 2 max y idx
-        q2_idx: poly2_extremes.ymax,
+        q2_idx: poly2_extremes.y_max.index,
         // set p1 and q2 to p1ymin and p2ymax initially
         p1: ymin1,
         q2: ymax2,

--- a/geo/src/lib.rs
+++ b/geo/src/lib.rs
@@ -101,7 +101,7 @@ pub mod prelude {
     pub use crate::algorithm::dimensions::HasDimensions;
     pub use crate::algorithm::euclidean_distance::EuclideanDistance;
     pub use crate::algorithm::euclidean_length::EuclideanLength;
-    pub use crate::algorithm::extremes::ExtremePoints;
+    pub use crate::algorithm::extremes::Extremes;
     pub use crate::algorithm::frechet_distance::FrechetDistance;
     pub use crate::algorithm::geodesic_distance::GeodesicDistance;
     pub use crate::algorithm::geodesic_length::GeodesicLength;

--- a/geo/src/types.rs
+++ b/geo/src/types.rs
@@ -1,4 +1,4 @@
-use crate::{CoordinateType, GeoFloat, Point};
+use crate::{GeoFloat, Point};
 
 /// The result of trying to find the closest spot on an object to a point.
 #[cfg_attr(feature = "use-serde", derive(Serialize, Deserialize))]

--- a/geo/src/types.rs
+++ b/geo/src/types.rs
@@ -1,39 +1,5 @@
 use crate::{CoordinateType, GeoFloat, Point};
 
-/// A container for _indices_ of the minimum and maximum `Point`s of a [`Geometry`](enum.Geometry.html).
-#[cfg_attr(feature = "use-serde", derive(Serialize, Deserialize))]
-#[derive(PartialEq, Clone, Copy, Debug)]
-pub struct Extremes {
-    pub ymin: usize,
-    pub xmax: usize,
-    pub ymax: usize,
-    pub xmin: usize,
-}
-
-impl From<Vec<usize>> for Extremes {
-    fn from(original: Vec<usize>) -> Extremes {
-        Extremes {
-            ymin: original[0],
-            xmax: original[1],
-            ymax: original[2],
-            xmin: original[3],
-        }
-    }
-}
-
-/// A container for the _coordinates_ of the minimum and maximum `Point`s of a [`Geometry`](enum.Geometry.html).
-#[cfg_attr(feature = "use-serde", derive(Serialize, Deserialize))]
-#[derive(PartialEq, Clone, Copy, Debug)]
-pub struct ExtremePoint<T>
-where
-    T: CoordinateType,
-{
-    pub ymin: Point<T>,
-    pub xmax: Point<T>,
-    pub ymax: Point<T>,
-    pub xmin: Point<T>,
-}
-
 /// The result of trying to find the closest spot on an object to a point.
 #[cfg_attr(feature = "use-serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, Copy, PartialEq)]


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

* Added
    * `geo::algorithm::extremes::Extremes` (trait)
    * `geo::algorithm::extremes::Outcome` (struct)
    * `geo::algorithm::extremes::Extreme` (struct)
* Removed
    * `geo::algorithm::extremes::ExtremeIndices` (trait)
    * `geo::algorithm::extremes::ExtremePoints` (trait)
    * `geo::Extremes` (struct)

The `Extremes` algorithm is now based on `CoordsIter` instead of `ConvexHull`. The trait now runs 6x faster than the previous implementation:

![Screen Shot 2021-01-06 at 12 26 13 PM](https://user-images.githubusercontent.com/416575/104126665-d78d6880-532b-11eb-9489-642e0068b9db.png)

This speeds up any algorithms that incorporate `Extremes`, like `Polygon` to `Polygon` distance:

![Screen Shot 2021-01-06 at 12 28 59 PM](https://user-images.githubusercontent.com/416575/104126680-e542ee00-532b-11eb-8cbb-868de0eeb97d.png)
