### PR TITLE
centroid fixups

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,8 @@
 [workspace]
 members = ["geo", "geo-types", "geo-postgis"]
+
+[patch.crates-io]
+
+# Ensure any transitive dependencies also use the local geo/geo-types
+geo = { path = "geo" }
+geo-types = { path = "geo-types" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,6 @@
 [workspace]
 members = ["geo", "geo-types", "geo-postgis"]
+
+[patch.crates-io]
+geo = { path = "geo" }
+geo-types = { path = "geo-types" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,2 @@
 [workspace]
 members = ["geo", "geo-types", "geo-postgis"]
-
-[patch.crates-io]
-geo = { path = "geo" }
-geo-types = { path = "geo-types" }

--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -8,6 +8,14 @@
 
 * Rewrite the crate documentation
   * <https://github.com/georust/geo/pull/619>
+* Fix `Centroid` algorithm for `MultiLineString` when all members have only one
+  point.
+  * <https://github.com/georust/geo/pull/629>
+* Implement `Centroid` algorithm on `Geometry` and its remaining variants.
+  * <https://github.com/georust/geo/pull/629>
+
+## 0.17.1
+
 * Add `GeodesicIntermediate` algorithm
   * <https://github.com/georust/geo/pull/608>
 

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -36,7 +36,7 @@ approx = "0.4.0"
 criterion = { version = "0.3" }
 # jts-test-runner is an internal crate which exists only to be part of the geo test suite.
 # As such it's kept unpublished. It's in a separate repo primarily because it's kind of large.
-jts-test-runner = { git = "https://github.com/georust/jts-test-runner", commit = "bf873f7858792498b70451c2818c40d4e0975264" }
+jts-test-runner = { git = "https://github.com/georust/jts-test-runner", rev = "3294b9af1d3e64fcc9caf9646a93d0116f7d8321" }
 rand = "0.8.0"
 
 [[bench]]

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -22,7 +22,7 @@ geographiclib-rs = { version = "0.2" }
 
 proj = { version = "0.20.3", optional = true }
 
-geo-types = { version = "0.7.0", path = "../geo-types", features = ["approx", "use-rstar"] }
+geo-types = { version = "0.7.0", features = ["approx", "use-rstar"] }
 
 robust = { version = "0.2.2" }
 
@@ -34,6 +34,9 @@ use-serde = ["serde", "geo-types/serde"]
 [dev-dependencies]
 approx = "0.4.0"
 criterion = { version = "0.3" }
+# jts-test-runner is an internal crate which exists only to be part of the geo test suite.
+# As such it's kept unpublished. It's in a separate repo primarily because it's kind of large.
+jts-test-runner = { git = "https://github.com/georust/jts-test-runner", commit = "bf873f7858792498b70451c2818c40d4e0975264" }
 rand = "0.8.0"
 
 [[bench]]

--- a/geo/fuzz/Cargo.toml
+++ b/geo/fuzz/Cargo.toml
@@ -12,10 +12,8 @@ cargo-fuzz = true
 libfuzzer-sys = "0.4"
 
 [dependencies.geo]
-path = ".."
 
 [dependencies.geo-types]
-path = "../../geo-types"
 features = ["arbitrary"]
 
 # Prevent this from interfering with workspaces
@@ -27,3 +25,7 @@ name = "simplify"
 path = "fuzz_targets/simplify.rs"
 test = false
 doc = false
+
+[patch.crates-io]
+geo = { path = ".." }
+geo-types = { path = "../../geo-types" }

--- a/geo/src/algorithm/centroid.rs
+++ b/geo/src/algorithm/centroid.rs
@@ -406,12 +406,15 @@ where
                             Geometry::GeometryCollection(geometry_collection) => {
                                 geometry_collection.iter().map(length).sum()
                             }
-                            Geometry::Point(_)
-                            | Geometry::MultiPoint(_)
-                            | Geometry::Polygon(_)
-                            | Geometry::MultiPolygon(_)
-                            | Geometry::Rect(_)
-                            | Geometry::Triangle(_) => T::zero(),
+                            Geometry::Point(_) | Geometry::MultiPoint(_) => unreachable!(
+                                "Point geometries can never be more than ZeroDimensional"
+                            ),
+                            Geometry::Polygon(_) | Geometry::MultiPolygon(_) => {
+                                debug_assert!(false, "Polygon/MultiPolygon should either be TwoDimensional or Empty, never OneDimensional");
+                                T::zero()
+                            }
+                            // degenerate Rect/Triangles can collapse to a line
+                            Geometry::Rect(_) | Geometry::Triangle(_) => T::zero(),
                         }
                     }
                     let weight = length(geometry);

