### PR TITLE
Add first fuzz target for fuzzing simplify algorithm.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
       - geo_types
       - geo
       - geo_postgis
+      - geo_fuzz
       - coverage
       - bench
     steps:
@@ -24,6 +25,7 @@ jobs:
       - name: Mark the job as a failure
         if: "!success()"
         run: exit 1
+
   geo_types:
     name: geo-types
     runs-on: ubuntu-latest
@@ -80,6 +82,24 @@ jobs:
       - run: cargo install cargo-all-features
       - run: cargo build-all-features
       - run: cargo test-all-features
+
+  geo_fuzz:
+    name: geo-fuzz
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    defaults:
+      run:
+        working-directory: geo/fuzz
+    strategy:
+      matrix:
+        container_image: ["georust/geo-ci:rust-1.49", "georust/geo-ci:rust-1.50"]
+    container:
+      image: ${{ matrix.container_image }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - run: cargo build --bins
+
   coverage:
     name: coverage
     runs-on: ubuntu-latest

--- a/geo/fuzz/.gitignore
+++ b/geo/fuzz/.gitignore
@@ -1,0 +1,3 @@
+target
+corpus
+artifacts

--- a/geo/fuzz/Cargo.toml
+++ b/geo/fuzz/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "geo-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.geo]
+path = ".."
+
+[dependencies.geo-types]
+path = "../../geo-types"
+features = ["arbitrary"]
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "simplify"
+path = "fuzz_targets/simplify.rs"
+test = false
+doc = false

--- a/geo/fuzz/fuzz_targets/simplify.rs
+++ b/geo/fuzz/fuzz_targets/simplify.rs
@@ -1,0 +1,11 @@
+#![no_main]
+
+use geo::algorithm::simplify::Simplify;
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|tuple: (geo_types::Polygon<f32>, f32)| {
+    if tuple.1 < 0. {
+        return;
+    }
+    tuple.0.simplify(&tuple.1);
+});

--- a/geo/fuzz/fuzz_targets/simplify.rs
+++ b/geo/fuzz/fuzz_targets/simplify.rs
@@ -1,8 +1,23 @@
 #![no_main]
 
+use geo::algorithm::euclidean_length::EuclideanLength;
 use geo::algorithm::simplify::Simplify;
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|tuple: (geo_types::Polygon<f32>, f32)| {
-    tuple.0.simplify(&tuple.1);
+    let (polygon, epsilon) = tuple;
+
+    let simplified = polygon.simplify(&epsilon);
+
+    check_result(polygon, simplified);
 });
+
+fn check_result(original: geo_types::Polygon<f32>, simplified: geo_types::Polygon<f32>) {
+    assert!(simplified.exterior().0.len() <= original.exterior().0.len());
+    assert!(simplified.exterior().euclidean_length() <= original.exterior().euclidean_length());
+
+    for interior in simplified.interiors() {
+        assert!(simplified.exterior().0.len() <= interior.0.len());
+        assert!(simplified.exterior().euclidean_length() <= interior.euclidean_length());
+    }
+}

--- a/geo/fuzz/fuzz_targets/simplify.rs
+++ b/geo/fuzz/fuzz_targets/simplify.rs
@@ -4,8 +4,5 @@ use geo::algorithm::simplify::Simplify;
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|tuple: (geo_types::Polygon<f32>, f32)| {
-    if tuple.1 < 0. {
-        return;
-    }
     tuple.0.simplify(&tuple.1);
 });


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- ~I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.~
---

Based off of https://github.com/georust/geo/pull/532.

Fuzzing allows us to find buggy edge cases and  alsocheck the validity of our algorithms (by comparing results against the result of other libraries like GEOS). This pull request just adds one fuzz target for fuzzing our `Simplify` algorithm to get us started.

How to fuzz:

```sh
cargo install cargo-fuzz
cd geo
cargo fuzz run simplify # cargo fuzz run <fuzz target>
```
