### PR TITLE
approx for all Geometry types

### DIFF
--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## Unreleased
+
+* Implement `RelativeEq` and `AbsDiffEq` for fuzzy comparison of remaining Geometry Types
+  * <https://github.com/georust/geo/pull/628>
+
 ## 0.7.1
 
 * Implement `Default` on `Coordinate` and `Point` structs (defaults to `(x: 0, y: 0)`)

--- a/geo-types/src/geometry.rs
+++ b/geo-types/src/geometry.rs
@@ -268,77 +268,32 @@ where
         epsilon: Self::Epsilon,
         max_relative: Self::Epsilon,
     ) -> bool {
-        match self {
-            Geometry::Point(g) => {
-                if let Geometry::Point(other) = other {
-                    g.relative_eq(other, epsilon, max_relative)
-                } else {
-                    false
-                }
+        match (self, other) {
+            (Geometry::Point(g1), Geometry::Point(g2)) => g1.relative_eq(g2, epsilon, max_relative),
+            (Geometry::Line(g1), Geometry::Line(g2)) => g1.relative_eq(g2, epsilon, max_relative),
+            (Geometry::LineString(g1), Geometry::LineString(g2)) => {
+                g1.relative_eq(g2, epsilon, max_relative)
             }
-            Geometry::Line(g) => {
-                if let Geometry::Line(other) = other {
-                    g.relative_eq(other, epsilon, max_relative)
-                } else {
-                    false
-                }
+            (Geometry::Polygon(g1), Geometry::Polygon(g2)) => {
+                g1.relative_eq(g2, epsilon, max_relative)
             }
-            Geometry::LineString(g) => {
-                if let Geometry::LineString(other) = other {
-                    g.relative_eq(other, epsilon, max_relative)
-                } else {
-                    false
-                }
+            (Geometry::MultiPoint(g1), Geometry::MultiPoint(g2)) => {
+                g1.relative_eq(g2, epsilon, max_relative)
             }
-            Geometry::Polygon(g) => {
-                if let Geometry::Polygon(other) = other {
-                    g.relative_eq(other, epsilon, max_relative)
-                } else {
-                    false
-                }
+            (Geometry::MultiLineString(g1), Geometry::MultiLineString(g2)) => {
+                g1.relative_eq(g2, epsilon, max_relative)
             }
-            Geometry::MultiPoint(g) => {
-                if let Geometry::MultiPoint(other) = other {
-                    g.relative_eq(other, epsilon, max_relative)
-                } else {
-                    false
-                }
+            (Geometry::MultiPolygon(g1), Geometry::MultiPolygon(g2)) => {
+                g1.relative_eq(g2, epsilon, max_relative)
             }
-            Geometry::MultiLineString(g) => {
-                if let Geometry::MultiLineString(other) = other {
-                    g.relative_eq(other, epsilon, max_relative)
-                } else {
-                    false
-                }
+            (Geometry::GeometryCollection(g1), Geometry::GeometryCollection(g2)) => {
+                g1.relative_eq(g2, epsilon, max_relative)
             }
-            Geometry::MultiPolygon(g) => {
-                if let Geometry::MultiPolygon(other) = other {
-                    g.relative_eq(other, epsilon, max_relative)
-                } else {
-                    false
-                }
+            (Geometry::Rect(g1), Geometry::Rect(g2)) => g1.relative_eq(g2, epsilon, max_relative),
+            (Geometry::Triangle(g1), Geometry::Triangle(g2)) => {
+                g1.relative_eq(g2, epsilon, max_relative)
             }
-            Geometry::GeometryCollection(g) => {
-                if let Geometry::GeometryCollection(other) = other {
-                    g.relative_eq(other, epsilon, max_relative)
-                } else {
-                    false
-                }
-            }
-            Geometry::Rect(g) => {
-                if let Geometry::Rect(other) = other {
-                    g.relative_eq(other, epsilon, max_relative)
-                } else {
-                    false
-                }
-            }
-            Geometry::Triangle(g) => {
-                if let Geometry::Triangle(other) = other {
-                    g.relative_eq(other, epsilon, max_relative)
-                } else {
-                    false
-                }
-            }
+            (_, _) => false,
         }
     }
 }
@@ -366,77 +321,22 @@ impl<T: AbsDiffEq<Epsilon = T> + CoordNum> AbsDiffEq for Geometry<T> {
     /// approx::assert_abs_diff_ne!(a, b, epsilon=0.001);
     /// ```
     fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
-        match self {
-            Geometry::Point(g) => {
-                if let Geometry::Point(other) = other {
-                    g.abs_diff_eq(other, epsilon)
-                } else {
-                    false
-                }
+        match (self, other) {
+            (Geometry::Point(g1), Geometry::Point(g2)) => g1.abs_diff_eq(g2, epsilon),
+            (Geometry::Line(g1), Geometry::Line(g2)) => g1.abs_diff_eq(g2, epsilon),
+            (Geometry::LineString(g1), Geometry::LineString(g2)) => g1.abs_diff_eq(g2, epsilon),
+            (Geometry::Polygon(g1), Geometry::Polygon(g2)) => g1.abs_diff_eq(g2, epsilon),
+            (Geometry::MultiPoint(g1), Geometry::MultiPoint(g2)) => g1.abs_diff_eq(g2, epsilon),
+            (Geometry::MultiLineString(g1), Geometry::MultiLineString(g2)) => {
+                g1.abs_diff_eq(g2, epsilon)
             }
-            Geometry::Line(g) => {
-                if let Geometry::Line(other) = other {
-                    g.abs_diff_eq(other, epsilon)
-                } else {
-                    false
-                }
+            (Geometry::MultiPolygon(g1), Geometry::MultiPolygon(g2)) => g1.abs_diff_eq(g2, epsilon),
+            (Geometry::GeometryCollection(g1), Geometry::GeometryCollection(g2)) => {
+                g1.abs_diff_eq(g2, epsilon)
             }
-            Geometry::LineString(g) => {
-                if let Geometry::LineString(other) = other {
-                    g.abs_diff_eq(other, epsilon)
-                } else {
-                    false
-                }
-            }
-            Geometry::Polygon(g) => {
-                if let Geometry::Polygon(other) = other {
-                    g.abs_diff_eq(other, epsilon)
-                } else {
-                    false
-                }
-            }
-            Geometry::MultiPoint(g) => {
-                if let Geometry::MultiPoint(other) = other {
-                    g.abs_diff_eq(other, epsilon)
-                } else {
-                    false
-                }
-            }
-            Geometry::MultiLineString(g) => {
-                if let Geometry::MultiLineString(other) = other {
-                    g.abs_diff_eq(other, epsilon)
-                } else {
-                    false
-                }
-            }
-            Geometry::MultiPolygon(g) => {
-                if let Geometry::MultiPolygon(other) = other {
-                    g.abs_diff_eq(other, epsilon)
-                } else {
-                    false
-                }
-            }
-            Geometry::GeometryCollection(g) => {
-                if let Geometry::GeometryCollection(other) = other {
-                    g.abs_diff_eq(other, epsilon)
-                } else {
-                    false
-                }
-            }
-            Geometry::Rect(g) => {
-                if let Geometry::Rect(other) = other {
-                    g.abs_diff_eq(other, epsilon)
-                } else {
-                    false
-                }
-            }
-            Geometry::Triangle(g) => {
-                if let Geometry::Triangle(other) = other {
-                    g.abs_diff_eq(other, epsilon)
-                } else {
-                    false
-                }
-            }
+            (Geometry::Rect(g1), Geometry::Rect(g2)) => g1.abs_diff_eq(g2, epsilon),
+            (Geometry::Triangle(g1), Geometry::Triangle(g2)) => g1.abs_diff_eq(g2, epsilon),
+            (_, _) => false,
         }
     }
 }

--- a/geo-types/src/geometry.rs
+++ b/geo-types/src/geometry.rs
@@ -2,6 +2,9 @@ use crate::{
     CoordNum, Error, GeometryCollection, Line, LineString, MultiLineString, MultiPoint,
     MultiPolygon, Point, Polygon, Rect, Triangle,
 };
+
+#[cfg(any(feature = "approx", test))]
+use approx::{AbsDiffEq, RelativeEq};
 use core::any::type_name;
 use std::convert::TryFrom;
 
@@ -232,5 +235,208 @@ where
         Geometry::GeometryCollection(_) => type_name::<GeometryCollection<T>>(),
         Geometry::Rect(_) => type_name::<Rect<T>>(),
         Geometry::Triangle(_) => type_name::<Triangle<T>>(),
+    }
+}
+
+#[cfg(any(feature = "approx", test))]
+impl<T> RelativeEq for Geometry<T>
+where
+    T: AbsDiffEq<Epsilon = T> + CoordNum + RelativeEq,
+{
+    #[inline]
+    fn default_max_relative() -> Self::Epsilon {
+        T::default_max_relative()
+    }
+
+    /// Equality assertion within a relative limit.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use geo_types::{Geometry, polygon};
+    ///
+    /// let a: Geometry<f32> = polygon![(x: 0., y: 0.), (x: 5., y: 0.), (x: 7., y: 9.), (x: 0., y: 0.)].into();
+    /// let b: Geometry<f32> = polygon![(x: 0., y: 0.), (x: 5., y: 0.), (x: 7.01, y: 9.), (x: 0., y: 0.)].into();
+    ///
+    /// approx::assert_relative_eq!(a, b, max_relative=0.1);
+    /// approx::assert_relative_ne!(a, b, max_relative=0.001);
+    /// ```
+    ///
+    fn relative_eq(
+        &self,
+        other: &Self,
+        epsilon: Self::Epsilon,
+        max_relative: Self::Epsilon,
+    ) -> bool {
+        match self {
+            Geometry::Point(g) => {
+                if let Geometry::Point(other) = other {
+                    g.relative_eq(other, epsilon, max_relative)
+                } else {
+                    false
+                }
+            }
+            Geometry::Line(g) => {
+                if let Geometry::Line(other) = other {
+                    g.relative_eq(other, epsilon, max_relative)
+                } else {
+                    false
+                }
+            }
+            Geometry::LineString(g) => {
+                if let Geometry::LineString(other) = other {
+                    g.relative_eq(other, epsilon, max_relative)
+                } else {
+                    false
+                }
+            }
+            Geometry::Polygon(g) => {
+                if let Geometry::Polygon(other) = other {
+                    g.relative_eq(other, epsilon, max_relative)
+                } else {
+                    false
+                }
+            }
+            Geometry::MultiPoint(g) => {
+                if let Geometry::MultiPoint(other) = other {
+                    g.relative_eq(other, epsilon, max_relative)
+                } else {
+                    false
+                }
+            }
+            Geometry::MultiLineString(g) => {
+                if let Geometry::MultiLineString(other) = other {
+                    g.relative_eq(other, epsilon, max_relative)
+                } else {
+                    false
+                }
+            }
+            Geometry::MultiPolygon(g) => {
+                if let Geometry::MultiPolygon(other) = other {
+                    g.relative_eq(other, epsilon, max_relative)
+                } else {
+                    false
+                }
+            }
+            Geometry::GeometryCollection(g) => {
+                if let Geometry::GeometryCollection(other) = other {
+                    g.relative_eq(other, epsilon, max_relative)
+                } else {
+                    false
+                }
+            }
+            Geometry::Rect(g) => {
+                if let Geometry::Rect(other) = other {
+                    g.relative_eq(other, epsilon, max_relative)
+                } else {
+                    false
+                }
+            }
+            Geometry::Triangle(g) => {
+                if let Geometry::Triangle(other) = other {
+                    g.relative_eq(other, epsilon, max_relative)
+                } else {
+                    false
+                }
+            }
+        }
+    }
+}
+
+#[cfg(any(feature = "approx", test))]
+impl<T: AbsDiffEq<Epsilon = T> + CoordNum> AbsDiffEq for Geometry<T> {
+    type Epsilon = T;
+
+    #[inline]
+    fn default_epsilon() -> Self::Epsilon {
+        T::default_epsilon()
+    }
+
+    /// Equality assertion with an absolute limit.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use geo_types::{Geometry, polygon};
+    ///
+    /// let a: Geometry<f32> = polygon![(x: 0., y: 0.), (x: 5., y: 0.), (x: 7., y: 9.), (x: 0., y: 0.)].into();
+    /// let b: Geometry<f32> = polygon![(x: 0., y: 0.), (x: 5., y: 0.), (x: 7.01, y: 9.), (x: 0., y: 0.)].into();
+    ///
+    /// approx::assert_abs_diff_eq!(a, b, epsilon=0.1);
+    /// approx::assert_abs_diff_ne!(a, b, epsilon=0.001);
+    /// ```
+    fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
+        match self {
+            Geometry::Point(g) => {
+                if let Geometry::Point(other) = other {
+                    g.abs_diff_eq(other, epsilon)
+                } else {
+                    false
+                }
+            }
+            Geometry::Line(g) => {
+                if let Geometry::Line(other) = other {
+                    g.abs_diff_eq(other, epsilon)
+                } else {
+                    false
+                }
+            }
+            Geometry::LineString(g) => {
+                if let Geometry::LineString(other) = other {
+                    g.abs_diff_eq(other, epsilon)
+                } else {
+                    false
+                }
+            }
+            Geometry::Polygon(g) => {
+                if let Geometry::Polygon(other) = other {
+                    g.abs_diff_eq(other, epsilon)
+                } else {
+                    false
+                }
+            }
+            Geometry::MultiPoint(g) => {
+                if let Geometry::MultiPoint(other) = other {
+                    g.abs_diff_eq(other, epsilon)
+                } else {
+                    false
+                }
+            }
+            Geometry::MultiLineString(g) => {
+                if let Geometry::MultiLineString(other) = other {
+                    g.abs_diff_eq(other, epsilon)
+                } else {
+                    false
+                }
+            }
+            Geometry::MultiPolygon(g) => {
+                if let Geometry::MultiPolygon(other) = other {
+                    g.abs_diff_eq(other, epsilon)
+                } else {
+                    false
+                }
+            }
+            Geometry::GeometryCollection(g) => {
+                if let Geometry::GeometryCollection(other) = other {
+                    g.abs_diff_eq(other, epsilon)
+                } else {
+                    false
+                }
+            }
+            Geometry::Rect(g) => {
+                if let Geometry::Rect(other) = other {
+                    g.abs_diff_eq(other, epsilon)
+                } else {
+                    false
+                }
+            }
+            Geometry::Triangle(g) => {
+                if let Geometry::Triangle(other) = other {
+                    g.abs_diff_eq(other, epsilon)
+                } else {
+                    false
+                }
+            }
+        }
     }
 }

--- a/geo-types/src/geometry_collection.rs
+++ b/geo-types/src/geometry_collection.rs
@@ -1,4 +1,7 @@
 use crate::{CoordNum, Geometry};
+
+#[cfg(any(feature = "approx", test))]
+use approx::{AbsDiffEq, RelativeEq};
 use std::iter::FromIterator;
 use std::ops::{Index, IndexMut};
 
@@ -220,5 +223,81 @@ impl<'a, T: CoordNum> GeometryCollection<T> {
 
     pub fn iter_mut(&'a mut self) -> IterMutHelper<'a, T> {
         self.into_iter()
+    }
+}
+
+#[cfg(any(feature = "approx", test))]
+impl<T> RelativeEq for GeometryCollection<T>
+where
+    T: AbsDiffEq<Epsilon = T> + CoordNum + RelativeEq,
+{
+    #[inline]
+    fn default_max_relative() -> Self::Epsilon {
+        T::default_max_relative()
+    }
+
+    /// Equality assertion within a relative limit.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use geo_types::{GeometryCollection, point};
+    ///
+    /// let a = GeometryCollection(vec![point![x: 1.0, y: 2.0].into()]);
+    /// let b = GeometryCollection(vec![point![x: 1.0, y: 2.01].into()]);
+    ///
+    /// approx::assert_relative_eq!(a, b, max_relative=0.1);
+    /// approx::assert_relative_ne!(a, b, max_relative=0.0001);
+    /// ```
+    #[inline]
+    fn relative_eq(
+        &self,
+        other: &Self,
+        epsilon: Self::Epsilon,
+        max_relative: Self::Epsilon,
+    ) -> bool {
+        if self.0.len() != other.0.len() {
+            return false;
+        }
+
+        let mut mp_zipper = self.iter().zip(other.iter());
+        mp_zipper.all(|(lhs, rhs)| lhs.relative_eq(&rhs, epsilon, max_relative))
+    }
+}
+
+#[cfg(any(feature = "approx", test))]
+impl<T> AbsDiffEq for GeometryCollection<T>
+where
+    T: AbsDiffEq<Epsilon = T> + CoordNum,
+    T::Epsilon: Copy,
+{
+    type Epsilon = T;
+
+    #[inline]
+    fn default_epsilon() -> Self::Epsilon {
+        T::default_epsilon()
+    }
+
+    /// Equality assertion with an absolute limit.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use geo_types::{GeometryCollection, point};
+    ///
+    /// let a = GeometryCollection(vec![point![x: 0.0, y: 0.0].into()]);
+    /// let b = GeometryCollection(vec![point![x: 0.0, y: 0.1].into()]);
+    ///
+    /// approx::abs_diff_eq!(a, b, epsilon=0.1);
+    /// approx::abs_diff_ne!(a, b, epsilon=0.001);
+    /// ```
+    #[inline]
+    fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
+        if self.0.len() != other.0.len() {
+            return false;
+        }
+
+        let mut mp_zipper = self.into_iter().zip(other.into_iter());
+        mp_zipper.all(|(lhs, rhs)| lhs.abs_diff_eq(&rhs, epsilon))
     }
 }

--- a/geo-types/src/line.rs
+++ b/geo-types/src/line.rs
@@ -209,7 +209,7 @@ impl<T: AbsDiffEq<Epsilon = T> + CoordNum> AbsDiffEq for Line<T> {
         T::default_epsilon()
     }
 
-    /// Equality assertion with a absolute limit.
+    /// Equality assertion with an absolute limit.
     ///
     /// # Examples
     ///

--- a/geo-types/src/line_string.rs
+++ b/geo-types/src/line_string.rs
@@ -351,7 +351,7 @@ impl<T: AbsDiffEq<Epsilon = T> + CoordNum> AbsDiffEq for LineString<T> {
         T::default_epsilon()
     }
 
-    /// Equality assertion with a absolute limit.
+    /// Equality assertion with an absolute limit.
     ///
     /// # Examples
     ///

--- a/geo-types/src/multi_point.rs
+++ b/geo-types/src/multi_point.rs
@@ -147,7 +147,7 @@ where
         T::default_epsilon()
     }
 
-    /// Equality assertion with a absolute limit.
+    /// Equality assertion with an absolute limit.
     ///
     /// # Examples
     ///

--- a/geo-types/src/point.rs
+++ b/geo-types/src/point.rs
@@ -458,7 +458,7 @@ where
         T::default_epsilon()
     }
 
-    /// Equality assertion with a absolute limit.
+    /// Equality assertion with an absolute limit.
     ///
     /// # Examples
     ///

--- a/geo-types/src/rect.rs
+++ b/geo-types/src/rect.rs
@@ -1,5 +1,8 @@
 use crate::{polygon, CoordFloat, CoordNum, Coordinate, Polygon};
 
+#[cfg(any(feature = "approx", test))]
+use approx::{AbsDiffEq, RelativeEq};
+
 /// An _axis-aligned_ bounded 2D rectangle whose area is
 /// defined by minimum and maximum `Coordinate`s.
 ///
@@ -264,6 +267,88 @@ impl<T: CoordFloat> Rect<T> {
 }
 
 static RECT_INVALID_BOUNDS_ERROR: &str = "Failed to create Rect: 'min' coordinate's x/y value must be smaller or equal to the 'max' x/y value";
+
+#[cfg(any(feature = "approx", test))]
+impl<T> RelativeEq for Rect<T>
+where
+    T: AbsDiffEq<Epsilon = T> + CoordNum + RelativeEq,
+{
+    #[inline]
+    fn default_max_relative() -> Self::Epsilon {
+        T::default_max_relative()
+    }
+
+    /// Equality assertion within a relative limit.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use geo_types::Rect;
+    ///
+    /// let a = Rect::new((0.0, 0.0), (10.0, 10.0));
+    /// let b = Rect::new((0.0, 0.0), (10.01, 10.0));
+    ///
+    /// approx::assert_relative_eq!(a, b, max_relative=0.1);
+    /// approx::assert_relative_ne!(a, b, max_relative=0.0001);
+    /// ```
+    #[inline]
+    fn relative_eq(
+        &self,
+        other: &Self,
+        epsilon: Self::Epsilon,
+        max_relative: Self::Epsilon,
+    ) -> bool {
+        if !self.min.relative_eq(&other.min, epsilon, max_relative) {
+            return false;
+        }
+
+        if !self.max.relative_eq(&other.max, epsilon, max_relative) {
+            return false;
+        }
+
+        true
+    }
+}
+
+#[cfg(any(feature = "approx", test))]
+impl<T> AbsDiffEq for Rect<T>
+where
+    T: AbsDiffEq<Epsilon = T> + CoordNum,
+    T::Epsilon: Copy,
+{
+    type Epsilon = T;
+
+    #[inline]
+    fn default_epsilon() -> Self::Epsilon {
+        T::default_epsilon()
+    }
+
+    /// Equality assertion with an absolute limit.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use geo_types::{point, Rect};
+    ///
+    /// let a = Rect::new((0.0, 0.0), (10.0, 10.0));
+    /// let b = Rect::new((0.0, 0.0), (10.01, 10.0));
+    ///
+    /// approx::abs_diff_eq!(a, b, epsilon=0.1);
+    /// approx::abs_diff_ne!(a, b, epsilon=0.001);
+    /// ```
+    #[inline]
+    fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
+        if !self.min.abs_diff_eq(&other.min, epsilon) {
+            return false;
+        }
+
+        if !self.max.abs_diff_eq(&other.max, epsilon) {
+            return false;
+        }
+
+        true
+    }
+}
 
 #[deprecated(
     since = "0.6.2",

--- a/geo-types/src/triangle.rs
+++ b/geo-types/src/triangle.rs
@@ -1,5 +1,8 @@
 use crate::{polygon, CoordNum, Coordinate, Line, Polygon};
 
+#[cfg(any(feature = "approx", test))]
+use approx::{AbsDiffEq, RelativeEq};
+
 /// A bounded 2D area whose three vertices are defined by
 /// `Coordinate`s. The semantics and validity are that of
 /// the equivalent [`Polygon`]; in addition, the three
@@ -52,5 +55,91 @@ impl<T: CoordNum> Triangle<T> {
 impl<IC: Into<Coordinate<T>> + Copy, T: CoordNum> From<[IC; 3]> for Triangle<T> {
     fn from(array: [IC; 3]) -> Triangle<T> {
         Triangle(array[0].into(), array[1].into(), array[2].into())
+    }
+}
+
+#[cfg(any(feature = "approx", test))]
+impl<T> RelativeEq for Triangle<T>
+where
+    T: AbsDiffEq<Epsilon = T> + CoordNum + RelativeEq,
+{
+    #[inline]
+    fn default_max_relative() -> Self::Epsilon {
+        T::default_max_relative()
+    }
+
+    /// Equality assertion within a relative limit.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use geo_types::{point, Triangle};
+    ///
+    /// let a = Triangle((0.0, 0.0).into(), (10.0, 10.0).into(), (0.0, 5.0).into());
+    /// let b = Triangle((0.0, 0.0).into(), (10.01, 10.0).into(), (0.0, 5.0).into());
+    ///
+    /// approx::assert_relative_eq!(a, b, max_relative=0.1);
+    /// approx::assert_relative_ne!(a, b, max_relative=0.0001);
+    /// ```
+    #[inline]
+    fn relative_eq(
+        &self,
+        other: &Self,
+        epsilon: Self::Epsilon,
+        max_relative: Self::Epsilon,
+    ) -> bool {
+        if !self.0.relative_eq(&other.0, epsilon, max_relative) {
+            return false;
+        }
+        if !self.1.relative_eq(&other.1, epsilon, max_relative) {
+            return false;
+        }
+        if !self.2.relative_eq(&other.2, epsilon, max_relative) {
+            return false;
+        }
+
+        true
+    }
+}
+
+#[cfg(any(feature = "approx", test))]
+impl<T> AbsDiffEq for Triangle<T>
+where
+    T: AbsDiffEq<Epsilon = T> + CoordNum,
+    T::Epsilon: Copy,
+{
+    type Epsilon = T;
+
+    #[inline]
+    fn default_epsilon() -> Self::Epsilon {
+        T::default_epsilon()
+    }
+
+    /// Equality assertion with an absolute limit.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use geo_types::{point, Triangle};
+    ///
+    /// let a = Triangle((0.0, 0.0).into(), (10.0, 10.0).into(), (0.0, 5.0).into());
+    /// let b = Triangle((0.0, 0.0).into(), (10.01, 10.0).into(), (0.0, 5.0).into());
+    ///
+    /// approx::abs_diff_eq!(a, b, epsilon=0.1);
+    /// approx::abs_diff_ne!(a, b, epsilon=0.001);
+    /// ```
+    #[inline]
+    fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
+        if !self.0.abs_diff_eq(&other.0, epsilon) {
+            return false;
+        }
+        if !self.1.abs_diff_eq(&other.1, epsilon) {
+            return false;
+        }
+        if !self.2.abs_diff_eq(&other.2, epsilon) {
+            return false;
+        }
+
+        true
     }
 }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Follow up to https://github.com/georust/geo/pull/567 which implemented for Coord, Point, LineString, and a few others, this PR implements it for the remaining types, and `Geometry` itself.

FYI this is a precursor to an integration I'm working on with some of the JTS test suite.