--- a/geo/src/algorithm/centroid.rs
+++ b/geo/src/algorithm/centroid.rs
@@ -430,7 +430,6 @@ where
                 (Dimensions::TwoDimensional, Some(centroid)) => {
                     let mut centroid_accum = centroid_2d_accum.unwrap_or_default();
 
-                    // REVIEW: unsigned?
                     let weight = geometry.unsigned_area();
 
                     if weight == T::zero() {

--- a/geo/src/algorithm/centroid.rs
+++ b/geo/src/algorithm/centroid.rs
@@ -174,14 +174,12 @@ where
                         },
                     );
             if total_length == T::zero() {
-                // length == 0 means that all points in all constituent linestrings were equal.
-                // we can just use the first defined point in this case.
-                for linestring in self.0.iter() {
-                    if !linestring.0.is_empty() {
-                        return Some(Point(linestring[0]));
-                    }
-                }
-                None // this should never happen, since all linestrings being empty was previously checked
+                // All line strings were 0 length - dimensionally equivalent to a multi point.
+                let points = self
+                    .iter()
+                    .flat_map(|line_string| Some(Point::from(*line_string.0.first()?)))
+                    .collect();
+                MultiPoint(points).centroid()
             } else {
                 Some(Point::new(sum_x / total_length, sum_y / total_length))
             }

