### PR TITLE
+Debug for CoordinateType

### DIFF
--- a/geo-types/src/coordinate.rs
+++ b/geo-types/src/coordinate.rs
@@ -1,4 +1,4 @@
-use crate::{CoordinateType, Point};
+use crate::{CoordNum, Point};
 
 #[cfg(any(feature = "approx", test))]
 use approx::{AbsDiffEq, RelativeEq, UlpsEq};
@@ -27,13 +27,13 @@ use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Coordinate<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     pub x: T,
     pub y: T,
 }
 
-impl<T: CoordinateType> From<(T, T)> for Coordinate<T> {
+impl<T: CoordNum> From<(T, T)> for Coordinate<T> {
     fn from(coords: (T, T)) -> Self {
         Coordinate {
             x: coords.0,
@@ -42,7 +42,7 @@ impl<T: CoordinateType> From<(T, T)> for Coordinate<T> {
     }
 }
 
-impl<T: CoordinateType> From<[T; 2]> for Coordinate<T> {
+impl<T: CoordNum> From<[T; 2]> for Coordinate<T> {
     fn from(coords: [T; 2]) -> Self {
         Coordinate {
             x: coords[0],
@@ -51,7 +51,7 @@ impl<T: CoordinateType> From<[T; 2]> for Coordinate<T> {
     }
 }
 
-impl<T: CoordinateType> From<Point<T>> for Coordinate<T> {
+impl<T: CoordNum> From<Point<T>> for Coordinate<T> {
     fn from(point: Point<T>) -> Self {
         Coordinate {
             x: point.x(),
@@ -62,7 +62,7 @@ impl<T: CoordinateType> From<Point<T>> for Coordinate<T> {
 
 impl<T> Coordinate<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     /// Returns a tuple that contains the x/horizontal & y/vertical component of the coordinate.
     ///
@@ -102,7 +102,7 @@ use std::ops::{Add, Div, Mul, Neg, Sub};
 /// ```
 impl<T> Neg for Coordinate<T>
 where
-    T: CoordinateType + Neg<Output = T>,
+    T: CoordNum + Neg<Output = T>,
 {
     type Output = Coordinate<T>;
 
@@ -127,7 +127,7 @@ where
 /// ```
 impl<T> Add for Coordinate<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     type Output = Coordinate<T>;
 
@@ -152,7 +152,7 @@ where
 /// ```
 impl<T> Sub for Coordinate<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     type Output = Coordinate<T>;
 
@@ -176,7 +176,7 @@ where
 /// ```
 impl<T> Mul<T> for Coordinate<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     type Output = Coordinate<T>;
 
@@ -200,7 +200,7 @@ where
 /// ```
 impl<T> Div<T> for Coordinate<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     type Output = Coordinate<T>;
 
@@ -223,7 +223,7 @@ use num_traits::Zero;
 /// assert_eq!(p.x, 0.);
 /// assert_eq!(p.y, 0.);
 /// ```
-impl<T: CoordinateType> Coordinate<T> {
+impl<T: CoordNum> Coordinate<T> {
     pub fn zero() -> Self {
         Coordinate {
             x: T::zero(),
@@ -232,7 +232,7 @@ impl<T: CoordinateType> Coordinate<T> {
     }
 }
 
-impl<T: CoordinateType> Zero for Coordinate<T> {
+impl<T: CoordNum> Zero for Coordinate<T> {
     fn zero() -> Self {
         Coordinate::zero()
     }
@@ -242,7 +242,7 @@ impl<T: CoordinateType> Zero for Coordinate<T> {
 }
 
 #[cfg(any(feature = "approx", test))]
-impl<T: CoordinateType + AbsDiffEq> AbsDiffEq for Coordinate<T>
+impl<T: CoordNum + AbsDiffEq> AbsDiffEq for Coordinate<T>
 where
     T::Epsilon: Copy,
 {
@@ -260,7 +260,7 @@ where
 }
 
 #[cfg(any(feature = "approx", test))]
-impl<T: CoordinateType + RelativeEq> RelativeEq for Coordinate<T>
+impl<T: CoordNum + RelativeEq> RelativeEq for Coordinate<T>
 where
     T::Epsilon: Copy,
 {
@@ -277,7 +277,7 @@ where
 }
 
 #[cfg(any(feature = "approx", test))]
-impl<T: CoordinateType + UlpsEq> UlpsEq for Coordinate<T>
+impl<T: CoordNum + UlpsEq> UlpsEq for Coordinate<T>
 where
     T::Epsilon: Copy,
 {

--- a/geo-types/src/geometry.rs
+++ b/geo-types/src/geometry.rs
@@ -2,7 +2,6 @@ use crate::{
     CoordinateType, GeometryCollection, Line, LineString, MultiLineString, MultiPoint,
     MultiPolygon, Point, Polygon, Rect, Triangle,
 };
-use num_traits::Float;
 use std::convert::TryFrom;
 use std::error::Error;
 use std::fmt;
@@ -198,10 +197,7 @@ impl Error for FailedToConvertError {
     }
 }
 
-impl<T> TryFrom<Geometry<T>> for Point<T>
-where
-    T: Float,
-{
+impl<T: CoordinateType> TryFrom<Geometry<T>> for Point<T> {
     type Error = FailedToConvertError;
 
     fn try_from(geom: Geometry<T>) -> Result<Point<T>, Self::Error> {
@@ -212,10 +208,7 @@ where
     }
 }
 
-impl<T> TryFrom<Geometry<T>> for Line<T>
-where
-    T: Float,
-{
+impl<T: CoordinateType> TryFrom<Geometry<T>> for Line<T> {
     type Error = FailedToConvertError;
 
     fn try_from(geom: Geometry<T>) -> Result<Line<T>, Self::Error> {
@@ -226,10 +219,7 @@ where
     }
 }
 
-impl<T> TryFrom<Geometry<T>> for LineString<T>
-where
-    T: Float,
-{
+impl<T: CoordinateType> TryFrom<Geometry<T>> for LineString<T> {
     type Error = FailedToConvertError;
 
     fn try_from(geom: Geometry<T>) -> Result<LineString<T>, Self::Error> {
@@ -240,10 +230,7 @@ where
     }
 }
 
-impl<T> TryFrom<Geometry<T>> for Polygon<T>
-where
-    T: Float,
-{
+impl<T: CoordinateType> TryFrom<Geometry<T>> for Polygon<T> {
     type Error = FailedToConvertError;
 
     fn try_from(geom: Geometry<T>) -> Result<Polygon<T>, Self::Error> {
@@ -254,10 +241,7 @@ where
     }
 }
 
-impl<T> TryFrom<Geometry<T>> for MultiPoint<T>
-where
-    T: Float,
-{
+impl<T: CoordinateType> TryFrom<Geometry<T>> for MultiPoint<T> {
     type Error = FailedToConvertError;
 
     fn try_from(geom: Geometry<T>) -> Result<MultiPoint<T>, Self::Error> {
@@ -268,10 +252,7 @@ where
     }
 }
 
-impl<T> TryFrom<Geometry<T>> for MultiLineString<T>
-where
-    T: Float,
-{
+impl<T: CoordinateType> TryFrom<Geometry<T>> for MultiLineString<T> {
     type Error = FailedToConvertError;
 
     fn try_from(geom: Geometry<T>) -> Result<MultiLineString<T>, Self::Error> {
@@ -282,10 +263,7 @@ where
     }
 }
 
-impl<T> TryFrom<Geometry<T>> for MultiPolygon<T>
-where
-    T: Float,
-{
+impl<T: CoordinateType> TryFrom<Geometry<T>> for MultiPolygon<T> {
     type Error = FailedToConvertError;
 
     fn try_from(geom: Geometry<T>) -> Result<MultiPolygon<T>, Self::Error> {

--- a/geo-types/src/geometry.rs
+++ b/geo-types/src/geometry.rs
@@ -1,6 +1,6 @@
 use crate::{
-    CoordinateType, GeometryCollection, Line, LineString, MultiLineString, MultiPoint,
-    MultiPolygon, Point, Polygon, Rect, Triangle,
+    CoordNum, GeometryCollection, Line, LineString, MultiLineString, MultiPoint, MultiPolygon,
+    Point, Polygon, Rect, Triangle,
 };
 use std::convert::TryFrom;
 use std::error::Error;
@@ -25,7 +25,7 @@ use std::fmt;
 #[derive(Eq, PartialEq, Clone, Debug, Hash)]
 pub enum Geometry<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     Point(Point<T>),
     Line(Line<T>),
@@ -39,55 +39,55 @@ where
     Triangle(Triangle<T>),
 }
 
-impl<T: CoordinateType> From<Point<T>> for Geometry<T> {
+impl<T: CoordNum> From<Point<T>> for Geometry<T> {
     fn from(x: Point<T>) -> Geometry<T> {
         Geometry::Point(x)
     }
 }
-impl<T: CoordinateType> From<Line<T>> for Geometry<T> {
+impl<T: CoordNum> From<Line<T>> for Geometry<T> {
     fn from(x: Line<T>) -> Geometry<T> {
         Geometry::Line(x)
     }
 }
-impl<T: CoordinateType> From<LineString<T>> for Geometry<T> {
+impl<T: CoordNum> From<LineString<T>> for Geometry<T> {
     fn from(x: LineString<T>) -> Geometry<T> {
         Geometry::LineString(x)
     }
 }
-impl<T: CoordinateType> From<Polygon<T>> for Geometry<T> {
+impl<T: CoordNum> From<Polygon<T>> for Geometry<T> {
     fn from(x: Polygon<T>) -> Geometry<T> {
         Geometry::Polygon(x)
     }
 }
-impl<T: CoordinateType> From<MultiPoint<T>> for Geometry<T> {
+impl<T: CoordNum> From<MultiPoint<T>> for Geometry<T> {
     fn from(x: MultiPoint<T>) -> Geometry<T> {
         Geometry::MultiPoint(x)
     }
 }
-impl<T: CoordinateType> From<MultiLineString<T>> for Geometry<T> {
+impl<T: CoordNum> From<MultiLineString<T>> for Geometry<T> {
     fn from(x: MultiLineString<T>) -> Geometry<T> {
         Geometry::MultiLineString(x)
     }
 }
-impl<T: CoordinateType> From<MultiPolygon<T>> for Geometry<T> {
+impl<T: CoordNum> From<MultiPolygon<T>> for Geometry<T> {
     fn from(x: MultiPolygon<T>) -> Geometry<T> {
         Geometry::MultiPolygon(x)
     }
 }
 
-impl<T: CoordinateType> From<Rect<T>> for Geometry<T> {
+impl<T: CoordNum> From<Rect<T>> for Geometry<T> {
     fn from(x: Rect<T>) -> Geometry<T> {
         Geometry::Rect(x)
     }
 }
 
-impl<T: CoordinateType> From<Triangle<T>> for Geometry<T> {
+impl<T: CoordNum> From<Triangle<T>> for Geometry<T> {
     fn from(x: Triangle<T>) -> Geometry<T> {
         Geometry::Triangle(x)
     }
 }
 
-impl<T: CoordinateType> Geometry<T> {
+impl<T: CoordNum> Geometry<T> {
     /// If this Geometry is a Point, then return that, else None.
     ///
     /// # Examples
@@ -197,7 +197,7 @@ impl Error for FailedToConvertError {
     }
 }
 
-impl<T: CoordinateType> TryFrom<Geometry<T>> for Point<T> {
+impl<T: CoordNum> TryFrom<Geometry<T>> for Point<T> {
     type Error = FailedToConvertError;
 
     fn try_from(geom: Geometry<T>) -> Result<Point<T>, Self::Error> {
@@ -208,7 +208,7 @@ impl<T: CoordinateType> TryFrom<Geometry<T>> for Point<T> {
     }
 }
 
-impl<T: CoordinateType> TryFrom<Geometry<T>> for Line<T> {
+impl<T: CoordNum> TryFrom<Geometry<T>> for Line<T> {
     type Error = FailedToConvertError;
 
     fn try_from(geom: Geometry<T>) -> Result<Line<T>, Self::Error> {
@@ -219,7 +219,7 @@ impl<T: CoordinateType> TryFrom<Geometry<T>> for Line<T> {
     }
 }
 
-impl<T: CoordinateType> TryFrom<Geometry<T>> for LineString<T> {
+impl<T: CoordNum> TryFrom<Geometry<T>> for LineString<T> {
     type Error = FailedToConvertError;
 
     fn try_from(geom: Geometry<T>) -> Result<LineString<T>, Self::Error> {
@@ -230,7 +230,7 @@ impl<T: CoordinateType> TryFrom<Geometry<T>> for LineString<T> {
     }
 }
 
-impl<T: CoordinateType> TryFrom<Geometry<T>> for Polygon<T> {
+impl<T: CoordNum> TryFrom<Geometry<T>> for Polygon<T> {
     type Error = FailedToConvertError;
 
     fn try_from(geom: Geometry<T>) -> Result<Polygon<T>, Self::Error> {
@@ -241,7 +241,7 @@ impl<T: CoordinateType> TryFrom<Geometry<T>> for Polygon<T> {
     }
 }
 
-impl<T: CoordinateType> TryFrom<Geometry<T>> for MultiPoint<T> {
+impl<T: CoordNum> TryFrom<Geometry<T>> for MultiPoint<T> {
     type Error = FailedToConvertError;
 
     fn try_from(geom: Geometry<T>) -> Result<MultiPoint<T>, Self::Error> {
@@ -252,7 +252,7 @@ impl<T: CoordinateType> TryFrom<Geometry<T>> for MultiPoint<T> {
     }
 }
 
-impl<T: CoordinateType> TryFrom<Geometry<T>> for MultiLineString<T> {
+impl<T: CoordNum> TryFrom<Geometry<T>> for MultiLineString<T> {
     type Error = FailedToConvertError;
 
     fn try_from(geom: Geometry<T>) -> Result<MultiLineString<T>, Self::Error> {
@@ -263,7 +263,7 @@ impl<T: CoordinateType> TryFrom<Geometry<T>> for MultiLineString<T> {
     }
 }
 
-impl<T: CoordinateType> TryFrom<Geometry<T>> for MultiPolygon<T> {
+impl<T: CoordNum> TryFrom<Geometry<T>> for MultiPolygon<T> {
     type Error = FailedToConvertError;
 
     fn try_from(geom: Geometry<T>) -> Result<MultiPolygon<T>, Self::Error> {

--- a/geo-types/src/geometry_collection.rs
+++ b/geo-types/src/geometry_collection.rs
@@ -1,4 +1,4 @@
-use crate::{CoordinateType, Geometry};
+use crate::{CoordNum, Geometry};
 use std::iter::FromIterator;
 use std::ops::{Index, IndexMut};
 
@@ -69,15 +69,15 @@ use std::ops::{Index, IndexMut};
 #[derive(Eq, PartialEq, Clone, Debug, Hash)]
 pub struct GeometryCollection<T>(pub Vec<Geometry<T>>)
 where
-    T: CoordinateType;
+    T: CoordNum;
 
-impl<T: CoordinateType> Default for GeometryCollection<T> {
+impl<T: CoordNum> Default for GeometryCollection<T> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<T: CoordinateType> GeometryCollection<T> {
+impl<T: CoordNum> GeometryCollection<T> {
     /// Return an empty GeometryCollection
     pub fn new() -> GeometryCollection<T> {
         GeometryCollection(Vec::new())
@@ -96,20 +96,20 @@ impl<T: CoordinateType> GeometryCollection<T> {
 
 /// Convert any Geometry (or anything that can be converted to a Geometry) into a
 /// GeometryCollection
-impl<T: CoordinateType, IG: Into<Geometry<T>>> From<IG> for GeometryCollection<T> {
+impl<T: CoordNum, IG: Into<Geometry<T>>> From<IG> for GeometryCollection<T> {
     fn from(x: IG) -> Self {
         GeometryCollection(vec![x.into()])
     }
 }
 
 /// Collect Geometries (or what can be converted to a Geometry) into a GeometryCollection
-impl<T: CoordinateType, IG: Into<Geometry<T>>> FromIterator<IG> for GeometryCollection<T> {
+impl<T: CoordNum, IG: Into<Geometry<T>>> FromIterator<IG> for GeometryCollection<T> {
     fn from_iter<I: IntoIterator<Item = IG>>(iter: I) -> Self {
         GeometryCollection(iter.into_iter().map(|g| g.into()).collect())
     }
 }
 
-impl<T: CoordinateType> Index<usize> for GeometryCollection<T> {
+impl<T: CoordNum> Index<usize> for GeometryCollection<T> {
     type Output = Geometry<T>;
 
     fn index(&self, index: usize) -> &Geometry<T> {
@@ -117,7 +117,7 @@ impl<T: CoordinateType> Index<usize> for GeometryCollection<T> {
     }
 }
 
-impl<T: CoordinateType> IndexMut<usize> for GeometryCollection<T> {
+impl<T: CoordNum> IndexMut<usize> for GeometryCollection<T> {
     fn index_mut(&mut self, index: usize) -> &mut Geometry<T> {
         self.0.index_mut(index)
     }
@@ -125,13 +125,13 @@ impl<T: CoordinateType> IndexMut<usize> for GeometryCollection<T> {
 
 // structure helper for consuming iterator
 #[derive(Debug)]
-pub struct IntoIteratorHelper<T: CoordinateType> {
+pub struct IntoIteratorHelper<T: CoordNum> {
     iter: ::std::vec::IntoIter<Geometry<T>>,
 }
 
 // implement the IntoIterator trait for a consuming iterator. Iteration will
 // consume the GeometryCollection
-impl<T: CoordinateType> IntoIterator for GeometryCollection<T> {
+impl<T: CoordNum> IntoIterator for GeometryCollection<T> {
     type Item = Geometry<T>;
     type IntoIter = IntoIteratorHelper<T>;
 
@@ -144,7 +144,7 @@ impl<T: CoordinateType> IntoIterator for GeometryCollection<T> {
 }
 
 // implement Iterator trait for the helper struct, to be used by adapters
-impl<T: CoordinateType> Iterator for IntoIteratorHelper<T> {
+impl<T: CoordNum> Iterator for IntoIteratorHelper<T> {
     type Item = Geometry<T>;
 
     // just return the reference
@@ -155,13 +155,13 @@ impl<T: CoordinateType> Iterator for IntoIteratorHelper<T> {
 
 // structure helper for non-consuming iterator
 #[derive(Debug)]
-pub struct IterHelper<'a, T: CoordinateType> {
+pub struct IterHelper<'a, T: CoordNum> {
     iter: ::std::slice::Iter<'a, Geometry<T>>,
 }
 
 // implement the IntoIterator trait for a non-consuming iterator. Iteration will
 // borrow the GeometryCollection
-impl<'a, T: CoordinateType> IntoIterator for &'a GeometryCollection<T> {
+impl<'a, T: CoordNum> IntoIterator for &'a GeometryCollection<T> {
     type Item = &'a Geometry<T>;
     type IntoIter = IterHelper<'a, T>;
 
@@ -174,7 +174,7 @@ impl<'a, T: CoordinateType> IntoIterator for &'a GeometryCollection<T> {
 }
 
 // implement the Iterator trait for the helper struct, to be used by adapters
-impl<'a, T: CoordinateType> Iterator for IterHelper<'a, T> {
+impl<'a, T: CoordNum> Iterator for IterHelper<'a, T> {
     type Item = &'a Geometry<T>;
 
     // just return the str reference
@@ -185,13 +185,13 @@ impl<'a, T: CoordinateType> Iterator for IterHelper<'a, T> {
 
 // structure helper for mutable non-consuming iterator
 #[derive(Debug)]
-pub struct IterMutHelper<'a, T: CoordinateType> {
+pub struct IterMutHelper<'a, T: CoordNum> {
     iter: ::std::slice::IterMut<'a, Geometry<T>>,
 }
 
 // implement the IntoIterator trait for a mutable non-consuming iterator. Iteration will
 // mutably borrow the GeometryCollection
-impl<'a, T: CoordinateType> IntoIterator for &'a mut GeometryCollection<T> {
+impl<'a, T: CoordNum> IntoIterator for &'a mut GeometryCollection<T> {
     type Item = &'a mut Geometry<T>;
     type IntoIter = IterMutHelper<'a, T>;
 
@@ -204,7 +204,7 @@ impl<'a, T: CoordinateType> IntoIterator for &'a mut GeometryCollection<T> {
 }
 
 // implement the Iterator trait for the helper struct, to be used by adapters
-impl<'a, T: CoordinateType> Iterator for IterMutHelper<'a, T> {
+impl<'a, T: CoordNum> Iterator for IterMutHelper<'a, T> {
     type Item = &'a mut Geometry<T>;
 
     // just return the str reference
@@ -213,7 +213,7 @@ impl<'a, T: CoordinateType> Iterator for IterMutHelper<'a, T> {
     }
 }
 
-impl<'a, T: CoordinateType> GeometryCollection<T> {
+impl<'a, T: CoordNum> GeometryCollection<T> {
     pub fn iter(&'a self) -> IterHelper<'a, T> {
         self.into_iter()
     }

--- a/geo-types/src/lib.rs
+++ b/geo-types/src/lib.rs
@@ -35,7 +35,7 @@
 //! [JTS]: https://github.com/locationtech/jts
 //! [GEOS]: https://trac.osgeo.org/geos
 extern crate num_traits;
-use num_traits::{Num, NumCast};
+use num_traits::{Float, Num, NumCast};
 use std::fmt::Debug;
 
 #[cfg(feature = "serde")]
@@ -57,13 +57,17 @@ impl<T: Num + Copy + NumCast + PartialOrd + Debug> CoordinateType for T {}
 
 /// The type of an x or y value of a point/coordinate.
 ///
-/// Floats (`f32` and `f64`) and Integers (`u8`, `i32` etc.)
-/// implement this. Many algorithms only make sense for
-/// Float types (like area, or length calculations).
+/// Floats (`f32` and `f64`) and Integers (`u8`, `i32` etc.) implement this.
+///
+/// For algorithms which only make sense for floating point, like area or length calculations,
+/// see [CoordFloat](trait.CoordFloat.html).
 #[allow(deprecated)]
 pub trait CoordNum: CoordinateType + Debug {}
 #[allow(deprecated)]
 impl<T: CoordinateType + Debug> CoordNum for T {}
+
+pub trait CoordFloat: CoordNum + Float {}
+impl<T: CoordNum + Float> CoordFloat for T {}
 
 mod coordinate;
 pub use crate::coordinate::Coordinate;

--- a/geo-types/src/lib.rs
+++ b/geo-types/src/lib.rs
@@ -51,7 +51,6 @@ extern crate approx;
 
 #[deprecated(since = "0.7", note = "use `CoordFloat` or `CoordNum` instead")]
 pub trait CoordinateType: Num + Copy + NumCast + PartialOrd + Debug {}
-// Little bit of a hack to make to make this work
 #[allow(deprecated)]
 impl<T: Num + Copy + NumCast + PartialOrd + Debug> CoordinateType for T {}
 

--- a/geo-types/src/lib.rs
+++ b/geo-types/src/lib.rs
@@ -36,6 +36,7 @@
 //! [GEOS]: https://trac.osgeo.org/geos
 extern crate num_traits;
 use num_traits::{Num, NumCast};
+use std::fmt::Debug;
 
 #[cfg(feature = "serde")]
 #[macro_use]
@@ -53,9 +54,9 @@ extern crate approx;
 /// Floats (`f32` and `f64`) and Integers (`u8`, `i32` etc.)
 /// implement this. Many algorithms only make sense for
 /// Float types (like area, or length calculations).
-pub trait CoordinateType: Num + Copy + NumCast + PartialOrd {}
+pub trait CoordinateType: Num + Copy + NumCast + PartialOrd + Debug {}
 // Little bit of a hack to make to make this work
-impl<T: Num + Copy + NumCast + PartialOrd> CoordinateType for T {}
+impl<T: Num + Copy + NumCast + PartialOrd + Debug> CoordinateType for T {}
 
 mod coordinate;
 pub use crate::coordinate::Coordinate;

--- a/geo-types/src/lib.rs
+++ b/geo-types/src/lib.rs
@@ -49,14 +49,21 @@ extern crate rstar;
 #[macro_use]
 extern crate approx;
 
+#[deprecated(since = "0.7", note = "use `CoordFloat` or `CoordNum` instead")]
+pub trait CoordinateType: Num + Copy + NumCast + PartialOrd + Debug {}
+// Little bit of a hack to make to make this work
+#[allow(deprecated)]
+impl<T: Num + Copy + NumCast + PartialOrd + Debug> CoordinateType for T {}
+
 /// The type of an x or y value of a point/coordinate.
 ///
 /// Floats (`f32` and `f64`) and Integers (`u8`, `i32` etc.)
 /// implement this. Many algorithms only make sense for
 /// Float types (like area, or length calculations).
-pub trait CoordinateType: Num + Copy + NumCast + PartialOrd + Debug {}
-// Little bit of a hack to make to make this work
-impl<T: Num + Copy + NumCast + PartialOrd + Debug> CoordinateType for T {}
+#[allow(deprecated)]
+pub trait CoordNum: CoordinateType + Debug {}
+#[allow(deprecated)]
+impl<T: CoordinateType + Debug> CoordNum for T {}
 
 mod coordinate;
 pub use crate::coordinate::Coordinate;

--- a/geo-types/src/line.rs
+++ b/geo-types/src/line.rs
@@ -1,4 +1,4 @@
-use crate::{Coordinate, CoordinateType, Point};
+use crate::{CoordNum, Coordinate, Point};
 #[cfg(any(feature = "approx", test))]
 use approx::{AbsDiffEq, RelativeEq};
 
@@ -13,7 +13,7 @@ use approx::{AbsDiffEq, RelativeEq};
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Line<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     pub start: Coordinate<T>,
     pub end: Coordinate<T>,
@@ -21,7 +21,7 @@ where
 
 impl<T> Line<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     /// Creates a new line segment.
     ///
@@ -161,7 +161,7 @@ where
     }
 }
 
-impl<T: CoordinateType> From<[(T, T); 2]> for Line<T> {
+impl<T: CoordNum> From<[(T, T); 2]> for Line<T> {
     fn from(coord: [(T, T); 2]) -> Line<T> {
         Line::new(coord[0], coord[1])
     }
@@ -169,7 +169,7 @@ impl<T: CoordinateType> From<[(T, T); 2]> for Line<T> {
 #[cfg(any(feature = "approx", test))]
 impl<T> RelativeEq for Line<T>
 where
-    T: AbsDiffEq<Epsilon = T> + CoordinateType + RelativeEq,
+    T: AbsDiffEq<Epsilon = T> + CoordNum + RelativeEq,
 {
     #[inline]
     fn default_max_relative() -> Self::Epsilon {
@@ -201,7 +201,7 @@ where
 }
 
 #[cfg(any(feature = "approx", test))]
-impl<T: AbsDiffEq<Epsilon = T> + CoordinateType> AbsDiffEq for Line<T> {
+impl<T: AbsDiffEq<Epsilon = T> + CoordNum> AbsDiffEq for Line<T> {
     type Epsilon = T;
 
     #[inline]

--- a/geo-types/src/line_string.rs
+++ b/geo-types/src/line_string.rs
@@ -1,7 +1,7 @@
 #[cfg(any(feature = "approx", test))]
 use approx::{AbsDiffEq, RelativeEq};
 
-use crate::{Coordinate, CoordinateType, Line, Point, Triangle};
+use crate::{CoordNum, Coordinate, Line, Point, Triangle};
 use std::iter::FromIterator;
 use std::ops::{Index, IndexMut};
 
@@ -112,13 +112,13 @@ use std::ops::{Index, IndexMut};
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct LineString<T>(pub Vec<Coordinate<T>>)
 where
-    T: CoordinateType;
+    T: CoordNum;
 
 /// A `Point` iterator returned by the `points_iter` method
 #[derive(Debug)]
-pub struct PointsIter<'a, T: CoordinateType + 'a>(::std::slice::Iter<'a, Coordinate<T>>);
+pub struct PointsIter<'a, T: CoordNum + 'a>(::std::slice::Iter<'a, Coordinate<T>>);
 
-impl<'a, T: CoordinateType> Iterator for PointsIter<'a, T> {
+impl<'a, T: CoordNum> Iterator for PointsIter<'a, T> {
     type Item = Point<T>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -126,13 +126,13 @@ impl<'a, T: CoordinateType> Iterator for PointsIter<'a, T> {
     }
 }
 
-impl<'a, T: CoordinateType> DoubleEndedIterator for PointsIter<'a, T> {
+impl<'a, T: CoordNum> DoubleEndedIterator for PointsIter<'a, T> {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.0.next_back().map(|c| Point(*c))
     }
 }
 
-impl<T: CoordinateType> LineString<T> {
+impl<T: CoordNum> LineString<T> {
     /// Return an iterator yielding the coordinates of a `LineString` as `Point`s
     pub fn points_iter(&self) -> PointsIter<T> {
         PointsIter(self.0.iter())
@@ -248,21 +248,21 @@ impl<T: CoordinateType> LineString<T> {
 }
 
 /// Turn a `Vec` of `Point`-like objects into a `LineString`.
-impl<T: CoordinateType, IC: Into<Coordinate<T>>> From<Vec<IC>> for LineString<T> {
+impl<T: CoordNum, IC: Into<Coordinate<T>>> From<Vec<IC>> for LineString<T> {
     fn from(v: Vec<IC>) -> Self {
         LineString(v.into_iter().map(|c| c.into()).collect())
     }
 }
 
 /// Turn an iterator of `Point`-like objects into a `LineString`.
-impl<T: CoordinateType, IC: Into<Coordinate<T>>> FromIterator<IC> for LineString<T> {
+impl<T: CoordNum, IC: Into<Coordinate<T>>> FromIterator<IC> for LineString<T> {
     fn from_iter<I: IntoIterator<Item = IC>>(iter: I) -> Self {
         LineString(iter.into_iter().map(|c| c.into()).collect())
     }
 }
 
 /// Iterate over all the [Coordinate](struct.Coordinates.html)s in this `LineString`.
-impl<T: CoordinateType> IntoIterator for LineString<T> {
+impl<T: CoordNum> IntoIterator for LineString<T> {
     type Item = Coordinate<T>;
     type IntoIter = ::std::vec::IntoIter<Coordinate<T>>;
 
@@ -272,7 +272,7 @@ impl<T: CoordinateType> IntoIterator for LineString<T> {
 }
 
 /// Mutably iterate over all the [Coordinate](struct.Coordinates.html)s in this `LineString`.
-impl<'a, T: CoordinateType> IntoIterator for &'a mut LineString<T> {
+impl<'a, T: CoordNum> IntoIterator for &'a mut LineString<T> {
     type Item = &'a mut Coordinate<T>;
     type IntoIter = ::std::slice::IterMut<'a, Coordinate<T>>;
 
@@ -281,7 +281,7 @@ impl<'a, T: CoordinateType> IntoIterator for &'a mut LineString<T> {
     }
 }
 
-impl<T: CoordinateType> Index<usize> for LineString<T> {
+impl<T: CoordNum> Index<usize> for LineString<T> {
     type Output = Coordinate<T>;
 
     fn index(&self, index: usize) -> &Coordinate<T> {
@@ -289,7 +289,7 @@ impl<T: CoordinateType> Index<usize> for LineString<T> {
     }
 }
 
-impl<T: CoordinateType> IndexMut<usize> for LineString<T> {
+impl<T: CoordNum> IndexMut<usize> for LineString<T> {
     fn index_mut(&mut self, index: usize) -> &mut Coordinate<T> {
         self.0.index_mut(index)
     }
@@ -298,7 +298,7 @@ impl<T: CoordinateType> IndexMut<usize> for LineString<T> {
 #[cfg(any(feature = "approx", test))]
 impl<T> RelativeEq for LineString<T>
 where
-    T: AbsDiffEq<Epsilon = T> + CoordinateType + RelativeEq,
+    T: AbsDiffEq<Epsilon = T> + CoordNum + RelativeEq,
 {
     #[inline]
     fn default_max_relative() -> Self::Epsilon {
@@ -343,7 +343,7 @@ where
 }
 
 #[cfg(any(feature = "approx", test))]
-impl<T: AbsDiffEq<Epsilon = T> + CoordinateType> AbsDiffEq for LineString<T> {
+impl<T: AbsDiffEq<Epsilon = T> + CoordNum> AbsDiffEq for LineString<T> {
     type Epsilon = T;
 
     #[inline]

--- a/geo-types/src/multi_line_string.rs
+++ b/geo-types/src/multi_line_string.rs
@@ -1,4 +1,4 @@
-use crate::{CoordinateType, LineString};
+use crate::{CoordNum, LineString};
 use std::iter::FromIterator;
 
 /// A collection of
@@ -32,9 +32,9 @@ use std::iter::FromIterator;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct MultiLineString<T>(pub Vec<LineString<T>>)
 where
-    T: CoordinateType;
+    T: CoordNum;
 
-impl<T: CoordinateType> MultiLineString<T> {
+impl<T: CoordNum> MultiLineString<T> {
     /// True if the MultiLineString is empty or if all of its LineStrings are closed - see
     /// [`LineString::is_closed`].
     ///
@@ -61,19 +61,19 @@ impl<T: CoordinateType> MultiLineString<T> {
     }
 }
 
-impl<T: CoordinateType, ILS: Into<LineString<T>>> From<ILS> for MultiLineString<T> {
+impl<T: CoordNum, ILS: Into<LineString<T>>> From<ILS> for MultiLineString<T> {
     fn from(ls: ILS) -> Self {
         MultiLineString(vec![ls.into()])
     }
 }
 
-impl<T: CoordinateType, ILS: Into<LineString<T>>> FromIterator<ILS> for MultiLineString<T> {
+impl<T: CoordNum, ILS: Into<LineString<T>>> FromIterator<ILS> for MultiLineString<T> {
     fn from_iter<I: IntoIterator<Item = ILS>>(iter: I) -> Self {
         MultiLineString(iter.into_iter().map(|ls| ls.into()).collect())
     }
 }
 
-impl<T: CoordinateType> IntoIterator for MultiLineString<T> {
+impl<T: CoordNum> IntoIterator for MultiLineString<T> {
     type Item = LineString<T>;
     type IntoIter = ::std::vec::IntoIter<LineString<T>>;
 
@@ -82,7 +82,7 @@ impl<T: CoordinateType> IntoIterator for MultiLineString<T> {
     }
 }
 
-impl<'a, T: CoordinateType> IntoIterator for &'a MultiLineString<T> {
+impl<'a, T: CoordNum> IntoIterator for &'a MultiLineString<T> {
     type Item = &'a LineString<T>;
     type IntoIter = ::std::slice::Iter<'a, LineString<T>>;
 
@@ -91,7 +91,7 @@ impl<'a, T: CoordinateType> IntoIterator for &'a MultiLineString<T> {
     }
 }
 
-impl<'a, T: CoordinateType> IntoIterator for &'a mut MultiLineString<T> {
+impl<'a, T: CoordNum> IntoIterator for &'a mut MultiLineString<T> {
     type Item = &'a mut LineString<T>;
     type IntoIter = ::std::slice::IterMut<'a, LineString<T>>;
 
@@ -100,7 +100,7 @@ impl<'a, T: CoordinateType> IntoIterator for &'a mut MultiLineString<T> {
     }
 }
 
-impl<T: CoordinateType> MultiLineString<T> {
+impl<T: CoordNum> MultiLineString<T> {
     pub fn iter(&self) -> impl Iterator<Item = &LineString<T>> {
         self.0.iter()
     }

--- a/geo-types/src/multi_point.rs
+++ b/geo-types/src/multi_point.rs
@@ -1,4 +1,4 @@
-use crate::{CoordinateType, Point};
+use crate::{CoordNum, Point};
 
 #[cfg(any(feature = "approx", test))]
 use approx::{AbsDiffEq, RelativeEq};
@@ -32,9 +32,9 @@ use std::iter::FromIterator;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct MultiPoint<T>(pub Vec<Point<T>>)
 where
-    T: CoordinateType;
+    T: CoordNum;
 
-impl<T: CoordinateType, IP: Into<Point<T>>> From<IP> for MultiPoint<T> {
+impl<T: CoordNum, IP: Into<Point<T>>> From<IP> for MultiPoint<T> {
     /// Convert a single `Point` (or something which can be converted to a `Point`) into a
     /// one-member `MultiPoint`
     fn from(x: IP) -> MultiPoint<T> {
@@ -42,7 +42,7 @@ impl<T: CoordinateType, IP: Into<Point<T>>> From<IP> for MultiPoint<T> {
     }
 }
 
-impl<T: CoordinateType, IP: Into<Point<T>>> From<Vec<IP>> for MultiPoint<T> {
+impl<T: CoordNum, IP: Into<Point<T>>> From<Vec<IP>> for MultiPoint<T> {
     /// Convert a `Vec` of `Points` (or `Vec` of things which can be converted to a `Point`) into a
     /// `MultiPoint`.
     fn from(v: Vec<IP>) -> MultiPoint<T> {
@@ -50,7 +50,7 @@ impl<T: CoordinateType, IP: Into<Point<T>>> From<Vec<IP>> for MultiPoint<T> {
     }
 }
 
-impl<T: CoordinateType, IP: Into<Point<T>>> FromIterator<IP> for MultiPoint<T> {
+impl<T: CoordNum, IP: Into<Point<T>>> FromIterator<IP> for MultiPoint<T> {
     /// Collect the results of a `Point` iterator into a `MultiPoint`
     fn from_iter<I: IntoIterator<Item = IP>>(iter: I) -> Self {
         MultiPoint(iter.into_iter().map(|p| p.into()).collect())
@@ -58,7 +58,7 @@ impl<T: CoordinateType, IP: Into<Point<T>>> FromIterator<IP> for MultiPoint<T> {
 }
 
 /// Iterate over the `Point`s in this `MultiPoint`.
-impl<T: CoordinateType> IntoIterator for MultiPoint<T> {
+impl<T: CoordNum> IntoIterator for MultiPoint<T> {
     type Item = Point<T>;
     type IntoIter = ::std::vec::IntoIter<Point<T>>;
 
@@ -67,7 +67,7 @@ impl<T: CoordinateType> IntoIterator for MultiPoint<T> {
     }
 }
 
-impl<'a, T: CoordinateType> IntoIterator for &'a MultiPoint<T> {
+impl<'a, T: CoordNum> IntoIterator for &'a MultiPoint<T> {
     type Item = &'a Point<T>;
     type IntoIter = ::std::slice::Iter<'a, Point<T>>;
 
@@ -76,7 +76,7 @@ impl<'a, T: CoordinateType> IntoIterator for &'a MultiPoint<T> {
     }
 }
 
-impl<'a, T: CoordinateType> IntoIterator for &'a mut MultiPoint<T> {
+impl<'a, T: CoordNum> IntoIterator for &'a mut MultiPoint<T> {
     type Item = &'a mut Point<T>;
     type IntoIter = ::std::slice::IterMut<'a, Point<T>>;
 
@@ -85,7 +85,7 @@ impl<'a, T: CoordinateType> IntoIterator for &'a mut MultiPoint<T> {
     }
 }
 
-impl<T: CoordinateType> MultiPoint<T> {
+impl<T: CoordNum> MultiPoint<T> {
     pub fn iter(&self) -> impl Iterator<Item = &Point<T>> {
         self.0.iter()
     }
@@ -98,7 +98,7 @@ impl<T: CoordinateType> MultiPoint<T> {
 #[cfg(any(feature = "approx", test))]
 impl<T> RelativeEq for MultiPoint<T>
 where
-    T: AbsDiffEq<Epsilon = T> + CoordinateType + RelativeEq,
+    T: AbsDiffEq<Epsilon = T> + CoordNum + RelativeEq,
 {
     #[inline]
     fn default_max_relative() -> Self::Epsilon {
@@ -137,7 +137,7 @@ where
 #[cfg(any(feature = "approx", test))]
 impl<T> AbsDiffEq for MultiPoint<T>
 where
-    T: AbsDiffEq<Epsilon = T> + CoordinateType,
+    T: AbsDiffEq<Epsilon = T> + CoordNum,
     T::Epsilon: Copy,
 {
     type Epsilon = T;

--- a/geo-types/src/multi_polygon.rs
+++ b/geo-types/src/multi_polygon.rs
@@ -1,4 +1,4 @@
-use crate::{CoordinateType, Polygon};
+use crate::{CoordNum, Polygon};
 use std::iter::FromIterator;
 
 /// A collection of [`Polygon`s](struct.Polygon.html). Can
@@ -26,27 +26,27 @@ use std::iter::FromIterator;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct MultiPolygon<T>(pub Vec<Polygon<T>>)
 where
-    T: CoordinateType;
+    T: CoordNum;
 
-impl<T: CoordinateType, IP: Into<Polygon<T>>> From<IP> for MultiPolygon<T> {
+impl<T: CoordNum, IP: Into<Polygon<T>>> From<IP> for MultiPolygon<T> {
     fn from(x: IP) -> Self {
         MultiPolygon(vec![x.into()])
     }
 }
 
-impl<T: CoordinateType, IP: Into<Polygon<T>>> From<Vec<IP>> for MultiPolygon<T> {
+impl<T: CoordNum, IP: Into<Polygon<T>>> From<Vec<IP>> for MultiPolygon<T> {
     fn from(x: Vec<IP>) -> Self {
         MultiPolygon(x.into_iter().map(|p| p.into()).collect())
     }
 }
 
-impl<T: CoordinateType, IP: Into<Polygon<T>>> FromIterator<IP> for MultiPolygon<T> {
+impl<T: CoordNum, IP: Into<Polygon<T>>> FromIterator<IP> for MultiPolygon<T> {
     fn from_iter<I: IntoIterator<Item = IP>>(iter: I) -> Self {
         MultiPolygon(iter.into_iter().map(|p| p.into()).collect())
     }
 }
 
-impl<T: CoordinateType> IntoIterator for MultiPolygon<T> {
+impl<T: CoordNum> IntoIterator for MultiPolygon<T> {
     type Item = Polygon<T>;
     type IntoIter = ::std::vec::IntoIter<Polygon<T>>;
 
@@ -55,7 +55,7 @@ impl<T: CoordinateType> IntoIterator for MultiPolygon<T> {
     }
 }
 
-impl<'a, T: CoordinateType> IntoIterator for &'a MultiPolygon<T> {
+impl<'a, T: CoordNum> IntoIterator for &'a MultiPolygon<T> {
     type Item = &'a Polygon<T>;
     type IntoIter = ::std::slice::Iter<'a, Polygon<T>>;
 
@@ -64,7 +64,7 @@ impl<'a, T: CoordinateType> IntoIterator for &'a MultiPolygon<T> {
     }
 }
 
-impl<'a, T: CoordinateType> IntoIterator for &'a mut MultiPolygon<T> {
+impl<'a, T: CoordNum> IntoIterator for &'a mut MultiPolygon<T> {
     type Item = &'a mut Polygon<T>;
     type IntoIter = ::std::slice::IterMut<'a, Polygon<T>>;
 
@@ -73,7 +73,7 @@ impl<'a, T: CoordinateType> IntoIterator for &'a mut MultiPolygon<T> {
     }
 }
 
-impl<T: CoordinateType> MultiPolygon<T> {
+impl<T: CoordNum> MultiPolygon<T> {
     pub fn iter(&self) -> impl Iterator<Item = &Polygon<T>> {
         self.0.iter()
     }

--- a/geo-types/src/point.rs
+++ b/geo-types/src/point.rs
@@ -1,4 +1,4 @@
-use crate::{Coordinate, CoordinateType};
+use crate::{CoordNum, Coordinate};
 
 #[cfg(any(feature = "approx", test))]
 use approx::{AbsDiffEq, RelativeEq};
@@ -31,21 +31,21 @@ use std::ops::{Add, Div, Mul, Neg, Sub};
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Point<T>(pub Coordinate<T>)
 where
-    T: CoordinateType;
+    T: CoordNum;
 
-impl<T: CoordinateType> From<Coordinate<T>> for Point<T> {
+impl<T: CoordNum> From<Coordinate<T>> for Point<T> {
     fn from(x: Coordinate<T>) -> Point<T> {
         Point(x)
     }
 }
 
-impl<T: CoordinateType> From<(T, T)> for Point<T> {
+impl<T: CoordNum> From<(T, T)> for Point<T> {
     fn from(coords: (T, T)) -> Point<T> {
         Point::new(coords.0, coords.1)
     }
 }
 
-impl<T: CoordinateType> From<[T; 2]> for Point<T> {
+impl<T: CoordNum> From<[T; 2]> for Point<T> {
     fn from(coords: [T; 2]) -> Point<T> {
         Point::new(coords[0], coords[1])
     }
@@ -53,7 +53,7 @@ impl<T: CoordinateType> From<[T; 2]> for Point<T> {
 
 impl<T> Point<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     /// Creates a new point.
     ///
@@ -215,7 +215,7 @@ where
 
 impl<T> Point<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     /// Returns the dot product of the two points:
     /// `dot = x1 * x2 + y1 * y2`
@@ -259,7 +259,7 @@ where
 
 impl<T> Point<T>
 where
-    T: CoordinateType + Float,
+    T: CoordNum + Float,
 {
     /// Converts the (x,y) components of Point to degrees
     ///
@@ -300,7 +300,7 @@ where
 
 impl<T> Neg for Point<T>
 where
-    T: CoordinateType + Neg<Output = T>,
+    T: CoordNum + Neg<Output = T>,
 {
     type Output = Point<T>;
 
@@ -323,7 +323,7 @@ where
 
 impl<T> Add for Point<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     type Output = Point<T>;
 
@@ -346,7 +346,7 @@ where
 
 impl<T> Sub for Point<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     type Output = Point<T>;
 
@@ -369,7 +369,7 @@ where
 
 impl<T> Mul<T> for Point<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     type Output = Point<T>;
 
@@ -392,7 +392,7 @@ where
 
 impl<T> Div<T> for Point<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     type Output = Point<T>;
 
@@ -416,7 +416,7 @@ where
 #[cfg(any(feature = "approx", test))]
 impl<T> RelativeEq for Point<T>
 where
-    T: AbsDiffEq<Epsilon = T> + CoordinateType + RelativeEq,
+    T: AbsDiffEq<Epsilon = T> + CoordNum + RelativeEq,
 {
     #[inline]
     fn default_max_relative() -> Self::Epsilon {
@@ -449,7 +449,7 @@ where
 #[cfg(any(feature = "approx", test))]
 impl<T> AbsDiffEq for Point<T>
 where
-    T: AbsDiffEq<Epsilon = T> + CoordinateType,
+    T: AbsDiffEq<Epsilon = T> + CoordNum,
     T::Epsilon: Copy,
 {
     type Epsilon = T::Epsilon;

--- a/geo-types/src/point.rs
+++ b/geo-types/src/point.rs
@@ -1,9 +1,8 @@
-use crate::{CoordNum, Coordinate};
+use crate::{CoordFloat, CoordNum, Coordinate};
 
 #[cfg(any(feature = "approx", test))]
 use approx::{AbsDiffEq, RelativeEq};
 
-use num_traits::Float;
 use std::ops::{Add, Div, Mul, Neg, Sub};
 
 /// A single point in 2D space.
@@ -259,7 +258,7 @@ where
 
 impl<T> Point<T>
 where
-    T: CoordNum + Float,
+    T: CoordFloat,
 {
     /// Converts the (x,y) components of Point to degrees
     ///

--- a/geo-types/src/polygon.rs
+++ b/geo-types/src/polygon.rs
@@ -1,4 +1,4 @@
-use crate::{CoordNum, LineString, Point, Rect, Triangle};
+use crate::{CoordFloat, CoordNum, LineString, Point, Rect, Triangle};
 use num_traits::{Float, Signed};
 
 /// A bounded two-dimensional area.
@@ -407,7 +407,7 @@ enum ListSign {
 
 impl<T> Polygon<T>
 where
-    T: CoordNum + Float + Signed,
+    T: CoordFloat + Signed,
 {
     /// Determine whether a Polygon is convex
     // For each consecutive pair of edges of the polygon (each triplet of points),

--- a/geo-types/src/polygon.rs
+++ b/geo-types/src/polygon.rs
@@ -1,4 +1,4 @@
-use crate::{CoordinateType, LineString, Point, Rect, Triangle};
+use crate::{CoordNum, LineString, Point, Rect, Triangle};
 use num_traits::{Float, Signed};
 
 /// A bounded two-dimensional area.
@@ -65,7 +65,7 @@ use num_traits::{Float, Signed};
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Polygon<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     exterior: LineString<T>,
     interiors: Vec<LineString<T>>,
@@ -73,7 +73,7 @@ where
 
 impl<T> Polygon<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     /// Create a new `Polygon` with the provided exterior `LineString` ring and
     /// interior `LineString` rings.
@@ -407,7 +407,7 @@ enum ListSign {
 
 impl<T> Polygon<T>
 where
-    T: CoordinateType + Float + Signed,
+    T: CoordNum + Float + Signed,
 {
     /// Determine whether a Polygon is convex
     // For each consecutive pair of edges of the polygon (each triplet of points),
@@ -445,7 +445,7 @@ where
     }
 }
 
-impl<T: CoordinateType> From<Rect<T>> for Polygon<T> {
+impl<T: CoordNum> From<Rect<T>> for Polygon<T> {
     fn from(r: Rect<T>) -> Polygon<T> {
         Polygon::new(
             vec![
@@ -461,7 +461,7 @@ impl<T: CoordinateType> From<Rect<T>> for Polygon<T> {
     }
 }
 
-impl<T: CoordinateType> From<Triangle<T>> for Polygon<T> {
+impl<T: CoordNum> From<Triangle<T>> for Polygon<T> {
     fn from(t: Triangle<T>) -> Polygon<T> {
         Polygon::new(vec![t.0, t.1, t.2, t.0].into(), Vec::new())
     }

--- a/geo-types/src/polygon.rs
+++ b/geo-types/src/polygon.rs
@@ -407,7 +407,7 @@ enum ListSign {
 
 impl<T> Polygon<T>
 where
-    T: Float + Signed,
+    T: CoordinateType + Float + Signed,
 {
     /// Determine whether a Polygon is convex
     // For each consecutive pair of edges of the polygon (each triplet of points),

--- a/geo-types/src/private_utils.rs
+++ b/geo-types/src/private_utils.rs
@@ -3,8 +3,7 @@
 // hidden module is public so the geo crate can reuse these algorithms to
 // prevent duplication. These functions are _not_ meant for public consumption.
 
-use crate::{CoordNum, Coordinate, Line, LineString, Point, Rect};
-use num_traits::Float;
+use crate::{CoordFloat, CoordNum, Coordinate, Line, LineString, Point, Rect};
 
 pub fn line_string_bounding_rect<T>(line_string: &LineString<T>) -> Option<Rect<T>>
 where
@@ -72,7 +71,7 @@ where
 
 pub fn line_segment_distance<T, C>(point: C, start: C, end: C) -> T
 where
-    T: CoordNum + Float,
+    T: CoordFloat,
     C: Into<Coordinate<T>>,
 {
     let point = point.into();
@@ -97,14 +96,14 @@ where
 
 pub fn line_euclidean_length<T>(line: Line<T>) -> T
 where
-    T: CoordNum + Float,
+    T: CoordFloat,
 {
     line.dx().hypot(line.dy())
 }
 
 pub fn point_line_string_euclidean_distance<T>(p: Point<T>, l: &LineString<T>) -> T
 where
-    T: CoordNum + Float,
+    T: CoordFloat,
 {
     // No need to continue if the point is on the LineString, or it's empty
     if line_string_contains_point(l, p) || l.0.is_empty() {
@@ -117,14 +116,14 @@ where
 
 pub fn point_line_euclidean_distance<T>(p: Point<T>, l: Line<T>) -> T
 where
-    T: CoordNum + Float,
+    T: CoordFloat,
 {
     line_segment_distance(p.0, l.start, l.end)
 }
 
 pub fn point_contains_point<T>(p1: Point<T>, p2: Point<T>) -> bool
 where
-    T: CoordNum + Float,
+    T: CoordFloat,
 {
     let distance = line_euclidean_length(Line::new(p1, p2)).to_f32().unwrap();
     approx::relative_eq!(distance, 0.0)
@@ -132,7 +131,7 @@ where
 
 pub fn line_string_contains_point<T>(line_string: &LineString<T>, point: Point<T>) -> bool
 where
-    T: CoordNum + Float,
+    T: CoordFloat,
 {
     // LineString without points
     if line_string.0.is_empty() {

--- a/geo-types/src/private_utils.rs
+++ b/geo-types/src/private_utils.rs
@@ -3,19 +3,19 @@
 // hidden module is public so the geo crate can reuse these algorithms to
 // prevent duplication. These functions are _not_ meant for public consumption.
 
-use crate::{Coordinate, CoordinateType, Line, LineString, Point, Rect};
+use crate::{CoordNum, Coordinate, Line, LineString, Point, Rect};
 use num_traits::Float;
 
 pub fn line_string_bounding_rect<T>(line_string: &LineString<T>) -> Option<Rect<T>>
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     get_bounding_rect(line_string.0.iter().cloned())
 }
 
 pub fn line_bounding_rect<T>(line: Line<T>) -> Rect<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     let a = line.start;
     let b = line.end;
@@ -30,7 +30,7 @@ where
 
 pub fn get_bounding_rect<I, T>(collection: I) -> Option<Rect<T>>
 where
-    T: CoordinateType,
+    T: CoordNum,
     I: IntoIterator<Item = Coordinate<T>>,
 {
     let mut iter = collection.into_iter();
@@ -59,7 +59,7 @@ where
 
 fn get_min_max<T>(p: T, min: T, max: T) -> (T, T)
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     if p > max {
         (min, p)
@@ -72,7 +72,7 @@ where
 
 pub fn line_segment_distance<T, C>(point: C, start: C, end: C) -> T
 where
-    T: CoordinateType + Float,
+    T: CoordNum + Float,
     C: Into<Coordinate<T>>,
 {
     let point = point.into();
@@ -97,14 +97,14 @@ where
 
 pub fn line_euclidean_length<T>(line: Line<T>) -> T
 where
-    T: CoordinateType + Float,
+    T: CoordNum + Float,
 {
     line.dx().hypot(line.dy())
 }
 
 pub fn point_line_string_euclidean_distance<T>(p: Point<T>, l: &LineString<T>) -> T
 where
-    T: CoordinateType + Float,
+    T: CoordNum + Float,
 {
     // No need to continue if the point is on the LineString, or it's empty
     if line_string_contains_point(l, p) || l.0.is_empty() {
@@ -117,14 +117,14 @@ where
 
 pub fn point_line_euclidean_distance<T>(p: Point<T>, l: Line<T>) -> T
 where
-    T: CoordinateType + Float,
+    T: CoordNum + Float,
 {
     line_segment_distance(p.0, l.start, l.end)
 }
 
 pub fn point_contains_point<T>(p1: Point<T>, p2: Point<T>) -> bool
 where
-    T: CoordinateType + Float,
+    T: CoordNum + Float,
 {
     let distance = line_euclidean_length(Line::new(p1, p2)).to_f32().unwrap();
     approx::relative_eq!(distance, 0.0)
@@ -132,7 +132,7 @@ where
 
 pub fn line_string_contains_point<T>(line_string: &LineString<T>, point: Point<T>) -> bool
 where
-    T: CoordinateType + Float,
+    T: CoordNum + Float,
 {
     // LineString without points
     if line_string.0.is_empty() {

--- a/geo-types/src/private_utils.rs
+++ b/geo-types/src/private_utils.rs
@@ -72,7 +72,7 @@ where
 
 pub fn line_segment_distance<T, C>(point: C, start: C, end: C) -> T
 where
-    T: Float,
+    T: CoordinateType + Float,
     C: Into<Coordinate<T>>,
 {
     let point = point.into();
@@ -97,14 +97,14 @@ where
 
 pub fn line_euclidean_length<T>(line: Line<T>) -> T
 where
-    T: Float,
+    T: CoordinateType + Float,
 {
     line.dx().hypot(line.dy())
 }
 
 pub fn point_line_string_euclidean_distance<T>(p: Point<T>, l: &LineString<T>) -> T
 where
-    T: Float,
+    T: CoordinateType + Float,
 {
     // No need to continue if the point is on the LineString, or it's empty
     if line_string_contains_point(l, p) || l.0.is_empty() {
@@ -117,14 +117,14 @@ where
 
 pub fn point_line_euclidean_distance<T>(p: Point<T>, l: Line<T>) -> T
 where
-    T: Float,
+    T: CoordinateType + Float,
 {
     line_segment_distance(p.0, l.start, l.end)
 }
 
 pub fn point_contains_point<T>(p1: Point<T>, p2: Point<T>) -> bool
 where
-    T: Float,
+    T: CoordinateType + Float,
 {
     let distance = line_euclidean_length(Line::new(p1, p2)).to_f32().unwrap();
     approx::relative_eq!(distance, 0.0)
@@ -132,7 +132,7 @@ where
 
 pub fn line_string_contains_point<T>(line_string: &LineString<T>, point: Point<T>) -> bool
 where
-    T: Float,
+    T: CoordinateType + Float,
 {
     // LineString without points
     if line_string.0.is_empty() {

--- a/geo-types/src/rect.rs
+++ b/geo-types/src/rect.rs
@@ -1,5 +1,4 @@
-use crate::{polygon, CoordNum, Coordinate, Polygon};
-use num_traits::Float;
+use crate::{polygon, CoordFloat, CoordNum, Coordinate, Polygon};
 
 /// An _axis-aligned_ bounded 2D rectangle whose area is
 /// defined by minimum and maximum `Coordinate`s.
@@ -235,7 +234,7 @@ impl<T: CoordNum> Rect<T> {
     }
 }
 
-impl<T: CoordNum + Float> Rect<T> {
+impl<T: CoordFloat> Rect<T> {
     /// Returns the center `Coordinate` of the `Rect`.
     ///
     /// # Examples

--- a/geo-types/src/rect.rs
+++ b/geo-types/src/rect.rs
@@ -1,4 +1,4 @@
-use crate::{polygon, Coordinate, CoordinateType, Polygon};
+use crate::{polygon, CoordNum, Coordinate, Polygon};
 use num_traits::Float;
 
 /// An _axis-aligned_ bounded 2D rectangle whose area is
@@ -39,13 +39,13 @@ use num_traits::Float;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Rect<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     min: Coordinate<T>,
     max: Coordinate<T>,
 }
 
-impl<T: CoordinateType> Rect<T> {
+impl<T: CoordNum> Rect<T> {
     /// Creates a new rectangle from two corner coordinates.
     ///
     /// # Examples
@@ -235,7 +235,7 @@ impl<T: CoordinateType> Rect<T> {
     }
 }
 
-impl<T: CoordinateType + Float> Rect<T> {
+impl<T: CoordNum + Float> Rect<T> {
     /// Returns the center `Coordinate` of the `Rect`.
     ///
     /// # Examples

--- a/geo-types/src/triangle.rs
+++ b/geo-types/src/triangle.rs
@@ -1,4 +1,4 @@
-use crate::{polygon, Coordinate, CoordinateType, Line, Polygon};
+use crate::{polygon, CoordNum, Coordinate, Line, Polygon};
 
 /// A bounded 2D area whose three vertices are defined by
 /// `Coordinate`s. The semantics and validity are that of
@@ -6,9 +6,9 @@ use crate::{polygon, Coordinate, CoordinateType, Line, Polygon};
 /// vertices must not be collinear and they must be distinct.
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct Triangle<T: CoordinateType>(pub Coordinate<T>, pub Coordinate<T>, pub Coordinate<T>);
+pub struct Triangle<T: CoordNum>(pub Coordinate<T>, pub Coordinate<T>, pub Coordinate<T>);
 
-impl<T: CoordinateType> Triangle<T> {
+impl<T: CoordNum> Triangle<T> {
     pub fn to_array(&self) -> [Coordinate<T>; 3] {
         [self.0, self.1, self.2]
     }
@@ -49,7 +49,7 @@ impl<T: CoordinateType> Triangle<T> {
     }
 }
 
-impl<IC: Into<Coordinate<T>> + Copy, T: CoordinateType> From<[IC; 3]> for Triangle<T> {
+impl<IC: Into<Coordinate<T>> + Copy, T: CoordNum> From<[IC; 3]> for Triangle<T> {
     fn from(array: [IC; 3]) -> Triangle<T> {
         Triangle(array[0].into(), array[1].into(), array[2].into())
     }

--- a/geo/benches/concave_hull.rs
+++ b/geo/benches/concave_hull.rs
@@ -4,13 +4,13 @@ extern crate geo;
 
 use criterion::Criterion;
 use geo::algorithm::concave_hull::ConcaveHull;
-use geo::{Coordinate, CoordinateType, LineString};
+use geo::{CoordNum, Coordinate, LineString};
 
 use num_traits::Signed;
 use rand::distributions::uniform::SampleUniform;
 use rand::Rng;
 
-pub fn uniform_points_in_range<S: CoordinateType + SampleUniform + Signed, R: Rng>(
+pub fn uniform_points_in_range<S: CoordNum + SampleUniform + Signed, R: Rng>(
     range: S,
     size: usize,
     rng: &mut R,

--- a/geo/benches/convex_hull.rs
+++ b/geo/benches/convex_hull.rs
@@ -4,12 +4,12 @@ extern crate geo;
 
 use criterion::Criterion;
 use geo::prelude::*;
-use geo::{Coordinate, CoordinateType, LineString};
+use geo::{CoordNum, Coordinate, LineString};
 
 use num_traits::Signed;
 use rand::distributions::uniform::SampleUniform;
 use rand::Rng;
-pub fn uniform_points_in_range<S: CoordinateType + SampleUniform + Signed, R: Rng>(
+pub fn uniform_points_in_range<S: CoordNum + SampleUniform + Signed, R: Rng>(
     range: S,
     size: usize,
     rng: &mut R,

--- a/geo/src/algorithm/area.rs
+++ b/geo/src/algorithm/area.rs
@@ -1,8 +1,7 @@
 use crate::{
-    CoordNum, Geometry, GeometryCollection, Line, LineString, MultiLineString, MultiPoint,
-    MultiPolygon, Point, Polygon, Rect, Triangle,
+    CoordFloat, CoordNum, Geometry, GeometryCollection, Line, LineString, MultiLineString,
+    MultiPoint, MultiPolygon, Point, Polygon, Rect, Triangle,
 };
-use num_traits::Float;
 
 pub(crate) fn twice_signed_ring_area<T>(linestring: &LineString<T>) -> T
 where
@@ -80,7 +79,7 @@ where
 // Calculation of simple (no interior holes) Polygon area
 pub(crate) fn get_linestring_area<T>(linestring: &LineString<T>) -> T
 where
-    T: CoordNum + Float,
+    T: CoordFloat,
 {
     twice_signed_ring_area(linestring) / (T::one() + T::one())
 }
@@ -129,7 +128,7 @@ where
 /// the output is the same as that of the exterior shell.
 impl<T> Area<T> for Polygon<T>
 where
-    T: CoordNum + Float,
+    T: CoordFloat,
 {
     fn signed_area(&self) -> T {
         let area = get_linestring_area(self.exterior());
@@ -188,7 +187,7 @@ where
 /// same.
 impl<T> Area<T> for MultiPolygon<T>
 where
-    T: CoordNum + Float,
+    T: CoordFloat,
 {
     fn signed_area(&self) -> T {
         self.0
@@ -219,7 +218,7 @@ where
 
 impl<T> Area<T> for Triangle<T>
 where
-    T: CoordNum + Float,
+    T: CoordFloat,
 {
     fn signed_area(&self) -> T {
         self.to_lines()
@@ -235,7 +234,7 @@ where
 
 impl<T> Area<T> for Geometry<T>
 where
-    T: CoordNum + Float,
+    T: CoordFloat,
 {
     fn signed_area(&self) -> T {
         match self {
@@ -270,7 +269,7 @@ where
 
 impl<T> Area<T> for GeometryCollection<T>
 where
-    T: CoordNum + Float,
+    T: CoordFloat,
 {
     fn signed_area(&self) -> T {
         self.0

--- a/geo/src/algorithm/area.rs
+++ b/geo/src/algorithm/area.rs
@@ -80,7 +80,7 @@ where
 // Calculation of simple (no interior holes) Polygon area
 pub(crate) fn get_linestring_area<T>(linestring: &LineString<T>) -> T
 where
-    T: Float,
+    T: CoordinateType + Float,
 {
     twice_signed_ring_area(linestring) / (T::one() + T::one())
 }
@@ -129,7 +129,7 @@ where
 /// the output is the same as that of the exterior shell.
 impl<T> Area<T> for Polygon<T>
 where
-    T: Float,
+    T: CoordinateType + Float,
 {
     fn signed_area(&self) -> T {
         let area = get_linestring_area(self.exterior());
@@ -188,7 +188,7 @@ where
 /// same.
 impl<T> Area<T> for MultiPolygon<T>
 where
-    T: Float,
+    T: CoordinateType + Float,
 {
     fn signed_area(&self) -> T {
         self.0
@@ -219,7 +219,7 @@ where
 
 impl<T> Area<T> for Triangle<T>
 where
-    T: Float,
+    T: CoordinateType + Float,
 {
     fn signed_area(&self) -> T {
         self.to_lines()
@@ -235,7 +235,7 @@ where
 
 impl<T> Area<T> for Geometry<T>
 where
-    T: Float,
+    T: CoordinateType + Float,
 {
     fn signed_area(&self) -> T {
         match self {
@@ -270,7 +270,7 @@ where
 
 impl<T> Area<T> for GeometryCollection<T>
 where
-    T: Float,
+    T: CoordinateType + Float,
 {
     fn signed_area(&self) -> T {
         self.0

--- a/geo/src/algorithm/area.rs
+++ b/geo/src/algorithm/area.rs
@@ -1,12 +1,12 @@
 use crate::{
-    CoordinateType, Geometry, GeometryCollection, Line, LineString, MultiLineString, MultiPoint,
+    CoordNum, Geometry, GeometryCollection, Line, LineString, MultiLineString, MultiPoint,
     MultiPolygon, Point, Polygon, Rect, Triangle,
 };
 use num_traits::Float;
 
 pub(crate) fn twice_signed_ring_area<T>(linestring: &LineString<T>) -> T
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     // LineString with less than 3 points is empty, or a
     // single point, or is not closed.
@@ -70,7 +70,7 @@ where
 /// ```
 pub trait Area<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     fn signed_area(&self) -> T;
 
@@ -80,14 +80,14 @@ where
 // Calculation of simple (no interior holes) Polygon area
 pub(crate) fn get_linestring_area<T>(linestring: &LineString<T>) -> T
 where
-    T: CoordinateType + Float,
+    T: CoordNum + Float,
 {
     twice_signed_ring_area(linestring) / (T::one() + T::one())
 }
 
 impl<T> Area<T> for Point<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     fn signed_area(&self) -> T {
         T::zero()
@@ -100,7 +100,7 @@ where
 
 impl<T> Area<T> for LineString<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     fn signed_area(&self) -> T {
         T::zero()
@@ -113,7 +113,7 @@ where
 
 impl<T> Area<T> for Line<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     fn signed_area(&self) -> T {
         T::zero()
@@ -129,7 +129,7 @@ where
 /// the output is the same as that of the exterior shell.
 impl<T> Area<T> for Polygon<T>
 where
-    T: CoordinateType + Float,
+    T: CoordNum + Float,
 {
     fn signed_area(&self) -> T {
         let area = get_linestring_area(self.exterior());
@@ -156,7 +156,7 @@ where
 
 impl<T> Area<T> for MultiPoint<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     fn signed_area(&self) -> T {
         T::zero()
@@ -169,7 +169,7 @@ where
 
 impl<T> Area<T> for MultiLineString<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     fn signed_area(&self) -> T {
         T::zero()
@@ -188,7 +188,7 @@ where
 /// same.
 impl<T> Area<T> for MultiPolygon<T>
 where
-    T: CoordinateType + Float,
+    T: CoordNum + Float,
 {
     fn signed_area(&self) -> T {
         self.0
@@ -206,7 +206,7 @@ where
 /// Because a `Rect` has no winding order, the area will always be positive.
 impl<T> Area<T> for Rect<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     fn signed_area(&self) -> T {
         self.width() * self.height()
@@ -219,7 +219,7 @@ where
 
 impl<T> Area<T> for Triangle<T>
 where
-    T: CoordinateType + Float,
+    T: CoordNum + Float,
 {
     fn signed_area(&self) -> T {
         self.to_lines()
@@ -235,7 +235,7 @@ where
 
 impl<T> Area<T> for Geometry<T>
 where
-    T: CoordinateType + Float,
+    T: CoordNum + Float,
 {
     fn signed_area(&self) -> T {
         match self {
@@ -270,7 +270,7 @@ where
 
 impl<T> Area<T> for GeometryCollection<T>
 where
-    T: CoordinateType + Float,
+    T: CoordNum + Float,
 {
     fn signed_area(&self) -> T {
         self.0

--- a/geo/src/algorithm/bearing.rs
+++ b/geo/src/algorithm/bearing.rs
@@ -1,12 +1,11 @@
-use crate::{CoordNum, Point};
-use num_traits::Float;
+use crate::{CoordFloat, Point};
 
 /// Returns the bearing to another Point in degrees.
 ///
 /// Bullock, R.: Great Circle Distances and Bearings Between Two Locations, 2007.
 /// (https://dtcenter.org/met/users/docs/write_ups/gc_simple.pdf)
 
-pub trait Bearing<T: CoordNum + Float> {
+pub trait Bearing<T: CoordFloat> {
     /// Returns the bearing to another Point in degrees, where North is 0° and East is 90°.
     ///
     /// # Examples
@@ -27,7 +26,7 @@ pub trait Bearing<T: CoordNum + Float> {
 
 impl<T> Bearing<T> for Point<T>
 where
-    T: CoordNum + Float,
+    T: CoordFloat,
 {
     fn bearing(&self, point: Point<T>) -> T {
         let (lng_a, lat_a) = (self.x().to_radians(), self.y().to_radians());

--- a/geo/src/algorithm/bearing.rs
+++ b/geo/src/algorithm/bearing.rs
@@ -1,4 +1,4 @@
-use crate::{CoordinateType, Point};
+use crate::{CoordNum, Point};
 use num_traits::Float;
 
 /// Returns the bearing to another Point in degrees.
@@ -6,7 +6,7 @@ use num_traits::Float;
 /// Bullock, R.: Great Circle Distances and Bearings Between Two Locations, 2007.
 /// (https://dtcenter.org/met/users/docs/write_ups/gc_simple.pdf)
 
-pub trait Bearing<T: CoordinateType + Float> {
+pub trait Bearing<T: CoordNum + Float> {
     /// Returns the bearing to another Point in degrees, where North is 0° and East is 90°.
     ///
     /// # Examples
@@ -27,7 +27,7 @@ pub trait Bearing<T: CoordinateType + Float> {
 
 impl<T> Bearing<T> for Point<T>
 where
-    T: CoordinateType + Float,
+    T: CoordNum + Float,
 {
     fn bearing(&self, point: Point<T>) -> T {
         let (lng_a, lat_a) = (self.x().to_radians(), self.y().to_radians());

--- a/geo/src/algorithm/bearing.rs
+++ b/geo/src/algorithm/bearing.rs
@@ -1,4 +1,4 @@
-use crate::Point;
+use crate::{CoordinateType, Point};
 use num_traits::Float;
 
 /// Returns the bearing to another Point in degrees.
@@ -6,7 +6,7 @@ use num_traits::Float;
 /// Bullock, R.: Great Circle Distances and Bearings Between Two Locations, 2007.
 /// (https://dtcenter.org/met/users/docs/write_ups/gc_simple.pdf)
 
-pub trait Bearing<T: Float> {
+pub trait Bearing<T: CoordinateType + Float> {
     /// Returns the bearing to another Point in degrees, where North is 0° and East is 90°.
     ///
     /// # Examples
@@ -27,7 +27,7 @@ pub trait Bearing<T: Float> {
 
 impl<T> Bearing<T> for Point<T>
 where
-    T: Float,
+    T: CoordinateType + Float,
 {
     fn bearing(&self, point: Point<T>) -> T {
         let (lng_a, lat_a) = (self.x().to_radians(), self.y().to_radians());

--- a/geo/src/algorithm/bounding_rect.rs
+++ b/geo/src/algorithm/bounding_rect.rs
@@ -1,12 +1,12 @@
 use crate::utils::{partial_max, partial_min};
 use crate::{
-    Coordinate, CoordinateType, Geometry, GeometryCollection, Line, LineString, MultiLineString,
+    CoordNum, Coordinate, Geometry, GeometryCollection, Line, LineString, MultiLineString,
     MultiPoint, MultiPolygon, Point, Polygon, Rect, Triangle,
 };
 use geo_types::private_utils::{get_bounding_rect, line_string_bounding_rect};
 
 /// Calculation of the bounding rectangle of a geometry.
-pub trait BoundingRect<T: CoordinateType> {
+pub trait BoundingRect<T: CoordNum> {
     type Output;
 
     /// Return the bounding rectangle of a geometry
@@ -35,7 +35,7 @@ pub trait BoundingRect<T: CoordinateType> {
 
 impl<T> BoundingRect<T> for Point<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     type Output = Rect<T>;
 
@@ -48,7 +48,7 @@ where
 
 impl<T> BoundingRect<T> for MultiPoint<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     type Output = Option<Rect<T>>;
 
@@ -61,7 +61,7 @@ where
 
 impl<T> BoundingRect<T> for Line<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     type Output = Rect<T>;
 
@@ -79,7 +79,7 @@ where
 
 impl<T> BoundingRect<T> for LineString<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     type Output = Option<Rect<T>>;
 
@@ -92,7 +92,7 @@ where
 
 impl<T> BoundingRect<T> for MultiLineString<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     type Output = Option<Rect<T>>;
 
@@ -105,7 +105,7 @@ where
 
 impl<T> BoundingRect<T> for Polygon<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     type Output = Option<Rect<T>>;
 
@@ -119,7 +119,7 @@ where
 
 impl<T> BoundingRect<T> for MultiPolygon<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     type Output = Option<Rect<T>>;
 
@@ -135,7 +135,7 @@ where
 
 impl<T> BoundingRect<T> for Triangle<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     type Output = Rect<T>;
 
@@ -146,7 +146,7 @@ where
 
 impl<T> BoundingRect<T> for Rect<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     type Output = Rect<T>;
 
@@ -157,7 +157,7 @@ where
 
 impl<T> BoundingRect<T> for Geometry<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     type Output = Option<Rect<T>>;
 
@@ -179,7 +179,7 @@ where
 
 impl<T> BoundingRect<T> for GeometryCollection<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     type Output = Option<Rect<T>>;
 
@@ -197,7 +197,7 @@ where
 }
 
 // Return a new rectangle that encompasses the provided rectangles
-fn bounding_rect_merge<T: CoordinateType>(a: Rect<T>, b: Rect<T>) -> Rect<T> {
+fn bounding_rect_merge<T: CoordNum>(a: Rect<T>, b: Rect<T>) -> Rect<T> {
     Rect::new(
         Coordinate {
             x: partial_min(a.min().x, b.min().x),

--- a/geo/src/algorithm/centroid.rs
+++ b/geo/src/algorithm/centroid.rs
@@ -1,10 +1,10 @@
-use num_traits::{Float, FromPrimitive};
+use num_traits::FromPrimitive;
 use std::iter::Sum;
 
 use crate::algorithm::area::{get_linestring_area, Area};
 use crate::algorithm::euclidean_length::EuclideanLength;
 use crate::{
-    CoordNum, Line, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon, Rect,
+    CoordFloat, Line, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon, Rect,
 };
 
 /// Calculation of the centroid.
@@ -61,7 +61,7 @@ pub trait Centroid {
 // Calculation of a Polygon centroid without interior rings
 fn simple_polygon_centroid<T>(poly_ext: &LineString<T>) -> Option<Point<T>>
 where
-    T: CoordNum + Float + FromPrimitive + Sum,
+    T: CoordFloat + FromPrimitive + Sum,
 {
     let area = get_linestring_area(poly_ext);
     if area == T::zero() {
@@ -92,7 +92,7 @@ where
 
 impl<T> Centroid for Line<T>
 where
-    T: CoordNum + Float,
+    T: CoordFloat,
 {
     type Output = Point<T>;
 
@@ -106,7 +106,7 @@ where
 
 impl<T> Centroid for LineString<T>
 where
-    T: CoordNum + Float,
+    T: CoordFloat,
 {
     type Output = Option<Point<T>>;
 
@@ -142,7 +142,7 @@ where
 
 impl<T> Centroid for MultiLineString<T>
 where
-    T: CoordNum + Float + FromPrimitive + Sum,
+    T: CoordFloat + FromPrimitive + Sum,
 {
     type Output = Option<Point<T>>;
 
@@ -190,7 +190,7 @@ where
 
 impl<T> Centroid for Polygon<T>
 where
-    T: CoordNum + Float + FromPrimitive + Sum,
+    T: CoordFloat + FromPrimitive + Sum,
 {
     type Output = Option<Point<T>>;
 
@@ -246,7 +246,7 @@ where
 
 impl<T> Centroid for MultiPolygon<T>
 where
-    T: CoordNum + Float + FromPrimitive + Sum,
+    T: CoordFloat + FromPrimitive + Sum,
 {
     type Output = Option<Point<T>>;
 
@@ -301,7 +301,7 @@ where
 
 impl<T> Centroid for Rect<T>
 where
-    T: CoordNum + Float,
+    T: CoordFloat,
 {
     type Output = Point<T>;
 
@@ -312,7 +312,7 @@ where
 
 impl<T> Centroid for Point<T>
 where
-    T: CoordNum + Float,
+    T: CoordFloat,
 {
     type Output = Point<T>;
 
@@ -335,7 +335,7 @@ where
 /// ```
 impl<T> Centroid for MultiPoint<T>
 where
-    T: CoordNum + Float,
+    T: CoordFloat,
 {
     type Output = Option<Point<T>>;
 
@@ -360,18 +360,17 @@ mod test {
     use crate::algorithm::euclidean_distance::EuclideanDistance;
     use crate::line_string;
     use crate::{
-        polygon, CoordNum, Coordinate, Line, LineString, MultiLineString, MultiPolygon, Point,
+        polygon, CoordFloat, Coordinate, Line, LineString, MultiLineString, MultiPolygon, Point,
         Polygon, Rect,
     };
-    use num_traits::Float;
 
     /// small helper to create a coordinate
-    fn c<T: CoordNum + Float>(x: T, y: T) -> Coordinate<T> {
+    fn c<T: CoordFloat>(x: T, y: T) -> Coordinate<T> {
         Coordinate { x, y }
     }
 
     /// small helper to create a point
-    fn p<T: CoordNum + Float>(x: T, y: T) -> Point<T> {
+    fn p<T: CoordFloat>(x: T, y: T) -> Point<T> {
         Point(c(x, y))
     }
 

--- a/geo/src/algorithm/centroid.rs
+++ b/geo/src/algorithm/centroid.rs
@@ -4,8 +4,7 @@ use std::iter::Sum;
 use crate::algorithm::area::{get_linestring_area, Area};
 use crate::algorithm::euclidean_length::EuclideanLength;
 use crate::{
-    CoordinateType, Line, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon,
-    Rect,
+    CoordNum, Line, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon, Rect,
 };
 
 /// Calculation of the centroid.
@@ -62,7 +61,7 @@ pub trait Centroid {
 // Calculation of a Polygon centroid without interior rings
 fn simple_polygon_centroid<T>(poly_ext: &LineString<T>) -> Option<Point<T>>
 where
-    T: CoordinateType + Float + FromPrimitive + Sum,
+    T: CoordNum + Float + FromPrimitive + Sum,
 {
     let area = get_linestring_area(poly_ext);
     if area == T::zero() {
@@ -93,7 +92,7 @@ where
 
 impl<T> Centroid for Line<T>
 where
-    T: CoordinateType + Float,
+    T: CoordNum + Float,
 {
     type Output = Point<T>;
 
@@ -107,7 +106,7 @@ where
 
 impl<T> Centroid for LineString<T>
 where
-    T: CoordinateType + Float,
+    T: CoordNum + Float,
 {
     type Output = Option<Point<T>>;
 
@@ -143,7 +142,7 @@ where
 
 impl<T> Centroid for MultiLineString<T>
 where
-    T: CoordinateType + Float + FromPrimitive + Sum,
+    T: CoordNum + Float + FromPrimitive + Sum,
 {
     type Output = Option<Point<T>>;
 
@@ -191,7 +190,7 @@ where
 
 impl<T> Centroid for Polygon<T>
 where
-    T: CoordinateType + Float + FromPrimitive + Sum,
+    T: CoordNum + Float + FromPrimitive + Sum,
 {
     type Output = Option<Point<T>>;
 
@@ -247,7 +246,7 @@ where
 
 impl<T> Centroid for MultiPolygon<T>
 where
-    T: CoordinateType + Float + FromPrimitive + Sum,
+    T: CoordNum + Float + FromPrimitive + Sum,
 {
     type Output = Option<Point<T>>;
 
@@ -302,7 +301,7 @@ where
 
 impl<T> Centroid for Rect<T>
 where
-    T: CoordinateType + Float,
+    T: CoordNum + Float,
 {
     type Output = Point<T>;
 
@@ -313,7 +312,7 @@ where
 
 impl<T> Centroid for Point<T>
 where
-    T: CoordinateType + Float,
+    T: CoordNum + Float,
 {
     type Output = Point<T>;
 
@@ -336,7 +335,7 @@ where
 /// ```
 impl<T> Centroid for MultiPoint<T>
 where
-    T: CoordinateType + Float,
+    T: CoordNum + Float,
 {
     type Output = Option<Point<T>>;
 
@@ -361,18 +360,18 @@ mod test {
     use crate::algorithm::euclidean_distance::EuclideanDistance;
     use crate::line_string;
     use crate::{
-        polygon, Coordinate, CoordinateType, Line, LineString, MultiLineString, MultiPolygon,
-        Point, Polygon, Rect,
+        polygon, CoordNum, Coordinate, Line, LineString, MultiLineString, MultiPolygon, Point,
+        Polygon, Rect,
     };
     use num_traits::Float;
 
     /// small helper to create a coordinate
-    fn c<T: CoordinateType + Float>(x: T, y: T) -> Coordinate<T> {
+    fn c<T: CoordNum + Float>(x: T, y: T) -> Coordinate<T> {
         Coordinate { x, y }
     }
 
     /// small helper to create a point
-    fn p<T: CoordinateType + Float>(x: T, y: T) -> Point<T> {
+    fn p<T: CoordNum + Float>(x: T, y: T) -> Point<T> {
         Point(c(x, y))
     }
 

--- a/geo/src/algorithm/centroid.rs
+++ b/geo/src/algorithm/centroid.rs
@@ -3,7 +3,10 @@ use std::iter::Sum;
 
 use crate::algorithm::area::{get_linestring_area, Area};
 use crate::algorithm::euclidean_length::EuclideanLength;
-use crate::{Line, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon, Rect};
+use crate::{
+    CoordinateType, Line, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon,
+    Rect,
+};
 
 /// Calculation of the centroid.
 /// The centroid is the arithmetic mean position of all points in the shape.
@@ -59,7 +62,7 @@ pub trait Centroid {
 // Calculation of a Polygon centroid without interior rings
 fn simple_polygon_centroid<T>(poly_ext: &LineString<T>) -> Option<Point<T>>
 where
-    T: Float + FromPrimitive + Sum,
+    T: CoordinateType + Float + FromPrimitive + Sum,
 {
     let area = get_linestring_area(poly_ext);
     if area == T::zero() {
@@ -90,7 +93,7 @@ where
 
 impl<T> Centroid for Line<T>
 where
-    T: Float,
+    T: CoordinateType + Float,
 {
     type Output = Point<T>;
 
@@ -104,7 +107,7 @@ where
 
 impl<T> Centroid for LineString<T>
 where
-    T: Float,
+    T: CoordinateType + Float,
 {
     type Output = Option<Point<T>>;
 
@@ -140,7 +143,7 @@ where
 
 impl<T> Centroid for MultiLineString<T>
 where
-    T: Float + FromPrimitive + Sum,
+    T: CoordinateType + Float + FromPrimitive + Sum,
 {
     type Output = Option<Point<T>>;
 
@@ -188,7 +191,7 @@ where
 
 impl<T> Centroid for Polygon<T>
 where
-    T: Float + FromPrimitive + Sum,
+    T: CoordinateType + Float + FromPrimitive + Sum,
 {
     type Output = Option<Point<T>>;
 
@@ -244,7 +247,7 @@ where
 
 impl<T> Centroid for MultiPolygon<T>
 where
-    T: Float + FromPrimitive + Sum,
+    T: CoordinateType + Float + FromPrimitive + Sum,
 {
     type Output = Option<Point<T>>;
 
@@ -299,7 +302,7 @@ where
 
 impl<T> Centroid for Rect<T>
 where
-    T: Float,
+    T: CoordinateType + Float,
 {
     type Output = Point<T>;
 
@@ -310,7 +313,7 @@ where
 
 impl<T> Centroid for Point<T>
 where
-    T: Float,
+    T: CoordinateType + Float,
 {
     type Output = Point<T>;
 
@@ -333,7 +336,7 @@ where
 /// ```
 impl<T> Centroid for MultiPoint<T>
 where
-    T: Float,
+    T: CoordinateType + Float,
 {
     type Output = Option<Point<T>>;
 
@@ -358,17 +361,18 @@ mod test {
     use crate::algorithm::euclidean_distance::EuclideanDistance;
     use crate::line_string;
     use crate::{
-        polygon, Coordinate, Line, LineString, MultiLineString, MultiPolygon, Point, Polygon, Rect,
+        polygon, Coordinate, CoordinateType, Line, LineString, MultiLineString, MultiPolygon,
+        Point, Polygon, Rect,
     };
     use num_traits::Float;
 
     /// small helper to create a coordinate
-    fn c<T: Float>(x: T, y: T) -> Coordinate<T> {
+    fn c<T: CoordinateType + Float>(x: T, y: T) -> Coordinate<T> {
         Coordinate { x, y }
     }
 
     /// small helper to create a point
-    fn p<T: Float>(x: T, y: T) -> Point<T> {
+    fn p<T: CoordinateType + Float>(x: T, y: T) -> Point<T> {
         Point(c(x, y))
     }
 

--- a/geo/src/algorithm/chamberlain_duquette_area.rs
+++ b/geo/src/algorithm/chamberlain_duquette_area.rs
@@ -1,4 +1,4 @@
-use crate::{CoordinateType, LineString, Polygon, EQUATORIAL_EARTH_RADIUS};
+use crate::{CoordNum, LineString, Polygon, EQUATORIAL_EARTH_RADIUS};
 use num_traits::Float;
 
 /// Calculate the signed approximate geodesic area of a `Geometry`.
@@ -46,7 +46,7 @@ use num_traits::Float;
 /// ```
 pub trait ChamberlainDuquetteArea<T>
 where
-    T: Float + CoordinateType,
+    T: Float + CoordNum,
 {
     fn chamberlain_duquette_signed_area(&self) -> T;
 
@@ -55,7 +55,7 @@ where
 
 impl<T> ChamberlainDuquetteArea<T> for Polygon<T>
 where
-    T: Float + CoordinateType,
+    T: Float + CoordNum,
 {
     fn chamberlain_duquette_signed_area(&self) -> T {
         self.interiors()
@@ -72,7 +72,7 @@ where
 
 fn ring_area<T>(coords: &LineString<T>) -> T
 where
-    T: Float + CoordinateType,
+    T: Float + CoordNum,
 {
     let mut total = T::zero();
     let coords_len = coords.0.len();

--- a/geo/src/algorithm/concave_hull.rs
+++ b/geo/src/algorithm/concave_hull.rs
@@ -6,7 +6,7 @@ use crate::utils::partial_min;
 use crate::{
     GeoFloat, Line, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon,
 };
-use geo_types::{Coordinate, CoordinateType};
+use geo_types::{CoordNum, Coordinate};
 use rstar::{RTree, RTreeNum};
 use std::collections::VecDeque;
 
@@ -45,7 +45,7 @@ use std::collections::VecDeque;
 /// assert_eq!(res.exterior(), &correct_hull);
 /// ```
 pub trait ConcaveHull {
-    type Scalar: CoordinateType;
+    type Scalar: CoordNum;
     fn concave_hull(&self, concavity: Self::Scalar) -> Polygon<Self::Scalar>;
 }
 

--- a/geo/src/algorithm/contains/geometry.rs
+++ b/geo/src/algorithm/contains/geometry.rs
@@ -1,5 +1,4 @@
 use super::Contains;
-use crate::kernels::*;
 use crate::*;
 
 // ┌──────────────────────────────┐
@@ -8,7 +7,7 @@ use crate::*;
 
 impl<T> Contains<Coordinate<T>> for Geometry<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     fn contains(&self, coord: &Coordinate<T>) -> bool {
         match self {
@@ -28,7 +27,7 @@ where
 
 impl<T> Contains<Point<T>> for Geometry<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     fn contains(&self, point: &Point<T>) -> bool {
         self.contains(&point.0)
@@ -41,7 +40,7 @@ where
 
 impl<T> Contains<Coordinate<T>> for GeometryCollection<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     fn contains(&self, coord: &Coordinate<T>) -> bool {
         self.iter().any(|geometry| geometry.contains(coord))
@@ -50,7 +49,7 @@ where
 
 impl<T> Contains<Point<T>> for GeometryCollection<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     fn contains(&self, point: &Point<T>) -> bool {
         self.contains(&point.0)

--- a/geo/src/algorithm/contains/line.rs
+++ b/geo/src/algorithm/contains/line.rs
@@ -1,7 +1,6 @@
 use super::Contains;
 use crate::intersects::Intersects;
-use crate::kernels::*;
-use crate::*;
+use crate::{Coordinate, GeoNum, Line, LineString, Point};
 
 // ┌──────────────────────────┐
 // │ Implementations for Line │
@@ -9,7 +8,7 @@ use crate::*;
 
 impl<T> Contains<Coordinate<T>> for Line<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     fn contains(&self, coord: &Coordinate<T>) -> bool {
         if self.start == self.end {
@@ -22,7 +21,7 @@ where
 
 impl<T> Contains<Point<T>> for Line<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     fn contains(&self, p: &Point<T>) -> bool {
         self.contains(&p.0)
@@ -31,7 +30,7 @@ where
 
 impl<T> Contains<Line<T>> for Line<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     fn contains(&self, line: &Line<T>) -> bool {
         if line.start == line.end {
@@ -44,7 +43,7 @@ where
 
 impl<T> Contains<LineString<T>> for Line<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     fn contains(&self, linestring: &LineString<T>) -> bool {
         // Empty linestring has no interior, and not

--- a/geo/src/algorithm/contains/line_string.rs
+++ b/geo/src/algorithm/contains/line_string.rs
@@ -119,7 +119,7 @@ where
 // └─────────────────────────────────────┘
 impl<G, T> Contains<G> for MultiLineString<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
     LineString<T>: Contains<G>,
 {
     fn contains(&self, rhs: &G) -> bool {

--- a/geo/src/algorithm/contains/line_string.rs
+++ b/geo/src/algorithm/contains/line_string.rs
@@ -1,7 +1,6 @@
 use super::Contains;
-use crate::kernels::*;
-use crate::*;
-use intersects::Intersects;
+use crate::intersects::Intersects;
+use crate::{CoordNum, Coordinate, GeoNum, Line, LineString, MultiLineString, Point};
 
 // ┌────────────────────────────────┐
 // │ Implementations for LineString │
@@ -9,7 +8,7 @@ use intersects::Intersects;
 
 impl<T> Contains<Coordinate<T>> for LineString<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     fn contains(&self, coord: &Coordinate<T>) -> bool {
         if self.0.is_empty() {
@@ -28,7 +27,7 @@ where
 
 impl<T> Contains<Point<T>> for LineString<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     fn contains(&self, p: &Point<T>) -> bool {
         self.contains(&p.0)
@@ -37,7 +36,7 @@ where
 
 impl<T> Contains<Line<T>> for LineString<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     fn contains(&self, line: &Line<T>) -> bool {
         if line.start == line.end {
@@ -107,7 +106,7 @@ where
 
 impl<T> Contains<LineString<T>> for LineString<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     fn contains(&self, rhs: &LineString<T>) -> bool {
         rhs.lines().all(|l| self.contains(&l))

--- a/geo/src/algorithm/contains/point.rs
+++ b/geo/src/algorithm/contains/point.rs
@@ -7,7 +7,7 @@ use crate::*;
 
 impl<T> Contains<Coordinate<T>> for Point<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     fn contains(&self, coord: &Coordinate<T>) -> bool {
         &self.0 == coord
@@ -16,7 +16,7 @@ where
 
 impl<T> Contains<Point<T>> for Point<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     fn contains(&self, p: &Point<T>) -> bool {
         self.contains(&p.0)
@@ -28,7 +28,7 @@ where
 // └────────────────────────────────┘
 impl<G, T> Contains<G> for MultiPoint<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
     Point<T>: Contains<G>,
 {
     fn contains(&self, rhs: &G) -> bool {

--- a/geo/src/algorithm/contains/polygon.rs
+++ b/geo/src/algorithm/contains/polygon.rs
@@ -1,7 +1,6 @@
 use super::Contains;
 use crate::intersects::Intersects;
-use crate::kernels::HasKernel;
-use crate::{CoordNum, Coordinate, Line, LineString, MultiPolygon, Point, Polygon};
+use crate::{CoordNum, Coordinate, GeoNum, Line, LineString, MultiPolygon, Point, Polygon};
 
 // ┌─────────────────────────────┐
 // │ Implementations for Polygon │
@@ -9,7 +8,7 @@ use crate::{CoordNum, Coordinate, Line, LineString, MultiPolygon, Point, Polygon
 
 impl<T> Contains<Coordinate<T>> for Polygon<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     fn contains(&self, coord: &Coordinate<T>) -> bool {
         use crate::algorithm::coordinate_position::{CoordPos, CoordinatePosition};
@@ -20,7 +19,7 @@ where
 
 impl<T> Contains<Point<T>> for Polygon<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     fn contains(&self, p: &Point<T>) -> bool {
         self.contains(&p.0)
@@ -31,7 +30,7 @@ where
 // line.start and line.end is on the boundaries
 impl<T> Contains<Line<T>> for Polygon<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     fn contains(&self, line: &Line<T>) -> bool {
         // both endpoints are contained in the polygon and the line
@@ -46,7 +45,7 @@ where
 // TODO: also check interiors
 impl<T> Contains<Polygon<T>> for Polygon<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     fn contains(&self, poly: &Polygon<T>) -> bool {
         // decompose poly's exterior ring into Lines, and check each for containment
@@ -57,7 +56,7 @@ where
 // TODO: ensure DE-9IM compliance
 impl<T> Contains<LineString<T>> for Polygon<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     fn contains(&self, linestring: &LineString<T>) -> bool {
         // All LineString points must be inside the Polygon

--- a/geo/src/algorithm/contains/polygon.rs
+++ b/geo/src/algorithm/contains/polygon.rs
@@ -1,7 +1,7 @@
 use super::Contains;
 use crate::intersects::Intersects;
 use crate::kernels::HasKernel;
-use crate::{Coordinate, CoordinateType, Line, LineString, MultiPolygon, Point, Polygon};
+use crate::{CoordNum, Coordinate, Line, LineString, MultiPolygon, Point, Polygon};
 
 // ┌─────────────────────────────┐
 // │ Implementations for Polygon │
@@ -80,7 +80,7 @@ where
 // TODO: ensure DE-9IM compliance
 impl<G, T> Contains<G> for MultiPolygon<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
     Polygon<T>: Contains<G>,
 {
     fn contains(&self, rhs: &G) -> bool {

--- a/geo/src/algorithm/contains/rect.rs
+++ b/geo/src/algorithm/contains/rect.rs
@@ -7,7 +7,7 @@ use crate::*;
 
 impl<T> Contains<Coordinate<T>> for Rect<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     fn contains(&self, coord: &Coordinate<T>) -> bool {
         coord.x > self.min().x
@@ -19,7 +19,7 @@ where
 
 impl<T> Contains<Point<T>> for Rect<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     fn contains(&self, p: &Point<T>) -> bool {
         self.contains(&p.0)
@@ -28,7 +28,7 @@ where
 
 impl<T> Contains<Rect<T>> for Rect<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     fn contains(&self, other: &Rect<T>) -> bool {
         // TODO: check for degenerate rectangle (which is a line or a point)

--- a/geo/src/algorithm/contains/triangle.rs
+++ b/geo/src/algorithm/contains/triangle.rs
@@ -1,6 +1,5 @@
 use super::Contains;
-use crate::kernels::*;
-use crate::*;
+use crate::{Coordinate, GeoNum, LineString, Point, Triangle};
 
 // ┌──────────────────────────────┐
 // │ Implementations for Triangle │
@@ -8,18 +7,18 @@ use crate::*;
 
 impl<T> Contains<Coordinate<T>> for Triangle<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     fn contains(&self, coord: &Coordinate<T>) -> bool {
         let ls = LineString(vec![self.0, self.1, self.2, self.0]);
-        use utils::*;
+        use crate::utils::{coord_pos_relative_to_ring, CoordPos};
         coord_pos_relative_to_ring(*coord, &ls) == CoordPos::Inside
     }
 }
 
 impl<T> Contains<Point<T>> for Triangle<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     fn contains(&self, point: &Point<T>) -> bool {
         self.contains(&point.0)

--- a/geo/src/algorithm/convex_hull/graham.rs
+++ b/geo/src/algorithm/convex_hull/graham.rs
@@ -1,6 +1,6 @@
 use super::{swap_remove_to_first, trivial_hull};
 use crate::algorithm::kernels::*;
-use crate::{Coordinate, LineString};
+use crate::{Coordinate, GeoNum, LineString};
 
 /// The [Graham's scan] algorithm to compute the convex hull
 /// of a collection of points. This algorithm is less
@@ -20,7 +20,7 @@ use crate::{Coordinate, LineString};
 /// [Graham's scan]: //en.wikipedia.org/wiki/Graham_scan
 pub fn graham_hull<T>(mut points: &mut [Coordinate<T>], include_on_hull: bool) -> LineString<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     if points.len() < 4 {
         // Nothing to build with fewer than four points.
@@ -89,8 +89,7 @@ where
 mod test {
     use super::*;
     use crate::algorithm::is_convex::IsConvex;
-    use std::fmt::Debug;
-    fn test_convexity<T: HasKernel + Debug>(initial: &[(T, T)]) {
+    fn test_convexity<T: GeoNum>(initial: &[(T, T)]) {
         let mut v: Vec<_> = initial
             .iter()
             .map(|e| Coordinate::from((e.0, e.1)))

--- a/geo/src/algorithm/convex_hull/mod.rs
+++ b/geo/src/algorithm/convex_hull/mod.rs
@@ -1,5 +1,4 @@
-use super::kernels::*;
-use crate::*;
+use crate::{Coordinate, GeoNum, LineString, MultiLineString, MultiPoint, MultiPolygon, Polygon};
 
 /// Returns the convex hull of a Polygon. The hull is always oriented counter-clockwise.
 ///
@@ -38,13 +37,13 @@ use crate::*;
 /// assert_eq!(res.exterior(), &correct_hull);
 /// ```
 pub trait ConvexHull {
-    type Scalar: CoordNum;
+    type Scalar: GeoNum;
     fn convex_hull(&self) -> Polygon<Self::Scalar>;
 }
 
 impl<T> ConvexHull for Polygon<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     type Scalar = T;
     fn convex_hull(&self) -> Polygon<T> {
@@ -54,7 +53,7 @@ where
 
 impl<T> ConvexHull for MultiPolygon<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     type Scalar = T;
     fn convex_hull(&self) -> Polygon<T> {
@@ -69,7 +68,7 @@ where
 
 impl<T> ConvexHull for LineString<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     type Scalar = T;
     fn convex_hull(&self) -> Polygon<T> {
@@ -79,7 +78,7 @@ where
 
 impl<T> ConvexHull for MultiLineString<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     type Scalar = T;
     fn convex_hull(&self) -> Polygon<T> {
@@ -90,7 +89,7 @@ where
 
 impl<T> ConvexHull for MultiPoint<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     type Scalar = T;
     fn convex_hull(&self) -> Polygon<T> {
@@ -111,7 +110,7 @@ pub use graham::graham_hull;
 // required.
 fn trivial_hull<T>(points: &mut [Coordinate<T>], include_on_hull: bool) -> LineString<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     assert!(points.len() < 4);
 

--- a/geo/src/algorithm/convex_hull/mod.rs
+++ b/geo/src/algorithm/convex_hull/mod.rs
@@ -38,7 +38,7 @@ use crate::*;
 /// assert_eq!(res.exterior(), &correct_hull);
 /// ```
 pub trait ConvexHull {
-    type Scalar: CoordinateType;
+    type Scalar: CoordNum;
     fn convex_hull(&self) -> Polygon<Self::Scalar>;
 }
 

--- a/geo/src/algorithm/convex_hull/qhull.rs
+++ b/geo/src/algorithm/convex_hull/qhull.rs
@@ -1,7 +1,7 @@
 use super::{swap_remove_to_first, trivial_hull};
-use crate::algorithm::kernels::*;
+use crate::kernels::{HasKernel, Kernel, Orientation};
 use crate::utils::partition_slice;
-use crate::{Coordinate, LineString};
+use crate::{Coordinate, GeoNum, LineString};
 
 // Determines if `p_c` lies on the positive side of the
 // segment `p_a` to `p_b`. In other words, whether segment
@@ -11,16 +11,16 @@ use crate::{Coordinate, LineString};
 #[inline]
 fn is_ccw<T>(p_a: Coordinate<T>, p_b: Coordinate<T>, p_c: Coordinate<T>) -> bool
 where
-    T: HasKernel,
+    T: GeoNum,
 {
-    let o = T::Ker::orient2d(p_a, p_b, p_c);
+    let o = <T as HasKernel>::Ker::orient2d(p_a, p_b, p_c);
     o == Orientation::CounterClockwise
 }
 
 // Adapted from https://web.archive.org/web/20180409175413/http://www.ahristov.com/tutorial/geometry-games/convex-hull.html
 pub fn quick_hull<T>(mut points: &mut [Coordinate<T>]) -> LineString<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     // can't build a hull from fewer than four points
     if points.len() < 4 {
@@ -70,7 +70,7 @@ fn hull_set<T>(
     mut set: &mut [Coordinate<T>],
     hull: &mut Vec<Coordinate<T>>,
 ) where
-    T: HasKernel,
+    T: GeoNum,
 {
     if set.is_empty() {
         return;

--- a/geo/src/algorithm/coordinate_position.rs
+++ b/geo/src/algorithm/coordinate_position.rs
@@ -1,10 +1,9 @@
 use crate::algorithm::{
     bounding_rect::BoundingRect, dimensions::HasDimensions, intersects::Intersects,
-    kernels::HasKernel,
 };
 use crate::{
-    Coordinate, Geometry, GeometryCollection, Line, LineString, MultiLineString, MultiPoint,
-    MultiPolygon, Point, Polygon, Rect, Triangle,
+    Coordinate, GeoNum, Geometry, GeometryCollection, Line, LineString, MultiLineString,
+    MultiPoint, MultiPolygon, Point, Polygon, Rect, Triangle,
 };
 
 /// The position of a `Coordinate` relative to a `Geometry`
@@ -35,7 +34,7 @@ pub enum CoordPos {
 /// assert_eq!(square_poly.coordinate_position(&outside_coord), CoordPos::Outside);
 /// ```
 pub trait CoordinatePosition {
-    type Scalar: HasKernel;
+    type Scalar: GeoNum;
     fn coordinate_position(&self, coord: &Coordinate<Self::Scalar>) -> CoordPos {
         let mut is_inside = false;
         let mut boundary_count = 0;
@@ -69,7 +68,7 @@ pub trait CoordinatePosition {
 
 impl<T> CoordinatePosition for Coordinate<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     type Scalar = T;
     fn calculate_coordinate_position(
@@ -86,7 +85,7 @@ where
 
 impl<T> CoordinatePosition for Point<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     type Scalar = T;
     fn calculate_coordinate_position(
@@ -103,7 +102,7 @@ where
 
 impl<T> CoordinatePosition for Line<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     type Scalar = T;
     fn calculate_coordinate_position(
@@ -129,7 +128,7 @@ where
 
 impl<T> CoordinatePosition for LineString<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     type Scalar = T;
     fn calculate_coordinate_position(
@@ -178,7 +177,7 @@ where
 
 impl<T> CoordinatePosition for Triangle<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     type Scalar = T;
     fn calculate_coordinate_position(
@@ -195,7 +194,7 @@ where
 
 impl<T> CoordinatePosition for Rect<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     type Scalar = T;
     fn calculate_coordinate_position(
@@ -212,7 +211,7 @@ where
 
 impl<T> CoordinatePosition for MultiPoint<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     type Scalar = T;
     fn calculate_coordinate_position(
@@ -229,7 +228,7 @@ where
 
 impl<T> CoordinatePosition for Polygon<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     type Scalar = T;
     fn calculate_coordinate_position(
@@ -274,7 +273,7 @@ where
 
 impl<T> CoordinatePosition for MultiLineString<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     type Scalar = T;
     fn calculate_coordinate_position(
@@ -291,7 +290,7 @@ where
 
 impl<T> CoordinatePosition for MultiPolygon<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     type Scalar = T;
     fn calculate_coordinate_position(
@@ -308,7 +307,7 @@ where
 
 impl<T> CoordinatePosition for GeometryCollection<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     type Scalar = T;
     fn calculate_coordinate_position(
@@ -325,7 +324,7 @@ where
 
 impl<T> CoordinatePosition for Geometry<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     type Scalar = T;
     fn calculate_coordinate_position(
@@ -377,7 +376,7 @@ where
 /// closed `LineString`.
 pub fn coord_pos_relative_to_ring<T>(coord: Coordinate<T>, linestring: &LineString<T>) -> CoordPos
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     // Use the ray-tracing algorithm: count #times a
     // horizontal ray from point (to positive infinity).

--- a/geo/src/algorithm/coords_iter.rs
+++ b/geo/src/algorithm/coords_iter.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 
 use crate::{
-    Coordinate, CoordinateType, Geometry, GeometryCollection, Line, LineString, MultiLineString,
+    CoordNum, Coordinate, Geometry, GeometryCollection, Line, LineString, MultiLineString,
     MultiPoint, MultiPolygon, Point, Polygon, Rect, Triangle,
 };
 
@@ -13,7 +13,7 @@ type CoordinateChainOnce<T> = iter::Chain<iter::Once<Coordinate<T>>, iter::Once<
 pub trait CoordsIter<'a> {
     type Iter: Iterator<Item = Coordinate<Self::Scalar>>;
     type ExteriorIter: Iterator<Item = Coordinate<Self::Scalar>>;
-    type Scalar: CoordinateType;
+    type Scalar: CoordNum;
 
     /// Iterate over all exterior and (if any) interior coordinates of a geometry.
     ///
@@ -97,7 +97,7 @@ pub trait CoordsIter<'a> {
 // │ Implementation for Point │
 // └──────────────────────────┘
 
-impl<'a, T: CoordinateType> CoordsIter<'a> for Point<T> {
+impl<'a, T: CoordNum> CoordsIter<'a> for Point<T> {
     type Iter = iter::Once<Coordinate<T>>;
     type ExteriorIter = Self::Iter;
     type Scalar = T;
@@ -120,7 +120,7 @@ impl<'a, T: CoordinateType> CoordsIter<'a> for Point<T> {
 // │ Implementation for Line │
 // └─────────────────────────┘
 
-impl<'a, T: CoordinateType> CoordsIter<'a> for Line<T> {
+impl<'a, T: CoordNum> CoordsIter<'a> for Line<T> {
     type Iter = iter::Chain<iter::Once<Coordinate<T>>, iter::Once<Coordinate<T>>>;
     type ExteriorIter = Self::Iter;
     type Scalar = T;
@@ -145,7 +145,7 @@ impl<'a, T: CoordinateType> CoordsIter<'a> for Line<T> {
 
 type LineStringIter<'a, T> = iter::Copied<slice::Iter<'a, Coordinate<T>>>;
 
-impl<'a, T: CoordinateType + 'a> CoordsIter<'a> for LineString<T> {
+impl<'a, T: CoordNum + 'a> CoordsIter<'a> for LineString<T> {
     type Iter = LineStringIter<'a, T>;
     type ExteriorIter = Self::Iter;
     type Scalar = T;
@@ -173,7 +173,7 @@ type PolygonIter<'a, T> = iter::Chain<
     iter::Flatten<MapCoordsIter<'a, T, slice::Iter<'a, LineString<T>>, LineString<T>>>,
 >;
 
-impl<'a, T: CoordinateType + 'a> CoordsIter<'a> for Polygon<T> {
+impl<'a, T: CoordNum + 'a> CoordsIter<'a> for Polygon<T> {
     type Iter = PolygonIter<'a, T>;
     type ExteriorIter = LineStringIter<'a, T>;
     type Scalar = T;
@@ -203,7 +203,7 @@ impl<'a, T: CoordinateType + 'a> CoordsIter<'a> for Polygon<T> {
 // │ Implementation for MultiPoint │
 // └───────────────────────────────┘
 
-impl<'a, T: CoordinateType + 'a> CoordsIter<'a> for MultiPoint<T> {
+impl<'a, T: CoordNum + 'a> CoordsIter<'a> for MultiPoint<T> {
     type Iter = iter::Flatten<MapCoordsIter<'a, T, slice::Iter<'a, Point<T>>, Point<T>>>;
     type ExteriorIter = Self::Iter;
     type Scalar = T;
@@ -226,7 +226,7 @@ impl<'a, T: CoordinateType + 'a> CoordsIter<'a> for MultiPoint<T> {
 // │ Implementation for MultiLineString │
 // └────────────────────────────────────┘
 
-impl<'a, T: CoordinateType + 'a> CoordsIter<'a> for MultiLineString<T> {
+impl<'a, T: CoordNum + 'a> CoordsIter<'a> for MultiLineString<T> {
     type Iter = iter::Flatten<MapCoordsIter<'a, T, slice::Iter<'a, LineString<T>>, LineString<T>>>;
     type ExteriorIter = Self::Iter;
     type Scalar = T;
@@ -252,7 +252,7 @@ impl<'a, T: CoordinateType + 'a> CoordsIter<'a> for MultiLineString<T> {
 // │ Implementation for MultiPolygon │
 // └─────────────────────────────────┘
 
-impl<'a, T: CoordinateType + 'a> CoordsIter<'a> for MultiPolygon<T> {
+impl<'a, T: CoordNum + 'a> CoordsIter<'a> for MultiPolygon<T> {
     type Iter = iter::Flatten<MapCoordsIter<'a, T, slice::Iter<'a, Polygon<T>>, Polygon<T>>>;
     type ExteriorIter =
         iter::Flatten<MapExteriorCoordsIter<'a, T, slice::Iter<'a, Polygon<T>>, Polygon<T>>>;
@@ -276,7 +276,7 @@ impl<'a, T: CoordinateType + 'a> CoordsIter<'a> for MultiPolygon<T> {
 // │ Implementation for GeometryCollection │
 // └───────────────────────────────────────┘
 
-impl<'a, T: CoordinateType + 'a> CoordsIter<'a> for GeometryCollection<T> {
+impl<'a, T: CoordNum + 'a> CoordsIter<'a> for GeometryCollection<T> {
     type Iter = Box<dyn Iterator<Item = Coordinate<T>> + 'a>;
     type ExteriorIter = Box<dyn Iterator<Item = Coordinate<T>> + 'a>;
     type Scalar = T;
@@ -308,7 +308,7 @@ type RectIter<T> = iter::Chain<
     iter::Once<Coordinate<T>>,
 >;
 
-impl<'a, T: CoordinateType + 'a> CoordsIter<'a> for Rect<T> {
+impl<'a, T: CoordNum + 'a> CoordsIter<'a> for Rect<T> {
     type Iter = RectIter<T>;
     type ExteriorIter = Self::Iter;
     type Scalar = T;
@@ -349,7 +349,7 @@ impl<'a, T: CoordinateType + 'a> CoordsIter<'a> for Rect<T> {
 // │ Implementation for Triangle │
 // └─────────────────────────────┘
 
-impl<'a, T: CoordinateType + 'a> CoordsIter<'a> for Triangle<T> {
+impl<'a, T: CoordNum + 'a> CoordsIter<'a> for Triangle<T> {
     type Iter = iter::Chain<CoordinateChainOnce<T>, iter::Once<Coordinate<T>>>;
     type ExteriorIter = Self::Iter;
     type Scalar = T;
@@ -374,7 +374,7 @@ impl<'a, T: CoordinateType + 'a> CoordsIter<'a> for Triangle<T> {
 // │ Implementation for Geometry │
 // └─────────────────────────────┘
 
-impl<'a, T: CoordinateType + 'a> CoordsIter<'a> for Geometry<T> {
+impl<'a, T: CoordNum + 'a> CoordsIter<'a> for Geometry<T> {
     type Iter = GeometryCoordsIter<'a, T>;
     type ExteriorIter = GeometryExteriorCoordsIter<'a, T>;
     type Scalar = T;
@@ -447,12 +447,12 @@ impl<'a, T: CoordinateType + 'a> CoordsIter<'a> for Geometry<T> {
 #[derive(Debug)]
 pub struct MapCoordsIter<
     'a,
-    T: 'a + CoordinateType,
+    T: 'a + CoordNum,
     Iter1: Iterator<Item = &'a Iter2>,
     Iter2: 'a + CoordsIter<'a>,
 >(Iter1, marker::PhantomData<T>);
 
-impl<'a, T: 'a + CoordinateType, Iter1: Iterator<Item = &'a Iter2>, Iter2: CoordsIter<'a>> Iterator
+impl<'a, T: 'a + CoordNum, Iter1: Iterator<Item = &'a Iter2>, Iter2: CoordsIter<'a>> Iterator
     for MapCoordsIter<'a, T, Iter1, Iter2>
 {
     type Item = Iter2::Iter;
@@ -471,12 +471,12 @@ impl<'a, T: 'a + CoordinateType, Iter1: Iterator<Item = &'a Iter2>, Iter2: Coord
 #[derive(Debug)]
 pub struct MapExteriorCoordsIter<
     'a,
-    T: 'a + CoordinateType,
+    T: 'a + CoordNum,
     Iter1: Iterator<Item = &'a Iter2>,
     Iter2: 'a + CoordsIter<'a>,
 >(Iter1, marker::PhantomData<T>);
 
-impl<'a, T: 'a + CoordinateType, Iter1: Iterator<Item = &'a Iter2>, Iter2: CoordsIter<'a>> Iterator
+impl<'a, T: 'a + CoordNum, Iter1: Iterator<Item = &'a Iter2>, Iter2: CoordsIter<'a>> Iterator
     for MapExteriorCoordsIter<'a, T, Iter1, Iter2>
 {
     type Item = Iter2::ExteriorIter;
@@ -492,7 +492,7 @@ impl<'a, T: 'a + CoordinateType, Iter1: Iterator<Item = &'a Iter2>, Iter2: Coord
 
 // Utility to transform Geometry into Iterator<Coordinate>
 #[doc(hidden)]
-pub enum GeometryCoordsIter<'a, T: CoordinateType + 'a> {
+pub enum GeometryCoordsIter<'a, T: CoordNum + 'a> {
     Point(<Point<T> as CoordsIter<'a>>::Iter),
     Line(<Line<T> as CoordsIter<'a>>::Iter),
     LineString(<LineString<T> as CoordsIter<'a>>::Iter),
@@ -505,7 +505,7 @@ pub enum GeometryCoordsIter<'a, T: CoordinateType + 'a> {
     Triangle(<Triangle<T> as CoordsIter<'a>>::Iter),
 }
 
-impl<'a, T: CoordinateType> Iterator for GeometryCoordsIter<'a, T> {
+impl<'a, T: CoordNum> Iterator for GeometryCoordsIter<'a, T> {
     type Item = Coordinate<T>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -539,7 +539,7 @@ impl<'a, T: CoordinateType> Iterator for GeometryCoordsIter<'a, T> {
     }
 }
 
-impl<'a, T: CoordinateType + Debug> fmt::Debug for GeometryCoordsIter<'a, T> {
+impl<'a, T: CoordNum + Debug> fmt::Debug for GeometryCoordsIter<'a, T> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             GeometryCoordsIter::Point(i) => fmt.debug_tuple("Point").field(i).finish(),
@@ -565,7 +565,7 @@ impl<'a, T: CoordinateType + Debug> fmt::Debug for GeometryCoordsIter<'a, T> {
 
 // Utility to transform Geometry into Iterator<Coordinate>
 #[doc(hidden)]
-pub enum GeometryExteriorCoordsIter<'a, T: CoordinateType + 'a> {
+pub enum GeometryExteriorCoordsIter<'a, T: CoordNum + 'a> {
     Point(<Point<T> as CoordsIter<'a>>::ExteriorIter),
     Line(<Line<T> as CoordsIter<'a>>::ExteriorIter),
     LineString(<LineString<T> as CoordsIter<'a>>::ExteriorIter),
@@ -578,7 +578,7 @@ pub enum GeometryExteriorCoordsIter<'a, T: CoordinateType + 'a> {
     Triangle(<Triangle<T> as CoordsIter<'a>>::ExteriorIter),
 }
 
-impl<'a, T: CoordinateType> Iterator for GeometryExteriorCoordsIter<'a, T> {
+impl<'a, T: CoordNum> Iterator for GeometryExteriorCoordsIter<'a, T> {
     type Item = Coordinate<T>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -612,7 +612,7 @@ impl<'a, T: CoordinateType> Iterator for GeometryExteriorCoordsIter<'a, T> {
     }
 }
 
-impl<'a, T: CoordinateType + Debug> fmt::Debug for GeometryExteriorCoordsIter<'a, T> {
+impl<'a, T: CoordNum + Debug> fmt::Debug for GeometryExteriorCoordsIter<'a, T> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             GeometryExteriorCoordsIter::Point(i) => fmt.debug_tuple("Point").field(i).finish(),

--- a/geo/src/algorithm/dimensions.rs
+++ b/geo/src/algorithm/dimensions.rs
@@ -1,5 +1,5 @@
 use crate::{
-    CoordinateType, Geometry, GeometryCollection, Line, LineString, MultiLineString, MultiPoint,
+    CoordNum, Geometry, GeometryCollection, Line, LineString, MultiLineString, MultiPoint,
     MultiPolygon, Point, Polygon, Rect, Triangle,
 };
 
@@ -131,7 +131,7 @@ pub trait HasDimensions {
     fn boundary_dimensions(&self) -> Dimensions;
 }
 
-impl<C: CoordinateType> HasDimensions for Geometry<C> {
+impl<C: CoordNum> HasDimensions for Geometry<C> {
     fn is_empty(&self) -> bool {
         match self {
             Geometry::Point(g) => g.is_empty(),
@@ -178,7 +178,7 @@ impl<C: CoordinateType> HasDimensions for Geometry<C> {
     }
 }
 
-impl<C: CoordinateType> HasDimensions for Point<C> {
+impl<C: CoordNum> HasDimensions for Point<C> {
     fn is_empty(&self) -> bool {
         false
     }
@@ -192,7 +192,7 @@ impl<C: CoordinateType> HasDimensions for Point<C> {
     }
 }
 
-impl<C: CoordinateType> HasDimensions for Line<C> {
+impl<C: CoordNum> HasDimensions for Line<C> {
     fn is_empty(&self) -> bool {
         false
     }
@@ -216,7 +216,7 @@ impl<C: CoordinateType> HasDimensions for Line<C> {
     }
 }
 
-impl<C: CoordinateType> HasDimensions for LineString<C> {
+impl<C: CoordNum> HasDimensions for LineString<C> {
     fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
@@ -259,7 +259,7 @@ impl<C: CoordinateType> HasDimensions for LineString<C> {
     }
 }
 
-impl<C: CoordinateType> HasDimensions for Polygon<C> {
+impl<C: CoordNum> HasDimensions for Polygon<C> {
     fn is_empty(&self) -> bool {
         self.exterior().is_empty()
     }
@@ -273,7 +273,7 @@ impl<C: CoordinateType> HasDimensions for Polygon<C> {
     }
 }
 
-impl<C: CoordinateType> HasDimensions for MultiPoint<C> {
+impl<C: CoordNum> HasDimensions for MultiPoint<C> {
     fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
@@ -291,7 +291,7 @@ impl<C: CoordinateType> HasDimensions for MultiPoint<C> {
     }
 }
 
-impl<C: CoordinateType> HasDimensions for MultiLineString<C> {
+impl<C: CoordNum> HasDimensions for MultiLineString<C> {
     fn is_empty(&self) -> bool {
         self.iter().all(LineString::is_empty)
     }
@@ -326,7 +326,7 @@ impl<C: CoordinateType> HasDimensions for MultiLineString<C> {
     }
 }
 
-impl<C: CoordinateType> HasDimensions for MultiPolygon<C> {
+impl<C: CoordNum> HasDimensions for MultiPolygon<C> {
     fn is_empty(&self) -> bool {
         self.iter().all(Polygon::is_empty)
     }
@@ -348,7 +348,7 @@ impl<C: CoordinateType> HasDimensions for MultiPolygon<C> {
     }
 }
 
-impl<C: CoordinateType> HasDimensions for GeometryCollection<C> {
+impl<C: CoordNum> HasDimensions for GeometryCollection<C> {
     fn is_empty(&self) -> bool {
         if self.0.is_empty() {
             true
@@ -385,7 +385,7 @@ impl<C: CoordinateType> HasDimensions for GeometryCollection<C> {
     }
 }
 
-impl<C: CoordinateType> HasDimensions for Rect<C> {
+impl<C: CoordNum> HasDimensions for Rect<C> {
     fn is_empty(&self) -> bool {
         false
     }
@@ -414,7 +414,7 @@ impl<C: CoordinateType> HasDimensions for Rect<C> {
     }
 }
 
-impl<C: CoordinateType> HasDimensions for Triangle<C> {
+impl<C: CoordNum> HasDimensions for Triangle<C> {
     fn is_empty(&self) -> bool {
         false
     }

--- a/geo/src/algorithm/euclidean_distance.rs
+++ b/geo/src/algorithm/euclidean_distance.rs
@@ -184,7 +184,7 @@ where
 
 impl<T> EuclideanDistance<T, Polygon<T>> for Point<T>
 where
-    T: GeoFloat + HasKernel,
+    T: GeoFloat,
 {
     /// Minimum distance from a Point to a Polygon
     fn euclidean_distance(&self, polygon: &Polygon<T>) -> T {
@@ -215,7 +215,7 @@ where
 
 impl<T> EuclideanDistance<T, MultiPolygon<T>> for Point<T>
 where
-    T: GeoFloat + HasKernel,
+    T: GeoFloat,
 {
     /// Minimum distance from a Point to a MultiPolygon
     fn euclidean_distance(&self, mpolygon: &MultiPolygon<T>) -> T {
@@ -268,7 +268,7 @@ where
 /// Line to Line distance
 impl<T> EuclideanDistance<T, Line<T>> for Line<T>
 where
-    T: GeoFloat + FloatConst + Signed + RTreeNum + HasKernel,
+    T: GeoFloat + FloatConst + Signed + RTreeNum,
 {
     fn euclidean_distance(&self, other: &Line<T>) -> T {
         if self.intersects(other) || self.contains(other) {
@@ -286,7 +286,7 @@ where
 /// Line to LineString
 impl<T> EuclideanDistance<T, LineString<T>> for Line<T>
 where
-    T: GeoFloat + FloatConst + Signed + RTreeNum + HasKernel,
+    T: GeoFloat + FloatConst + Signed + RTreeNum,
 {
     fn euclidean_distance(&self, other: &LineString<T>) -> T {
         other.euclidean_distance(self)
@@ -296,7 +296,7 @@ where
 // Line to Polygon distance
 impl<T> EuclideanDistance<T, Polygon<T>> for Line<T>
 where
-    T: GeoFloat + Signed + RTreeNum + FloatConst + HasKernel,
+    T: GeoFloat + Signed + RTreeNum + FloatConst,
 {
     fn euclidean_distance(&self, other: &Polygon<T>) -> T {
         if other.contains(self) || self.intersects(other) {
@@ -330,7 +330,7 @@ where
 /// Line to MultiPolygon distance
 impl<T> EuclideanDistance<T, MultiPolygon<T>> for Line<T>
 where
-    T: GeoFloat + FloatConst + Signed + RTreeNum + HasKernel,
+    T: GeoFloat + FloatConst + Signed + RTreeNum,
 {
     fn euclidean_distance(&self, mpolygon: &MultiPolygon<T>) -> T {
         mpolygon
@@ -358,7 +358,7 @@ where
 /// LineString to Line
 impl<T> EuclideanDistance<T, Line<T>> for LineString<T>
 where
-    T: GeoFloat + FloatConst + Signed + RTreeNum + HasKernel,
+    T: GeoFloat + FloatConst + Signed + RTreeNum,
 {
     fn euclidean_distance(&self, other: &Line<T>) -> T {
         self.lines().fold(Bounded::max_value(), |acc, line| {
@@ -370,7 +370,7 @@ where
 /// LineString-LineString distance
 impl<T> EuclideanDistance<T, LineString<T>> for LineString<T>
 where
-    T: GeoFloat + HasKernel + Signed + RTreeNum,
+    T: GeoFloat + Signed + RTreeNum,
 {
     fn euclidean_distance(&self, other: &LineString<T>) -> T {
         if self.intersects(other) {
@@ -384,7 +384,7 @@ where
 /// LineString to Polygon
 impl<T> EuclideanDistance<T, Polygon<T>> for LineString<T>
 where
-    T: GeoFloat + FloatConst + Signed + RTreeNum + HasKernel,
+    T: GeoFloat + FloatConst + Signed + RTreeNum,
 {
     fn euclidean_distance(&self, other: &Polygon<T>) -> T {
         if self.intersects(other) || other.contains(self) {
@@ -422,7 +422,7 @@ where
 
 impl<T> EuclideanDistance<T, Point<T>> for Polygon<T>
 where
-    T: GeoFloat + HasKernel,
+    T: GeoFloat,
 {
     /// Minimum distance from a Polygon to a Point
     fn euclidean_distance(&self, point: &Point<T>) -> T {
@@ -433,7 +433,7 @@ where
 // Polygon to Line distance
 impl<T> EuclideanDistance<T, Line<T>> for Polygon<T>
 where
-    T: GeoFloat + FloatConst + Signed + RTreeNum + HasKernel,
+    T: GeoFloat + FloatConst + Signed + RTreeNum,
 {
     fn euclidean_distance(&self, other: &Line<T>) -> T {
         other.euclidean_distance(self)
@@ -443,7 +443,7 @@ where
 /// Polygon to LineString distance
 impl<T> EuclideanDistance<T, LineString<T>> for Polygon<T>
 where
-    T: GeoFloat + FloatConst + Signed + RTreeNum + HasKernel,
+    T: GeoFloat + FloatConst + Signed + RTreeNum,
 {
     fn euclidean_distance(&self, other: &LineString<T>) -> T {
         other.euclidean_distance(self)
@@ -453,7 +453,7 @@ where
 // Polygon to Polygon distance
 impl<T> EuclideanDistance<T, Polygon<T>> for Polygon<T>
 where
-    T: GeoFloat + FloatConst + RTreeNum + HasKernel,
+    T: GeoFloat + FloatConst + RTreeNum,
 {
     /// This implementation has a "fast path" in cases where both input polygons are convex:
     /// it switches to an implementation of the "rotating calipers" method described in [Pirzadeh (1999), pp24—30](http://digitool.library.mcgill.ca/R/?func=dbin-jump-full&object_id=21623&local_base=GEN01-MCG02),
@@ -495,7 +495,7 @@ where
 
 impl<T> EuclideanDistance<T, Point<T>> for MultiPolygon<T>
 where
-    T: GeoFloat + HasKernel,
+    T: GeoFloat,
 {
     /// Minimum distance from a MultiPolygon to a Point
     fn euclidean_distance(&self, point: &Point<T>) -> T {
@@ -506,7 +506,7 @@ where
 /// MultiPolygon to Line distance
 impl<T> EuclideanDistance<T, Line<T>> for MultiPolygon<T>
 where
-    T: GeoFloat + FloatConst + Signed + RTreeNum + HasKernel,
+    T: GeoFloat + FloatConst + Signed + RTreeNum,
 {
     fn euclidean_distance(&self, other: &Line<T>) -> T {
         other.euclidean_distance(self)
@@ -519,7 +519,7 @@ where
 
 impl<T> EuclideanDistance<T, Point<T>> for Triangle<T>
 where
-    T: GeoFloat + HasKernel,
+    T: GeoFloat,
 {
     fn euclidean_distance(&self, point: &Point<T>) -> T {
         if self.contains(point) {

--- a/geo/src/algorithm/euclidean_distance.rs
+++ b/geo/src/algorithm/euclidean_distance.rs
@@ -2,12 +2,10 @@ use crate::algorithm::contains::Contains;
 use crate::algorithm::euclidean_length::EuclideanLength;
 use crate::algorithm::intersects::Intersects;
 use crate::algorithm::polygon_distance_fast_path::*;
-use crate::kernels::*;
 use crate::utils::{coord_pos_relative_to_ring, CoordPos};
-use crate::GeoFloat;
 use crate::{
-    Coordinate, Line, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon,
-    Triangle,
+    Coordinate, GeoFloat, GeoNum, Line, LineString, MultiLineString, MultiPoint, MultiPolygon,
+    Point, Polygon, Triangle,
 };
 use num_traits::{float::FloatConst, Bounded, Float, Signed};
 
@@ -543,7 +541,7 @@ where
 /// contain a point from the candidate Polygon's outer shell in their simple representations
 fn ring_contains_point<T>(poly: &Polygon<T>, p: Point<T>) -> bool
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     match coord_pos_relative_to_ring(p.0, &poly.exterior()) {
         CoordPos::Inside => true,

--- a/geo/src/algorithm/euclidean_length.rs
+++ b/geo/src/algorithm/euclidean_length.rs
@@ -1,7 +1,7 @@
 use num_traits::Float;
 use std::iter::Sum;
 
-use crate::{Line, LineString, MultiLineString};
+use crate::{CoordinateType, Line, LineString, MultiLineString};
 
 /// Calculation of the length
 
@@ -29,7 +29,7 @@ pub trait EuclideanLength<T, RHS = Self> {
 
 impl<T> EuclideanLength<T> for Line<T>
 where
-    T: Float,
+    T: CoordinateType + Float,
 {
     fn euclidean_length(&self) -> T {
         ::geo_types::private_utils::line_euclidean_length(*self)
@@ -38,7 +38,7 @@ where
 
 impl<T> EuclideanLength<T> for LineString<T>
 where
-    T: Float + Sum,
+    T: CoordinateType + Float + Sum,
 {
     fn euclidean_length(&self) -> T {
         self.lines().map(|line| line.euclidean_length()).sum()
@@ -47,7 +47,7 @@ where
 
 impl<T> EuclideanLength<T> for MultiLineString<T>
 where
-    T: Float + Sum,
+    T: CoordinateType + Float + Sum,
 {
     fn euclidean_length(&self) -> T {
         self.0

--- a/geo/src/algorithm/euclidean_length.rs
+++ b/geo/src/algorithm/euclidean_length.rs
@@ -1,7 +1,6 @@
-use num_traits::Float;
 use std::iter::Sum;
 
-use crate::{CoordNum, Line, LineString, MultiLineString};
+use crate::{CoordFloat, Line, LineString, MultiLineString};
 
 /// Calculation of the length
 
@@ -29,7 +28,7 @@ pub trait EuclideanLength<T, RHS = Self> {
 
 impl<T> EuclideanLength<T> for Line<T>
 where
-    T: CoordNum + Float,
+    T: CoordFloat,
 {
     fn euclidean_length(&self) -> T {
         ::geo_types::private_utils::line_euclidean_length(*self)
@@ -38,7 +37,7 @@ where
 
 impl<T> EuclideanLength<T> for LineString<T>
 where
-    T: CoordNum + Float + Sum,
+    T: CoordFloat + Sum,
 {
     fn euclidean_length(&self) -> T {
         self.lines().map(|line| line.euclidean_length()).sum()
@@ -47,7 +46,7 @@ where
 
 impl<T> EuclideanLength<T> for MultiLineString<T>
 where
-    T: CoordNum + Float + Sum,
+    T: CoordFloat + Sum,
 {
     fn euclidean_length(&self) -> T {
         self.0

--- a/geo/src/algorithm/euclidean_length.rs
+++ b/geo/src/algorithm/euclidean_length.rs
@@ -1,7 +1,7 @@
 use num_traits::Float;
 use std::iter::Sum;
 
-use crate::{CoordinateType, Line, LineString, MultiLineString};
+use crate::{CoordNum, Line, LineString, MultiLineString};
 
 /// Calculation of the length
 
@@ -29,7 +29,7 @@ pub trait EuclideanLength<T, RHS = Self> {
 
 impl<T> EuclideanLength<T> for Line<T>
 where
-    T: CoordinateType + Float,
+    T: CoordNum + Float,
 {
     fn euclidean_length(&self) -> T {
         ::geo_types::private_utils::line_euclidean_length(*self)
@@ -38,7 +38,7 @@ where
 
 impl<T> EuclideanLength<T> for LineString<T>
 where
-    T: CoordinateType + Float + Sum,
+    T: CoordNum + Float + Sum,
 {
     fn euclidean_length(&self) -> T {
         self.lines().map(|line| line.euclidean_length()).sum()
@@ -47,7 +47,7 @@ where
 
 impl<T> EuclideanLength<T> for MultiLineString<T>
 where
-    T: CoordinateType + Float + Sum,
+    T: CoordNum + Float + Sum,
 {
     fn euclidean_length(&self) -> T {
         self.0

--- a/geo/src/algorithm/extremes.rs
+++ b/geo/src/algorithm/extremes.rs
@@ -1,5 +1,5 @@
 use crate::algorithm::coords_iter::CoordsIter;
-use crate::{Coordinate, CoordinateType};
+use crate::{CoordNum, Coordinate};
 
 /// Find the extreme coordinates and indices of a geometry.
 ///
@@ -24,18 +24,18 @@ use crate::{Coordinate, CoordinateType};
 /// assert_eq!(extremes.y_max.coord.x, 1.);
 /// assert_eq!(extremes.y_max.coord.y, 2.);
 /// ```
-pub trait Extremes<'a, T: CoordinateType> {
+pub trait Extremes<'a, T: CoordNum> {
     fn extremes(&'a self) -> Option<Outcome<T>>;
 }
 
 #[derive(Debug, PartialEq)]
-pub struct Extreme<T: CoordinateType> {
+pub struct Extreme<T: CoordNum> {
     pub index: usize,
     pub coord: Coordinate<T>,
 }
 
 #[derive(Debug, PartialEq)]
-pub struct Outcome<T: CoordinateType> {
+pub struct Outcome<T: CoordNum> {
     pub x_min: Extreme<T>,
     pub y_min: Extreme<T>,
     pub x_max: Extreme<T>,
@@ -45,7 +45,7 @@ pub struct Outcome<T: CoordinateType> {
 impl<'a, T, G> Extremes<'a, T> for G
 where
     G: CoordsIter<'a, Scalar = T>,
-    T: CoordinateType,
+    T: CoordNum,
 {
     fn extremes(&'a self) -> Option<Outcome<T>> {
         let mut iter = self.exterior_coords_iter().enumerate();

--- a/geo/src/algorithm/haversine_destination.rs
+++ b/geo/src/algorithm/haversine_destination.rs
@@ -1,11 +1,11 @@
-use crate::{CoordinateType, Point, MEAN_EARTH_RADIUS};
+use crate::{CoordNum, Point, MEAN_EARTH_RADIUS};
 use num_traits::{Float, FromPrimitive};
 
 /// Returns a new Point using the distance to the existing Point and a bearing for the direction
 ///
 /// *Note*: this implementation uses a mean earth radius of 6371.088 km, based on the [recommendation of
 /// the IUGG](ftp://athena.fsv.cvut.cz/ZFG/grs80-Moritz.pdf)
-pub trait HaversineDestination<T: CoordinateType + Float> {
+pub trait HaversineDestination<T: CoordNum + Float> {
     /// Returns a new Point using distance to the existing Point and a bearing for the direction
     ///
     /// # Units
@@ -28,7 +28,7 @@ pub trait HaversineDestination<T: CoordinateType + Float> {
 
 impl<T> HaversineDestination<T> for Point<T>
 where
-    T: CoordinateType + Float + FromPrimitive,
+    T: CoordNum + Float + FromPrimitive,
 {
     fn haversine_destination(&self, bearing: T, distance: T) -> Point<T> {
         let center_lng = self.x().to_radians();

--- a/geo/src/algorithm/haversine_destination.rs
+++ b/geo/src/algorithm/haversine_destination.rs
@@ -1,11 +1,11 @@
-use crate::{Point, MEAN_EARTH_RADIUS};
+use crate::{CoordinateType, Point, MEAN_EARTH_RADIUS};
 use num_traits::{Float, FromPrimitive};
 
 /// Returns a new Point using the distance to the existing Point and a bearing for the direction
 ///
 /// *Note*: this implementation uses a mean earth radius of 6371.088 km, based on the [recommendation of
 /// the IUGG](ftp://athena.fsv.cvut.cz/ZFG/grs80-Moritz.pdf)
-pub trait HaversineDestination<T: Float> {
+pub trait HaversineDestination<T: CoordinateType + Float> {
     /// Returns a new Point using distance to the existing Point and a bearing for the direction
     ///
     /// # Units
@@ -28,7 +28,7 @@ pub trait HaversineDestination<T: Float> {
 
 impl<T> HaversineDestination<T> for Point<T>
 where
-    T: Float + FromPrimitive,
+    T: CoordinateType + Float + FromPrimitive,
 {
     fn haversine_destination(&self, bearing: T, distance: T) -> Point<T> {
         let center_lng = self.x().to_radians();

--- a/geo/src/algorithm/haversine_destination.rs
+++ b/geo/src/algorithm/haversine_destination.rs
@@ -67,10 +67,9 @@ mod test {
     fn direct_and_indirect_destinations_are_close() {
         let p_1 = Point::<f64>::new(9.177789688110352, 48.776781529534965);
         let p_2 = p_1.haversine_destination(45., 10000.);
-        let square_edge = { pow(10000., 2) / 2. }.sqrt();
+        let square_edge = { pow(10000., 2) / 2f64 }.sqrt();
         let p_3 = p_1.haversine_destination(0., square_edge);
         let p_4 = p_3.haversine_destination(90., square_edge);
-        assert_relative_eq!(p_4.x(), p_2.x(), epsilon = 1.0e-6);
-        assert_relative_eq!(p_4.y(), p_2.y(), epsilon = 1.0e-6);
+        assert_relative_eq!(p_4, p_2, epsilon = 1.0e-6);
     }
 }

--- a/geo/src/algorithm/haversine_destination.rs
+++ b/geo/src/algorithm/haversine_destination.rs
@@ -1,11 +1,11 @@
-use crate::{CoordNum, Point, MEAN_EARTH_RADIUS};
-use num_traits::{Float, FromPrimitive};
+use crate::{CoordFloat, Point, MEAN_EARTH_RADIUS};
+use num_traits::FromPrimitive;
 
 /// Returns a new Point using the distance to the existing Point and a bearing for the direction
 ///
 /// *Note*: this implementation uses a mean earth radius of 6371.088 km, based on the [recommendation of
 /// the IUGG](ftp://athena.fsv.cvut.cz/ZFG/grs80-Moritz.pdf)
-pub trait HaversineDestination<T: CoordNum + Float> {
+pub trait HaversineDestination<T: CoordFloat> {
     /// Returns a new Point using distance to the existing Point and a bearing for the direction
     ///
     /// # Units
@@ -28,7 +28,7 @@ pub trait HaversineDestination<T: CoordNum + Float> {
 
 impl<T> HaversineDestination<T> for Point<T>
 where
-    T: CoordNum + Float + FromPrimitive,
+    T: CoordFloat + FromPrimitive,
 {
     fn haversine_destination(&self, bearing: T, distance: T) -> Point<T> {
         let center_lng = self.x().to_radians();

--- a/geo/src/algorithm/haversine_distance.rs
+++ b/geo/src/algorithm/haversine_distance.rs
@@ -1,4 +1,4 @@
-use crate::{Point, MEAN_EARTH_RADIUS};
+use crate::{CoordinateType, Point, MEAN_EARTH_RADIUS};
 use num_traits::{Float, FromPrimitive};
 
 /// Determine the distance between two geometries using the [haversine formula].
@@ -41,7 +41,7 @@ pub trait HaversineDistance<T, Rhs = Self> {
 
 impl<T> HaversineDistance<T, Point<T>> for Point<T>
 where
-    T: Float + FromPrimitive,
+    T: CoordinateType + Float + FromPrimitive,
 {
     fn haversine_distance(&self, rhs: &Point<T>) -> T {
         let two = T::one() + T::one();

--- a/geo/src/algorithm/haversine_distance.rs
+++ b/geo/src/algorithm/haversine_distance.rs
@@ -1,5 +1,5 @@
-use crate::{CoordNum, Point, MEAN_EARTH_RADIUS};
-use num_traits::{Float, FromPrimitive};
+use crate::{CoordFloat, Point, MEAN_EARTH_RADIUS};
+use num_traits::FromPrimitive;
 
 /// Determine the distance between two geometries using the [haversine formula].
 ///
@@ -41,7 +41,7 @@ pub trait HaversineDistance<T, Rhs = Self> {
 
 impl<T> HaversineDistance<T, Point<T>> for Point<T>
 where
-    T: CoordNum + Float + FromPrimitive,
+    T: CoordFloat + FromPrimitive,
 {
     fn haversine_distance(&self, rhs: &Point<T>) -> T {
         let two = T::one() + T::one();

--- a/geo/src/algorithm/haversine_distance.rs
+++ b/geo/src/algorithm/haversine_distance.rs
@@ -1,4 +1,4 @@
-use crate::{CoordinateType, Point, MEAN_EARTH_RADIUS};
+use crate::{CoordNum, Point, MEAN_EARTH_RADIUS};
 use num_traits::{Float, FromPrimitive};
 
 /// Determine the distance between two geometries using the [haversine formula].
@@ -41,7 +41,7 @@ pub trait HaversineDistance<T, Rhs = Self> {
 
 impl<T> HaversineDistance<T, Point<T>> for Point<T>
 where
-    T: CoordinateType + Float + FromPrimitive,
+    T: CoordNum + Float + FromPrimitive,
 {
     fn haversine_distance(&self, rhs: &Point<T>) -> T {
         let two = T::one() + T::one();

--- a/geo/src/algorithm/haversine_intermediate.rs
+++ b/geo/src/algorithm/haversine_intermediate.rs
@@ -1,9 +1,9 @@
-use crate::{Point, MEAN_EARTH_RADIUS};
+use crate::{CoordinateType, Point, MEAN_EARTH_RADIUS};
 use num_traits::{Float, FromPrimitive};
 
 /// Returns a new Point along a great circle route between two existing points
 
-pub trait HaversineIntermediate<T: Float> {
+pub trait HaversineIntermediate<T: CoordinateType + Float> {
     /// Returns a new Point along a great circle route between two existing points.
     ///
     /// # Examples
@@ -41,7 +41,7 @@ pub trait HaversineIntermediate<T: Float> {
 
 impl<T> HaversineIntermediate<T> for Point<T>
 where
-    T: Float + FromPrimitive,
+    T: CoordinateType + Float + FromPrimitive,
 {
     fn haversine_intermediate(&self, other: &Point<T>, f: T) -> Point<T> {
         let params = get_params(&self, &other);
@@ -99,7 +99,10 @@ struct HaversineParams<T: Float + FromPrimitive> {
 }
 
 #[allow(clippy::many_single_char_names)]
-fn get_point<T: Float + FromPrimitive>(params: &HaversineParams<T>, f: T) -> Point<T> {
+fn get_point<T: CoordinateType + Float + FromPrimitive>(
+    params: &HaversineParams<T>,
+    f: T,
+) -> Point<T> {
     let one = T::one();
 
     let HaversineParams {
@@ -126,7 +129,10 @@ fn get_point<T: Float + FromPrimitive>(params: &HaversineParams<T>, f: T) -> Poi
 }
 
 #[allow(clippy::many_single_char_names)]
-fn get_params<T: Float + FromPrimitive>(p1: &Point<T>, p2: &Point<T>) -> HaversineParams<T> {
+fn get_params<T: CoordinateType + Float + FromPrimitive>(
+    p1: &Point<T>,
+    p2: &Point<T>,
+) -> HaversineParams<T> {
     let one = T::one();
     let two = one + one;
 

--- a/geo/src/algorithm/haversine_intermediate.rs
+++ b/geo/src/algorithm/haversine_intermediate.rs
@@ -1,9 +1,9 @@
-use crate::{CoordNum, Point, MEAN_EARTH_RADIUS};
-use num_traits::{Float, FromPrimitive};
+use crate::{CoordFloat, Point, MEAN_EARTH_RADIUS};
+use num_traits::FromPrimitive;
 
 /// Returns a new Point along a great circle route between two existing points
 
-pub trait HaversineIntermediate<T: CoordNum + Float> {
+pub trait HaversineIntermediate<T: CoordFloat> {
     /// Returns a new Point along a great circle route between two existing points.
     ///
     /// # Examples
@@ -41,7 +41,7 @@ pub trait HaversineIntermediate<T: CoordNum + Float> {
 
 impl<T> HaversineIntermediate<T> for Point<T>
 where
-    T: CoordNum + Float + FromPrimitive,
+    T: CoordFloat + FromPrimitive,
 {
     fn haversine_intermediate(&self, other: &Point<T>, f: T) -> Point<T> {
         let params = get_params(&self, &other);
@@ -88,7 +88,7 @@ where
 }
 
 #[allow(clippy::many_single_char_names)]
-struct HaversineParams<T: Float + FromPrimitive> {
+struct HaversineParams<T: num_traits::Float + FromPrimitive> {
     d: T,
     n: T,
     o: T,
@@ -99,7 +99,7 @@ struct HaversineParams<T: Float + FromPrimitive> {
 }
 
 #[allow(clippy::many_single_char_names)]
-fn get_point<T: CoordNum + Float + FromPrimitive>(params: &HaversineParams<T>, f: T) -> Point<T> {
+fn get_point<T: CoordFloat + FromPrimitive>(params: &HaversineParams<T>, f: T) -> Point<T> {
     let one = T::one();
 
     let HaversineParams {
@@ -126,10 +126,7 @@ fn get_point<T: CoordNum + Float + FromPrimitive>(params: &HaversineParams<T>, f
 }
 
 #[allow(clippy::many_single_char_names)]
-fn get_params<T: CoordNum + Float + FromPrimitive>(
-    p1: &Point<T>,
-    p2: &Point<T>,
-) -> HaversineParams<T> {
+fn get_params<T: CoordFloat + FromPrimitive>(p1: &Point<T>, p2: &Point<T>) -> HaversineParams<T> {
     let one = T::one();
     let two = one + one;
 

--- a/geo/src/algorithm/haversine_intermediate.rs
+++ b/geo/src/algorithm/haversine_intermediate.rs
@@ -1,9 +1,9 @@
-use crate::{CoordinateType, Point, MEAN_EARTH_RADIUS};
+use crate::{CoordNum, Point, MEAN_EARTH_RADIUS};
 use num_traits::{Float, FromPrimitive};
 
 /// Returns a new Point along a great circle route between two existing points
 
-pub trait HaversineIntermediate<T: CoordinateType + Float> {
+pub trait HaversineIntermediate<T: CoordNum + Float> {
     /// Returns a new Point along a great circle route between two existing points.
     ///
     /// # Examples
@@ -41,7 +41,7 @@ pub trait HaversineIntermediate<T: CoordinateType + Float> {
 
 impl<T> HaversineIntermediate<T> for Point<T>
 where
-    T: CoordinateType + Float + FromPrimitive,
+    T: CoordNum + Float + FromPrimitive,
 {
     fn haversine_intermediate(&self, other: &Point<T>, f: T) -> Point<T> {
         let params = get_params(&self, &other);
@@ -99,10 +99,7 @@ struct HaversineParams<T: Float + FromPrimitive> {
 }
 
 #[allow(clippy::many_single_char_names)]
-fn get_point<T: CoordinateType + Float + FromPrimitive>(
-    params: &HaversineParams<T>,
-    f: T,
-) -> Point<T> {
+fn get_point<T: CoordNum + Float + FromPrimitive>(params: &HaversineParams<T>, f: T) -> Point<T> {
     let one = T::one();
 
     let HaversineParams {
@@ -129,7 +126,7 @@ fn get_point<T: CoordinateType + Float + FromPrimitive>(
 }
 
 #[allow(clippy::many_single_char_names)]
-fn get_params<T: CoordinateType + Float + FromPrimitive>(
+fn get_params<T: CoordNum + Float + FromPrimitive>(
     p1: &Point<T>,
     p2: &Point<T>,
 ) -> HaversineParams<T> {

--- a/geo/src/algorithm/haversine_length.rs
+++ b/geo/src/algorithm/haversine_length.rs
@@ -1,7 +1,7 @@
 use num_traits::{Float, FromPrimitive};
 
 use crate::algorithm::haversine_distance::HaversineDistance;
-use crate::{CoordinateType, Line, LineString, MultiLineString};
+use crate::{CoordNum, Line, LineString, MultiLineString};
 
 /// Determine the length of a geometry using the [haversine formula].
 ///
@@ -43,7 +43,7 @@ pub trait HaversineLength<T, RHS = Self> {
 
 impl<T> HaversineLength<T> for Line<T>
 where
-    T: CoordinateType + Float + FromPrimitive,
+    T: CoordNum + Float + FromPrimitive,
 {
     fn haversine_length(&self) -> T {
         let (start, end) = self.points();
@@ -53,7 +53,7 @@ where
 
 impl<T> HaversineLength<T> for LineString<T>
 where
-    T: CoordinateType + Float + FromPrimitive,
+    T: CoordNum + Float + FromPrimitive,
 {
     fn haversine_length(&self) -> T {
         self.lines().fold(T::zero(), |total_length, line| {
@@ -64,7 +64,7 @@ where
 
 impl<T> HaversineLength<T> for MultiLineString<T>
 where
-    T: CoordinateType + Float + FromPrimitive,
+    T: CoordNum + Float + FromPrimitive,
 {
     fn haversine_length(&self) -> T {
         self.0

--- a/geo/src/algorithm/haversine_length.rs
+++ b/geo/src/algorithm/haversine_length.rs
@@ -1,7 +1,7 @@
-use num_traits::{Float, FromPrimitive};
+use num_traits::FromPrimitive;
 
 use crate::algorithm::haversine_distance::HaversineDistance;
-use crate::{CoordNum, Line, LineString, MultiLineString};
+use crate::{CoordFloat, Line, LineString, MultiLineString};
 
 /// Determine the length of a geometry using the [haversine formula].
 ///
@@ -43,7 +43,7 @@ pub trait HaversineLength<T, RHS = Self> {
 
 impl<T> HaversineLength<T> for Line<T>
 where
-    T: CoordNum + Float + FromPrimitive,
+    T: CoordFloat + FromPrimitive,
 {
     fn haversine_length(&self) -> T {
         let (start, end) = self.points();
@@ -53,7 +53,7 @@ where
 
 impl<T> HaversineLength<T> for LineString<T>
 where
-    T: CoordNum + Float + FromPrimitive,
+    T: CoordFloat + FromPrimitive,
 {
     fn haversine_length(&self) -> T {
         self.lines().fold(T::zero(), |total_length, line| {
@@ -64,7 +64,7 @@ where
 
 impl<T> HaversineLength<T> for MultiLineString<T>
 where
-    T: CoordNum + Float + FromPrimitive,
+    T: CoordFloat + FromPrimitive,
 {
     fn haversine_length(&self) -> T {
         self.0

--- a/geo/src/algorithm/haversine_length.rs
+++ b/geo/src/algorithm/haversine_length.rs
@@ -1,7 +1,7 @@
 use num_traits::{Float, FromPrimitive};
 
 use crate::algorithm::haversine_distance::HaversineDistance;
-use crate::{Line, LineString, MultiLineString};
+use crate::{CoordinateType, Line, LineString, MultiLineString};
 
 /// Determine the length of a geometry using the [haversine formula].
 ///
@@ -43,7 +43,7 @@ pub trait HaversineLength<T, RHS = Self> {
 
 impl<T> HaversineLength<T> for Line<T>
 where
-    T: Float + FromPrimitive,
+    T: CoordinateType + Float + FromPrimitive,
 {
     fn haversine_length(&self) -> T {
         let (start, end) = self.points();
@@ -53,7 +53,7 @@ where
 
 impl<T> HaversineLength<T> for LineString<T>
 where
-    T: Float + FromPrimitive,
+    T: CoordinateType + Float + FromPrimitive,
 {
     fn haversine_length(&self) -> T {
         self.lines().fold(T::zero(), |total_length, line| {
@@ -64,7 +64,7 @@ where
 
 impl<T> HaversineLength<T> for MultiLineString<T>
 where
-    T: Float + FromPrimitive,
+    T: CoordinateType + Float + FromPrimitive,
 {
     fn haversine_length(&self) -> T {
         self.0

--- a/geo/src/algorithm/intersects/collections.rs
+++ b/geo/src/algorithm/intersects/collections.rs
@@ -3,7 +3,7 @@ use crate::*;
 
 impl<T, G> Intersects<G> for Geometry<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
     Point<T>: Intersects<G>,
     MultiPoint<T>: Intersects<G>,
     Line<T>: Intersects<G>,
@@ -36,7 +36,7 @@ symmetric_intersects_impl!(Polygon<T>, Geometry<T>);
 
 impl<T, G> Intersects<G> for GeometryCollection<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
     Geometry<T>: Intersects<G>,
 {
     fn intersects(&self, rhs: &G) -> bool {

--- a/geo/src/algorithm/intersects/coordinate.rs
+++ b/geo/src/algorithm/intersects/coordinate.rs
@@ -3,7 +3,7 @@ use crate::*;
 
 impl<T> Intersects<Coordinate<T>> for Coordinate<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     fn intersects(&self, rhs: &Coordinate<T>) -> bool {
         self == rhs
@@ -13,7 +13,7 @@ where
 // The other side of this is handled via a blanket impl.
 impl<T> Intersects<Point<T>> for Coordinate<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     fn intersects(&self, rhs: &Point<T>) -> bool {
         self == &rhs.0

--- a/geo/src/algorithm/intersects/line.rs
+++ b/geo/src/algorithm/intersects/line.rs
@@ -4,7 +4,7 @@ use crate::*;
 
 impl<T> Intersects<Coordinate<T>> for Line<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     fn intersects(&self, rhs: &Coordinate<T>) -> bool {
         // First we check if the point is collinear with the line.
@@ -19,7 +19,7 @@ symmetric_intersects_impl!(Line<T>, Point<T>);
 
 impl<T> Intersects<Line<T>> for Line<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     fn intersects(&self, line: &Line<T>) -> bool {
         // Special case: self is equiv. to a point.

--- a/geo/src/algorithm/intersects/line_string.rs
+++ b/geo/src/algorithm/intersects/line_string.rs
@@ -4,7 +4,7 @@ use crate::*;
 // Blanket implementation using self.lines().any().
 impl<T, G> Intersects<G> for LineString<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
     Line<T>: Intersects<G>,
 {
     fn intersects(&self, geom: &G) -> bool {
@@ -17,7 +17,7 @@ symmetric_intersects_impl!(Line<T>, LineString<T>);
 // Blanket implementation from LineString<T>
 impl<T, G> Intersects<G> for MultiLineString<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
     LineString<T>: Intersects<G>,
 {
     fn intersects(&self, rhs: &G) -> bool {

--- a/geo/src/algorithm/intersects/mod.rs
+++ b/geo/src/algorithm/intersects/mod.rs
@@ -55,7 +55,7 @@ macro_rules! symmetric_intersects_impl {
         impl<T> $crate::algorithm::intersects::Intersects<$k> for $t
         where
             $k: $crate::algorithm::intersects::Intersects<$t>,
-            T: CoordinateType,
+            T: CoordNum,
         {
             fn intersects(&self, rhs: &$k) -> bool {
                 rhs.intersects(self)
@@ -102,7 +102,7 @@ where
 #[inline]
 fn point_in_rect<T>(value: Coordinate<T>, bound_1: Coordinate<T>, bound_2: Coordinate<T>) -> bool
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     value_in_between(value.x, bound_1.x, bound_2.x)
         && value_in_between(value.y, bound_1.y, bound_2.y)

--- a/geo/src/algorithm/intersects/point.rs
+++ b/geo/src/algorithm/intersects/point.rs
@@ -4,7 +4,7 @@ use crate::*;
 // Blanket implementation from Coordinate<T>
 impl<T, G> Intersects<G> for Point<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
     Coordinate<T>: Intersects<G>,
 {
     fn intersects(&self, rhs: &G) -> bool {
@@ -15,7 +15,7 @@ where
 // Blanket implementation from Point<T>
 impl<T, G> Intersects<G> for MultiPoint<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
     Point<T>: Intersects<G>,
 {
     fn intersects(&self, rhs: &G) -> bool {

--- a/geo/src/algorithm/intersects/polygon.rs
+++ b/geo/src/algorithm/intersects/polygon.rs
@@ -1,11 +1,13 @@
 use super::Intersects;
-use crate::kernels::*;
 use crate::utils::{coord_pos_relative_to_ring, CoordPos};
-use crate::*;
+use crate::{
+    CoordNum, Coordinate, GeoNum, Line, LineString, MultiLineString, MultiPolygon, Point, Polygon,
+    Rect,
+};
 
 impl<T> Intersects<Coordinate<T>> for Polygon<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     fn intersects(&self, p: &Coordinate<T>) -> bool {
         coord_pos_relative_to_ring(*p, &self.exterior()) != CoordPos::Outside
@@ -20,7 +22,7 @@ symmetric_intersects_impl!(Polygon<T>, Point<T>);
 
 impl<T> Intersects<Line<T>> for Polygon<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     fn intersects(&self, line: &Line<T>) -> bool {
         self.exterior().intersects(line)
@@ -35,7 +37,7 @@ symmetric_intersects_impl!(Polygon<T>, MultiLineString<T>);
 
 impl<T> Intersects<Rect<T>> for Polygon<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     fn intersects(&self, rect: &Rect<T>) -> bool {
         self.intersects(&rect.clone().to_polygon())
@@ -45,7 +47,7 @@ symmetric_intersects_impl!(Rect<T>, Polygon<T>);
 
 impl<T> Intersects<Polygon<T>> for Polygon<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     fn intersects(&self, polygon: &Polygon<T>) -> bool {
         // self intersects (or contains) any line in polygon
@@ -60,7 +62,7 @@ where
 
 impl<G, T> Intersects<G> for MultiPolygon<T>
 where
-    T: HasKernel,
+    T: GeoNum,
     Polygon<T>: Intersects<G>,
 {
     fn intersects(&self, rhs: &G) -> bool {

--- a/geo/src/algorithm/intersects/rect.rs
+++ b/geo/src/algorithm/intersects/rect.rs
@@ -1,5 +1,4 @@
 use super::{value_in_range, Intersects};
-use crate::kernels::*;
 use crate::*;
 
 impl<T> Intersects<Coordinate<T>> for Rect<T>
@@ -37,7 +36,7 @@ where
 // an allocation.
 impl<T> Intersects<Line<T>> for Rect<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     fn intersects(&self, rhs: &Line<T>) -> bool {
         let lt = self.min();

--- a/geo/src/algorithm/intersects/rect.rs
+++ b/geo/src/algorithm/intersects/rect.rs
@@ -4,7 +4,7 @@ use crate::*;
 
 impl<T> Intersects<Coordinate<T>> for Rect<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     fn intersects(&self, rhs: &Coordinate<T>) -> bool {
         // Funnily, we don't use point_in_rect, as we know
@@ -20,7 +20,7 @@ symmetric_intersects_impl!(Rect<T>, MultiPoint<T>);
 
 impl<T> Intersects<Rect<T>> for Rect<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     fn intersects(&self, other: &Rect<T>) -> bool {
         let x_overlap = value_in_range(self.min().x, other.min().x, other.max().x)

--- a/geo/src/algorithm/intersects/triangle.rs
+++ b/geo/src/algorithm/intersects/triangle.rs
@@ -3,7 +3,7 @@ use crate::*;
 
 impl<T, G> Intersects<G> for Triangle<T>
 where
-    T: CoordinateType,
+    T: CoordNum,
     Polygon<T>: Intersects<G>,
 {
     fn intersects(&self, rhs: &G) -> bool {

--- a/geo/src/algorithm/kernels/mod.rs
+++ b/geo/src/algorithm/kernels/mod.rs
@@ -1,4 +1,4 @@
-use crate::{Coordinate, CoordinateType};
+use crate::{CoordNum, Coordinate};
 use num_traits::Zero;
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
@@ -10,7 +10,7 @@ pub enum Orientation {
 
 /// Kernel trait to provide predicates to operate on
 /// different scalar types.
-pub trait Kernel<T: CoordinateType> {
+pub trait Kernel<T: CoordNum> {
     /// Gives the orientation of 3 2-dimensional points:
     /// ccw, cw or collinear (None)
     fn orient2d(p: Coordinate<T>, q: Coordinate<T>, r: Coordinate<T>) -> Orientation {
@@ -43,7 +43,7 @@ pub trait Kernel<T: CoordinateType> {
 }
 
 /// Marker trait to assign Kernel for scalars
-pub trait HasKernel: CoordinateType {
+pub trait HasKernel: CoordNum {
     type Ker: Kernel<Self>;
 }
 

--- a/geo/src/algorithm/kernels/robust.rs
+++ b/geo/src/algorithm/kernels/robust.rs
@@ -1,5 +1,7 @@
-use super::{Kernel, Orientation};
+use super::{CoordinateType, Kernel, Orientation};
 use crate::Coordinate;
+
+use num_traits::{Float, NumCast};
 
 /// Robust kernel that uses [fast robust
 /// predicates](//www.cs.cmu.edu/~quake/robust.html) to
@@ -9,8 +11,10 @@ use crate::Coordinate;
 #[derive(Default, Debug)]
 pub struct RobustKernel;
 
-use num_traits::{Float, NumCast};
-impl<T: Float> Kernel<T> for RobustKernel {
+impl<T> Kernel<T> for RobustKernel
+where
+    T: CoordinateType + Float,
+{
     fn orient2d(p: Coordinate<T>, q: Coordinate<T>, r: Coordinate<T>) -> Orientation {
         use robust::{orient2d, Coord};
 

--- a/geo/src/algorithm/kernels/robust.rs
+++ b/geo/src/algorithm/kernels/robust.rs
@@ -1,4 +1,4 @@
-use super::{CoordinateType, Kernel, Orientation};
+use super::{CoordNum, Kernel, Orientation};
 use crate::Coordinate;
 
 use num_traits::{Float, NumCast};
@@ -13,7 +13,7 @@ pub struct RobustKernel;
 
 impl<T> Kernel<T> for RobustKernel
 where
-    T: CoordinateType + Float,
+    T: CoordNum + Float,
 {
     fn orient2d(p: Coordinate<T>, q: Coordinate<T>, r: Coordinate<T>) -> Orientation {
         use robust::{orient2d, Coord};

--- a/geo/src/algorithm/kernels/simple.rs
+++ b/geo/src/algorithm/kernels/simple.rs
@@ -1,5 +1,5 @@
 use super::Kernel;
-use crate::CoordinateType;
+use crate::CoordNum;
 
 /// Simple kernel provides the direct implementation of the
 /// predicates. These are meant to be used with exact
@@ -7,4 +7,4 @@ use crate::CoordinateType;
 #[derive(Default, Debug)]
 pub struct SimpleKernel;
 
-impl<T: CoordinateType> Kernel<T> for SimpleKernel {}
+impl<T: CoordNum> Kernel<T> for SimpleKernel {}

--- a/geo/src/algorithm/line_interpolate_point.rs
+++ b/geo/src/algorithm/line_interpolate_point.rs
@@ -2,9 +2,7 @@ use crate::coords_iter::CoordsIter;
 use num_traits::Float;
 use std::ops::AddAssign;
 
-use crate::{
-    algorithm::euclidean_length::EuclideanLength, CoordinateType, Line, LineString, Point,
-};
+use crate::{algorithm::euclidean_length::EuclideanLength, CoordNum, Line, LineString, Point};
 
 /// Returns an option of the point that lies a given fraction along the line.
 ///
@@ -42,7 +40,7 @@ pub trait LineInterpolatePoint<F: Float> {
 
 impl<T> LineInterpolatePoint<T> for Line<T>
 where
-    T: CoordinateType + Float,
+    T: CoordNum + Float,
 {
     type Output = Option<Point<T>>;
 
@@ -72,7 +70,7 @@ where
 
 impl<T> LineInterpolatePoint<T> for LineString<T>
 where
-    T: CoordinateType + Float + AddAssign + std::fmt::Debug,
+    T: CoordNum + Float + AddAssign + std::fmt::Debug,
     Line<T>: EuclideanLength<T>,
     LineString<T>: EuclideanLength<T>,
 {

--- a/geo/src/algorithm/line_interpolate_point.rs
+++ b/geo/src/algorithm/line_interpolate_point.rs
@@ -1,8 +1,7 @@
 use crate::coords_iter::CoordsIter;
-use num_traits::Float;
 use std::ops::AddAssign;
 
-use crate::{algorithm::euclidean_length::EuclideanLength, CoordNum, Line, LineString, Point};
+use crate::{algorithm::euclidean_length::EuclideanLength, CoordFloat, Line, LineString, Point};
 
 /// Returns an option of the point that lies a given fraction along the line.
 ///
@@ -32,7 +31,7 @@ use crate::{algorithm::euclidean_length::EuclideanLength, CoordNum, Line, LineSt
 /// assert_eq!(linestring.line_interpolate_point(0.75), Some(point!(x: 0.0, y: 0.5)));
 /// assert_eq!(linestring.line_interpolate_point(2.0), Some(point!(x: 0.0, y: 1.0)));
 /// ```
-pub trait LineInterpolatePoint<F: Float> {
+pub trait LineInterpolatePoint<F: CoordFloat> {
     type Output;
 
     fn line_interpolate_point(&self, fraction: F) -> Self::Output;
@@ -40,7 +39,7 @@ pub trait LineInterpolatePoint<F: Float> {
 
 impl<T> LineInterpolatePoint<T> for Line<T>
 where
-    T: CoordNum + Float,
+    T: CoordFloat,
 {
     type Output = Option<Point<T>>;
 
@@ -70,7 +69,7 @@ where
 
 impl<T> LineInterpolatePoint<T> for LineString<T>
 where
-    T: CoordNum + Float + AddAssign + std::fmt::Debug,
+    T: CoordFloat + AddAssign + std::fmt::Debug,
     Line<T>: EuclideanLength<T>,
     LineString<T>: EuclideanLength<T>,
 {
@@ -115,6 +114,7 @@ mod test {
         algorithm::{closest_point::ClosestPoint, line_locate_point::LineLocatePoint},
         point, Coordinate,
     };
+    use num_traits::Float;
 
     #[test]
     fn test_line_interpolate_point_line() {

--- a/geo/src/algorithm/line_locate_point.rs
+++ b/geo/src/algorithm/line_locate_point.rs
@@ -1,8 +1,7 @@
 use crate::{
     algorithm::{euclidean_distance::EuclideanDistance, euclidean_length::EuclideanLength},
-    CoordNum, Line, LineString, Point,
+    CoordFloat, Line, LineString, Point,
 };
-use num_traits::Float;
 use std::ops::AddAssign;
 
 /// Returns a (option of the) fraction of the line's total length
@@ -41,7 +40,7 @@ pub trait LineLocatePoint<T, Rhs> {
 
 impl<T> LineLocatePoint<T, Point<T>> for Line<T>
 where
-    T: CoordNum + Float,
+    T: CoordFloat,
 {
     type Output = Option<T>;
     type Rhs = Point<T>;
@@ -78,7 +77,7 @@ where
 
 impl<T> LineLocatePoint<T, Point<T>> for LineString<T>
 where
-    T: CoordNum + Float + AddAssign,
+    T: CoordFloat + AddAssign,
     Line<T>: EuclideanDistance<T, Point<T>> + EuclideanLength<T>,
     LineString<T>: EuclideanLength<T>,
 {
@@ -111,6 +110,7 @@ where
 mod test {
     use super::*;
     use crate::{point, Coordinate};
+    use num_traits::Float;
 
     #[test]
     fn test_line_locate_point_line() {

--- a/geo/src/algorithm/line_locate_point.rs
+++ b/geo/src/algorithm/line_locate_point.rs
@@ -1,6 +1,6 @@
 use crate::{
     algorithm::{euclidean_distance::EuclideanDistance, euclidean_length::EuclideanLength},
-    CoordinateType, Line, LineString, Point,
+    CoordNum, Line, LineString, Point,
 };
 use num_traits::Float;
 use std::ops::AddAssign;
@@ -41,7 +41,7 @@ pub trait LineLocatePoint<T, Rhs> {
 
 impl<T> LineLocatePoint<T, Point<T>> for Line<T>
 where
-    T: CoordinateType + Float,
+    T: CoordNum + Float,
 {
     type Output = Option<T>;
     type Rhs = Point<T>;
@@ -78,7 +78,7 @@ where
 
 impl<T> LineLocatePoint<T, Point<T>> for LineString<T>
 where
-    T: CoordinateType + Float + AddAssign,
+    T: CoordNum + Float + AddAssign,
     Line<T>: EuclideanDistance<T, Point<T>> + EuclideanLength<T>,
     LineString<T>: EuclideanLength<T>,
 {

--- a/geo/src/algorithm/map_coords.rs
+++ b/geo/src/algorithm/map_coords.rs
@@ -35,7 +35,7 @@
 //! ```
 
 use crate::{
-    Coordinate, CoordinateType, Geometry, GeometryCollection, Line, LineString, MultiLineString,
+    CoordNum, Coordinate, Geometry, GeometryCollection, Line, LineString, MultiLineString,
     MultiPoint, MultiPolygon, Point, Polygon, Rect, Triangle,
 };
 use std::error::Error;
@@ -71,8 +71,8 @@ pub trait MapCoords<T, NT> {
     /// ```
     fn map_coords(&self, func: impl Fn(&(T, T)) -> (NT, NT) + Copy) -> Self::Output
     where
-        T: CoordinateType,
-        NT: CoordinateType;
+        T: CoordNum,
+        NT: CoordNum;
 }
 
 /// Map a fallible function over all the coordinates in a geometry, returning a Result
@@ -135,8 +135,8 @@ pub trait TryMapCoords<T, NT> {
         func: impl Fn(&(T, T)) -> Result<(NT, NT), Box<dyn Error + Send + Sync>> + Copy,
     ) -> Result<Self::Output, Box<dyn Error + Send + Sync>>
     where
-        T: CoordinateType,
-        NT: CoordinateType;
+        T: CoordNum,
+        NT: CoordNum;
 }
 
 /// Map a function over all the coordinates in an object in place
@@ -156,10 +156,10 @@ pub trait MapCoordsInplace<T> {
     /// ```
     fn map_coords_inplace(&mut self, func: impl Fn(&(T, T)) -> (T, T) + Copy)
     where
-        T: CoordinateType;
+        T: CoordNum;
 }
 
-impl<T: CoordinateType, NT: CoordinateType> MapCoords<T, NT> for Point<T> {
+impl<T: CoordNum, NT: CoordNum> MapCoords<T, NT> for Point<T> {
     type Output = Point<NT>;
 
     fn map_coords(&self, func: impl Fn(&(T, T)) -> (NT, NT) + Copy) -> Self::Output {
@@ -168,7 +168,7 @@ impl<T: CoordinateType, NT: CoordinateType> MapCoords<T, NT> for Point<T> {
     }
 }
 
-impl<T: CoordinateType, NT: CoordinateType> TryMapCoords<T, NT> for Point<T> {
+impl<T: CoordNum, NT: CoordNum> TryMapCoords<T, NT> for Point<T> {
     type Output = Point<NT>;
 
     fn try_map_coords(
@@ -180,7 +180,7 @@ impl<T: CoordinateType, NT: CoordinateType> TryMapCoords<T, NT> for Point<T> {
     }
 }
 
-impl<T: CoordinateType> MapCoordsInplace<T> for Point<T> {
+impl<T: CoordNum> MapCoordsInplace<T> for Point<T> {
     fn map_coords_inplace(&mut self, func: impl Fn(&(T, T)) -> (T, T)) {
         let new_point = func(&(self.0.x, self.0.y));
         self.0.x = new_point.0;
@@ -188,7 +188,7 @@ impl<T: CoordinateType> MapCoordsInplace<T> for Point<T> {
     }
 }
 
-impl<T: CoordinateType, NT: CoordinateType> MapCoords<T, NT> for Line<T> {
+impl<T: CoordNum, NT: CoordNum> MapCoords<T, NT> for Line<T> {
     type Output = Line<NT>;
 
     fn map_coords(&self, func: impl Fn(&(T, T)) -> (NT, NT) + Copy) -> Self::Output {
@@ -199,7 +199,7 @@ impl<T: CoordinateType, NT: CoordinateType> MapCoords<T, NT> for Line<T> {
     }
 }
 
-impl<T: CoordinateType, NT: CoordinateType> TryMapCoords<T, NT> for Line<T> {
+impl<T: CoordNum, NT: CoordNum> TryMapCoords<T, NT> for Line<T> {
     type Output = Line<NT>;
 
     fn try_map_coords(
@@ -213,7 +213,7 @@ impl<T: CoordinateType, NT: CoordinateType> TryMapCoords<T, NT> for Line<T> {
     }
 }
 
-impl<T: CoordinateType> MapCoordsInplace<T> for Line<T> {
+impl<T: CoordNum> MapCoordsInplace<T> for Line<T> {
     fn map_coords_inplace(&mut self, func: impl Fn(&(T, T)) -> (T, T)) {
         let new_start = func(&(self.start.x, self.start.y));
         self.start.x = new_start.0;
@@ -225,7 +225,7 @@ impl<T: CoordinateType> MapCoordsInplace<T> for Line<T> {
     }
 }
 
-impl<T: CoordinateType, NT: CoordinateType> MapCoords<T, NT> for LineString<T> {
+impl<T: CoordNum, NT: CoordNum> MapCoords<T, NT> for LineString<T> {
     type Output = LineString<NT>;
 
     fn map_coords(&self, func: impl Fn(&(T, T)) -> (NT, NT) + Copy) -> Self::Output {
@@ -237,7 +237,7 @@ impl<T: CoordinateType, NT: CoordinateType> MapCoords<T, NT> for LineString<T> {
     }
 }
 
-impl<T: CoordinateType, NT: CoordinateType> TryMapCoords<T, NT> for LineString<T> {
+impl<T: CoordNum, NT: CoordNum> TryMapCoords<T, NT> for LineString<T> {
     type Output = LineString<NT>;
 
     fn try_map_coords(
@@ -252,7 +252,7 @@ impl<T: CoordinateType, NT: CoordinateType> TryMapCoords<T, NT> for LineString<T
     }
 }
 
-impl<T: CoordinateType> MapCoordsInplace<T> for LineString<T> {
+impl<T: CoordNum> MapCoordsInplace<T> for LineString<T> {
     fn map_coords_inplace(&mut self, func: impl Fn(&(T, T)) -> (T, T)) {
         for p in &mut self.0 {
             let new_coords = func(&(p.x, p.y));
@@ -262,7 +262,7 @@ impl<T: CoordinateType> MapCoordsInplace<T> for LineString<T> {
     }
 }
 
-impl<T: CoordinateType, NT: CoordinateType> MapCoords<T, NT> for Polygon<T> {
+impl<T: CoordNum, NT: CoordNum> MapCoords<T, NT> for Polygon<T> {
     type Output = Polygon<NT>;
 
     fn map_coords(&self, func: impl Fn(&(T, T)) -> (NT, NT) + Copy) -> Self::Output {
@@ -276,7 +276,7 @@ impl<T: CoordinateType, NT: CoordinateType> MapCoords<T, NT> for Polygon<T> {
     }
 }
 
-impl<T: CoordinateType, NT: CoordinateType> TryMapCoords<T, NT> for Polygon<T> {
+impl<T: CoordNum, NT: CoordNum> TryMapCoords<T, NT> for Polygon<T> {
     type Output = Polygon<NT>;
 
     fn try_map_coords(
@@ -293,7 +293,7 @@ impl<T: CoordinateType, NT: CoordinateType> TryMapCoords<T, NT> for Polygon<T> {
     }
 }
 
-impl<T: CoordinateType> MapCoordsInplace<T> for Polygon<T> {
+impl<T: CoordNum> MapCoordsInplace<T> for Polygon<T> {
     fn map_coords_inplace(&mut self, func: impl Fn(&(T, T)) -> (T, T) + Copy) {
         self.exterior_mut(|line_string| {
             line_string.map_coords_inplace(func);
@@ -307,7 +307,7 @@ impl<T: CoordinateType> MapCoordsInplace<T> for Polygon<T> {
     }
 }
 
-impl<T: CoordinateType, NT: CoordinateType> MapCoords<T, NT> for MultiPoint<T> {
+impl<T: CoordNum, NT: CoordNum> MapCoords<T, NT> for MultiPoint<T> {
     type Output = MultiPoint<NT>;
 
     fn map_coords(&self, func: impl Fn(&(T, T)) -> (NT, NT) + Copy) -> Self::Output {
@@ -315,7 +315,7 @@ impl<T: CoordinateType, NT: CoordinateType> MapCoords<T, NT> for MultiPoint<T> {
     }
 }
 
-impl<T: CoordinateType, NT: CoordinateType> TryMapCoords<T, NT> for MultiPoint<T> {
+impl<T: CoordNum, NT: CoordNum> TryMapCoords<T, NT> for MultiPoint<T> {
     type Output = MultiPoint<NT>;
 
     fn try_map_coords(
@@ -331,7 +331,7 @@ impl<T: CoordinateType, NT: CoordinateType> TryMapCoords<T, NT> for MultiPoint<T
     }
 }
 
-impl<T: CoordinateType> MapCoordsInplace<T> for MultiPoint<T> {
+impl<T: CoordNum> MapCoordsInplace<T> for MultiPoint<T> {
     fn map_coords_inplace(&mut self, func: impl Fn(&(T, T)) -> (T, T) + Copy) {
         for p in &mut self.0 {
             p.map_coords_inplace(func);
@@ -339,7 +339,7 @@ impl<T: CoordinateType> MapCoordsInplace<T> for MultiPoint<T> {
     }
 }
 
-impl<T: CoordinateType, NT: CoordinateType> MapCoords<T, NT> for MultiLineString<T> {
+impl<T: CoordNum, NT: CoordNum> MapCoords<T, NT> for MultiLineString<T> {
     type Output = MultiLineString<NT>;
 
     fn map_coords(&self, func: impl Fn(&(T, T)) -> (NT, NT) + Copy) -> Self::Output {
@@ -347,7 +347,7 @@ impl<T: CoordinateType, NT: CoordinateType> MapCoords<T, NT> for MultiLineString
     }
 }
 
-impl<T: CoordinateType, NT: CoordinateType> TryMapCoords<T, NT> for MultiLineString<T> {
+impl<T: CoordNum, NT: CoordNum> TryMapCoords<T, NT> for MultiLineString<T> {
     type Output = MultiLineString<NT>;
 
     fn try_map_coords(
@@ -363,7 +363,7 @@ impl<T: CoordinateType, NT: CoordinateType> TryMapCoords<T, NT> for MultiLineStr
     }
 }
 
-impl<T: CoordinateType> MapCoordsInplace<T> for MultiLineString<T> {
+impl<T: CoordNum> MapCoordsInplace<T> for MultiLineString<T> {
     fn map_coords_inplace(&mut self, func: impl Fn(&(T, T)) -> (T, T) + Copy) {
         for p in &mut self.0 {
             p.map_coords_inplace(func);
@@ -371,7 +371,7 @@ impl<T: CoordinateType> MapCoordsInplace<T> for MultiLineString<T> {
     }
 }
 
-impl<T: CoordinateType, NT: CoordinateType> MapCoords<T, NT> for MultiPolygon<T> {
+impl<T: CoordNum, NT: CoordNum> MapCoords<T, NT> for MultiPolygon<T> {
     type Output = MultiPolygon<NT>;
 
     fn map_coords(&self, func: impl Fn(&(T, T)) -> (NT, NT) + Copy) -> Self::Output {
@@ -379,7 +379,7 @@ impl<T: CoordinateType, NT: CoordinateType> MapCoords<T, NT> for MultiPolygon<T>
     }
 }
 
-impl<T: CoordinateType, NT: CoordinateType> TryMapCoords<T, NT> for MultiPolygon<T> {
+impl<T: CoordNum, NT: CoordNum> TryMapCoords<T, NT> for MultiPolygon<T> {
     type Output = MultiPolygon<NT>;
 
     fn try_map_coords(
@@ -395,7 +395,7 @@ impl<T: CoordinateType, NT: CoordinateType> TryMapCoords<T, NT> for MultiPolygon
     }
 }
 
-impl<T: CoordinateType> MapCoordsInplace<T> for MultiPolygon<T> {
+impl<T: CoordNum> MapCoordsInplace<T> for MultiPolygon<T> {
     fn map_coords_inplace(&mut self, func: impl Fn(&(T, T)) -> (T, T) + Copy) {
         for p in &mut self.0 {
             p.map_coords_inplace(func);
@@ -403,7 +403,7 @@ impl<T: CoordinateType> MapCoordsInplace<T> for MultiPolygon<T> {
     }
 }
 
-impl<T: CoordinateType, NT: CoordinateType> MapCoords<T, NT> for Geometry<T> {
+impl<T: CoordNum, NT: CoordNum> MapCoords<T, NT> for Geometry<T> {
     type Output = Geometry<NT>;
 
     fn map_coords(&self, func: impl Fn(&(T, T)) -> (NT, NT) + Copy) -> Self::Output {
@@ -422,7 +422,7 @@ impl<T: CoordinateType, NT: CoordinateType> MapCoords<T, NT> for Geometry<T> {
     }
 }
 
-impl<T: CoordinateType, NT: CoordinateType> TryMapCoords<T, NT> for Geometry<T> {
+impl<T: CoordNum, NT: CoordNum> TryMapCoords<T, NT> for Geometry<T> {
     type Output = Geometry<NT>;
 
     fn try_map_coords(
@@ -448,7 +448,7 @@ impl<T: CoordinateType, NT: CoordinateType> TryMapCoords<T, NT> for Geometry<T> 
     }
 }
 
-impl<T: CoordinateType> MapCoordsInplace<T> for Geometry<T> {
+impl<T: CoordNum> MapCoordsInplace<T> for Geometry<T> {
     fn map_coords_inplace(&mut self, func: impl Fn(&(T, T)) -> (T, T) + Copy) {
         match *self {
             Geometry::Point(ref mut x) => x.map_coords_inplace(func),
@@ -465,7 +465,7 @@ impl<T: CoordinateType> MapCoordsInplace<T> for Geometry<T> {
     }
 }
 
-impl<T: CoordinateType, NT: CoordinateType> MapCoords<T, NT> for GeometryCollection<T> {
+impl<T: CoordNum, NT: CoordNum> MapCoords<T, NT> for GeometryCollection<T> {
     type Output = GeometryCollection<NT>;
 
     fn map_coords(&self, func: impl Fn(&(T, T)) -> (NT, NT) + Copy) -> Self::Output {
@@ -473,7 +473,7 @@ impl<T: CoordinateType, NT: CoordinateType> MapCoords<T, NT> for GeometryCollect
     }
 }
 
-impl<T: CoordinateType, NT: CoordinateType> TryMapCoords<T, NT> for GeometryCollection<T> {
+impl<T: CoordNum, NT: CoordNum> TryMapCoords<T, NT> for GeometryCollection<T> {
     type Output = GeometryCollection<NT>;
 
     fn try_map_coords(
@@ -489,7 +489,7 @@ impl<T: CoordinateType, NT: CoordinateType> TryMapCoords<T, NT> for GeometryColl
     }
 }
 
-impl<T: CoordinateType> MapCoordsInplace<T> for GeometryCollection<T> {
+impl<T: CoordNum> MapCoordsInplace<T> for GeometryCollection<T> {
     fn map_coords_inplace(&mut self, func: impl Fn(&(T, T)) -> (T, T) + Copy) {
         for p in &mut self.0 {
             p.map_coords_inplace(func);
@@ -507,7 +507,7 @@ fn normalize_rect_bounds<T: PartialOrd>(min: &mut (T, T), max: &mut (T, T)) {
     }
 }
 
-impl<T: CoordinateType, NT: CoordinateType> MapCoords<T, NT> for Rect<T> {
+impl<T: CoordNum, NT: CoordNum> MapCoords<T, NT> for Rect<T> {
     type Output = Rect<NT>;
 
     fn map_coords(&self, func: impl Fn(&(T, T)) -> (NT, NT) + Copy) -> Self::Output {
@@ -528,7 +528,7 @@ impl<T: CoordinateType, NT: CoordinateType> MapCoords<T, NT> for Rect<T> {
     }
 }
 
-impl<T: CoordinateType, NT: CoordinateType> TryMapCoords<T, NT> for Rect<T> {
+impl<T: CoordNum, NT: CoordNum> TryMapCoords<T, NT> for Rect<T> {
     type Output = Rect<NT>;
 
     fn try_map_coords(
@@ -552,7 +552,7 @@ impl<T: CoordinateType, NT: CoordinateType> TryMapCoords<T, NT> for Rect<T> {
     }
 }
 
-impl<T: CoordinateType> MapCoordsInplace<T> for Rect<T> {
+impl<T: CoordNum> MapCoordsInplace<T> for Rect<T> {
     fn map_coords_inplace(&mut self, func: impl Fn(&(T, T)) -> (T, T)) {
         let mut new_min = func(&self.min().x_y());
         let mut new_max = func(&self.max().x_y());
@@ -564,7 +564,7 @@ impl<T: CoordinateType> MapCoordsInplace<T> for Rect<T> {
     }
 }
 
-impl<T: CoordinateType, NT: CoordinateType> MapCoords<T, NT> for Triangle<T> {
+impl<T: CoordNum, NT: CoordNum> MapCoords<T, NT> for Triangle<T> {
     type Output = Triangle<NT>;
 
     fn map_coords(&self, func: impl Fn(&(T, T)) -> (NT, NT) + Copy) -> Self::Output {
@@ -580,7 +580,7 @@ impl<T: CoordinateType, NT: CoordinateType> MapCoords<T, NT> for Triangle<T> {
     }
 }
 
-impl<T: CoordinateType, NT: CoordinateType> TryMapCoords<T, NT> for Triangle<T> {
+impl<T: CoordNum, NT: CoordNum> TryMapCoords<T, NT> for Triangle<T> {
     type Output = Triangle<NT>;
 
     fn try_map_coords(
@@ -599,7 +599,7 @@ impl<T: CoordinateType, NT: CoordinateType> TryMapCoords<T, NT> for Triangle<T> 
     }
 }
 
-impl<T: CoordinateType> MapCoordsInplace<T> for Triangle<T> {
+impl<T: CoordNum> MapCoordsInplace<T> for Triangle<T> {
     fn map_coords_inplace(&mut self, func: impl Fn(&(T, T)) -> (T, T)) {
         let p1 = func(&self.0.x_y());
         let p2 = func(&self.1.x_y());

--- a/geo/src/algorithm/orient.rs
+++ b/geo/src/algorithm/orient.rs
@@ -1,5 +1,4 @@
-use super::kernels::*;
-use crate::{MultiPolygon, Polygon};
+use crate::{GeoNum, MultiPolygon, Polygon};
 
 use crate::algorithm::winding_order::{Winding, WindingOrder};
 
@@ -68,7 +67,7 @@ pub trait Orient {
 
 impl<T> Orient for Polygon<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     fn orient(&self, direction: Direction) -> Polygon<T> {
         orient(self, direction)
@@ -77,7 +76,7 @@ where
 
 impl<T> Orient for MultiPolygon<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     fn orient(&self, direction: Direction) -> MultiPolygon<T> {
         MultiPolygon(self.iter().map(|poly| poly.orient(direction)).collect())
@@ -100,7 +99,7 @@ pub enum Direction {
 // and the interior ring(s) will be oriented clockwise
 fn orient<T>(poly: &Polygon<T>, direction: Direction) -> Polygon<T>
 where
-    T: HasKernel,
+    T: GeoNum,
 {
     let interiors = poly
         .interiors()

--- a/geo/src/algorithm/rotate.rs
+++ b/geo/src/algorithm/rotate.rs
@@ -1,13 +1,15 @@
 use crate::algorithm::centroid::Centroid;
 use crate::algorithm::map_coords::MapCoords;
-use crate::{Line, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon};
+use crate::{
+    CoordinateType, Line, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon,
+};
 use num_traits::{Float, FromPrimitive};
 use std::iter::Sum;
 
 #[inline]
 fn rotate_inner<T>(x: T, y: T, x0: T, y0: T, sin_theta: T, cos_theta: T) -> Point<T>
 where
-    T: Float,
+    T: CoordinateType + Float,
 {
     let x = x - x0;
     let y = y - y0;
@@ -19,7 +21,7 @@ where
 
 // Rotate a single point "angle" degrees about an origin. Origin can be an
 // arbitrary point. Pass Point::new(0., 0.) for the actual origin.
-fn rotate_one<T: Float>(angle: T, origin: Point<T>, point: Point<T>) -> Point<T> {
+fn rotate_one<T: CoordinateType + Float>(angle: T, origin: Point<T>, point: Point<T>) -> Point<T> {
     let (sin_theta, cos_theta) = angle.to_radians().sin_cos();
     rotate_inner(
         point.x(),
@@ -39,7 +41,7 @@ fn rotate_many<T>(
     points: impl Iterator<Item = Point<T>>,
 ) -> impl Iterator<Item = Point<T>>
 where
-    T: Float,
+    T: CoordinateType + Float,
 {
     let (sin_theta, cos_theta) = angle.to_radians().sin_cos();
     let (x0, y0) = origin.x_y();
@@ -79,7 +81,7 @@ pub trait Rotate<T> {
     /// ```
     fn rotate(&self, angle: T) -> Self
     where
-        T: Float;
+        T: CoordinateType + Float;
 }
 
 pub trait RotatePoint<T> {
@@ -116,12 +118,12 @@ pub trait RotatePoint<T> {
     /// ```
     fn rotate_around_point(&self, angle: T, point: Point<T>) -> Self
     where
-        T: Float;
+        T: CoordinateType + Float;
 }
 
 impl<T, G> RotatePoint<T> for G
 where
-    T: Float,
+    T: CoordinateType + Float,
     G: MapCoords<T, T, Output = G>,
 {
     fn rotate_around_point(&self, angle: T, point: Point<T>) -> Self {
@@ -133,7 +135,7 @@ where
 
 impl<T> Rotate<T> for Point<T>
 where
-    T: Float,
+    T: CoordinateType + Float,
 {
     /// Rotate the Point about itself by the given number of degrees
     /// This operation leaves the point coordinates unchanged
@@ -144,7 +146,7 @@ where
 
 impl<T> Rotate<T> for Line<T>
 where
-    T: Float,
+    T: CoordinateType + Float,
 {
     fn rotate(&self, angle: T) -> Self {
         let centroid = self.centroid();
@@ -157,7 +159,7 @@ where
 
 impl<T> Rotate<T> for LineString<T>
 where
-    T: Float,
+    T: CoordinateType + Float,
 {
     /// Rotate the LineString about its centroid by the given number of degrees
     fn rotate(&self, angle: T) -> Self {
@@ -167,7 +169,7 @@ where
 
 impl<T> Rotate<T> for Polygon<T>
 where
-    T: Float + FromPrimitive + Sum,
+    T: CoordinateType + Float + FromPrimitive + Sum,
 {
     /// Rotate the Polygon about its centroid by the given number of degrees
     fn rotate(&self, angle: T) -> Self {
@@ -189,7 +191,7 @@ where
 
 impl<T> Rotate<T> for MultiPolygon<T>
 where
-    T: Float + FromPrimitive + Sum,
+    T: CoordinateType + Float + FromPrimitive + Sum,
 {
     /// Rotate the contained Polygons about their centroids by the given number of degrees
     fn rotate(&self, angle: T) -> Self {
@@ -199,7 +201,7 @@ where
 
 impl<T> Rotate<T> for MultiLineString<T>
 where
-    T: Float + FromPrimitive,
+    T: CoordinateType + Float + FromPrimitive,
 {
     /// Rotate the contained LineStrings about their centroids by the given number of degrees
     fn rotate(&self, angle: T) -> Self {
@@ -209,7 +211,7 @@ where
 
 impl<T> Rotate<T> for MultiPoint<T>
 where
-    T: Float + FromPrimitive,
+    T: CoordinateType + Float + FromPrimitive,
 {
     /// Rotate the contained Points about their centroids by the given number of degrees
     fn rotate(&self, angle: T) -> Self {

--- a/geo/src/algorithm/rotate.rs
+++ b/geo/src/algorithm/rotate.rs
@@ -1,15 +1,15 @@
 use crate::algorithm::centroid::Centroid;
 use crate::algorithm::map_coords::MapCoords;
 use crate::{
-    CoordNum, Line, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon,
+    CoordFloat, Line, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon,
 };
-use num_traits::{Float, FromPrimitive};
+use num_traits::FromPrimitive;
 use std::iter::Sum;
 
 #[inline]
 fn rotate_inner<T>(x: T, y: T, x0: T, y0: T, sin_theta: T, cos_theta: T) -> Point<T>
 where
-    T: CoordNum + Float,
+    T: CoordFloat,
 {
     let x = x - x0;
     let y = y - y0;
@@ -21,7 +21,7 @@ where
 
 // Rotate a single point "angle" degrees about an origin. Origin can be an
 // arbitrary point. Pass Point::new(0., 0.) for the actual origin.
-fn rotate_one<T: CoordNum + Float>(angle: T, origin: Point<T>, point: Point<T>) -> Point<T> {
+fn rotate_one<T: CoordFloat>(angle: T, origin: Point<T>, point: Point<T>) -> Point<T> {
     let (sin_theta, cos_theta) = angle.to_radians().sin_cos();
     rotate_inner(
         point.x(),
@@ -41,7 +41,7 @@ fn rotate_many<T>(
     points: impl Iterator<Item = Point<T>>,
 ) -> impl Iterator<Item = Point<T>>
 where
-    T: CoordNum + Float,
+    T: CoordFloat,
 {
     let (sin_theta, cos_theta) = angle.to_radians().sin_cos();
     let (x0, y0) = origin.x_y();
@@ -81,7 +81,7 @@ pub trait Rotate<T> {
     /// ```
     fn rotate(&self, angle: T) -> Self
     where
-        T: CoordNum + Float;
+        T: CoordFloat;
 }
 
 pub trait RotatePoint<T> {
@@ -118,12 +118,12 @@ pub trait RotatePoint<T> {
     /// ```
     fn rotate_around_point(&self, angle: T, point: Point<T>) -> Self
     where
-        T: CoordNum + Float;
+        T: CoordFloat;
 }
 
 impl<T, G> RotatePoint<T> for G
 where
-    T: CoordNum + Float,
+    T: CoordFloat,
     G: MapCoords<T, T, Output = G>,
 {
     fn rotate_around_point(&self, angle: T, point: Point<T>) -> Self {
@@ -135,7 +135,7 @@ where
 
 impl<T> Rotate<T> for Point<T>
 where
-    T: CoordNum + Float,
+    T: CoordFloat,
 {
     /// Rotate the Point about itself by the given number of degrees
     /// This operation leaves the point coordinates unchanged
@@ -146,7 +146,7 @@ where
 
 impl<T> Rotate<T> for Line<T>
 where
-    T: CoordNum + Float,
+    T: CoordFloat,
 {
     fn rotate(&self, angle: T) -> Self {
         let centroid = self.centroid();
@@ -159,7 +159,7 @@ where
 
 impl<T> Rotate<T> for LineString<T>
 where
-    T: CoordNum + Float,
+    T: CoordFloat,
 {
     /// Rotate the LineString about its centroid by the given number of degrees
     fn rotate(&self, angle: T) -> Self {
@@ -169,7 +169,7 @@ where
 
 impl<T> Rotate<T> for Polygon<T>
 where
-    T: CoordNum + Float + FromPrimitive + Sum,
+    T: CoordFloat + FromPrimitive + Sum,
 {
     /// Rotate the Polygon about its centroid by the given number of degrees
     fn rotate(&self, angle: T) -> Self {
@@ -191,7 +191,7 @@ where
 
 impl<T> Rotate<T> for MultiPolygon<T>
 where
-    T: CoordNum + Float + FromPrimitive + Sum,
+    T: CoordFloat + FromPrimitive + Sum,
 {
     /// Rotate the contained Polygons about their centroids by the given number of degrees
     fn rotate(&self, angle: T) -> Self {
@@ -201,7 +201,7 @@ where
 
 impl<T> Rotate<T> for MultiLineString<T>
 where
-    T: CoordNum + Float + FromPrimitive,
+    T: CoordFloat + FromPrimitive,
 {
     /// Rotate the contained LineStrings about their centroids by the given number of degrees
     fn rotate(&self, angle: T) -> Self {
@@ -211,7 +211,7 @@ where
 
 impl<T> Rotate<T> for MultiPoint<T>
 where
-    T: CoordNum + Float + FromPrimitive,
+    T: CoordFloat + FromPrimitive,
 {
     /// Rotate the contained Points about their centroids by the given number of degrees
     fn rotate(&self, angle: T) -> Self {

--- a/geo/src/algorithm/rotate.rs
+++ b/geo/src/algorithm/rotate.rs
@@ -1,7 +1,7 @@
 use crate::algorithm::centroid::Centroid;
 use crate::algorithm::map_coords::MapCoords;
 use crate::{
-    CoordinateType, Line, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon,
+    CoordNum, Line, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon,
 };
 use num_traits::{Float, FromPrimitive};
 use std::iter::Sum;
@@ -9,7 +9,7 @@ use std::iter::Sum;
 #[inline]
 fn rotate_inner<T>(x: T, y: T, x0: T, y0: T, sin_theta: T, cos_theta: T) -> Point<T>
 where
-    T: CoordinateType + Float,
+    T: CoordNum + Float,
 {
     let x = x - x0;
     let y = y - y0;
@@ -21,7 +21,7 @@ where
 
 // Rotate a single point "angle" degrees about an origin. Origin can be an
 // arbitrary point. Pass Point::new(0., 0.) for the actual origin.
-fn rotate_one<T: CoordinateType + Float>(angle: T, origin: Point<T>, point: Point<T>) -> Point<T> {
+fn rotate_one<T: CoordNum + Float>(angle: T, origin: Point<T>, point: Point<T>) -> Point<T> {
     let (sin_theta, cos_theta) = angle.to_radians().sin_cos();
     rotate_inner(
         point.x(),
@@ -41,7 +41,7 @@ fn rotate_many<T>(
     points: impl Iterator<Item = Point<T>>,
 ) -> impl Iterator<Item = Point<T>>
 where
-    T: CoordinateType + Float,
+    T: CoordNum + Float,
 {
     let (sin_theta, cos_theta) = angle.to_radians().sin_cos();
     let (x0, y0) = origin.x_y();
@@ -81,7 +81,7 @@ pub trait Rotate<T> {
     /// ```
     fn rotate(&self, angle: T) -> Self
     where
-        T: CoordinateType + Float;
+        T: CoordNum + Float;
 }
 
 pub trait RotatePoint<T> {
@@ -118,12 +118,12 @@ pub trait RotatePoint<T> {
     /// ```
     fn rotate_around_point(&self, angle: T, point: Point<T>) -> Self
     where
-        T: CoordinateType + Float;
+        T: CoordNum + Float;
 }
 
 impl<T, G> RotatePoint<T> for G
 where
-    T: CoordinateType + Float,
+    T: CoordNum + Float,
     G: MapCoords<T, T, Output = G>,
 {
     fn rotate_around_point(&self, angle: T, point: Point<T>) -> Self {
@@ -135,7 +135,7 @@ where
 
 impl<T> Rotate<T> for Point<T>
 where
-    T: CoordinateType + Float,
+    T: CoordNum + Float,
 {
     /// Rotate the Point about itself by the given number of degrees
     /// This operation leaves the point coordinates unchanged
@@ -146,7 +146,7 @@ where
 
 impl<T> Rotate<T> for Line<T>
 where
-    T: CoordinateType + Float,
+    T: CoordNum + Float,
 {
     fn rotate(&self, angle: T) -> Self {
         let centroid = self.centroid();
@@ -159,7 +159,7 @@ where
 
 impl<T> Rotate<T> for LineString<T>
 where
-    T: CoordinateType + Float,
+    T: CoordNum + Float,
 {
     /// Rotate the LineString about its centroid by the given number of degrees
     fn rotate(&self, angle: T) -> Self {
@@ -169,7 +169,7 @@ where
 
 impl<T> Rotate<T> for Polygon<T>
 where
-    T: CoordinateType + Float + FromPrimitive + Sum,
+    T: CoordNum + Float + FromPrimitive + Sum,
 {
     /// Rotate the Polygon about its centroid by the given number of degrees
     fn rotate(&self, angle: T) -> Self {
@@ -191,7 +191,7 @@ where
 
 impl<T> Rotate<T> for MultiPolygon<T>
 where
-    T: CoordinateType + Float + FromPrimitive + Sum,
+    T: CoordNum + Float + FromPrimitive + Sum,
 {
     /// Rotate the contained Polygons about their centroids by the given number of degrees
     fn rotate(&self, angle: T) -> Self {
@@ -201,7 +201,7 @@ where
 
 impl<T> Rotate<T> for MultiLineString<T>
 where
-    T: CoordinateType + Float + FromPrimitive,
+    T: CoordNum + Float + FromPrimitive,
 {
     /// Rotate the contained LineStrings about their centroids by the given number of degrees
     fn rotate(&self, angle: T) -> Self {
@@ -211,7 +211,7 @@ where
 
 impl<T> Rotate<T> for MultiPoint<T>
 where
-    T: CoordinateType + Float + FromPrimitive,
+    T: CoordNum + Float + FromPrimitive,
 {
     /// Rotate the contained Points about their centroids by the given number of degrees
     fn rotate(&self, angle: T) -> Self {

--- a/geo/src/algorithm/translate.rs
+++ b/geo/src/algorithm/translate.rs
@@ -1,5 +1,5 @@
 use crate::algorithm::map_coords::{MapCoords, MapCoordsInplace};
-use crate::CoordinateType;
+use crate::CoordNum;
 
 pub trait Translate<T> {
     /// Translate a Geometry along its axes by the given offsets
@@ -26,17 +26,17 @@ pub trait Translate<T> {
     /// ```
     fn translate(&self, xoff: T, yoff: T) -> Self
     where
-        T: CoordinateType;
+        T: CoordNum;
 
     /// Translate a Geometry along its axes, but in place.
     fn translate_inplace(&mut self, xoff: T, yoff: T)
     where
-        T: CoordinateType;
+        T: CoordNum;
 }
 
 impl<T, G> Translate<T> for G
 where
-    T: CoordinateType,
+    T: CoordNum,
     G: MapCoords<T, T, Output = G> + MapCoordsInplace<T>,
 {
     fn translate(&self, xoff: T, yoff: T) -> Self {

--- a/geo/src/algorithm/vincenty_distance.rs
+++ b/geo/src/algorithm/vincenty_distance.rs
@@ -4,8 +4,8 @@
 // - https://nathanrooy.github.io/posts/2016-12-18/vincenty-formula-with-python/
 // - https://github.com/janantala/GPS-distance/blob/master/java/Distance.java
 
-use crate::{CoordNum, Point, EARTH_FLATTENING, EQUATORIAL_EARTH_RADIUS, POLAR_EARTH_RADIUS};
-use num_traits::{Float, FromPrimitive};
+use crate::{CoordFloat, Point, EARTH_FLATTENING, EQUATORIAL_EARTH_RADIUS, POLAR_EARTH_RADIUS};
+use num_traits::FromPrimitive;
 use std::{error, fmt};
 
 /// Determine the distance between two geometries using [Vincenty’s formulae].
@@ -45,7 +45,7 @@ pub trait VincentyDistance<T, Rhs = Self> {
 
 impl<T> VincentyDistance<T, Point<T>> for Point<T>
 where
-    T: CoordNum + Float + FromPrimitive,
+    T: CoordFloat + FromPrimitive,
 {
     #[allow(non_snake_case)]
     fn vincenty_distance(&self, rhs: &Point<T>) -> Result<T, FailedToConvergeError> {

--- a/geo/src/algorithm/vincenty_distance.rs
+++ b/geo/src/algorithm/vincenty_distance.rs
@@ -4,7 +4,7 @@
 // - https://nathanrooy.github.io/posts/2016-12-18/vincenty-formula-with-python/
 // - https://github.com/janantala/GPS-distance/blob/master/java/Distance.java
 
-use crate::{CoordinateType, Point, EARTH_FLATTENING, EQUATORIAL_EARTH_RADIUS, POLAR_EARTH_RADIUS};
+use crate::{CoordNum, Point, EARTH_FLATTENING, EQUATORIAL_EARTH_RADIUS, POLAR_EARTH_RADIUS};
 use num_traits::{Float, FromPrimitive};
 use std::{error, fmt};
 
@@ -45,7 +45,7 @@ pub trait VincentyDistance<T, Rhs = Self> {
 
 impl<T> VincentyDistance<T, Point<T>> for Point<T>
 where
-    T: CoordinateType + Float + FromPrimitive,
+    T: CoordNum + Float + FromPrimitive,
 {
     #[allow(non_snake_case)]
     fn vincenty_distance(&self, rhs: &Point<T>) -> Result<T, FailedToConvergeError> {

--- a/geo/src/algorithm/vincenty_distance.rs
+++ b/geo/src/algorithm/vincenty_distance.rs
@@ -4,7 +4,7 @@
 // - https://nathanrooy.github.io/posts/2016-12-18/vincenty-formula-with-python/
 // - https://github.com/janantala/GPS-distance/blob/master/java/Distance.java
 
-use crate::{Point, EARTH_FLATTENING, EQUATORIAL_EARTH_RADIUS, POLAR_EARTH_RADIUS};
+use crate::{CoordinateType, Point, EARTH_FLATTENING, EQUATORIAL_EARTH_RADIUS, POLAR_EARTH_RADIUS};
 use num_traits::{Float, FromPrimitive};
 use std::{error, fmt};
 
@@ -45,7 +45,7 @@ pub trait VincentyDistance<T, Rhs = Self> {
 
 impl<T> VincentyDistance<T, Point<T>> for Point<T>
 where
-    T: Float + FromPrimitive,
+    T: CoordinateType + Float + FromPrimitive,
 {
     #[allow(non_snake_case)]
     fn vincenty_distance(&self, rhs: &Point<T>) -> Result<T, FailedToConvergeError> {

--- a/geo/src/algorithm/vincenty_length.rs
+++ b/geo/src/algorithm/vincenty_length.rs
@@ -1,7 +1,7 @@
-use num_traits::{Float, FromPrimitive};
+use num_traits::FromPrimitive;
 
 use crate::algorithm::vincenty_distance::{FailedToConvergeError, VincentyDistance};
-use crate::{CoordNum, Line, LineString, MultiLineString};
+use crate::{CoordFloat, Line, LineString, MultiLineString};
 
 /// Determine the length of a geometry using [Vincenty’s formulae].
 ///
@@ -42,7 +42,7 @@ pub trait VincentyLength<T, RHS = Self> {
 
 impl<T> VincentyLength<T> for Line<T>
 where
-    T: CoordNum + Float + FromPrimitive,
+    T: CoordFloat + FromPrimitive,
 {
     /// The units of the returned value is meters.
     fn vincenty_length(&self) -> Result<T, FailedToConvergeError> {
@@ -53,7 +53,7 @@ where
 
 impl<T> VincentyLength<T> for LineString<T>
 where
-    T: CoordNum + Float + FromPrimitive,
+    T: CoordFloat + FromPrimitive,
 {
     fn vincenty_length(&self) -> Result<T, FailedToConvergeError> {
         let mut length = T::zero();
@@ -66,7 +66,7 @@ where
 
 impl<T> VincentyLength<T> for MultiLineString<T>
 where
-    T: CoordNum + Float + FromPrimitive,
+    T: CoordFloat + FromPrimitive,
 {
     fn vincenty_length(&self) -> Result<T, FailedToConvergeError> {
         let mut length = T::zero();

--- a/geo/src/algorithm/vincenty_length.rs
+++ b/geo/src/algorithm/vincenty_length.rs
@@ -1,7 +1,7 @@
 use num_traits::{Float, FromPrimitive};
 
 use crate::algorithm::vincenty_distance::{FailedToConvergeError, VincentyDistance};
-use crate::{CoordinateType, Line, LineString, MultiLineString};
+use crate::{CoordNum, Line, LineString, MultiLineString};
 
 /// Determine the length of a geometry using [Vincenty’s formulae].
 ///
@@ -42,7 +42,7 @@ pub trait VincentyLength<T, RHS = Self> {
 
 impl<T> VincentyLength<T> for Line<T>
 where
-    T: CoordinateType + Float + FromPrimitive,
+    T: CoordNum + Float + FromPrimitive,
 {
     /// The units of the returned value is meters.
     fn vincenty_length(&self) -> Result<T, FailedToConvergeError> {
@@ -53,7 +53,7 @@ where
 
 impl<T> VincentyLength<T> for LineString<T>
 where
-    T: CoordinateType + Float + FromPrimitive,
+    T: CoordNum + Float + FromPrimitive,
 {
     fn vincenty_length(&self) -> Result<T, FailedToConvergeError> {
         let mut length = T::zero();
@@ -66,7 +66,7 @@ where
 
 impl<T> VincentyLength<T> for MultiLineString<T>
 where
-    T: CoordinateType + Float + FromPrimitive,
+    T: CoordNum + Float + FromPrimitive,
 {
     fn vincenty_length(&self) -> Result<T, FailedToConvergeError> {
         let mut length = T::zero();

--- a/geo/src/algorithm/vincenty_length.rs
+++ b/geo/src/algorithm/vincenty_length.rs
@@ -1,7 +1,7 @@
 use num_traits::{Float, FromPrimitive};
 
 use crate::algorithm::vincenty_distance::{FailedToConvergeError, VincentyDistance};
-use crate::{Line, LineString, MultiLineString};
+use crate::{CoordinateType, Line, LineString, MultiLineString};
 
 /// Determine the length of a geometry using [Vincenty’s formulae].
 ///
@@ -42,7 +42,7 @@ pub trait VincentyLength<T, RHS = Self> {
 
 impl<T> VincentyLength<T> for Line<T>
 where
-    T: Float + FromPrimitive,
+    T: CoordinateType + Float + FromPrimitive,
 {
     /// The units of the returned value is meters.
     fn vincenty_length(&self) -> Result<T, FailedToConvergeError> {
@@ -53,7 +53,7 @@ where
 
 impl<T> VincentyLength<T> for LineString<T>
 where
-    T: Float + FromPrimitive,
+    T: CoordinateType + Float + FromPrimitive,
 {
     fn vincenty_length(&self) -> Result<T, FailedToConvergeError> {
         let mut length = T::zero();
@@ -66,7 +66,7 @@ where
 
 impl<T> VincentyLength<T> for MultiLineString<T>
 where
-    T: Float + FromPrimitive,
+    T: CoordinateType + Float + FromPrimitive,
 {
     fn vincenty_length(&self) -> Result<T, FailedToConvergeError> {
         let mut length = T::zero();

--- a/geo/src/algorithm/winding_order.rs
+++ b/geo/src/algorithm/winding_order.rs
@@ -1,7 +1,7 @@
 use super::kernels::*;
 use crate::coords_iter::CoordsIter;
 use crate::utils::EitherIter;
-use crate::{CoordinateType, LineString, Point};
+use crate::{CoordNum, LineString, Point};
 use geo_types::PointsIter;
 use std::iter::Rev;
 
@@ -11,11 +11,11 @@ pub struct Points<'a, T>(
     pub(crate) EitherIter<Point<T>, PointsIter<'a, T>, Rev<PointsIter<'a, T>>>,
 )
 where
-    T: CoordinateType + 'a;
+    T: CoordNum + 'a;
 
 impl<'a, T> Iterator for Points<'a, T>
 where
-    T: CoordinateType,
+    T: CoordNum,
 {
     type Item = Point<T>;
 
@@ -37,7 +37,7 @@ pub enum WindingOrder {
 ///
 /// [CGAL's Polygon_2::orientation]: //doc.cgal.org/latest/Polygon/classCGAL_1_1Polygon__2.html#a4ce8b4b8395406243ac16c2a120ffc15
 pub trait Winding {
-    type Scalar: CoordinateType;
+    type Scalar: CoordNum;
 
     /// Return the winding order of this object if it
     /// contains at least three distinct coordinates, and

--- a/geo/src/lib.rs
+++ b/geo/src/lib.rs
@@ -54,7 +54,7 @@ pub use crate::traits::ToGeo;
 pub use crate::types::*;
 
 pub use geo_types::{
-    line_string, point, polygon, Coordinate, CoordinateType, Geometry, GeometryCollection, Line,
+    line_string, point, polygon, CoordNum, Coordinate, Geometry, GeometryCollection, Line,
     LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon, Rect, Triangle,
 };
 
@@ -153,10 +153,10 @@ pub mod prelude {
 /// }
 /// ```
 pub trait GeoFloat:
-    num_traits::Float + CoordinateType + algorithm::kernels::HasKernel + std::fmt::Debug
+    num_traits::Float + CoordNum + algorithm::kernels::HasKernel + std::fmt::Debug
 {
 }
 impl<T> GeoFloat for T where
-    T: num_traits::Float + CoordinateType + algorithm::kernels::HasKernel + std::fmt::Debug
+    T: num_traits::Float + CoordNum + algorithm::kernels::HasKernel + std::fmt::Debug
 {
 }

--- a/geo/src/lib.rs
+++ b/geo/src/lib.rs
@@ -123,12 +123,13 @@ pub mod prelude {
     pub use crate::algorithm::vincenty_length::VincentyLength;
 }
 
-/// A common floating point trait used for geo algorithms.
+/// A common numeric trait used for geo algorithms.
 ///
 /// Different numeric types have different tradeoffs. `geo` strives to utilize generics to allow
 /// users to choose their numeric types. If you are writing a function which you'd like to be
-/// generic over the floating point types supported by geo, you probably want to constrain
-/// your function input to GeoFloat.
+/// generic over all the numeric types supported by geo, you probably want to constraint
+/// your function input to `GeoFloat`. For methods which work for integers, and not just floating
+/// point, see [`GeoNum`](trait.GeoFloat.html).
 ///
 /// # Examples
 ///
@@ -152,11 +153,8 @@ pub mod prelude {
 ///     })
 /// }
 /// ```
-pub trait GeoFloat:
-    num_traits::Float + CoordNum + algorithm::kernels::HasKernel + std::fmt::Debug
-{
-}
-impl<T> GeoFloat for T where
-    T: num_traits::Float + CoordNum + algorithm::kernels::HasKernel + std::fmt::Debug
-{
-}
+pub trait GeoFloat: num_traits::Float + GeoNum {}
+impl<T> GeoFloat for T where T: num_traits::Float + GeoNum {}
+
+pub trait GeoNum: CoordNum + algorithm::kernels::HasKernel {}
+impl<T> GeoNum for T where T: CoordNum + algorithm::kernels::HasKernel {}

--- a/geo/src/lib.rs
+++ b/geo/src/lib.rs
@@ -129,7 +129,7 @@ pub mod prelude {
 /// users to choose their numeric types. If you are writing a function which you'd like to be
 /// generic over all the numeric types supported by geo, you probably want to constraint
 /// your function input to `GeoFloat`. For methods which work for integers, and not just floating
-/// point, see [`GeoNum`](trait.GeoFloat.html).
+/// point, see [`GeoNum`].
 ///
 /// # Examples
 ///

--- a/geo/src/lib.rs
+++ b/geo/src/lib.rs
@@ -54,8 +54,8 @@ pub use crate::traits::ToGeo;
 pub use crate::types::*;
 
 pub use geo_types::{
-    line_string, point, polygon, CoordNum, Coordinate, Geometry, GeometryCollection, Line,
-    LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon, Rect, Triangle,
+    line_string, point, polygon, CoordFloat, CoordNum, Coordinate, Geometry, GeometryCollection,
+    Line, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon, Rect, Triangle,
 };
 
 /// This module includes all the functions of geometric calculations

--- a/geo/src/traits.rs
+++ b/geo/src/traits.rs
@@ -1,10 +1,10 @@
 pub use crate::Geometry;
 
-use crate::CoordinateType;
+use crate::CoordNum;
 
 #[deprecated(
     note = "Will be removed in an upcoming version. Switch to std::convert::Into<Geo> or std::convert::TryInto<Geo>."
 )]
-pub trait ToGeo<T: CoordinateType> {
+pub trait ToGeo<T: CoordNum> {
     fn to_geo(&self) -> Geometry<T>;
 }

--- a/geo/src/utils.rs
+++ b/geo/src/utils.rs
@@ -1,6 +1,6 @@
 //! Internal utility functions, types, and data structures.
 
-use geo_types::{Coordinate, CoordinateType};
+use geo_types::{CoordNum, Coordinate};
 
 /// Partition a mutable slice in-place so that it contains all elements for
 /// which `predicate(e)` is `true`, followed by all elements for which
@@ -83,7 +83,7 @@ use std::cmp::Ordering;
 /// x coordinate, and break ties with the y coordinate.
 /// Expects none of coordinates to be uncomparable (eg. nan)
 #[inline]
-pub fn lex_cmp<T: CoordinateType>(p: &Coordinate<T>, q: &Coordinate<T>) -> Ordering {
+pub fn lex_cmp<T: CoordNum>(p: &Coordinate<T>, q: &Coordinate<T>) -> Ordering {
     p.x.partial_cmp(&q.x)
         .unwrap()
         .then(p.y.partial_cmp(&q.y).unwrap())
@@ -94,7 +94,7 @@ pub fn lex_cmp<T: CoordinateType>(p: &Coordinate<T>, q: &Coordinate<T>) -> Order
 ///
 /// Should only be called on a non-empty slice with no `nan`
 /// coordinates.
-pub fn least_index<T: CoordinateType>(pts: &[Coordinate<T>]) -> usize {
+pub fn least_index<T: CoordNum>(pts: &[Coordinate<T>]) -> usize {
     pts.iter()
         .enumerate()
         .min_by(|(_, p), (_, q)| lex_cmp(p, q))
@@ -107,7 +107,7 @@ pub fn least_index<T: CoordinateType>(pts: &[Coordinate<T>]) -> usize {
 ///
 /// Should only be called on a non-empty slice with no `nan`
 /// coordinates.
-pub fn least_and_greatest_index<T: CoordinateType>(pts: &[Coordinate<T>]) -> (usize, usize) {
+pub fn least_and_greatest_index<T: CoordNum>(pts: &[Coordinate<T>]) -> (usize, usize) {
     assert_ne!(pts.len(), 0);
     let (min, max) = pts
         .iter()


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [TODO] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

This is intended to address https://github.com/georust/geo/issues/597

I took a broader approach, and wonder if people are interested in it. The tldr is:

### geo-types
- deprecate `CoordinateType`; (now includes `std::fmt::Debug`)
- Add `trait CoordNum: CoordinateType;` 
- Add `trait CoordFloat: CoordNum + num_traits::Float`

### geo
Add `trait GeoNum: CoordNum + HasKernel`
Add `trait GeoFloat: CoordFloat + HasKernel`

**downstream adoption**

If your crate interops with geo-types, you may need  to make changes like this:

```
pub fn foo<T>(line_string: &geo_types::LineString<T>)
where
-    T: num_traits::Float,
+    T: geo_types::CoordFloat,
{
```

or this (this one is actually only a deprecation, so you could leave it as is for now, but eventually you'll need to make the change):
```
pub fn foo<T>(line_string: &geo_types::LineString<T>)
where
-    T: geo_types::CoordinateType
+    T: geo_types::CoordNum
{
```

**alternative considered**

If I went with the minimal approach to adding Debug trait, changes would instead need to look like this:

This one, for non-floats, could remain untouched:
```
pub fn foo<T>(line_string: &geo_types::LineString<T>)
where
    T: geo_types::CoordinateType
{
```

But anything restricted to floats would need to explicitly include Debug

```
pub fn foo<T>(line_string: &geo_types::LineString<T>)
where
-    T: num_traits::Float,
+    T: num_traits::Float + std::fmt::Debug,
{
```

**motivation:**

I initially completed #597 with the most conservative approach, achieved in the first two commits. The first simply adds Debug to CoordinateType and the second fixes the resulting compiler errors. 

This is a breaking change for anyone constraining generic implementations to just `num_traits::Float`, e.g. like [geojson crate does](https://github.com/georust/geojson/blob/master/src/conversion/to_geo_types.rs#L31) (fix here: https://github.com/georust/geojson/compare/mkirk/geo-types-0.7?expand=1), and polylabel (fix here: https://github.com/urschrei/polylabel-rs/compare/master...michaelkirk:mkirk/geo-types-0.7?expand=1)

Compare this to a crate like [geo-booleanop](https://github.com/21re/rust-geo-booleanop/blob/master/lib/src/boolean/helper.rs#L61), for which things "just work" because they targeted CoordinateType.

This got me thinking that, similar to #577 (yet unreleased), if we want people to write code targeting geo-types in a generic way, it might be helpful to make it clearer and easier how to do so.

So, I've added a CoordFloat and a CoordNum which is basically just a rename of CoordinateType, and applied them liberally within our own code base. I'm hoping this would drive others to reach for these traits rather than specific num_traits when implementing code intended for generic geo-types interop. 

For crates like geo-booleanop, which targeted CoordinateType, things "just work" after the update, but they'll see a deprecation notice like:
```
$ cargo build
warning: use of deprecated trait `geo_types::CoordinateType`: use `CoordFloat` or `CoordNum` instead
 --> lib/src/boolean/helper.rs:2:29
  |
2 | use geo_types::{Coordinate, CoordinateType};
  |                             ^^^^^^^^^^^^^^
  |
  = note: `#[warn(deprecated)]` on by default
```

Which I think is acceptably clear.

It's a large number of lines changed change overall, I know! But it's mostly mechanical, and I thought, since we're breaking geo-types, maybe this is a good time to bite the bullet and avoid some future pain. 

If it's too controversial, as I said, the minimal amount of change we need to enable Debug for CoordinateType is the first three commits (through and including "address fallout of "Add Debug to CoordinateType"). It's still a pretty big change with just that, and note that this will still break the crates I mentioned. I intend to fix the ones I know about, but there's a long tail of crates, which is why I hate breaking geo-types. 

In the few that I've checked it's been quick to adapt to the change, but it might be worth announcing and letting sit open for a while in case downstream geo-types users want to weigh in.