### PR TITLE
Specify the details of conversion failures in an exported error enum

### DIFF
--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -4,6 +4,8 @@
 
 * Implement `Default` on `Coordinate` and `Point` structs (defaults to `(x: 0, y: 0)`)
   * <https://github.com/georust/geo/pull/616>
+* Add specific details about conversion failures in the newly public `geo_types::Error`
+  * <https://github.com/georust/geo/pull/614>
 
 ## 0.7.0
 

--- a/geo-types/src/error.rs
+++ b/geo-types/src/error.rs
@@ -1,0 +1,44 @@
+use std::fmt;
+
+#[derive(Debug)]
+pub enum Error {
+    MismatchedGeometry {
+        expected: &'static str,
+        found: &'static str,
+    },
+}
+
+impl std::error::Error for Error {}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::MismatchedGeometry { expected, found } => {
+                write!(f, "Expected a {}, but found a {}", expected, found)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{Geometry, Point, Rect};
+    use std::convert::TryFrom;
+
+    #[test]
+    fn error_output() {
+        let point = Point::new(1.0, 2.0);
+        let point_geometry = Geometry::from(point);
+
+        let rect = Rect::new(Point::new(1.0, 2.0), Point::new(3.0, 4.0));
+        let rect_geometry = Geometry::from(rect);
+
+        Point::try_from(point_geometry).expect("failed to unwrap inner enum Point");
+
+        let failure = Point::try_from(rect_geometry).unwrap_err();
+        assert_eq!(
+            format!("{}", failure),
+            "Expected a geo_types::point::Point<f64>, but found a geo_types::rect::Rect<f64>"
+        );
+    }
+}

--- a/geo-types/src/lib.rs
+++ b/geo-types/src/lib.rs
@@ -117,6 +117,9 @@ mod rect;
 #[allow(deprecated)]
 pub use crate::rect::{InvalidRectCoordinatesError, Rect};
 
+mod error;
+pub use error::Error;
+
 #[macro_use]
 mod macros;
 

--- a/geo-types/src/lib.rs
+++ b/geo-types/src/lib.rs
@@ -114,6 +114,7 @@ mod triangle;
 pub use crate::triangle::Triangle;
 
 mod rect;
+#[allow(deprecated)]
 pub use crate::rect::{InvalidRectCoordinatesError, Rect};
 
 #[macro_use]

--- a/geo-types/src/rect.rs
+++ b/geo-types/src/rect.rs
@@ -85,6 +85,7 @@ impl<T: CoordNum> Rect<T> {
         since = "0.6.2",
         note = "Use `Rect::new` instead, since `Rect::try_new` will never Error"
     )]
+    #[allow(deprecated)]
     pub fn try_new<C>(c1: C, c2: C) -> Result<Rect<T>, InvalidRectCoordinatesError>
     where
         C: Into<Coordinate<T>>,
@@ -264,11 +265,17 @@ impl<T: CoordFloat> Rect<T> {
 
 static RECT_INVALID_BOUNDS_ERROR: &str = "Failed to create Rect: 'min' coordinate's x/y value must be smaller or equal to the 'max' x/y value";
 
+#[deprecated(
+    since = "0.6.2",
+    note = "Use `Rect::new` instead, since `Rect::try_new` will never Error"
+)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct InvalidRectCoordinatesError;
 
+#[allow(deprecated)]
 impl std::error::Error for InvalidRectCoordinatesError {}
 
+#[allow(deprecated)]
 impl std::fmt::Display for InvalidRectCoordinatesError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", RECT_INVALID_BOUNDS_ERROR)


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

I came across this while trying to improve ergonomics of the WKT crate, which relies on this conversion logic. (see https://github.com/georust/wkt/pull/57)

I *think* this is not a breaking change (see comment inline), but would appreciate confirmation. If I'm wrong, and it indeed is a breaking change, I'd prefer to hold off on merging it for now. 