--- a/geo/src/algorithm/centroid.rs
+++ b/geo/src/algorithm/centroid.rs
@@ -484,8 +484,8 @@ where
 mod test {
     use crate::algorithm::centroid::Centroid;
     use crate::{
-        line_string, point, polygon, CoordFloat, Coordinate, Line, LineString, MultiLineString,
-        MultiPolygon, Point, Polygon, Rect,
+        line_string, point, polygon, CoordFloat, Coordinate, GeometryCollection, Line, LineString,
+        MultiLineString, MultiPoint, MultiPolygon, Point, Polygon, Rect,
     };
 
     /// small helper to create a coordinate
@@ -808,5 +808,19 @@ mod test {
     fn line_test() {
         let line1 = Line::new(c(0., 1.), c(1., 3.));
         assert_eq!(line1.centroid(), point![x: 0.5, y: 2.]);
+    }
+    #[test]
+    fn collection_weighting() {
+        let p0 = point!(x: 0.0, y: 0.0);
+        let p1 = point!(x: 2.0, y: 0.0);
+        let p2 = point!(x: 2.0, y: 2.0);
+        let p3 = point!(x: 0.0, y: 2.0);
+
+        let multi_point = MultiPoint(vec![p0, p1, p2, p3]);
+        assert_eq!(multi_point.centroid().unwrap(), point!(x: 1.0, y: 1.0));
+
+        let collection = GeometryCollection(vec![MultiPoint(vec![p1, p2, p3]).into(), p0.into()]);
+
+        assert_eq!(collection.centroid().unwrap(), point!(x: 1.0, y: 1.0));
     }
 }

--- a/geo/src/algorithm/centroid.rs
+++ b/geo/src/algorithm/centroid.rs
@@ -362,6 +362,21 @@ where
     fn centroid(&self) -> Self::Output {
         use crate::algorithm::dimensions::{Dimensions, HasDimensions};
 
+        // The Geometries in the GeometryCollection could have different dimensionality. Centroids
+        // must be considered separately by dimensionality.
+        //
+        // e.g. If I have several Points, adding a new `Point` will affect their centroid.
+        //
+        // However, because a Point is zero dimensional, it is infinitely small when compared to
+        // any 2-D Polygon. Thus a Point will not affect the centroid of any GeometryCollection
+        // containing a 2-D Polygon.
+        //
+        // So, for each Geometry in the GeometryCollection, we accumulate that Geometry's
+        // `(centroid, weight)` with that of other geometries of the same dimensionality. And at
+        // the end, the centroid of the GeometryCollection as a whole is the highest dimensional
+        // centroid which has `Some` value.
+
+        // (accumulated centroid, accumulated weight) tuples for each dimensionality.
         let mut centroid_0d_accum: Option<(Point<T>, T)> = None;
         let mut centroid_1d_accum: Option<(Point<T>, T)> = None;
         let mut centroid_2d_accum: Option<(Point<T>, T)> = None;

--- a/geo/src/algorithm/centroid.rs
+++ b/geo/src/algorithm/centroid.rs
@@ -457,11 +457,9 @@ where
 #[cfg(test)]
 mod test {
     use crate::algorithm::centroid::Centroid;
-    use crate::algorithm::euclidean_distance::EuclideanDistance;
-    use crate::line_string;
     use crate::{
-        polygon, CoordFloat, Coordinate, Line, LineString, MultiLineString, MultiPolygon, Point,
-        Polygon, Rect,
+        line_string, point, polygon, CoordFloat, Coordinate, Line, LineString, MultiLineString,
+        MultiPolygon, Point, Polygon, Rect,
     };
 
     /// small helper to create a coordinate
@@ -530,7 +528,7 @@ mod test {
             line_string![coord],
             line_string![coord],
         ]);
-        assert_eq!(mls.centroid(), Some(Point(coord)));
+        assert_relative_eq!(mls.centroid().unwrap(), Point(coord));
     }
     #[test]
     fn multilinestring_one_line_test() {
@@ -543,7 +541,7 @@ mod test {
             (x: 11., y: 1.)
         ];
         let mls: MultiLineString<f64> = MultiLineString(vec![linestring]);
-        assert_eq!(mls.centroid(), Some(Point(Coordinate { x: 6., y: 1. })));
+        assert_relative_eq!(mls.centroid().unwrap(), Point(Coordinate { x: 6., y: 1. }));
     }
     #[test]
     fn multilinestring_test() {
@@ -551,12 +549,9 @@ mod test {
         let v2 = line_string![(x: 1.0, y: 10.0), (x: 2.0, y: 0.0), (x: 3.0, y: 1.0)];
         let v3 = line_string![(x: -12.0, y: -100.0), (x: 7.0, y: 8.0)];
         let mls = MultiLineString(vec![v1, v2, v3]);
-        assert_eq!(
-            mls.centroid(),
-            Some(Point(Coordinate {
-                x: -1.9097834383655845,
-                y: -37.683866439745714
-            }))
+        assert_relative_eq!(
+            mls.centroid().unwrap(),
+            point![x: -1.9097834383655845, y: -37.683866439745714]
         );
     }
     // Tests: Centroid of Polygon
@@ -567,11 +562,11 @@ mod test {
     }
     #[test]
     fn polygon_one_point_test() {
-        let p = Point(Coordinate { x: 2., y: 1. });
+        let p = point![ x: 2., y: 1. ];
         let v = Vec::new();
         let linestring = line_string![p.0];
         let poly = Polygon::new(linestring, v);
-        assert_eq!(poly.centroid(), Some(p));
+        assert_relative_eq!(poly.centroid().unwrap(), p);
     }
 
     #[test]
@@ -623,7 +618,7 @@ mod test {
             (x: 0., y: 2.),
             (x: 0., y: 0.)
         ];
-        assert_eq!(poly.centroid(), Some(Point::new(1., 1.)));
+        assert_relative_eq!(poly.centroid().unwrap(), point![x:1., y:1.]);
     }
     #[test]
     fn polygon_hole_test() {
@@ -760,11 +755,11 @@ mod test {
         let linestring =
             LineString::from(vec![p(7., 1.), p(8., 1.), p(8., 2.), p(7., 2.), p(7., 1.)]);
         let poly2 = Polygon::new(linestring, Vec::new());
-        let dist = MultiPolygon(vec![poly1, poly2])
-            .centroid()
-            .unwrap()
-            .euclidean_distance(&p(4.07142857142857, 1.92857142857143));
-        assert_relative_eq!(dist, 0.0, epsilon = 1e-14); // the results is larger than f64::EPSILON
+        let centroid = MultiPolygon(vec![poly1, poly2]).centroid().unwrap();
+        assert_relative_eq!(
+            centroid,
+            point![x: 4.071428571428571, y: 1.9285714285714286]
+        );
     }
     #[test]
     fn multipolygon_two_polygons_of_opposite_clockwise_test() {
@@ -772,20 +767,20 @@ mod test {
         let poly1 = Polygon::new(linestring, Vec::new());
         let linestring = LineString::from(vec![(0., 0.), (-2., 0.), (-2., 2.), (0., 2.), (0., 0.)]);
         let poly2 = Polygon::new(linestring, Vec::new());
-        assert_eq!(
-            MultiPolygon(vec![poly1, poly2]).centroid(),
-            Some(Point::new(0., 1.))
+        assert_relative_eq!(
+            MultiPolygon(vec![poly1, poly2]).centroid().unwrap(),
+            point![x: 0., y: 1.]
         );
     }
     #[test]
     fn bounding_rect_test() {
         let bounding_rect = Rect::new(Coordinate { x: 0., y: 50. }, Coordinate { x: 4., y: 100. });
-        let point = Point(Coordinate { x: 2., y: 75. });
+        let point = point![x: 2., y: 75.];
         assert_eq!(point, bounding_rect.centroid());
     }
     #[test]
     fn line_test() {
         let line1 = Line::new(c(0., 1.), c(1., 3.));
-        assert_eq!(line1.centroid(), Point::new(0.5, 2.));
+        assert_eq!(line1.centroid(), point![x: 0.5, y: 2.]);
     }
 }

--- a/geo/src/algorithm/dimensions.rs
+++ b/geo/src/algorithm/dimensions.rs
@@ -187,7 +187,6 @@ impl<C: CoordNum> HasDimensions for LineString<C> {
             return Dimensions::Empty;
         }
 
-        debug_assert!(self.0.len() > 1, "invalid line_string with 1 coord");
         let first = self.0[0];
         if self.0.iter().any(|&coord| first != coord) {
             Dimensions::OneDimensional
@@ -396,7 +395,12 @@ impl<C: CoordNum> HasDimensions for Triangle<C> {
         if self.0 == self.1 && self.1 == self.2 {
             // degenerate triangle is a point
             Dimensions::ZeroDimensional
-        } else if self.0 == self.1 || self.1 == self.2 || self.2 == self.0 {
+        } else if self.0 == self.1
+            || self.1 == self.2
+            || self.2 == self.0
+            || (self.0.x == self.1.x && self.0.x == self.2.x)
+            || (self.0.y == self.1.y && self.0.y == self.2.y)
+        {
             // degenerate triangle is a line
             Dimensions::OneDimensional
         } else {

--- a/geo/src/algorithm/dimensions.rs
+++ b/geo/src/algorithm/dimensions.rs
@@ -1,5 +1,6 @@
+use crate::algorithm::kernels::Orientation::Collinear;
 use crate::{
-    CoordNum, Geometry, GeometryCollection, Line, LineString, MultiLineString, MultiPoint,
+    CoordNum, GeoNum, Geometry, GeometryCollection, Line, LineString, MultiLineString, MultiPoint,
     MultiPolygon, Point, Polygon, Rect, Triangle,
 };
 
@@ -131,7 +132,7 @@ pub trait HasDimensions {
     fn boundary_dimensions(&self) -> Dimensions;
 }
 
-impl<C: CoordNum> HasDimensions for Geometry<C> {
+impl<C: GeoNum> HasDimensions for Geometry<C> {
     crate::geometry_delegate_impl! {
         fn is_empty(&self) -> bool;
         fn dimensions(&self) -> Dimensions;
@@ -320,7 +321,7 @@ impl<C: CoordNum> HasDimensions for MultiPolygon<C> {
     }
 }
 
-impl<C: CoordNum> HasDimensions for GeometryCollection<C> {
+impl<C: GeoNum> HasDimensions for GeometryCollection<C> {
     fn is_empty(&self) -> bool {
         if self.0.is_empty() {
             true
@@ -386,23 +387,21 @@ impl<C: CoordNum> HasDimensions for Rect<C> {
     }
 }
 
-impl<C: CoordNum> HasDimensions for Triangle<C> {
+impl<C: crate::GeoNum> HasDimensions for Triangle<C> {
     fn is_empty(&self) -> bool {
         false
     }
 
     fn dimensions(&self) -> Dimensions {
-        if self.0 == self.1 && self.1 == self.2 {
-            // degenerate triangle is a point
-            Dimensions::ZeroDimensional
-        } else if self.0 == self.1
-            || self.1 == self.2
-            || self.2 == self.0
-            || (self.0.x == self.1.x && self.0.x == self.2.x)
-            || (self.0.y == self.1.y && self.0.y == self.2.y)
-        {
-            // degenerate triangle is a line
-            Dimensions::OneDimensional
+        use crate::algorithm::kernels::Kernel;
+        if Collinear == C::Ker::orient2d(self.0, self.1, self.2) {
+            if self.0 == self.1 && self.1 == self.2 {
+                // degenerate triangle is a point
+                Dimensions::ZeroDimensional
+            } else {
+                // degenerate triangle is a line
+                Dimensions::OneDimensional
+            }
         } else {
             Dimensions::TwoDimensional
         }

--- a/geo/src/algorithm/dimensions.rs
+++ b/geo/src/algorithm/dimensions.rs
@@ -226,7 +226,19 @@ impl<C: CoordNum> HasDimensions for Polygon<C> {
     }
 
     fn dimensions(&self) -> Dimensions {
-        Dimensions::TwoDimensional
+        use crate::algorithm::coords_iter::CoordsIter;
+        let mut coords = self.exterior_coords_iter();
+        match coords.next() {
+            None => Dimensions::Empty,
+            Some(coord_0) => {
+                if coords.all(|coord_n| coord_0 == coord_n) {
+                    // all coords are a single point
+                    Dimensions::ZeroDimensional
+                } else {
+                    Dimensions::TwoDimensional
+                }
+            }
+        }
     }
 
     fn boundary_dimensions(&self) -> Dimensions {

--- a/geo/src/algorithm/rotate.rs
+++ b/geo/src/algorithm/rotate.rs
@@ -1,10 +1,9 @@
 use crate::algorithm::centroid::Centroid;
 use crate::algorithm::map_coords::MapCoords;
 use crate::{
-    CoordFloat, Line, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon,
+    CoordFloat, GeoFloat, Line, LineString, MultiLineString, MultiPoint, MultiPolygon, Point,
+    Polygon,
 };
-use num_traits::FromPrimitive;
-use std::iter::Sum;
 
 #[inline]
 fn rotate_inner<T>(x: T, y: T, x0: T, y0: T, sin_theta: T, cos_theta: T) -> Point<T>
@@ -146,7 +145,7 @@ where
 
 impl<T> Rotate<T> for Line<T>
 where
-    T: CoordFloat,
+    T: GeoFloat,
 {
     fn rotate(&self, angle: T) -> Self {
         let centroid = self.centroid();
@@ -159,7 +158,7 @@ where
 
 impl<T> Rotate<T> for LineString<T>
 where
-    T: CoordFloat,
+    T: GeoFloat,
 {
     /// Rotate the LineString about its centroid by the given number of degrees
     fn rotate(&self, angle: T) -> Self {
@@ -169,7 +168,7 @@ where
 
 impl<T> Rotate<T> for Polygon<T>
 where
-    T: CoordFloat + FromPrimitive + Sum,
+    T: GeoFloat,
 {
     /// Rotate the Polygon about its centroid by the given number of degrees
     fn rotate(&self, angle: T) -> Self {
@@ -191,7 +190,7 @@ where
 
 impl<T> Rotate<T> for MultiPolygon<T>
 where
-    T: CoordFloat + FromPrimitive + Sum,
+    T: GeoFloat,
 {
     /// Rotate the contained Polygons about their centroids by the given number of degrees
     fn rotate(&self, angle: T) -> Self {
@@ -201,7 +200,7 @@ where
 
 impl<T> Rotate<T> for MultiLineString<T>
 where
-    T: CoordFloat + FromPrimitive,
+    T: GeoFloat,
 {
     /// Rotate the contained LineStrings about their centroids by the given number of degrees
     fn rotate(&self, angle: T) -> Self {
@@ -211,7 +210,7 @@ where
 
 impl<T> Rotate<T> for MultiPoint<T>
 where
-    T: CoordFloat + FromPrimitive,
+    T: CoordFloat,
 {
     /// Rotate the contained Points about their centroids by the given number of degrees
     fn rotate(&self, angle: T) -> Self {

--- a/geo/tests/jts_tests.rs
+++ b/geo/tests/jts_tests.rs
@@ -1,0 +1,57 @@
+use jts_test_runner::TestRunner;
+
+#[test]
+fn test_centroid() {
+    let mut runner = TestRunner::new().matching_filename_glob("*Centroid.xml");
+    runner.run().expect("test cases failed");
+
+    // sanity check that *something* was run
+    assert!(
+        runner.failures().len() + runner.successes().len() > 0,
+        "No tests were run."
+    );
+
+    if !runner.failures().is_empty() {
+        let failure_text = runner
+            .failures()
+            .iter()
+            .map(|failure| format!("{}", failure))
+            .collect::<Vec<String>>()
+            .join("\n");
+        panic!(
+            "{} failures / {} successes in JTS test suite:\n{}",
+            runner.failures().len(),
+            runner.successes().len(),
+            failure_text
+        );
+    }
+}
+
+#[test]
+// several of the ConvexHull tests are currently failing
+#[ignore]
+fn test_all_general() {
+    let mut runner = TestRunner::new();
+    runner.run().expect("test cases failed");
+
+    // sanity check that *something* was run
+    assert!(
+        runner.failures().len() + runner.successes().len() > 0,
+        "No tests were run."
+    );
+
+    if !runner.failures().is_empty() {
+        let failure_text = runner
+            .failures()
+            .iter()
+            .map(|failure| format!("{}", failure))
+            .collect::<Vec<String>>()
+            .join("\n");
+        panic!(
+            "{} failures / {} successes in JTS test suite:\n{}",
+            runner.failures().len(),
+            runner.successes().len(),
+            failure_text
+        );
+    }
+}


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

- Fixes the implementation for a MultiLineString with zero length lines
- `impl Centroid for Geometry` and it's remaining variants.

FYI: I found these via the JTS test suite runner I'm working on here: https://github.com/michaelkirk/jts-test-runner/pull/1/files 


Status:
- [x] integrate jts-test-runner centroid tests
- [x] needs review http://github.com/michaelkirk/jts-test-runner/pull/1
- [x] move http://github.com/michaelkirk/jts-test-runner/pull/1 to georust
- [ ] publish jts-test-runner? (alternatively, we could leave it unpublished and just reference GH for this unique crate)
- [x] publish wkt
- [x] remove unpublished references from `patch.crates-io`