### PR TITLE
Remove clippy warnings. #630

### DIFF
--- a/geo-types/src/line_string.rs
+++ b/geo-types/src/line_string.rs
@@ -171,7 +171,7 @@ impl<T: CoordNum> LineString<T> {
     /// );
     /// assert!(lines.next().is_none());
     /// ```
-    pub fn lines<'a>(&'a self) -> impl ExactSizeIterator + Iterator<Item = Line<T>> + 'a {
+    pub fn lines(&'_ self) -> impl ExactSizeIterator + Iterator<Item = Line<T>> + '_ {
         self.0.windows(2).map(|w| {
             // slice::windows(N) is guaranteed to yield a slice with exactly N elements
             unsafe { Line::new(*w.get_unchecked(0), *w.get_unchecked(1)) }
@@ -179,7 +179,7 @@ impl<T: CoordNum> LineString<T> {
     }
 
     /// An iterator which yields the coordinates of a `LineString` as `Triangle`s
-    pub fn triangles<'a>(&'a self) -> impl ExactSizeIterator + Iterator<Item = Triangle<T>> + 'a {
+    pub fn triangles(&'_ self) -> impl ExactSizeIterator + Iterator<Item = Triangle<T>> + '_ {
         self.0.windows(3).map(|w| {
             // slice::windows(N) is guaranteed to yield a slice with exactly N elements
             unsafe {


### PR DESCRIPTION
- [x ] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Minor fixup: Removes clippy warnings.