### PR TITLE
Migrate CoordsIter::T to be an associated type.

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -17,6 +17,8 @@
   * <https://github.com/georust/geo/pull/584>
 * Performance improvements to `simplify`
   * <https://github.com/georust/geo/pull/584>
+* The `T` generic parameter for `CoordsIter` is now an associated type
+  * <https://github.com/georust/geo/pull/593>
 
 
 ## 0.16.0


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

# Previously

With the previous design, this would compile:

```rust
impl<'a> CoordsIter<'a, f32> for Polygon<f32> {
    ...
}

impl<'a> CoordsIter<'a, f64> for Polygon<f32> {
    ...
}
```

Even though this is not what our implementations actually look like, to the compiler it's possible for there to be multiple implementations of `CoordsIter` for `Polygon<f32>`.

This was problematic when [I started rewriting](https://github.com/georust/geo/pull/592) our `ExtremeIndices` trait to be generic over any type that implements `CoordsIter`:

```rust
impl<'a, T, G> ExtremeIndices for G
where
    T: CoordinateType,
    G: CoordsIter<'a, T>,
{
    fn extreme_indices(&self) -> Result<Extremes, ()> {
        ...
    }
}
```

This is the compilation error:

```
the type parameter `T` is not constrained by the impl trait, self type, or predicates
```

The issue is that if someone writes this with this new `ExtremeIndices` implementation:

```rust
let p: Polygon<f32> = polygon![...];
p.extreme_indices()
```

The compiler doesn't know which implementation to choose: `impl<'a> CoordsIter<'a, f32> for Polygon<f32>` or `impl<'a> CoordsIter<'a, f64> for Polygon<f32>`.

So we need a way to tell the compiler we only have _one_ implementation of `CoordsIter` per type. The root issue being that there is a free generic parameter in the `CoordsIter` definition.

# Now

To fix this, we will move the `T` type parameter to an associated type. Writing this would be a compiler error:

```rust
impl<'a> CoordsIter<'a> for Polygon<f32> {
    type Scalar = f32;
    ...
}

impl<'a> CoordsIter<'a> for Polygon<f32> {
    type Scalar = f64;
    ...
}
```

```
conflicting implementations of trait `algorithm::coords_iter::CoordsIter<'_>` for type `geo_types::Polygon<f32>`
```

This unblocks https://github.com/georust/geo/pull/592