### PR TITLE
Don't redundantly sort Rect inputs (cleanup - no change in behavior)

### DIFF
--- a/geo-types/src/private_utils.rs
+++ b/geo-types/src/private_utils.rs
@@ -16,15 +16,7 @@ pub fn line_bounding_rect<T>(line: Line<T>) -> Rect<T>
 where
     T: CoordNum,
 {
-    let a = line.start;
-    let b = line.end;
-    let (xmin, xmax) = if a.x <= b.x { (a.x, b.x) } else { (b.x, a.x) };
-    let (ymin, ymax) = if a.y <= b.y { (a.y, b.y) } else { (b.y, a.y) };
-
-    Rect::new(
-        Coordinate { x: xmin, y: ymin },
-        Coordinate { x: xmax, y: ymax },
-    )
+    Rect::new(line.start, line.end)
 }
 
 pub fn get_bounding_rect<I, T>(collection: I) -> Option<Rect<T>>

--- a/geo/src/algorithm/bounding_rect.rs
+++ b/geo/src/algorithm/bounding_rect.rs
@@ -66,14 +66,7 @@ where
     type Output = Rect<T>;
 
     fn bounding_rect(&self) -> Self::Output {
-        let a = self.start;
-        let b = self.end;
-        let (xmin, xmax) = if a.x <= b.x { (a.x, b.x) } else { (b.x, a.x) };
-        let (ymin, ymax) = if a.y <= b.y { (a.y, b.y) } else { (b.y, a.y) };
-        Rect::new(
-            Coordinate { x: xmin, y: ymin },
-            Coordinate { x: xmax, y: ymax },
-        )
+        Rect::new(self.start, self.end)
     }
 }
 


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] ~~I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.~~
---

Since ec69add2df63ec4e2a9f04c52bc824d8427cef54, `Rect::new` already sorts it's input by min/max, and so there's no longer a need to manually sort min/max points.

