### PR TITLE
Introduce the geomgraph module for DE-9IM Relate trait

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -4,6 +4,12 @@
 
 * Add `line_intersection` to compute point or segment intersection of two Lines.
   * <https://github.com/georust/geo/pull/636>
+* Add `Relate` trait to topologically relate two geometries based on [DE-9IM](https://en.wikipedia.org/wiki/DE-9IM) semantics.
+  * <https://github.com/georust/geo/pull/639>
+* Fix `Contains` implementation for Polygons to match the OGC spec using the new `Relate` trait
+  * <https://github.com/georust/geo/pull/639>
+* BREAKING: `Contains` no longer supports integer `Polygon` and `Geometry`
+  * <https://github.com/georust/geo/pull/639>
 
 ## 0.17.1
 

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -19,6 +19,7 @@ num-traits = "0.2"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 rstar = { version = "0.8" }
 geographiclib-rs = { version = "0.2" }
+log = "0.4.11"
 
 proj = { version = "0.20.3", optional = true }
 
@@ -32,11 +33,12 @@ proj-network = ["use-proj", "proj/network"]
 use-serde = ["serde", "geo-types/serde"]
 
 [dev-dependencies]
+pretty_env_logger = "0.4"
 approx = "0.4.0"
 criterion = { version = "0.3" }
 # jts-test-runner is an internal crate which exists only to be part of the geo test suite.
 # As such it's kept unpublished. It's in a separate repo primarily because it's kind of large.
-jts-test-runner = { git = "https://github.com/georust/jts-test-runner", rev = "3294b9af1d3e64fcc9caf9646a93d0116f7d8321" }
+jts-test-runner = { git = "https://github.com/georust/jts-test-runner", rev = "4a69a552546bd3d1dec574a51280dbc82bb417ce" }
 rand = "0.8.0"
 
 [[bench]]
@@ -73,6 +75,10 @@ harness = false
 
 [[bench]]
 name = "rotate"
+harness = false
+
+[[bench]]
+name = "relate"
 harness = false
 
 [[bench]]

--- a/geo/benches/relate.rs
+++ b/geo/benches/relate.rs
@@ -1,0 +1,36 @@
+#[macro_use]
+extern crate criterion;
+extern crate geo;
+
+use crate::geo::relate::Relate;
+use criterion::Criterion;
+use geo::{LineString, Polygon};
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("relate overlapping 50-point polygons", |bencher| {
+        let points = include!("../src/algorithm/test_fixtures/norway_main.rs");
+
+        let sub_polygon = {
+            let points = points[0..50].to_vec();
+            let mut exterior = LineString::<f32>::from(points);
+            exterior.close();
+            Polygon::new(exterior, vec![])
+        };
+
+        let polygon = {
+            let points = points[40..90].to_vec();
+            let mut exterior = LineString::<f32>::from(points);
+            exterior.close();
+            Polygon::new(exterior, vec![])
+        };
+
+        bencher.iter(|| {
+            criterion::black_box(
+                criterion::black_box(&polygon).relate(criterion::black_box(&sub_polygon)),
+            );
+        });
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/geo/src/algorithm/bounding_rect.rs
+++ b/geo/src/algorithm/bounding_rect.rs
@@ -1,7 +1,7 @@
 use crate::utils::{partial_max, partial_min};
 use crate::{
-    CoordNum, Coordinate, Geometry, GeometryCollection, Line, LineString, MultiLineString,
-    MultiPoint, MultiPolygon, Point, Polygon, Rect, Triangle,
+    CoordNum, Coordinate, Geometry, GeometryCollection, GeometryCow, Line, LineString,
+    MultiLineString, MultiPoint, MultiPolygon, Point, Polygon, Rect, Triangle,
 };
 use geo_types::private_utils::{get_bounding_rect, line_string_bounding_rect};
 
@@ -155,6 +155,17 @@ where
     type Output = Option<Rect<T>>;
 
     crate::geometry_delegate_impl! {
+       fn bounding_rect(&self) -> Self::Output;
+    }
+}
+
+impl<T> BoundingRect<T> for GeometryCow<'_, T>
+where
+    T: CoordNum,
+{
+    type Output = Option<Rect<T>>;
+
+    crate::geometry_cow_delegate_impl! {
        fn bounding_rect(&self) -> Self::Output;
     }
 }

--- a/geo/src/algorithm/centroid.rs
+++ b/geo/src/algorithm/centroid.rs
@@ -615,8 +615,8 @@ mod test {
             .centroid()
             .unwrap()
             .map_coords(|&(x, y)| (x - shift_x, y - shift_y));
-        eprintln!("centroid {:?}", centroid.0);
-        eprintln!("new_centroid {:?}", new_centroid.0);
+        debug!("centroid {:?}", centroid.0);
+        debug!("new_centroid {:?}", new_centroid.0);
         assert_relative_eq!(centroid.0.x, new_centroid.0.x, max_relative = 0.0001);
         assert_relative_eq!(centroid.0.y, new_centroid.0.y, max_relative = 0.0001);
     }

--- a/geo/src/algorithm/contains/geometry.rs
+++ b/geo/src/algorithm/contains/geometry.rs
@@ -9,8 +9,8 @@ impl<T> Contains<Coordinate<T>> for Geometry<T>
 where
     T: GeoNum,
 {
-    geometry_delegate_impl! {
-        fn contains(&self, coord: &Coordinate<T>) -> bool;
+    fn contains(&self, coord: &Coordinate<T>) -> bool {
+        self.contains(&Point::from(*coord))
     }
 }
 
@@ -18,8 +18,8 @@ impl<T> Contains<Point<T>> for Geometry<T>
 where
     T: GeoNum,
 {
-    fn contains(&self, point: &Point<T>) -> bool {
-        self.contains(&point.0)
+    geometry_delegate_impl! {
+        fn contains(&self, point: &Point<T>) -> bool;
     }
 }
 

--- a/geo/src/algorithm/contains/mod.rs
+++ b/geo/src/algorithm/contains/mod.rs
@@ -370,29 +370,45 @@ mod test {
     #[test]
     fn line_in_polygon_test() {
         let c = |x, y| Coordinate { x, y };
-        let line = Line::new(c(0, 10), c(30, 40));
-        let linestring0 = line_string![c(-10, 0), c(50, 0), c(50, 50), c(0, 50), c(-10, 0)];
+        let line = Line::new(c(0.0, 10.0), c(30.0, 40.0));
+        let linestring0 = line_string![
+            c(-10.0, 0.0),
+            c(50.0, 0.0),
+            c(50.0, 50.0),
+            c(0.0, 50.0),
+            c(-10.0, 0.0)
+        ];
         let poly0 = Polygon::new(linestring0, Vec::new());
-        let linestring1 = line_string![c(0, 0), c(0, 20), c(20, 20), c(20, 0), c(0, 0)];
+        let linestring1 = line_string![
+            c(0.0, 0.0),
+            c(0.0, 20.0),
+            c(20.0, 20.0),
+            c(20.0, 0.0),
+            c(0.0, 0.0)
+        ];
         let poly1 = Polygon::new(linestring1, Vec::new());
         assert!(poly0.contains(&line));
         assert!(!poly1.contains(&line));
     }
     #[test]
-    #[ignore]
     fn line_in_polygon_edgecases_test() {
         // Some DE-9IM edge cases for checking line is
         // inside polygon The end points of the line can be
-        // on the boundary of the polygon but we don't allow
-        // that yet.
+        // on the boundary of the polygon.
         let c = |x, y| Coordinate { x, y };
         // A non-convex polygon
-        let linestring0 = line_string![c(0, 0), c(1, 1), c(1, -1), c(-1, -1), c(-1, 1)];
+        let linestring0 = line_string![
+            c(0.0, 0.0),
+            c(1.0, 1.0),
+            c(1.0, -1.0),
+            c(-1.0, -1.0),
+            c(-1.0, 1.0)
+        ];
         let poly = Polygon::new(linestring0, Vec::new());
 
-        assert!(poly.contains(&Line::new(c(0, 0), c(1, -1))));
-        assert!(poly.contains(&Line::new(c(-1, 1), c(1, -1))));
-        assert!(!poly.contains(&Line::new(c(-1, 1), c(1, 1))));
+        assert!(poly.contains(&Line::new(c(0.0, 0.0), c(1.0, -1.0))));
+        assert!(poly.contains(&Line::new(c(-1.0, 1.0), c(1.0, -1.0))));
+        assert!(!poly.contains(&Line::new(c(-1.0, 1.0), c(1.0, 1.0))));
     }
     #[test]
     fn line_in_linestring_edgecases() {

--- a/geo/src/algorithm/coordinate_position.rs
+++ b/geo/src/algorithm/coordinate_position.rs
@@ -2,12 +2,12 @@ use crate::algorithm::{
     bounding_rect::BoundingRect, dimensions::HasDimensions, intersects::Intersects,
 };
 use crate::{
-    Coordinate, GeoNum, Geometry, GeometryCollection, Line, LineString, MultiLineString,
-    MultiPoint, MultiPolygon, Point, Polygon, Rect, Triangle,
+    Coordinate, GeoNum, Geometry, GeometryCollection, GeometryCow, Line, LineString,
+    MultiLineString, MultiPoint, MultiPolygon, Point, Polygon, Rect, Triangle,
 };
 
 /// The position of a `Coordinate` relative to a `Geometry`
-#[derive(PartialEq, Clone, Debug)]
+#[derive(PartialEq, Clone, Copy, Debug)]
 pub enum CoordPos {
     OnBoundary,
     Inside,
@@ -327,48 +327,23 @@ where
     T: GeoNum,
 {
     type Scalar = T;
-    fn calculate_coordinate_position(
-        &self,
-        coord: &Coordinate<T>,
-        is_inside: &mut bool,
-        boundary_count: &mut usize,
-    ) {
-        if self.is_empty() {
-            return;
-        }
+    crate::geometry_delegate_impl! {
+        fn calculate_coordinate_position(
+            &self,
+            coord: &Coordinate<T>,
+            is_inside: &mut bool,
+            boundary_count: &mut usize) -> ();
+    }
+}
 
-        match self {
-            Geometry::Point(point) => {
-                point.calculate_coordinate_position(coord, is_inside, boundary_count)
-            }
-            Geometry::Line(line) => {
-                line.calculate_coordinate_position(coord, is_inside, boundary_count)
-            }
-            Geometry::LineString(line_string) => {
-                line_string.calculate_coordinate_position(coord, is_inside, boundary_count)
-            }
-            Geometry::Polygon(polygon) => {
-                polygon.calculate_coordinate_position(coord, is_inside, boundary_count)
-            }
-            Geometry::Rect(rect) => {
-                rect.calculate_coordinate_position(coord, is_inside, boundary_count)
-            }
-            Geometry::Triangle(triangle) => {
-                triangle.calculate_coordinate_position(coord, is_inside, boundary_count)
-            }
-            Geometry::MultiPoint(multi_point) => {
-                multi_point.calculate_coordinate_position(coord, is_inside, boundary_count)
-            }
-            Geometry::MultiLineString(multi_line_string) => {
-                multi_line_string.calculate_coordinate_position(coord, is_inside, boundary_count)
-            }
-            Geometry::MultiPolygon(multi_polygon) => {
-                multi_polygon.calculate_coordinate_position(coord, is_inside, boundary_count)
-            }
-            Geometry::GeometryCollection(geometry_collection) => {
-                geometry_collection.calculate_coordinate_position(coord, is_inside, boundary_count)
-            }
-        }
+impl<'a, T: GeoNum> CoordinatePosition for GeometryCow<'a, T> {
+    type Scalar = T;
+    crate::geometry_cow_delegate_impl! {
+        fn calculate_coordinate_position(
+            &self,
+            coord: &Coordinate<T>,
+            is_inside: &mut bool,
+            boundary_count: &mut usize) -> ();
     }
 }
 

--- a/geo/src/algorithm/dimensions.rs
+++ b/geo/src/algorithm/dimensions.rs
@@ -1,7 +1,7 @@
 use crate::algorithm::kernels::Orientation::Collinear;
 use crate::{
-    CoordNum, GeoNum, Geometry, GeometryCollection, Line, LineString, MultiLineString, MultiPoint,
-    MultiPolygon, Point, Polygon, Rect, Triangle,
+    CoordNum, GeoNum, Geometry, GeometryCollection, GeometryCow, Line, LineString, MultiLineString,
+    MultiPoint, MultiPolygon, Point, Polygon, Rect, Triangle,
 };
 
 /// Geometries can have 0, 1, or two dimensions. Or, in the case of an [`empty`](#is_empty)
@@ -134,6 +134,14 @@ pub trait HasDimensions {
 
 impl<C: GeoNum> HasDimensions for Geometry<C> {
     crate::geometry_delegate_impl! {
+        fn is_empty(&self) -> bool;
+        fn dimensions(&self) -> Dimensions;
+        fn boundary_dimensions(&self) -> Dimensions;
+    }
+}
+
+impl<C: GeoNum> HasDimensions for GeometryCow<'_, C> {
+    crate::geometry_cow_delegate_impl! {
         fn is_empty(&self) -> bool;
         fn dimensions(&self) -> Dimensions;
         fn boundary_dimensions(&self) -> Dimensions;

--- a/geo/src/algorithm/mod.rs
+++ b/geo/src/algorithm/mod.rs
@@ -66,6 +66,8 @@ pub(crate) mod polygon_distance_fast_path;
 /// Coordinate projections and transformations using the current stable version of [PROJ](http://proj.org).
 #[cfg(feature = "use-proj")]
 pub mod proj;
+/// Relate two geometries based on DE-9IM
+pub mod relate;
 /// Rotate a `Geometry` around either its centroid or a `Point` by an angle given in degrees.
 pub mod rotate;
 /// Simplify `Geometries` using the Ramer-Douglas-Peucker algorithm.

--- a/geo/src/algorithm/relate/edge_end_builder.rs
+++ b/geo/src/algorithm/relate/edge_end_builder.rs
@@ -1,0 +1,125 @@
+use super::geomgraph::{Edge, EdgeEnd, EdgeIntersection};
+use crate::GeoFloat;
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+/// Computes the [`EdgeEnd`]s which arise from an [`Edge`] who has had its `edge_intersections`
+/// populated with self and proper [`EdgeIntersection`]s.
+///
+/// Based on [JTS's EdgeEndBuilder as of 1.18.1](https://github.com/locationtech/jts/blob/jts-1.18.1/modules/core/src/main/java/org/locationtech/jts/operation/relate/EdgeEndBuilder.java)
+pub(crate) struct EdgeEndBuilder<F: GeoFloat> {
+    _marker: std::marker::PhantomData<F>,
+}
+
+impl<F: GeoFloat> EdgeEndBuilder<F> {
+    pub fn new() -> Self {
+        EdgeEndBuilder {
+            _marker: std::marker::PhantomData,
+        }
+    }
+
+    pub fn compute_ends_for_edges(&self, edges: &[Rc<RefCell<Edge<F>>>]) -> Vec<EdgeEnd<F>> {
+        let mut list = vec![];
+        for edge in edges {
+            self.compute_ends_for_edge(&mut edge.borrow_mut(), &mut list);
+        }
+        list
+    }
+
+    /// Creates stub edges for all the intersections in the [`Edge`] (if any) and inserts them into
+    /// the graph's `list`.
+    fn compute_ends_for_edge(&self, edge: &mut Edge<F>, list: &mut Vec<EdgeEnd<F>>) {
+        edge.add_edge_intersection_list_endpoints();
+
+        let mut ei_iter = edge.edge_intersections().iter();
+        let mut ei_prev;
+        let mut ei_curr = None;
+        let mut ei_next = ei_iter.next();
+        if ei_next.is_none() {
+            return;
+        }
+
+        loop {
+            ei_prev = ei_curr;
+            ei_curr = ei_next;
+            ei_next = ei_iter.next();
+            if let Some(ei_curr) = ei_curr {
+                self.create_edge_end_for_prev(edge, list, ei_curr, ei_prev);
+                self.create_edge_end_for_next(edge, list, ei_curr, ei_next);
+            }
+
+            if ei_curr.is_none() {
+                break;
+            }
+        }
+    }
+
+    /// Adds a `EdgeEnd`, if any, to `list` for the edge before the intersection ei_curr.
+    ///
+    /// The previous intersection is provided in case it is the endpoint for the stub edge.
+    /// Otherwise, the previous point from the parent edge will be the endpoint.
+    fn create_edge_end_for_prev(
+        &self,
+        edge: &Edge<F>,
+        list: &mut Vec<EdgeEnd<F>>,
+        ei_curr: &EdgeIntersection<F>,
+        ei_prev: Option<&EdgeIntersection<F>>,
+    ) {
+        let mut i_prev = ei_curr.segment_index();
+        if ei_curr.distance().is_zero() {
+            // if at the start of the edge there is no previous edge
+            if i_prev == 0 {
+                return;
+            }
+            i_prev -= 1;
+        }
+
+        let mut coord_prev = edge.coords()[i_prev];
+        // if prev intersection is past the previous vertex, use it instead
+        if let Some(ei_prev) = ei_prev {
+            if ei_prev.segment_index() >= i_prev {
+                coord_prev = ei_prev.coordinate();
+            }
+        }
+
+        let mut label = edge.label().clone();
+        // since edgeStub is oriented opposite to its parent edge, have to flip sides for edge label
+        label.flip();
+
+        let edge_end = EdgeEnd::new(ei_curr.coordinate(), coord_prev, label);
+        list.push(edge_end);
+    }
+
+    /// Adds a `EdgeEnd`, if any, to `list` for the edge after the intersection ei_curr.
+    ///
+    /// The next intersection is provided in case it is the endpoint for the stub edge.
+    /// Otherwise, the next point from the parent edge will be the endpoint.
+    fn create_edge_end_for_next(
+        &self,
+        edge: &Edge<F>,
+        list: &mut Vec<EdgeEnd<F>>,
+        ei_curr: &EdgeIntersection<F>,
+        ei_next: Option<&EdgeIntersection<F>>,
+    ) {
+        let i_next = ei_curr.segment_index() + 1;
+
+        // if there is no next edge there is nothing to do
+        if i_next >= edge.coords().len() && ei_next.is_none() {
+            return;
+        }
+
+        let mut coord_next = edge.coords()[i_next];
+
+        // if the next intersection is in the same segment as the current, use it as the endpoint
+        if let Some(ei_next) = ei_next {
+            if ei_next.segment_index() == ei_curr.segment_index() {
+                coord_next = ei_next.coordinate();
+            }
+        }
+
+        let label = edge.label().clone();
+        let edge_end = EdgeEnd::new(ei_curr.coordinate(), coord_next, label);
+        list.push(edge_end);
+    }
+}

--- a/geo/src/algorithm/relate/geomgraph/edge.rs
+++ b/geo/src/algorithm/relate/geomgraph/edge.rs
@@ -1,0 +1,158 @@
+use super::{Dimensions, Direction, EdgeIntersection, IntersectionMatrix, Label};
+use super::{LineIntersection, LineIntersector, RobustLineIntersector};
+use crate::{Coordinate, GeoFloat, Line};
+
+use std::collections::BTreeSet;
+
+/// An `Edge` represents a one dimensional line in a geometry.
+///
+/// This is based on [JTS's `Edge` as of 1.18.1](https://github.com/locationtech/jts/blob/jts-1.18.1/modules/core/src/main/java/org/locationtech/jts/geomgraph/Edge.java)
+#[derive(Debug)]
+pub(crate) struct Edge<F: GeoFloat> {
+    /// `coordinates` of the line geometry
+    coords: Vec<Coordinate<F>>,
+
+    /// an edge is "isolated" if no other edge touches it
+    is_isolated: bool,
+
+    /// other edges that this edge intersects with
+    edge_intersections: BTreeSet<EdgeIntersection<F>>,
+
+    /// where the line's topological classification to the two geometries is recorded
+    label: Label,
+}
+
+impl<F: GeoFloat> Edge<F> {
+    /// Create a new Edge.
+    ///
+    /// - `coords` a *non-empty* Vec of Coordinates
+    /// - `label` an appropriately dimensioned topology label for the Edge. See [`TopologyPosition`]
+    ///    for details
+    pub(crate) fn new(mut coords: Vec<Coordinate<F>>, label: Label) -> Edge<F> {
+        assert!(!coords.is_empty(), "Can't add empty edge");
+        // Once set, `edge.coords` never changes length.
+        coords.shrink_to_fit();
+        Edge {
+            coords,
+            label,
+            is_isolated: true,
+            edge_intersections: BTreeSet::new(),
+        }
+    }
+
+    pub(crate) fn label(&self) -> &Label {
+        &self.label
+    }
+
+    pub(crate) fn label_mut(&mut self) -> &mut Label {
+        &mut self.label
+    }
+
+    pub fn coords(&self) -> &[Coordinate<F>] {
+        &self.coords
+    }
+
+    pub fn is_isolated(&self) -> bool {
+        self.is_isolated
+    }
+    pub fn mark_as_unisolated(&mut self) {
+        self.is_isolated = false;
+    }
+
+    pub fn edge_intersections(&self) -> &BTreeSet<EdgeIntersection<F>> {
+        &self.edge_intersections
+    }
+
+    pub fn edge_intersections_mut(&mut self) -> &mut BTreeSet<EdgeIntersection<F>> {
+        &mut self.edge_intersections
+    }
+
+    pub fn add_edge_intersection_list_endpoints(&mut self) {
+        let max_segment_index = self.coords().len() - 1;
+        let first_coord = self.coords()[0];
+        let max_coord = self.coords()[max_segment_index];
+        self.edge_intersections_mut()
+            .insert(EdgeIntersection::new(first_coord, 0, F::zero()));
+        self.edge_intersections_mut().insert(EdgeIntersection::new(
+            max_coord,
+            max_segment_index,
+            F::zero(),
+        ));
+    }
+
+    pub fn is_closed(&self) -> bool {
+        self.coords().first() == self.coords().last()
+    }
+
+    /// Adds EdgeIntersections for one or both intersections found for a segment of an edge to the
+    /// edge intersection list.
+    pub fn add_intersections(
+        &mut self,
+        intersection: LineIntersection<F>,
+        line: Line<F>,
+        segment_index: usize,
+    ) {
+        match intersection {
+            LineIntersection::SinglePoint { intersection, .. } => {
+                self.add_intersection(intersection, line, segment_index);
+            }
+            LineIntersection::Collinear { intersection } => {
+                self.add_intersection(intersection.start, line, segment_index);
+                self.add_intersection(intersection.end, line, segment_index);
+            }
+        }
+    }
+
+    /// Add an EdgeIntersection for `intersection`.
+    ///
+    /// An intersection that falls exactly on a vertex of the edge is normalized to use the higher
+    /// of the two possible `segment_index`
+    pub fn add_intersection(
+        &mut self,
+        intersection_coord: Coordinate<F>,
+        line: Line<F>,
+        segment_index: usize,
+    ) {
+        let mut normalized_segment_index = segment_index;
+        let mut distance = RobustLineIntersector::compute_edge_distance(intersection_coord, line);
+
+        let next_segment_index = normalized_segment_index + 1;
+
+        if next_segment_index < self.coords.len() {
+            let next_coord = self.coords[next_segment_index];
+            if intersection_coord == next_coord {
+                normalized_segment_index = next_segment_index;
+                distance = F::zero();
+            }
+        }
+        self.edge_intersections.insert(EdgeIntersection::new(
+            intersection_coord,
+            normalized_segment_index,
+            distance,
+        ));
+    }
+
+    /// Update the IM with the contribution for this component.
+    ///
+    /// A component only contributes if it has a labelling for both parent geometries
+    pub fn update_intersection_matrix(label: &Label, intersection_matrix: &mut IntersectionMatrix) {
+        intersection_matrix.set_at_least_if_in_both(
+            label.position(0, Direction::On),
+            label.position(1, Direction::On),
+            Dimensions::OneDimensional,
+        );
+
+        if label.is_area() {
+            intersection_matrix.set_at_least_if_in_both(
+                label.position(0, Direction::Left),
+                label.position(1, Direction::Left),
+                Dimensions::TwoDimensional,
+            );
+            intersection_matrix.set_at_least_if_in_both(
+                label.position(0, Direction::Right),
+                label.position(1, Direction::Right),
+                Dimensions::TwoDimensional,
+            );
+        }
+    }
+}

--- a/geo/src/algorithm/relate/geomgraph/edge_end.rs
+++ b/geo/src/algorithm/relate/geomgraph/edge_end.rs
@@ -1,0 +1,176 @@
+use super::{CoordNode, Edge, Label, Quadrant};
+use crate::{Coordinate, GeoFloat};
+
+use std::cell::RefCell;
+use std::fmt;
+
+/// Models the end of an edge incident on a node.
+///
+/// EdgeEnds have a direction determined by the direction of the ray from the initial
+/// point to the next point.
+///
+/// EdgeEnds are comparable by their EdgeEndKey, under the ordering
+/// "a has a greater angle with the x-axis than b".
+///
+/// This ordering is used to sort EdgeEnds around a node.
+///
+/// This is based on [JTS's EdgeEnd as of 1.18.1](https://github.com/locationtech/jts/blob/jts-1.18.1/modules/core/src/main/java/org/locationtech/jts/geomgraph/EdgeEnd.java)
+#[derive(Clone, Debug)]
+pub(crate) struct EdgeEnd<F>
+where
+    F: GeoFloat,
+{
+    label: Label,
+    key: EdgeEndKey<F>,
+}
+
+#[derive(Clone)]
+pub(crate) struct EdgeEndKey<F>
+where
+    F: GeoFloat,
+{
+    coord_0: Coordinate<F>,
+    coord_1: Coordinate<F>,
+    delta: Coordinate<F>,
+    quadrant: Option<Quadrant>,
+}
+
+impl<F: GeoFloat> fmt::Debug for EdgeEndKey<F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("EdgeEndKey")
+            .field(
+                "coords",
+                &format!("{:?} -> {:?}", &self.coord_0, &self.coord_1),
+            )
+            .field("quadrant", &self.quadrant)
+            .finish()
+    }
+}
+
+impl<F> EdgeEnd<F>
+where
+    F: GeoFloat,
+{
+    pub fn new(coord_0: Coordinate<F>, coord_1: Coordinate<F>, label: Label) -> EdgeEnd<F> {
+        let delta = coord_1 - coord_0;
+        let quadrant = Quadrant::new(delta.x, delta.y);
+        EdgeEnd {
+            label,
+            key: EdgeEndKey {
+                coord_0,
+                coord_1,
+                delta,
+                quadrant,
+            },
+        }
+    }
+
+    pub fn label(&self) -> &Label {
+        &self.label
+    }
+
+    pub fn label_mut(&mut self) -> &mut Label {
+        &mut self.label
+    }
+
+    pub fn coordinate(&self) -> &Coordinate<F> {
+        &self.key.coord_0
+    }
+
+    pub fn key(&self) -> &EdgeEndKey<F> {
+        &self.key
+    }
+}
+
+impl<F> std::cmp::Eq for EdgeEndKey<F> where F: GeoFloat {}
+
+impl<F> std::cmp::PartialEq for EdgeEndKey<F>
+where
+    F: GeoFloat,
+{
+    fn eq(&self, other: &EdgeEndKey<F>) -> bool {
+        self.delta == other.delta
+    }
+}
+
+impl<F> std::cmp::PartialOrd for EdgeEndKey<F>
+where
+    F: GeoFloat,
+{
+    fn partial_cmp(&self, other: &EdgeEndKey<F>) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<F> std::cmp::Ord for EdgeEndKey<F>
+where
+    F: GeoFloat,
+{
+    fn cmp(&self, other: &EdgeEndKey<F>) -> std::cmp::Ordering {
+        self.compare_direction(other)
+    }
+}
+
+impl<F> EdgeEndKey<F>
+where
+    F: GeoFloat,
+{
+    pub(crate) fn compare_direction(&self, other: &EdgeEndKey<F>) -> std::cmp::Ordering {
+        use std::cmp::Ordering;
+        if self.delta == other.delta {
+            return Ordering::Equal;
+        }
+
+        match (self.quadrant, other.quadrant) {
+            (Some(q1), Some(q2)) if q1 > q2 => Ordering::Greater,
+            (Some(q1), Some(q2)) if q1 < q2 => Ordering::Less,
+            _ => {
+                use crate::algorithm::kernels::{Kernel, Orientation};
+                match F::Ker::orient2d(other.coord_0, other.coord_1, self.coord_1) {
+                    Orientation::Clockwise => Ordering::Less,
+                    Orientation::CounterClockwise => Ordering::Greater,
+                    Orientation::Collinear => Ordering::Equal,
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_ord() {
+        let fake_label = Label::empty_line_or_point();
+        let edge_end_1 = EdgeEnd::new(
+            Coordinate::zero(),
+            Coordinate { x: 1.0, y: 1.0 },
+            fake_label.clone(),
+        );
+        let edge_end_2 = EdgeEnd::new(
+            Coordinate::zero(),
+            Coordinate { x: 1.0, y: 1.0 },
+            fake_label.clone(),
+        );
+        assert_eq!(
+            edge_end_1.key().cmp(&edge_end_2.key()),
+            std::cmp::Ordering::Equal
+        );
+
+        // edge_end_3 is clockwise from edge_end_1
+        let edge_end_3 = EdgeEnd::new(
+            Coordinate::zero(),
+            Coordinate { x: 1.0, y: -1.0 },
+            fake_label.clone(),
+        );
+        assert_eq!(
+            edge_end_1.key().cmp(&edge_end_3.key()),
+            std::cmp::Ordering::Less
+        );
+        assert_eq!(
+            edge_end_3.key().cmp(&edge_end_1.key()),
+            std::cmp::Ordering::Greater
+        );
+    }
+}

--- a/geo/src/algorithm/relate/geomgraph/edge_end_bundle.rs
+++ b/geo/src/algorithm/relate/geomgraph/edge_end_bundle.rs
@@ -1,0 +1,191 @@
+use super::{CoordPos, Direction, Edge, EdgeEnd, GeometryGraph, IntersectionMatrix, Label};
+use crate::{Coordinate, GeoFloat};
+
+/// A collection of [`EdgeEnds`](EdgeEnd) which obey the following invariant:
+/// They originate at the same node and have the same direction.
+///
+/// This is based on [JTS's `EdgeEndBundle` as of 1.18.1](https://github.com/locationtech/jts/blob/jts-1.18.1/modules/core/src/main/java/org/locationtech/jts/operation/relate/EdgeEndBundle.java)
+#[derive(Clone, Debug)]
+pub(crate) struct EdgeEndBundle<F>
+where
+    F: GeoFloat,
+{
+    coordinate: Coordinate<F>,
+    edge_ends: Vec<EdgeEnd<F>>,
+}
+
+impl<F> EdgeEndBundle<F>
+where
+    F: GeoFloat,
+{
+    pub(crate) fn new(coordinate: Coordinate<F>) -> Self {
+        Self {
+            coordinate,
+            edge_ends: vec![],
+        }
+    }
+
+    fn edge_ends_iter(&self) -> impl Iterator<Item = &EdgeEnd<F>> {
+        self.edge_ends.iter()
+    }
+
+    fn edge_ends_iter_mut(&mut self) -> impl Iterator<Item = &mut EdgeEnd<F>> {
+        self.edge_ends.iter_mut()
+    }
+
+    pub(crate) fn insert(&mut self, edge_end: EdgeEnd<F>) {
+        self.edge_ends.push(edge_end);
+    }
+
+    pub(crate) fn into_labeled(mut self) -> LabeledEdgeEndBundle<F> {
+        let is_area = self
+            .edge_ends_iter()
+            .any(|edge_end| edge_end.label().is_area());
+
+        let mut label = if is_area {
+            Label::empty_area()
+        } else {
+            Label::empty_line_or_point()
+        };
+
+        for i in 0..2 {
+            self.compute_label_on(&mut label, i);
+            if is_area {
+                self.compute_label_side(&mut label, i, Direction::Left);
+                self.compute_label_side(&mut label, i, Direction::Right);
+            }
+        }
+
+        LabeledEdgeEndBundle {
+            label,
+            edge_end_bundle: self,
+        }
+    }
+
+    /// Compute the overall ON position for the list of EdgeEnds.
+    /// (This is essentially equivalent to computing the self-overlay of a single Geometry)
+    ///
+    /// EdgeEnds can be either on the boundary (e.g. Polygon edge)
+    /// OR in the interior (e.g. segment of a LineString)
+    /// of their parent Geometry.
+    ///
+    /// In addition, GeometryCollections use a boundary node rule to determine whether a segment is
+    /// on the boundary or not.
+    ///
+    /// Finally, in GeometryCollections it can occur that an edge is both
+    /// on the boundary and in the interior (e.g. a LineString segment lying on
+    /// top of a Polygon edge.) In this case the Boundary is given precedence.
+    ///
+    /// These observations result in the following rules for computing the ON location:
+    /// - if there are an odd number of Bdy edges, the attribute is Bdy
+    /// - if there are an even number >= 2 of Bdy edges, the attribute is Int
+    /// - if there are any Int edges, the attribute is Int
+    /// - otherwise, the attribute is None
+    ///
+    fn compute_label_on(&mut self, label: &mut Label, geom_index: usize) {
+        let mut boundary_count = 0;
+        let mut found_interior = false;
+
+        for edge_end in self.edge_ends_iter() {
+            match edge_end.label().on_position(geom_index) {
+                Some(CoordPos::OnBoundary) => {
+                    boundary_count += 1;
+                }
+                Some(CoordPos::Inside) => {
+                    found_interior = true;
+                }
+                None | Some(CoordPos::Outside) => {}
+            }
+        }
+
+        let mut position = None;
+        if found_interior {
+            position = Some(CoordPos::Inside);
+        }
+
+        if boundary_count > 0 {
+            position = Some(GeometryGraph::<'_, F>::determine_boundary(boundary_count));
+        }
+
+        if let Some(location) = position {
+            label.set_on_position(geom_index, location);
+        } else {
+            // This is technically a diversion from JTS, but I don't think we'd ever
+            // get here, unless `l.on_location` was *already* None, in which cases this is a
+            // no-op, so assert that assumption.
+            // If this assert is rightfully triggered, we may need to add a method like
+            // `l.clear_on_location(geom_index)`
+            debug_assert!(
+                label.on_position(geom_index).is_none(),
+                "diverging from JTS, which would have replaced the existing Location with None"
+            );
+        }
+    }
+
+    /// To compute the summary label for a side, the algorithm is:
+    ///     FOR all edges
+    ///       IF any edge's location is INTERIOR for the side, side location = INTERIOR
+    ///       ELSE IF there is at least one EXTERIOR attribute, side location = EXTERIOR
+    ///       ELSE  side location = NULL
+    /// Note that it is possible for two sides to have apparently contradictory information
+    /// i.e. one edge side may indicate that it is in the interior of a geometry, while
+    /// another edge side may indicate the exterior of the same geometry.  This is
+    /// not an incompatibility - GeometryCollections may contain two Polygons that touch
+    /// along an edge.  This is the reason for Interior-primacy rule above - it
+    /// results in the summary label having the Geometry interior on _both_ sides.
+    fn compute_label_side(&mut self, label: &mut Label, geom_index: usize, side: Direction) {
+        let mut position = None;
+        for edge_end in self.edge_ends_iter_mut() {
+            if edge_end.label().is_area() {
+                match edge_end.label_mut().position(geom_index, side) {
+                    Some(CoordPos::Inside) => {
+                        position = Some(CoordPos::Inside);
+                        break;
+                    }
+                    Some(CoordPos::Outside) => {
+                        position = Some(CoordPos::Outside);
+                    }
+                    None | Some(CoordPos::OnBoundary) => {}
+                }
+            }
+        }
+
+        if let Some(position) = position {
+            label.set_position(geom_index, side, position);
+        }
+    }
+}
+
+/// An [`EdgeEndBundle`] whose topological relationships have been aggregated into a single
+/// [`Label`].
+///
+/// `update_intersection_matrix` applies this aggregated topology to an `IntersectionMatrix`.
+#[derive(Clone, Debug)]
+pub(crate) struct LabeledEdgeEndBundle<F>
+where
+    F: GeoFloat,
+{
+    label: Label,
+    edge_end_bundle: EdgeEndBundle<F>,
+}
+
+impl<F> LabeledEdgeEndBundle<F>
+where
+    F: GeoFloat,
+{
+    pub fn label(&self) -> &Label {
+        &self.label
+    }
+
+    pub fn label_mut(&mut self) -> &mut Label {
+        &mut self.label
+    }
+
+    pub fn update_intersection_matrix(&self, intersection_matrix: &mut IntersectionMatrix) {
+        Edge::<F>::update_intersection_matrix(self.label(), intersection_matrix);
+    }
+
+    pub fn coordinate(&self) -> &Coordinate<F> {
+        &self.edge_end_bundle.coordinate
+    }
+}

--- a/geo/src/algorithm/relate/geomgraph/edge_end_bundle_star.rs
+++ b/geo/src/algorithm/relate/geomgraph/edge_end_bundle_star.rs
@@ -1,0 +1,200 @@
+use super::{
+    Dimensions, Direction, EdgeEnd, EdgeEndBundle, EdgeEndKey, GeometryGraph, IntersectionMatrix,
+    LabeledEdgeEndBundle,
+};
+use crate::algorithm::coordinate_position::{CoordPos, CoordinatePosition};
+use crate::{Coordinate, GeoFloat, GeometryCow};
+
+/// An ordered list of [`EdgeEndBundle`]s around a [`RelateNodeFactory::Node`].
+///
+/// They are maintained in CCW order (starting with the positive x-axis) around the node
+/// for efficient lookup and topology building.
+///
+/// This is based on [JTS's `EdgeEndBundleStar` as of 1.18.1](https://github.com/locationtech/jts/blob/jts-1.18.1/modules/core/src/main/java/org/locationtech/jts/operation/relate/EdgeEndBundleStar.java)
+#[derive(Clone, Debug)]
+pub(crate) struct EdgeEndBundleStar<F>
+where
+    F: GeoFloat,
+{
+    edge_map: std::collections::BTreeMap<EdgeEndKey<F>, EdgeEndBundle<F>>,
+    point_in_area_location: Option<[CoordPos; 2]>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct LabeledEdgeEndBundleStar<F>
+where
+    F: GeoFloat,
+{
+    edges: Vec<LabeledEdgeEndBundle<F>>,
+}
+
+impl<F: GeoFloat> LabeledEdgeEndBundleStar<F> {
+    pub(crate) fn new(
+        edges: Vec<LabeledEdgeEndBundle<F>>,
+        graph_a: &GeometryGraph<F>,
+        graph_b: &GeometryGraph<F>,
+    ) -> Self {
+        let mut labeled_bundle_star = Self { edges };
+        labeled_bundle_star.compute_labeling(graph_a, graph_b);
+        labeled_bundle_star
+    }
+
+    /// Compute a label for the star based on the labels of its EdgeEndBundles.
+    fn compute_labeling(&mut self, graph_a: &GeometryGraph<F>, graph_b: &GeometryGraph<F>) {
+        self.propagate_side_labels(0);
+        self.propagate_side_labels(1);
+        let mut has_dimensional_collapse_edge = [false, false];
+        for edge_end in self.edges.iter() {
+            let label = edge_end.label();
+            for (geom_index, is_collapsed) in has_dimensional_collapse_edge.iter_mut().enumerate() {
+                *is_collapsed = label.is_line(geom_index)
+                    && label.on_position(geom_index) == Some(CoordPos::OnBoundary);
+            }
+        }
+        for edge_end_bundle in &mut self.edges {
+            let coord = *edge_end_bundle.coordinate();
+            let label = edge_end_bundle.label_mut();
+            for (geom_index, is_dimensionally_collapsed) in
+                has_dimensional_collapse_edge.iter().enumerate()
+            {
+                if label.is_any_empty(geom_index) {
+                    let position: CoordPos = if *is_dimensionally_collapsed {
+                        CoordPos::Outside
+                    } else {
+                        // PERF: In JTS this is memoized, but that gets a little tricky with rust's
+                        // borrow checker. Let's wait to see if it's a hotspot.
+                        let geometry = match geom_index {
+                            0 => graph_a.geometry(),
+                            1 => graph_b.geometry(),
+                            _ => unreachable!("invalid geom_index"),
+                        };
+                        use crate::algorithm::dimensions::HasDimensions;
+                        if geometry.dimensions() == Dimensions::TwoDimensional {
+                            geometry.coordinate_position(&coord)
+                        } else {
+                            // if geometry is *not* an area, Coord is always Outside
+                            CoordPos::Outside
+                        }
+                    };
+                    label.set_all_positions_if_empty(geom_index, position);
+                }
+            }
+        }
+        debug!("edge_end_bundle_star: {:?}", self);
+    }
+
+    fn propagate_side_labels(&mut self, geom_index: usize) {
+        let mut start_position = None;
+
+        for edge_ends in self.edge_end_bundles_iter() {
+            let label = edge_ends.label();
+            if label.is_geom_area(geom_index) {
+                if let Some(position) = label.position(geom_index, Direction::Left) {
+                    start_position = Some(position);
+                }
+            }
+        }
+        if start_position.is_none() {
+            return;
+        }
+        let mut current_position = start_position.unwrap();
+
+        for edge_ends in self.edge_end_bundles_iter_mut() {
+            let label = edge_ends.label_mut();
+            if label.position(geom_index, Direction::On).is_none() {
+                label.set_position(geom_index, Direction::On, current_position);
+            }
+            if label.is_geom_area(geom_index) {
+                let left_position = label.position(geom_index, Direction::Left);
+                let right_position = label.position(geom_index, Direction::Right);
+
+                if let Some(right_position) = right_position {
+                    debug_assert!(right_position == current_position, "side_location conflict with coordinate: {:?}, right_location: {:?}, current_location: {:?}", edge_ends.coordinate(), right_position, current_position);
+                    assert!(left_position.is_some(), "found single null side");
+                    current_position = left_position.unwrap();
+                } else {
+                    debug_assert!(label.position(geom_index, Direction::Left).is_none());
+                    label.set_position(geom_index, Direction::Right, current_position);
+                    label.set_position(geom_index, Direction::Left, current_position);
+                }
+            }
+        }
+    }
+
+    fn edge_end_bundles_iter(&self) -> impl Iterator<Item = &LabeledEdgeEndBundle<F>> {
+        self.edges.iter()
+    }
+
+    fn edge_end_bundles_iter_mut(&mut self) -> impl Iterator<Item = &mut LabeledEdgeEndBundle<F>> {
+        self.edges.iter_mut()
+    }
+
+    pub fn update_intersection_matrix(&self, intersection_matrix: &mut IntersectionMatrix) {
+        for edge_end_bundle in self.edge_end_bundles_iter() {
+            edge_end_bundle.update_intersection_matrix(intersection_matrix);
+            debug!(
+                "updated intersection_matrix: {:?} from edge_end_bundle: {:?}",
+                intersection_matrix, edge_end_bundle
+            );
+        }
+    }
+}
+
+impl<F> EdgeEndBundleStar<F>
+where
+    F: GeoFloat,
+{
+    pub(crate) fn new() -> Self {
+        EdgeEndBundleStar {
+            edge_map: std::collections::BTreeMap::new(),
+            point_in_area_location: None,
+        }
+    }
+
+    pub(crate) fn insert(&mut self, edge_end: EdgeEnd<F>) {
+        let bundle = self
+            .edge_map
+            .entry(edge_end.key().clone())
+            .or_insert_with(|| EdgeEndBundle::new(*edge_end.coordinate()));
+        bundle.insert(edge_end);
+    }
+
+    fn edge_end_bundles_iter(&self) -> impl Iterator<Item = &EdgeEndBundle<F>> {
+        self.edge_map.values()
+    }
+
+    fn edge_end_bundles_iter_mut(&mut self) -> impl Iterator<Item = &mut EdgeEndBundle<F>> {
+        self.edge_map.values_mut()
+    }
+
+    /// Compute labeling for the star's EdgeEndBundles, and use them to compute an overall label
+    /// for the star.
+    ///
+    /// Implementation Note: This is a bit of a divergence from JTS in two ways.
+    ///
+    /// Firstly, JTS doesn't leverage optionals, and sets nullable `Label`s, whereas here we convert
+    /// to an explicitly labeled type to avoid unwrapping optionals later.
+    ///
+    /// Secondly, in JTS this functionality does not live directly on EdgeEndBundleStar, but rather
+    /// on it's parent class [EdgeEndStar](https://github.com/locationtech/jts/blob/jts-1.18.1/modules/core/src/main/java/org/locationtech/jts/geomgraph/EdgeEndStar.java#L117)
+    ///
+    /// Since we're only using this one subclass (EdgeEndBundleStar), we skip the
+    /// complexity of mapping Java inheritance to Rust and implement this functionality
+    /// on EdgeEndBundleStar directly.
+    ///
+    /// If/When we implement overlay operations we might consider extracting the superclass
+    /// behavior.
+    pub(crate) fn into_labeled(
+        self,
+        graph_a: &GeometryGraph<F>,
+        graph_b: &GeometryGraph<F>,
+    ) -> LabeledEdgeEndBundleStar<F> {
+        debug!("edge_end_bundle_star: {:?}", self);
+        let labeled_edges = self
+            .edge_map
+            .into_iter()
+            .map(|(_k, v)| v.into_labeled())
+            .collect();
+        LabeledEdgeEndBundleStar::new(labeled_edges, graph_a, graph_b)
+    }
+}

--- a/geo/src/algorithm/relate/geomgraph/edge_intersection.rs
+++ b/geo/src/algorithm/relate/geomgraph/edge_intersection.rs
@@ -1,0 +1,75 @@
+use crate::{Coordinate, GeoFloat};
+
+/// Represents a point on an edge which intersects with another edge.
+///
+/// The intersection may either be a single point, or a line segment (in which case this point is
+/// the start of the line segment) The intersection point must be precise.
+///
+/// This is based on [JTS's EdgeIntersection as of 1.18.1](https://github.com/locationtech/jts/blob/jts-1.18.1/modules/core/src/main/java/org/locationtech/jts/geomgraph/EdgeIntersection.java)
+#[derive(Debug)]
+pub(crate) struct EdgeIntersection<F: GeoFloat> {
+    coord: Coordinate<F>,
+    segment_index: usize,
+    dist: F,
+}
+
+impl<F: GeoFloat> EdgeIntersection<F> {
+    pub fn new(coord: Coordinate<F>, segment_index: usize, dist: F) -> EdgeIntersection<F> {
+        EdgeIntersection {
+            coord,
+            segment_index,
+            dist,
+        }
+    }
+
+    pub fn coordinate(&self) -> Coordinate<F> {
+        self.coord
+    }
+
+    pub fn segment_index(&self) -> usize {
+        self.segment_index
+    }
+
+    pub fn distance(&self) -> F {
+        self.dist
+    }
+}
+
+impl<F: GeoFloat> std::cmp::PartialEq for EdgeIntersection<F> {
+    fn eq(&self, other: &EdgeIntersection<F>) -> bool {
+        self.segment_index == other.segment_index && self.dist == other.dist
+    }
+}
+
+impl<F: GeoFloat> std::cmp::Eq for EdgeIntersection<F> {}
+
+impl<F: GeoFloat> std::cmp::PartialOrd for EdgeIntersection<F> {
+    fn partial_cmp(&self, other: &EdgeIntersection<F>) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<F: GeoFloat> std::cmp::Ord for EdgeIntersection<F> {
+    fn cmp(&self, other: &EdgeIntersection<F>) -> std::cmp::Ordering {
+        if self.segment_index < other.segment_index {
+            return std::cmp::Ordering::Less;
+        }
+        if self.segment_index > other.segment_index {
+            return std::cmp::Ordering::Greater;
+        }
+        if self.dist < other.dist {
+            return std::cmp::Ordering::Less;
+        }
+        if self.dist > other.dist {
+            return std::cmp::Ordering::Greater;
+        }
+
+        // BTreeMap requires nodes to be fully `Ord`, but we're comparing floats, so we require
+        // non-NaN for valid results.
+        debug_assert!(!self.dist.is_nan() && !other.dist.is_nan());
+
+        std::cmp::Ordering::Equal
+    }
+}
+
+impl<F: GeoFloat> EdgeIntersection<F> {}

--- a/geo/src/algorithm/relate/geomgraph/geometry_graph.rs
+++ b/geo/src/algorithm/relate/geomgraph/geometry_graph.rs
@@ -1,0 +1,387 @@
+use super::{
+    index::{EdgeSetIntersector, SegmentIntersector, SimpleEdgeSetIntersector},
+    CoordNode, CoordPos, Direction, Edge, Label, LineIntersector, PlanarGraph, TopologyPosition,
+};
+
+use crate::algorithm::dimensions::HasDimensions;
+use crate::{Coordinate, GeoFloat, GeometryCow, Line, LineString, Point, Polygon};
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+/// The computation of the [`IntersectionMatrix`] relies on the use of a
+/// structure called a "topology graph". The topology graph contains [nodes](CoordNode) and
+/// [edges](Edge) corresponding to the nodes and line segments of a [`Geometry`]. Each
+/// node and edge in the graph is labeled with its topological location
+/// relative to the source geometry.
+///
+/// Note that there is no requirement that points of self-intersection be a
+/// vertex. Thus to obtain a correct topology graph, [`Geometry`] must be
+/// self-noded before constructing their graphs.
+///
+/// Two fundamental operations are supported by topology graphs:
+///   - Computing the intersections between all the edges and nodes of a single graph
+///   - Computing the intersections between the edges and nodes of two different graphs
+///
+/// GeometryGraph is based on [JTS's `GeomGraph` as of 1.18.1](https://github.com/locationtech/jts/blob/jts-1.18.1/modules/core/src/main/java/org/locationtech/jts/geomgraph/GeometryGraph.java)
+pub(crate) struct GeometryGraph<'a, F>
+where
+    F: GeoFloat,
+{
+    arg_index: usize,
+    parent_geometry: &'a GeometryCow<'a, F>,
+    use_boundary_determination_rule: bool,
+    planar_graph: PlanarGraph<F>,
+}
+
+///  PlanarGraph delegations
+///
+/// In JTS, which is written in Java, GeometryGraph inherits from PlanarGraph. Here in Rust land we
+/// use composition and delegation to the same effect.
+impl<F> GeometryGraph<'_, F>
+where
+    F: GeoFloat,
+{
+    pub fn edges(&self) -> &[Rc<RefCell<Edge<F>>>] {
+        self.planar_graph.edges()
+    }
+
+    pub fn insert_edge(&mut self, edge: Edge<F>) {
+        self.planar_graph.insert_edge(edge)
+    }
+
+    pub fn is_boundary_node(&self, coord: Coordinate<F>) -> bool {
+        self.planar_graph.is_boundary_node(self.arg_index, coord)
+    }
+
+    pub fn add_node_with_coordinate(&mut self, coord: Coordinate<F>) -> &mut CoordNode<F> {
+        self.planar_graph.add_node_with_coordinate(coord)
+    }
+
+    pub fn nodes_iter(&self) -> impl Iterator<Item = &CoordNode<F>> {
+        self.planar_graph.nodes.iter()
+    }
+}
+
+impl<'a, F> GeometryGraph<'a, F>
+where
+    F: GeoFloat,
+{
+    pub fn new(arg_index: usize, parent_geometry: &'a GeometryCow<F>) -> Self {
+        let mut graph = GeometryGraph {
+            arg_index,
+            parent_geometry,
+            use_boundary_determination_rule: true,
+            planar_graph: PlanarGraph::new(),
+        };
+        graph.add_geometry(parent_geometry);
+        graph
+    }
+
+    pub fn geometry(&self) -> &GeometryCow<F> {
+        self.parent_geometry
+    }
+
+    /// Determine whether a component (node or edge) that appears multiple times in elements
+    /// of a Multi-Geometry is in the boundary or the interior of the Geometry
+    pub fn determine_boundary(boundary_count: usize) -> CoordPos {
+        // For now, we only support the SFS "Mod-2 Rule"
+        // We could make this configurable if we wanted to support alternative boundary rules.
+        if boundary_count % 2 == 1 {
+            CoordPos::OnBoundary
+        } else {
+            CoordPos::Inside
+        }
+    }
+
+    fn create_edge_set_intersector() -> Box<dyn EdgeSetIntersector<F>> {
+        // PERF: faster algorithms exist. This one was chosen for simplicity of implementation and
+        //       debugging
+        Box::new(SimpleEdgeSetIntersector::new())
+    }
+
+    fn boundary_nodes(&self) -> impl Iterator<Item = &CoordNode<F>> {
+        self.planar_graph.boundary_nodes(self.arg_index)
+    }
+
+    pub fn add_geometry(&mut self, geometry: &GeometryCow<F>) {
+        if geometry.is_empty() {
+            return;
+        }
+        match geometry {
+            GeometryCow::Line(line) => self.add_line(line),
+            GeometryCow::Rect(rect) => {
+                // PERF: avoid this conversion/clone?
+                self.add_polygon(&rect.to_polygon());
+            }
+            GeometryCow::Point(point) => {
+                self.add_point(point);
+            }
+            GeometryCow::Polygon(polygon) => self.add_polygon(polygon),
+            GeometryCow::Triangle(triangle) => {
+                // PERF: avoid this conversion/clone?
+                self.add_polygon(&triangle.to_polygon());
+            }
+            GeometryCow::LineString(line_string) => self.add_line_string(line_string),
+            GeometryCow::MultiPoint(multi_point) => {
+                for point in &multi_point.0 {
+                    self.add_point(point);
+                }
+            }
+            GeometryCow::MultiPolygon(multi_polygon) => {
+                // check if this Geometry should obey the Boundary Determination Rule
+                // all collections except MultiPolygons obey the rule
+                self.use_boundary_determination_rule = false;
+                for polygon in &multi_polygon.0 {
+                    self.add_polygon(polygon);
+                }
+            }
+            GeometryCow::MultiLineString(multi_line_string) => {
+                for line_string in &multi_line_string.0 {
+                    self.add_line_string(line_string);
+                }
+            }
+            GeometryCow::GeometryCollection(geometry_collection) => {
+                for geometry in geometry_collection.iter() {
+                    self.add_geometry(&GeometryCow::from(geometry));
+                }
+            }
+        }
+    }
+
+    fn add_polygon_ring(
+        &mut self,
+        linear_ring: &LineString<F>,
+        cw_left: CoordPos,
+        cw_right: CoordPos,
+    ) {
+        debug_assert!(linear_ring.is_closed());
+        if linear_ring.is_empty() {
+            return;
+        }
+
+        let mut coords: Vec<Coordinate<F>> = Vec::with_capacity(linear_ring.0.len());
+        // remove repeated coords
+        for coord in &linear_ring.0 {
+            if coords.last() != Some(coord) {
+                coords.push(*coord)
+            }
+        }
+
+        if coords.len() < 4 {
+            // TODO: we could return an Err here, but this has ramifications for how we can
+            // use this code in other operations - do we want all our methods, like `contains` to
+            // return a Result?
+            warn!("encountered invalid ring, which has undefined results");
+        }
+        let first_point = coords[0];
+
+        use crate::algorithm::winding_order::{Winding, WindingOrder};
+        let (left, right) = match linear_ring.winding_order() {
+            Some(WindingOrder::Clockwise) => (cw_left, cw_right),
+            Some(WindingOrder::CounterClockwise) => (cw_right, cw_left),
+            None => {
+                warn!("polygon had no winding order. Results are undefined.");
+                (cw_left, cw_right)
+            }
+        };
+
+        let edge = Edge::new(
+            coords,
+            Label::new(
+                self.arg_index,
+                TopologyPosition::area(CoordPos::OnBoundary, left, right),
+            ),
+        );
+        self.insert_edge(edge);
+
+        // insert the endpoint as a node, to mark that it is on the boundary
+        self.insert_point(self.arg_index, first_point, CoordPos::OnBoundary);
+    }
+
+    fn add_polygon(&mut self, polygon: &Polygon<F>) {
+        self.add_polygon_ring(polygon.exterior(), CoordPos::Outside, CoordPos::Inside);
+        // Holes are topologically labeled opposite to the shell, since
+        // the interior of the polygon lies on their opposite side
+        // (on the left, if the hole is oriented CW)
+        for hole in polygon.interiors() {
+            self.add_polygon_ring(hole, CoordPos::Inside, CoordPos::Outside)
+        }
+    }
+
+    fn add_line_string(&mut self, line_string: &LineString<F>) {
+        if line_string.is_empty() {
+            return;
+        }
+
+        let mut coords: Vec<Coordinate<F>> = Vec::with_capacity(line_string.0.len());
+        for coord in &line_string.0 {
+            if coords.last() != Some(coord) {
+                coords.push(*coord)
+            }
+        }
+
+        if coords.len() < 2 {
+            // TODO: we could return an Err here, but this has ramifications for how we can
+            // use this code in other operations - do we want all our methods, like `contains` to
+            // return a Result?
+            warn!("encountered invalid linestring, which has undefined results");
+        }
+        self.insert_boundary_point(*coords.first().unwrap());
+        self.insert_boundary_point(*coords.last().unwrap());
+
+        let edge = Edge::new(
+            coords,
+            Label::new(
+                self.arg_index,
+                TopologyPosition::line_or_point(CoordPos::Inside),
+            ),
+        );
+        self.insert_edge(edge);
+    }
+
+    fn add_line(&mut self, line: &Line<F>) {
+        self.insert_boundary_point(line.start);
+        self.insert_boundary_point(line.end);
+
+        let edge = Edge::new(
+            vec![line.start, line.end],
+            Label::new(
+                self.arg_index,
+                TopologyPosition::line_or_point(CoordPos::Inside),
+            ),
+        );
+
+        self.insert_edge(edge);
+    }
+
+    /// Add a point computed externally.  The point is assumed to be a
+    /// Point Geometry part, which has a location of INTERIOR.
+    fn add_point(&mut self, point: &Point<F>) {
+        self.insert_point(self.arg_index, point.clone().into(), CoordPos::Inside);
+    }
+
+    /// Compute self-nodes, taking advantage of the Geometry type to minimize the number of
+    /// intersection tests.  (E.g. rings are not tested for self-intersection, since they are
+    /// assumed to be valid).
+    ///
+    /// `line_intersector` the [`LineIntersector`] to use to determine intersection
+    pub fn compute_self_nodes(
+        &mut self,
+        line_intersector: Box<dyn LineIntersector<F>>,
+    ) -> SegmentIntersector<F> {
+        let mut segment_intersector = SegmentIntersector::new(line_intersector, true);
+
+        let mut edge_set_intersector = Self::create_edge_set_intersector();
+
+        // optimize intersection search for valid Polygons and LinearRings
+        let is_rings = match self.geometry() {
+            GeometryCow::LineString(ls) => ls.is_closed(),
+            GeometryCow::MultiLineString(ls) => ls.is_closed(),
+            GeometryCow::Polygon(_) | GeometryCow::MultiPolygon(_) => true,
+            _ => false,
+        };
+        let check_for_self_intersecting_edges = !is_rings;
+
+        edge_set_intersector.compute_intersections_within_set(
+            self.edges(),
+            check_for_self_intersecting_edges,
+            &mut segment_intersector,
+        );
+
+        self.add_self_intersection_nodes();
+
+        segment_intersector
+    }
+
+    pub fn compute_edge_intersections(
+        &self,
+        other: &GeometryGraph<F>,
+        line_intersector: Box<dyn LineIntersector<F>>,
+    ) -> SegmentIntersector<F> {
+        let mut segment_intersector = SegmentIntersector::new(line_intersector, false);
+        segment_intersector.set_boundary_nodes(
+            self.boundary_nodes().into_iter().cloned().collect(),
+            other.boundary_nodes().into_iter().cloned().collect(),
+        );
+
+        let mut edge_set_intersector = Self::create_edge_set_intersector();
+        edge_set_intersector.compute_intersections_between_sets(
+            self.edges(),
+            other.edges(),
+            &mut segment_intersector,
+        );
+
+        segment_intersector
+    }
+
+    fn insert_point(&mut self, arg_index: usize, coord: Coordinate<F>, position: CoordPos) {
+        let node: &mut CoordNode<F> = self.add_node_with_coordinate(coord);
+        node.label_mut().set_on_position(arg_index, position);
+    }
+
+    /// Add the boundary points of 1-dim (line) geometries.
+    fn insert_boundary_point(&mut self, coord: Coordinate<F>) {
+        let arg_index = self.arg_index;
+        let node: &mut CoordNode<F> = self.add_node_with_coordinate(coord);
+
+        let label: &mut Label = node.label_mut();
+
+        // determine the current location for the point (if any)
+        let boundary_count = {
+            let prev_boundary_count =
+                if Some(CoordPos::OnBoundary) == label.position(arg_index, Direction::On) {
+                    1
+                } else {
+                    0
+                };
+            prev_boundary_count + 1
+        };
+
+        let new_position = Self::determine_boundary(boundary_count);
+        label.set_on_position(arg_index, new_position);
+    }
+
+    fn add_self_intersection_nodes(&mut self) {
+        let positions_and_intersections: Vec<(CoordPos, Vec<Coordinate<F>>)> = self
+            .edges()
+            .iter()
+            .map(|cell| cell.borrow())
+            .map(|edge| {
+                let position = edge
+                    .label()
+                    .on_position(self.arg_index)
+                    .expect("all edge labels should have an `on` position by now");
+                let coordinates = edge
+                    .edge_intersections()
+                    .iter()
+                    .map(|edge_intersection| edge_intersection.coordinate());
+
+                (position, coordinates.collect())
+            })
+            .collect();
+
+        for (position, edge_intersection_coordinates) in positions_and_intersections {
+            for coordinate in edge_intersection_coordinates {
+                self.add_self_intersection_node(coordinate, position)
+            }
+        }
+    }
+
+    /// Add a node for a self-intersection.
+    ///
+    /// If the node is a potential boundary node (e.g. came from an edge which is a boundary), then
+    /// insert it as a potential boundary node.  Otherwise, just add it as a regular node.
+    fn add_self_intersection_node(&mut self, coord: Coordinate<F>, position: CoordPos) {
+        // if this node is already a boundary node, don't change it
+        if self.is_boundary_node(coord) {
+            return;
+        }
+
+        if position == CoordPos::OnBoundary && self.use_boundary_determination_rule {
+            self.insert_boundary_point(coord)
+        } else {
+            self.insert_point(self.arg_index, coord, position)
+        }
+    }
+}

--- a/geo/src/algorithm/relate/geomgraph/index/edge_set_intersector.rs
+++ b/geo/src/algorithm/relate/geomgraph/index/edge_set_intersector.rs
@@ -1,0 +1,30 @@
+use super::super::Edge;
+use super::SegmentIntersector;
+use crate::{Coordinate, GeoFloat};
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+pub(crate) trait EdgeSetIntersector<F: GeoFloat> {
+    /// Compute all intersections between the edges within a set, recording those intersections on
+    /// the intersecting edges.
+    ///
+    /// `edges`: the set of edges to check. Mutated to record any intersections.
+    /// `check_for_self_intersecting_edges`: if false, an edge is not checked for intersections with itself.
+    /// `segment_intersector`: the SegmentIntersector to use
+    fn compute_intersections_within_set(
+        &mut self,
+        edges: &[Rc<RefCell<Edge<F>>>],
+        check_for_self_intersecting_edges: bool,
+        segment_intersector: &mut SegmentIntersector<F>,
+    );
+
+    /// Compute all intersections between two sets of edges, recording those intersections on
+    /// the intersecting edges.
+    fn compute_intersections_between_sets(
+        &mut self,
+        edges0: &[Rc<RefCell<Edge<F>>>],
+        edges1: &[Rc<RefCell<Edge<F>>>],
+        segment_intersector: &mut SegmentIntersector<F>,
+    );
+}

--- a/geo/src/algorithm/relate/geomgraph/index/mod.rs
+++ b/geo/src/algorithm/relate/geomgraph/index/mod.rs
@@ -1,0 +1,7 @@
+mod edge_set_intersector;
+mod segment_intersector;
+mod simple_edge_set_intersector;
+
+pub(crate) use edge_set_intersector::EdgeSetIntersector;
+pub(crate) use segment_intersector::SegmentIntersector;
+pub(crate) use simple_edge_set_intersector::SimpleEdgeSetIntersector;

--- a/geo/src/algorithm/relate/geomgraph/index/segment_intersector.rs
+++ b/geo/src/algorithm/relate/geomgraph/index/segment_intersector.rs
@@ -1,0 +1,175 @@
+use super::super::{CoordNode, Edge, LineIntersection, LineIntersector};
+use crate::{Coordinate, GeoFloat, Line};
+
+use std::cell::{Ref, RefCell};
+
+/// Computes the intersection of line segments and adds the intersection to the [`Edge`s] containing
+/// the segments.
+pub(crate) struct SegmentIntersector<F>
+where
+    F: GeoFloat,
+{
+    // Though JTS leaves this abstract - we might consider hard coding it to a RobustLineIntersector
+    line_intersector: Box<dyn LineIntersector<F>>,
+    edges_are_from_same_geometry: bool,
+    proper_intersection_point: Option<Coordinate<F>>,
+    has_proper_interior_intersection: bool,
+    boundary_nodes: Option<[Vec<CoordNode<F>>; 2]>,
+}
+
+impl<F> SegmentIntersector<F>
+where
+    F: GeoFloat,
+{
+    fn is_adjacent_segments(i1: usize, i2: usize) -> bool {
+        let difference = if i1 > i2 { i1 - i2 } else { i2 - i1 };
+        difference == 1
+    }
+
+    pub fn new(
+        line_intersector: Box<dyn LineIntersector<F>>,
+        edges_are_from_same_geometry: bool,
+    ) -> SegmentIntersector<F> {
+        SegmentIntersector {
+            line_intersector,
+            edges_are_from_same_geometry,
+            has_proper_interior_intersection: false,
+            proper_intersection_point: None,
+            boundary_nodes: None,
+        }
+    }
+    pub fn set_boundary_nodes(
+        &mut self,
+        boundary_nodes_0: Vec<CoordNode<F>>,
+        boundary_nodes_1: Vec<CoordNode<F>>,
+    ) {
+        debug_assert!(
+            self.boundary_nodes.is_none(),
+            "Should only set boundaries between geometries once"
+        );
+        self.boundary_nodes = Some([boundary_nodes_0, boundary_nodes_1]);
+    }
+
+    pub fn has_proper_intersection(&self) -> bool {
+        self.proper_intersection_point.is_some()
+    }
+
+    pub fn has_proper_interior_intersection(&self) -> bool {
+        self.has_proper_interior_intersection
+    }
+
+    /// A trivial intersection is an apparent self-intersection which in fact is simply the point
+    /// shared by adjacent line segments.  Note that closed edges require a special check for the
+    /// point shared by the beginning and end segments.
+    fn is_trivial_intersection(
+        &self,
+        intersection: LineIntersection<F>,
+        edge0: &RefCell<Edge<F>>,
+        segment_index_0: usize,
+        edge1: &RefCell<Edge<F>>,
+        segment_index_1: usize,
+    ) -> bool {
+        if edge0.as_ptr() != edge1.as_ptr() {
+            return false;
+        }
+
+        if matches!(intersection, LineIntersection::Collinear { .. }) {
+            return false;
+        }
+
+        if Self::is_adjacent_segments(segment_index_0, segment_index_1) {
+            return true;
+        }
+
+        let edge0 = edge0.borrow();
+        if edge0.is_closed() {
+            // first and last coords in a ring are adjacent
+            let max_segment_index = edge0.coords().len() - 1;
+            if (segment_index_0 == 0 && segment_index_1 == max_segment_index)
+                || (segment_index_1 == 0 && segment_index_0 == max_segment_index)
+            {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    pub fn add_intersections(
+        &mut self,
+        edge0: &RefCell<Edge<F>>,
+        segment_index_0: usize,
+        edge1: &RefCell<Edge<F>>,
+        segment_index_1: usize,
+    ) {
+        // avoid a segment spuriously "intersecting" with itself
+        if edge0.as_ptr() == edge1.as_ptr() && segment_index_0 == segment_index_1 {
+            return;
+        }
+
+        let line_0 = Line::new(
+            edge0.borrow().coords()[segment_index_0],
+            edge0.borrow().coords()[segment_index_0 + 1],
+        );
+        let line_1 = Line::new(
+            edge1.borrow().coords()[segment_index_1],
+            edge1.borrow().coords()[segment_index_1 + 1],
+        );
+
+        let intersection = self.line_intersector.compute_intersection(line_0, line_1);
+
+        if intersection.is_none() {
+            return;
+        }
+        let intersection = intersection.unwrap();
+
+        if !self.edges_are_from_same_geometry {
+            edge0.borrow_mut().mark_as_unisolated();
+            edge1.borrow_mut().mark_as_unisolated();
+        }
+        if !self.is_trivial_intersection(
+            intersection,
+            edge0,
+            segment_index_0,
+            edge1,
+            segment_index_1,
+        ) {
+            if self.edges_are_from_same_geometry || !intersection.is_proper() {
+                // In the case of self-noding, `edge0` might alias `edge1`, so it's imperative that
+                // the mutable borrow's are short lived and do not overlap.
+                edge0
+                    .borrow_mut()
+                    .add_intersections(intersection, line_0, segment_index_0);
+
+                edge1
+                    .borrow_mut()
+                    .add_intersections(intersection, line_1, segment_index_1);
+            }
+            if let LineIntersection::SinglePoint {
+                is_proper: true,
+                intersection: intersection_coord,
+            } = intersection
+            {
+                self.proper_intersection_point = Some(intersection_coord);
+
+                if !self.is_boundary_point(&intersection_coord, &self.boundary_nodes) {
+                    self.has_proper_interior_intersection = true
+                }
+            }
+        }
+    }
+
+    fn is_boundary_point(
+        &self,
+        intersection: &Coordinate<F>,
+        boundary_nodes: &Option<[Vec<CoordNode<F>>; 2]>,
+    ) -> bool {
+        match &boundary_nodes {
+            Some(boundary_nodes) => boundary_nodes
+                .iter()
+                .flatten()
+                .any(|node| intersection == node.coordinate()),
+            None => false,
+        }
+    }
+}

--- a/geo/src/algorithm/relate/geomgraph/index/simple_edge_set_intersector.rs
+++ b/geo/src/algorithm/relate/geomgraph/index/simple_edge_set_intersector.rs
@@ -1,0 +1,59 @@
+use super::super::Edge;
+use super::{EdgeSetIntersector, SegmentIntersector};
+use crate::GeoFloat;
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+pub(crate) struct SimpleEdgeSetIntersector;
+
+impl SimpleEdgeSetIntersector {
+    pub fn new() -> Self {
+        SimpleEdgeSetIntersector
+    }
+
+    fn compute_intersects<F: GeoFloat>(
+        &mut self,
+        edge0: &Rc<RefCell<Edge<F>>>,
+        edge1: &Rc<RefCell<Edge<F>>>,
+        segment_intersector: &mut SegmentIntersector<F>,
+    ) {
+        let edge0_coords_len = edge0.borrow().coords().len() - 1;
+        let edge1_coords_len = edge1.borrow().coords().len() - 1;
+        for i0 in 0..edge0_coords_len {
+            for i1 in 0..edge1_coords_len {
+                segment_intersector.add_intersections(edge0, i0, edge1, i1);
+            }
+        }
+    }
+}
+
+impl<F: GeoFloat> EdgeSetIntersector<F> for SimpleEdgeSetIntersector {
+    fn compute_intersections_within_set(
+        &mut self,
+        edges: &[Rc<RefCell<Edge<F>>>],
+        check_for_self_intersecting_edges: bool,
+        segment_intersector: &mut SegmentIntersector<F>,
+    ) {
+        for edge0 in edges.iter() {
+            for edge1 in edges.iter() {
+                if check_for_self_intersecting_edges || edge0.as_ptr() != edge1.as_ptr() {
+                    self.compute_intersects(edge0, edge1, segment_intersector);
+                }
+            }
+        }
+    }
+
+    fn compute_intersections_between_sets(
+        &mut self,
+        edges0: &[Rc<RefCell<Edge<F>>>],
+        edges1: &[Rc<RefCell<Edge<F>>>],
+        segment_intersector: &mut SegmentIntersector<F>,
+    ) {
+        for edge0 in edges0 {
+            for edge1 in edges1 {
+                self.compute_intersects(edge0, edge1, segment_intersector);
+            }
+        }
+    }
+}

--- a/geo/src/algorithm/relate/geomgraph/intersection_matrix.rs
+++ b/geo/src/algorithm/relate/geomgraph/intersection_matrix.rs
@@ -1,0 +1,232 @@
+use crate::algorithm::coordinate_position::CoordPos;
+use crate::algorithm::dimensions::Dimensions;
+
+/// Models a *Dimensionally Extended Nine-Intersection Model (DE-9IM)* matrix.
+///
+/// DE-9IM matrix values (such as "212FF1FF2") specify the topological relationship between
+/// two [Geometeries](struct.Geometry.html).
+///
+/// DE-9IM matrices are 3x3 matrices that represent the topological locations
+/// that occur in a geometry (Interior, Boundary, Exterior).
+///
+/// The indices are provided by the enum cases
+/// [CoordPos::Inside, CoordPos::OnBoundary, CoordPos::Outside](CoordPos).
+///
+/// The matrix entries represent the [Dimensions](enum.Dimension.html) of each intersection.
+///
+/// For a description of the DE-9IM and the spatial predicates derived from it,
+/// see the following references:
+/// - [OGC 99-049 OpenGIS Simple Features Specification for SQL](http://portal.opengeospatial.org/files/?artifact_id=829), Section 2.1.13
+/// - [OGC 06-103r4 OpenGIS Implementation Standard for Geographic information - Simple feature access - Part 1: Common architecture](http://portal.opengeospatial.org/files/?artifact_id=25355), Section 6.1.15 (which provides some further details on certain predicate specifications).
+/// - Wikipedia article on [DE-9IM](https://en.wikipedia.org/wiki/DE-9IM)
+///
+/// This implementation is heavily based on that from the [JTS project](https://github.com/locationtech/jts/blob/master/modules/core/src/main/java/org/locationtech/jts/geom/IntersectionMatrix.java).
+#[derive(PartialEq, Eq)]
+pub struct IntersectionMatrix(LocationArray<LocationArray<Dimensions>>);
+
+/// Helper struct so we can index IntersectionMatrix by CoordPos
+///
+/// CoordPos enum members are ordered: OnBondary, Inside, Outside
+/// DE-9IM matrices are ordered: Inside, Boundary, Exterior
+///
+/// So we can't simply `CoordPos as usize` without losing the conventional ordering
+/// of elements, which is useful for debug / interop.
+#[derive(PartialEq, Eq, Clone, Copy)]
+struct LocationArray<T>([T; 3]);
+
+impl<T> LocationArray<T> {
+    fn iter(&self) -> impl Iterator<Item = &T> {
+        self.0.iter()
+    }
+}
+
+impl<T> std::ops::Index<CoordPos> for LocationArray<T> {
+    type Output = T;
+
+    fn index(&self, index: CoordPos) -> &Self::Output {
+        match index {
+            CoordPos::Inside => &self.0[0],
+            CoordPos::OnBoundary => &self.0[1],
+            CoordPos::Outside => &self.0[2],
+        }
+    }
+}
+
+impl<T> std::ops::IndexMut<CoordPos> for LocationArray<T> {
+    fn index_mut(&mut self, index: CoordPos) -> &mut Self::Output {
+        match index {
+            CoordPos::Inside => &mut self.0[0],
+            CoordPos::OnBoundary => &mut self.0[1],
+            CoordPos::Outside => &mut self.0[2],
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct InvalidInputError {
+    message: String,
+}
+
+impl InvalidInputError {
+    fn new(message: String) -> Self {
+        Self { message }
+    }
+}
+
+impl std::error::Error for InvalidInputError {}
+impl std::fmt::Display for InvalidInputError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "invalid input:  {}", self.message)
+    }
+}
+
+impl std::fmt::Debug for IntersectionMatrix {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fn char_for_dim(dim: &Dimensions) -> &'static str {
+            match dim {
+                Dimensions::Empty => "F",
+                Dimensions::ZeroDimensional => "0",
+                Dimensions::OneDimensional => "1",
+                Dimensions::TwoDimensional => "2",
+            }
+        }
+        let text = self
+            .0
+            .iter()
+            .flat_map(|r| r.iter().map(char_for_dim))
+            .collect::<Vec<&str>>()
+            .join("");
+
+        write!(f, "IntersectionMatrix({})", &text)
+    }
+}
+
+impl IntersectionMatrix {
+    pub fn empty() -> Self {
+        IntersectionMatrix(LocationArray([LocationArray([Dimensions::Empty; 3]); 3]))
+    }
+
+    /// Set `dimensions` of the cell specified by the positions.
+    ///
+    /// `position_a`: which position `dimensions` applies to within the first geometry
+    /// `position_b`: which position `dimensions` applies to within the second geometry
+    /// `dimensions`: the dimension of the incident
+    pub(crate) fn set(
+        &mut self,
+        position_a: CoordPos,
+        position_b: CoordPos,
+        dimensions: Dimensions,
+    ) {
+        self.0[position_a][position_b] = dimensions;
+    }
+
+    /// Reports an incident of `dimensions`, which updates the IntersectionMatrix if it's greater
+    /// than what has been reported so far.
+    ///
+    /// `position_a`: which position `minimum_dimensions` applies to within the first geometry
+    /// `position_b`: which position `minimum_dimensions` applies to within the second geometry
+    /// `minimum_dimensions`: the dimension of the incident
+    pub(crate) fn set_at_least(
+        &mut self,
+        position_a: CoordPos,
+        position_b: CoordPos,
+        minimum_dimensions: Dimensions,
+    ) {
+        if self.0[position_a][position_b] < minimum_dimensions {
+            self.0[position_a][position_b] = minimum_dimensions;
+        }
+    }
+
+    /// If both geometries have `Some` position, then changes the specified element to at
+    /// least `minimum_dimensions`.
+    ///
+    /// Else, if either is none, do nothing.
+    ///
+    /// `position_a`: which position `minimum_dimensions` applies to within the first geometry, or
+    ///               `None` if the dimension was not incident with the first geometry.
+    /// `position_b`: which position `minimum_dimensions` applies to within the second geometry, or
+    ///               `None` if the dimension was not incident with the second geometry.
+    /// `minimum_dimensions`: the dimension of the incident
+    pub(crate) fn set_at_least_if_in_both(
+        &mut self,
+        position_a: Option<CoordPos>,
+        position_b: Option<CoordPos>,
+        minimum_dimensions: Dimensions,
+    ) {
+        if let (Some(position_a), Some(position_b)) = (position_a, position_b) {
+            self.set_at_least(position_a, position_b, minimum_dimensions);
+        }
+    }
+
+    pub(crate) fn set_at_least_from_string(
+        &mut self,
+        dimensions: &str,
+    ) -> Result<(), InvalidInputError> {
+        if dimensions.len() != 9 {
+            let message = format!("Expected dimensions length 9, found: {}", dimensions.len());
+            return Err(InvalidInputError::new(message));
+        }
+
+        let mut chars = dimensions.chars();
+        for a in &[CoordPos::Inside, CoordPos::OnBoundary, CoordPos::Outside] {
+            for b in &[CoordPos::Inside, CoordPos::OnBoundary, CoordPos::Outside] {
+                match chars.next().expect("already validated length is 9") {
+                    '0' => self.0[*a][*b] = self.0[*a][*b].max(Dimensions::ZeroDimensional),
+                    '1' => self.0[*a][*b] = self.0[*a][*b].max(Dimensions::OneDimensional),
+                    '2' => self.0[*a][*b] = self.0[*a][*b].max(Dimensions::TwoDimensional),
+                    'F' => {}
+                    other => {
+                        let message = format!("expected '0', '1', '2', or 'F'. Found: {}", other);
+                        return Err(InvalidInputError::new(message));
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Tests if this matrix matches `[FF*FF****]`.
+    ///
+    /// returns `true` if the two geometries related by this matrix are disjoint
+    pub fn is_disjoint(&self) -> bool {
+        self.0[CoordPos::Inside][CoordPos::Inside] == Dimensions::Empty
+            && self.0[CoordPos::Inside][CoordPos::OnBoundary] == Dimensions::Empty
+            && self.0[CoordPos::OnBoundary][CoordPos::Inside] == Dimensions::Empty
+            && self.0[CoordPos::OnBoundary][CoordPos::OnBoundary] == Dimensions::Empty
+    }
+
+    /// Tests if `is_disjoint` returns false.
+    ///
+    /// returns `true` if the two geometries related by this matrix intersect.
+    pub fn is_intersects(&self) -> bool {
+        !self.is_disjoint()
+    }
+
+    /// Tests whether this matrix matches `[T*F**F***]`.
+    ///
+    /// returns `true` if the first geometry is within the second.
+    pub fn is_within(&self) -> bool {
+        self.0[CoordPos::Inside][CoordPos::Inside] != Dimensions::Empty
+            && self.0[CoordPos::Inside][CoordPos::Outside] == Dimensions::Empty
+            && self.0[CoordPos::OnBoundary][CoordPos::Outside] == Dimensions::Empty
+    }
+
+    /// Tests whether this matrix matches `[T*****FF*]`.
+    ///
+    /// returns `true` if the first geometry contains the second.
+    pub fn is_contains(&self) -> bool {
+        self.0[CoordPos::Inside][CoordPos::Inside] != Dimensions::Empty
+            && self.0[CoordPos::Outside][CoordPos::Inside] == Dimensions::Empty
+            && self.0[CoordPos::Outside][CoordPos::OnBoundary] == Dimensions::Empty
+    }
+}
+
+impl std::str::FromStr for IntersectionMatrix {
+    type Err = InvalidInputError;
+    fn from_str(str: &str) -> Result<Self, Self::Err> {
+        let mut im = IntersectionMatrix::empty();
+        im.set_at_least_from_string(str)?;
+        Ok(im)
+    }
+}

--- a/geo/src/algorithm/relate/geomgraph/label.rs
+++ b/geo/src/algorithm/relate/geomgraph/label.rs
@@ -1,0 +1,120 @@
+use super::{CoordPos, Direction, TopologyPosition};
+
+use std::fmt;
+
+/// A GeometryGraph has components (nodes and edges) which are labeled with their topological
+/// relations to the geometries.
+///
+/// More precisely, each `Label` holds a `TopologyPosition` for each geometry that states whether
+/// the node or edge being labeled occurs `Inside`, `Outside`, or `OnBoundary` of the geometry.
+///
+/// For lines and points, a `TopologyPosition` tracks only an `On` position,
+/// while areas have positions for `On`, `Left`, and `Right`.
+///
+/// If the component has *no* incidence with one of the geometries, than the `Label`'s
+/// `TopologyPosition` for that geometry is called `empty`.
+#[derive(Clone)]
+pub(crate) struct Label {
+    geometry_topologies: [TopologyPosition; 2],
+}
+
+impl fmt::Debug for Label {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Label {{ A: {:?}, B: {:?} }}",
+            &self.geometry_topologies[0], &self.geometry_topologies[1]
+        )
+    }
+}
+
+impl Label {
+    /// Construct an empty `Label` for relating a 1-D line or 0-D point to both geometries.
+    pub fn empty_line_or_point() -> Label {
+        Label {
+            geometry_topologies: [
+                TopologyPosition::empty_line_or_point(),
+                TopologyPosition::empty_line_or_point(),
+            ],
+        }
+    }
+
+    /// Construct an empty `Label` for relating a 2-D area to both geometries.
+    pub fn empty_area() -> Self {
+        Self {
+            geometry_topologies: [
+                TopologyPosition::empty_area(),
+                TopologyPosition::empty_area(),
+            ],
+        }
+    }
+
+    /// Construct a `Label` initialized with `position` for the geometry specified by
+    /// `geom_index`.
+    ///
+    /// The label's position for the other geometry will be initialized as empty.
+    pub fn new(geom_index: usize, position: TopologyPosition) -> Self {
+        let mut label = match position {
+            TopologyPosition::LineOrPoint { .. } => Self::empty_line_or_point(),
+            TopologyPosition::Area { .. } => Self::empty_area(),
+        };
+        label.geometry_topologies[geom_index] = position;
+        label
+    }
+
+    pub fn flip(&mut self) {
+        self.geometry_topologies[0].flip();
+        self.geometry_topologies[1].flip();
+    }
+
+    pub fn position(&self, geom_index: usize, direction: Direction) -> Option<CoordPos> {
+        self.geometry_topologies[geom_index].get(direction)
+    }
+
+    pub fn on_position(&self, geom_index: usize) -> Option<CoordPos> {
+        self.geometry_topologies[geom_index].get(Direction::On)
+    }
+
+    pub fn set_position(&mut self, geom_index: usize, direction: Direction, position: CoordPos) {
+        self.geometry_topologies[geom_index].set_position(direction, position);
+    }
+
+    pub fn set_on_position(&mut self, geom_index: usize, position: CoordPos) {
+        self.geometry_topologies[geom_index].set_position(Direction::On, position);
+    }
+
+    pub fn set_all_positions(&mut self, geom_index: usize, position: CoordPos) {
+        self.geometry_topologies[geom_index].set_all_positions(position)
+    }
+
+    pub fn set_all_positions_if_empty(&mut self, geom_index: usize, postion: CoordPos) {
+        self.geometry_topologies[geom_index].set_all_positions_if_empty(postion)
+    }
+
+    pub fn geometry_count(&self) -> usize {
+        self.geometry_topologies
+            .iter()
+            .filter(|location| !location.is_empty())
+            .count()
+    }
+
+    pub fn is_empty(&self, geom_index: usize) -> bool {
+        self.geometry_topologies[geom_index].is_empty()
+    }
+
+    pub fn is_any_empty(&self, geom_index: usize) -> bool {
+        self.geometry_topologies[geom_index].is_any_empty()
+    }
+
+    pub fn is_area(&self) -> bool {
+        self.geometry_topologies[0].is_area() || self.geometry_topologies[1].is_area()
+    }
+
+    pub fn is_geom_area(&self, geom_index: usize) -> bool {
+        self.geometry_topologies[geom_index].is_area()
+    }
+
+    pub fn is_line(&self, geom_index: usize) -> bool {
+        self.geometry_topologies[geom_index].is_line()
+    }
+}

--- a/geo/src/algorithm/relate/geomgraph/line_intersector.rs
+++ b/geo/src/algorithm/relate/geomgraph/line_intersector.rs
@@ -1,0 +1,6 @@
+pub(crate) use crate::algorithm::line_intersection::LineIntersection;
+use crate::{Coordinate, GeoFloat, Line};
+
+pub(crate) trait LineIntersector<F: GeoFloat> {
+    fn compute_intersection(&mut self, l1: Line<F>, l2: Line<F>) -> Option<LineIntersection<F>>;
+}

--- a/geo/src/algorithm/relate/geomgraph/mod.rs
+++ b/geo/src/algorithm/relate/geomgraph/mod.rs
@@ -1,0 +1,48 @@
+#![allow(dead_code)]
+#![allow(unused_imports)]
+
+use std::fmt;
+
+pub(crate) use edge::Edge;
+pub(crate) use edge_end::{EdgeEnd, EdgeEndKey};
+pub(crate) use edge_end_bundle::{EdgeEndBundle, LabeledEdgeEndBundle};
+pub(crate) use edge_end_bundle_star::{EdgeEndBundleStar, LabeledEdgeEndBundleStar};
+pub(crate) use edge_intersection::EdgeIntersection;
+pub(crate) use geometry_graph::GeometryGraph;
+pub(crate) use intersection_matrix::IntersectionMatrix;
+pub(crate) use label::Label;
+pub(crate) use line_intersector::{LineIntersection, LineIntersector};
+pub(crate) use node::CoordNode;
+use planar_graph::PlanarGraph;
+pub(crate) use quadrant::Quadrant;
+pub(crate) use robust_line_intersector::RobustLineIntersector;
+use topology_position::TopologyPosition;
+
+use crate::dimensions::Dimensions;
+pub use crate::utils::CoordPos;
+
+mod edge;
+mod edge_end;
+mod edge_end_bundle;
+mod edge_end_bundle_star;
+mod edge_intersection;
+mod geometry_graph;
+pub(crate) mod index;
+mod label;
+mod node;
+pub(crate) mod node_map;
+mod planar_graph;
+mod quadrant;
+mod topology_position;
+
+pub(crate) mod intersection_matrix;
+mod line_intersector;
+mod robust_line_intersector;
+
+/// Position relative to a point
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub(crate) enum Direction {
+    On,
+    Left,
+    Right,
+}

--- a/geo/src/algorithm/relate/geomgraph/node.rs
+++ b/geo/src/algorithm/relate/geomgraph/node.rs
@@ -1,0 +1,71 @@
+use super::{CoordPos, Dimensions, EdgeEnd, EdgeEndBundleStar, IntersectionMatrix, Label};
+use crate::{Coordinate, GeoFloat};
+
+#[derive(Debug, Clone)]
+pub(crate) struct CoordNode<F>
+where
+    F: GeoFloat,
+{
+    coordinate: Coordinate<F>,
+    label: Label,
+}
+
+impl<F: GeoFloat> CoordNode<F> {
+    pub(crate) fn label(&self) -> &Label {
+        &self.label
+    }
+
+    pub(crate) fn label_mut(&mut self) -> &mut Label {
+        &mut self.label
+    }
+
+    pub(crate) fn is_isolated(&self) -> bool {
+        self.label.geometry_count() == 1
+    }
+}
+
+impl<F> CoordNode<F>
+where
+    F: GeoFloat,
+{
+    pub fn new(coordinate: Coordinate<F>) -> CoordNode<F> {
+        CoordNode {
+            coordinate,
+            label: Label::empty_line_or_point(),
+        }
+    }
+
+    pub fn coordinate(&self) -> &Coordinate<F> {
+        &self.coordinate
+    }
+
+    pub fn set_label_on_position(&mut self, geom_index: usize, position: CoordPos) {
+        self.label.set_on_position(geom_index, position)
+    }
+
+    /// Updates the label of a node to BOUNDARY, obeying the mod-2 rule.
+    pub fn set_label_boundary(&mut self, geom_index: usize) {
+        let new_position = match self.label.on_position(geom_index) {
+            Some(CoordPos::OnBoundary) => CoordPos::Inside,
+            Some(CoordPos::Inside) => CoordPos::OnBoundary,
+            None | Some(CoordPos::Outside) => CoordPos::OnBoundary,
+        };
+        self.label.set_on_position(geom_index, new_position);
+    }
+
+    // In JTS this method is implemented on a `GraphComponent` superclass, but since it's only used
+    // by this one "subclass" I've implemented it directly on the node, rather than introducing
+    // something like a `GraphComponent` trait
+    pub fn update_intersection_matrix(&self, intersection_matrix: &mut IntersectionMatrix) {
+        assert!(self.label.geometry_count() >= 2, "found partial label");
+        intersection_matrix.set_at_least_if_in_both(
+            self.label.on_position(0),
+            self.label.on_position(1),
+            Dimensions::ZeroDimensional,
+        );
+        debug!(
+            "updated intersection_matrix: {:?} from node: {:?}",
+            intersection_matrix, self
+        );
+    }
+}

--- a/geo/src/algorithm/relate/geomgraph/node_map.rs
+++ b/geo/src/algorithm/relate/geomgraph/node_map.rs
@@ -1,0 +1,111 @@
+use super::{CoordNode, CoordPos, EdgeEnd};
+use crate::{Coordinate, GeoFloat};
+
+use std::collections::BTreeMap;
+use std::fmt;
+use std::marker::PhantomData;
+
+/// A map of nodes, indexed by the coordinate of the node
+pub(crate) struct NodeMap<F, NF>
+where
+    F: GeoFloat,
+    NF: NodeFactory<F>,
+{
+    map: BTreeMap<NodeKey<F>, NF::Node>,
+    _node_factory: PhantomData<NF>,
+}
+
+/// Creates the node stored in `NodeMap`
+pub(crate) trait NodeFactory<F: GeoFloat> {
+    type Node;
+    fn create_node(coordinate: Coordinate<F>) -> Self::Node;
+}
+
+impl<F, NF> fmt::Debug for NodeMap<F, NF>
+where
+    F: GeoFloat,
+    NF: NodeFactory<F>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("NodeMap")
+            .field("map.len()", &self.map.len())
+            .finish()
+    }
+}
+
+#[derive(Clone)]
+struct NodeKey<F: GeoFloat>(Coordinate<F>);
+
+impl<F: GeoFloat> std::cmp::Ord for NodeKey<F> {
+    fn cmp(&self, other: &NodeKey<F>) -> std::cmp::Ordering {
+        debug_assert!(!self.0.x.is_nan());
+        debug_assert!(!self.0.y.is_nan());
+        debug_assert!(!other.0.x.is_nan());
+        debug_assert!(!other.0.y.is_nan());
+        crate::utils::lex_cmp(&self.0, &other.0)
+    }
+}
+
+impl<F: GeoFloat> std::cmp::PartialOrd for NodeKey<F> {
+    fn partial_cmp(&self, other: &NodeKey<F>) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<F: GeoFloat> std::cmp::PartialEq for NodeKey<F> {
+    fn eq(&self, other: &NodeKey<F>) -> bool {
+        debug_assert!(!self.0.x.is_nan());
+        debug_assert!(!self.0.y.is_nan());
+        debug_assert!(!other.0.x.is_nan());
+        debug_assert!(!other.0.y.is_nan());
+        self.0 == other.0
+    }
+}
+
+impl<F: GeoFloat> std::cmp::Eq for NodeKey<F> {}
+
+impl<F, NF> NodeMap<F, NF>
+where
+    F: GeoFloat,
+    NF: NodeFactory<F>,
+{
+    pub fn new() -> Self {
+        NodeMap {
+            map: BTreeMap::new(),
+            _node_factory: PhantomData,
+        }
+    }
+    /// Adds a `NF::Node` with the given `Coordinate`.
+    ///
+    /// Note: Coordinates must be non-NaN.
+    pub fn insert_node_with_coordinate(&mut self, coord: Coordinate<F>) -> &mut NF::Node {
+        debug_assert!(
+            !coord.x.is_nan() && !coord.y.is_nan(),
+            "NaN coordinates are not supported"
+        );
+        let key = NodeKey(coord);
+        self.map
+            .entry(key)
+            .or_insert_with(|| NF::create_node(coord))
+    }
+
+    /// returns the `NF::Node`, if any, matching `coord`
+    pub fn find(&self, coord: Coordinate<F>) -> Option<&NF::Node> {
+        self.map.get(&NodeKey(coord))
+    }
+
+    /// Iterates across `NF::Node`s in lexical order of their `Coordinate`
+    pub fn iter(&self) -> impl Iterator<Item = &NF::Node> {
+        self.map.values()
+    }
+
+    /// Iterates across `NF::Node`s in lexical order of their `Coordinate`
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut NF::Node> {
+        self.map.values_mut()
+    }
+
+    /// Iterates across `NF::Node`s in lexical order of their `Coordinate`
+    pub fn into_iter(self) -> impl Iterator<Item = NF::Node> {
+        self.map.into_iter().map(|(_k, v)| v)
+    }
+}

--- a/geo/src/algorithm/relate/geomgraph/planar_graph.rs
+++ b/geo/src/algorithm/relate/geomgraph/planar_graph.rs
@@ -1,0 +1,64 @@
+use super::{
+    node_map::{NodeFactory, NodeMap},
+    CoordNode, CoordPos, Edge, Label,
+};
+use crate::{Coordinate, GeoFloat};
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+pub(crate) struct PlanarGraphNode;
+
+/// The basic node constructor does not allow for incident edges
+impl<F> NodeFactory<F> for PlanarGraphNode
+where
+    F: GeoFloat,
+{
+    type Node = CoordNode<F>;
+    fn create_node(coordinate: Coordinate<F>) -> Self::Node {
+        CoordNode::new(coordinate)
+    }
+}
+
+pub(crate) struct PlanarGraph<F: GeoFloat> {
+    pub(crate) nodes: NodeMap<F, PlanarGraphNode>,
+    edges: Vec<Rc<RefCell<Edge<F>>>>,
+}
+
+impl<F: GeoFloat> PlanarGraph<F> {
+    pub fn edges(&self) -> &[Rc<RefCell<Edge<F>>>] {
+        &self.edges
+    }
+
+    pub fn new() -> Self {
+        PlanarGraph {
+            nodes: NodeMap::new(),
+            edges: vec![],
+        }
+    }
+
+    pub fn is_boundary_node(&self, geom_index: usize, coord: Coordinate<F>) -> bool {
+        self.nodes
+            .find(coord)
+            .and_then(|node| node.label().on_position(geom_index))
+            .map(|position| position == CoordPos::OnBoundary)
+            .unwrap_or(false)
+    }
+
+    pub fn insert_edge(&mut self, edge: Edge<F>) {
+        self.edges.push(Rc::new(RefCell::new(edge)));
+    }
+
+    pub fn add_node_with_coordinate(&mut self, coord: Coordinate<F>) -> &mut CoordNode<F> {
+        self.nodes.insert_node_with_coordinate(coord)
+    }
+
+    pub fn boundary_nodes(&self, geom_index: usize) -> impl Iterator<Item = &CoordNode<F>> {
+        self.nodes.iter().filter(move |node| {
+            matches!(
+                node.label().on_position(geom_index),
+                Some(CoordPos::OnBoundary)
+            )
+        })
+    }
+}

--- a/geo/src/algorithm/relate/geomgraph/quadrant.rs
+++ b/geo/src/algorithm/relate/geomgraph/quadrant.rs
@@ -1,0 +1,34 @@
+use crate::GeoNum;
+
+/// Utility functions for working with quadrants of the cartesian plane,
+/// which are labeled as follows:
+/// ```ignore
+///          (+)
+///        NW ┃ NE
+///    (-) ━━━╋━━━━ (+)
+///        SW ┃ SE
+///          (-)
+/// ```
+#[derive(Debug, Clone, Copy, PartialOrd, PartialEq)]
+pub enum Quadrant {
+    NE,
+    NW,
+    SW,
+    SE,
+}
+
+impl Quadrant {
+    pub fn new<F: GeoNum>(dx: F, dy: F) -> Option<Quadrant> {
+        if dx.is_zero() && dy.is_zero() {
+            return None;
+        }
+
+        match (dy >= F::zero(), dx >= F::zero()) {
+            (true, true) => Quadrant::NE,
+            (true, false) => Quadrant::NW,
+            (false, false) => Quadrant::SW,
+            (false, true) => Quadrant::SE,
+        }
+        .into()
+    }
+}

--- a/geo/src/algorithm/relate/geomgraph/robust_line_intersector.rs
+++ b/geo/src/algorithm/relate/geomgraph/robust_line_intersector.rs
@@ -1,0 +1,74 @@
+use super::{LineIntersection, LineIntersector};
+use crate::algorithm::kernels::{Kernel, Orientation, RobustKernel};
+use crate::bounding_rect::BoundingRect;
+use crate::contains::Contains;
+use crate::intersects::Intersects;
+use crate::num_traits::Zero;
+use crate::{Coordinate, GeoFloat, Line, Rect};
+
+/// A robust version of [LineIntersector](traits.LineIntersector).
+#[derive(Clone)]
+pub(crate) struct RobustLineIntersector;
+
+impl RobustLineIntersector {
+    pub fn new() -> RobustLineIntersector {
+        RobustLineIntersector
+    }
+}
+
+impl<F: GeoFloat> LineIntersector<F> for RobustLineIntersector {
+    fn compute_intersection(&mut self, p: Line<F>, q: Line<F>) -> Option<LineIntersection<F>> {
+        crate::algorithm::line_intersection::line_intersection(p, q)
+    }
+}
+
+impl RobustLineIntersector {
+    /// Computes the "edge distance" of an intersection point p along a segment.
+    ///
+    /// The edge distance is a metric of the point along the edge.
+    /// The metric used is a robust and easy to compute metric function.
+    /// It is _not_ equivalent to the usual Euclidean metric.
+    /// It relies on the fact that either the x or the y ordinates of the
+    /// points in the edge are unique, depending on whether the edge is longer in
+    /// the horizontal or vertical direction.
+    ///
+    /// NOTE: This function may produce incorrect distances for inputs where p is not precisely
+    /// on p1-p2 (E.g. p = (139,9) p1 = (139,10), p2 = (280,1) produces distance 0.0, which is
+    /// incorrect.
+    ///
+    /// My hypothesis is that the function is safe to use for points which are the
+    /// result of _rounding_ points which lie on the line,
+    /// but not safe to use for _truncated_ points.
+    pub fn compute_edge_distance<F: GeoFloat>(intersection: Coordinate<F>, line: Line<F>) -> F {
+        let dx = (line.end.x - line.start.x).abs();
+        let dy = (line.end.y - line.start.y).abs();
+
+        let mut dist: F;
+        if intersection == line.start {
+            dist = F::zero();
+        } else if intersection == line.end {
+            if dx > dy {
+                dist = dx;
+            } else {
+                dist = dy;
+            }
+        } else {
+            let intersection_dx = (intersection.x - line.start.x).abs();
+            let intersection_dy = (intersection.y - line.start.y).abs();
+            if dx > dy {
+                dist = intersection_dx;
+            } else {
+                dist = intersection_dy;
+            }
+            // hack to ensure that non-endpoints always have a non-zero distance
+            if dist == F::zero() && intersection != line.start {
+                dist = intersection_dx.max(intersection_dy);
+            }
+        }
+        debug_assert!(
+            !(dist == F::zero() && intersection != line.start),
+            "Bad distance calculation"
+        );
+        dist
+    }
+}

--- a/geo/src/algorithm/relate/geomgraph/topology_position.rs
+++ b/geo/src/algorithm/relate/geomgraph/topology_position.rs
@@ -1,0 +1,197 @@
+use super::{CoordPos, Direction};
+
+use std::fmt;
+
+/// A `TopologyPosition` is the labelling of a graph component's topological relationship to a
+/// single Geometry for each of the component's [`Direction`s](Direction).
+///
+/// If the graph component is an _area_ edge, there is a position for each [`Direction`]:
+/// - [`On`](Direction::On): on the edge
+/// - [`Left`](Direction::Left): left-hand side of the edge
+/// - [`Right`](Direction::Right): right-hand side
+///
+/// If the parent component is a _line_ edge or a node (a point), there is a single
+/// topological relationship attribute for the [`On`](Direction::On) position.
+///
+/// See [`CoordPos`] for the possible values.
+#[derive(Copy, Clone)]
+pub(crate) enum TopologyPosition {
+    Area {
+        on: Option<CoordPos>,
+        left: Option<CoordPos>,
+        right: Option<CoordPos>,
+    },
+    LineOrPoint {
+        on: Option<CoordPos>,
+    },
+}
+
+impl fmt::Debug for TopologyPosition {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fn fmt_position(position: &Option<CoordPos>, f: &mut fmt::Formatter) -> fmt::Result {
+            match position {
+                Some(CoordPos::Inside) => write!(f, "i"),
+                Some(CoordPos::OnBoundary) => write!(f, "b"),
+                Some(CoordPos::Outside) => write!(f, "e"),
+                None => write!(f, "_"),
+            }
+        }
+        match self {
+            Self::LineOrPoint { on } => fmt_position(on, f)?,
+            Self::Area { on, left, right } => {
+                fmt_position(left, f)?;
+                fmt_position(on, f)?;
+                fmt_position(right, f)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl TopologyPosition {
+    pub fn area(on: CoordPos, left: CoordPos, right: CoordPos) -> Self {
+        Self::Area {
+            on: Some(on),
+            left: Some(left),
+            right: Some(right),
+        }
+    }
+
+    pub fn empty_area() -> Self {
+        Self::Area {
+            on: None,
+            left: None,
+            right: None,
+        }
+    }
+
+    pub fn line_or_point(on: CoordPos) -> Self {
+        Self::LineOrPoint { on: Some(on) }
+    }
+
+    pub fn empty_line_or_point() -> Self {
+        Self::LineOrPoint { on: None }
+    }
+
+    pub fn get(&self, direction: Direction) -> Option<CoordPos> {
+        match (direction, self) {
+            (Direction::Left, Self::Area { left, .. }) => *left,
+            (Direction::Right, Self::Area { right, .. }) => *right,
+            (Direction::On, Self::LineOrPoint { on }) | (Direction::On, Self::Area { on, .. }) => {
+                *on
+            }
+            (_, Self::LineOrPoint { .. }) => {
+                panic!("LineOrPoint only has a position for `Direction::On`")
+            }
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        matches!(
+            self,
+            Self::LineOrPoint { on: None }
+                | Self::Area {
+                    on: None,
+                    left: None,
+                    right: None,
+                }
+        )
+    }
+
+    pub fn is_any_empty(&self) -> bool {
+        !matches!(
+            self,
+            Self::LineOrPoint { on: Some(_) }
+                | Self::Area {
+                    on: Some(_),
+                    left: Some(_),
+                    right: Some(_),
+                }
+        )
+    }
+
+    pub fn is_area(&self) -> bool {
+        matches!(self, Self::Area { .. })
+    }
+
+    pub fn is_line(&self) -> bool {
+        matches!(self, Self::LineOrPoint { .. })
+    }
+
+    pub fn flip(&mut self) {
+        match self {
+            Self::LineOrPoint { .. } => {}
+            Self::Area { left, right, .. } => {
+                std::mem::swap(left, right);
+            }
+        }
+    }
+
+    pub fn set_all_positions(&mut self, position: CoordPos) {
+        match self {
+            Self::LineOrPoint { on } => {
+                *on = Some(position);
+            }
+            Self::Area { on, left, right } => {
+                *on = Some(position);
+                *left = Some(position);
+                *right = Some(position);
+            }
+        }
+    }
+
+    pub fn set_all_positions_if_empty(&mut self, position: CoordPos) {
+        match self {
+            Self::LineOrPoint { on } => {
+                if on.is_none() {
+                    *on = Some(position);
+                }
+            }
+            Self::Area { on, left, right } => {
+                if on.is_none() {
+                    *on = Some(position);
+                }
+                if left.is_none() {
+                    *left = Some(position);
+                }
+                if right.is_none() {
+                    *right = Some(position);
+                }
+            }
+        }
+    }
+
+    pub fn set_position(&mut self, direction: Direction, position: CoordPos) {
+        match (direction, self) {
+            (Direction::On, Self::LineOrPoint { on }) => *on = Some(position),
+            (_, Self::LineOrPoint { .. }) => {
+                panic!("invalid assignment dimensions for Self::Line")
+            }
+            (Direction::On, Self::Area { on, .. }) => *on = Some(position),
+            (Direction::Left, Self::Area { left, .. }) => *left = Some(position),
+            (Direction::Right, Self::Area { right, .. }) => *right = Some(position),
+        }
+    }
+
+    pub fn set_on_position(&mut self, position: CoordPos) {
+        match self {
+            Self::LineOrPoint { on } | Self::Area { on, .. } => {
+                *on = Some(position);
+            }
+        }
+    }
+
+    pub fn set_locations(&mut self, new_on: CoordPos, new_left: CoordPos, new_right: CoordPos) {
+        match self {
+            Self::LineOrPoint { .. } => {
+                error!("invalid assignment dimensions for {:?}", self);
+                debug_assert!(false, "invalid assignment dimensions for {:?}", self);
+            }
+            Self::Area { on, left, right } => {
+                *on = Some(new_on);
+                *left = Some(new_left);
+                *right = Some(new_right);
+            }
+        }
+    }
+}

--- a/geo/src/algorithm/relate/mod.rs
+++ b/geo/src/algorithm/relate/mod.rs
@@ -1,0 +1,118 @@
+pub(crate) use edge_end_builder::EdgeEndBuilder;
+pub use geomgraph::intersection_matrix::IntersectionMatrix;
+
+use crate::{
+    GeoFloat, Geometry, GeometryCollection, GeometryCow, Line, LineString, MultiLineString,
+    MultiPoint, MultiPolygon, Point, Polygon, Rect, Triangle,
+};
+
+mod edge_end_builder;
+mod geomgraph;
+mod relate_operation;
+
+/// Topologically relate two geometries based on [DE-9IM](https://en.wikipedia.org/wiki/DE-9IM) semantics.
+///
+/// See [`IntersectionMatrix`] for details.
+///
+/// # Examples
+///
+/// ```
+/// use geo::{Coordinate, Line, Rect, line_string};
+/// use crate::geo::relate::Relate;
+///
+/// let line = Line::new(Coordinate { x: 2.0, y: 2.0}, Coordinate { x: 4.0, y: 4.0 });
+/// let rect = Rect::new(Coordinate { x: 2.0, y: 2.0}, Coordinate { x: 4.0, y: 4.0 });
+/// let intersection_matrix = rect.relate(&line);
+///
+/// assert!(intersection_matrix.is_intersects());
+/// assert!(!intersection_matrix.is_disjoint());
+/// assert!(intersection_matrix.is_contains());
+/// assert!(!intersection_matrix.is_within());
+///
+/// let line = Line::new(Coordinate { x: 1.0, y: 1.0}, Coordinate { x: 5.0, y: 5.0 });
+/// let rect = Rect::new(Coordinate { x: 2.0, y: 2.0}, Coordinate { x: 4.0, y: 4.0 });
+/// let intersection_matrix = rect.relate(&line);
+/// assert!(intersection_matrix.is_intersects());
+/// assert!(!intersection_matrix.is_disjoint());
+/// assert!(!intersection_matrix.is_contains());
+/// assert!(!intersection_matrix.is_within());
+///
+/// let rect_boundary = line_string![
+///     (x: 2.0, y: 2.0),
+///     (x: 4.0, y: 2.0),
+///     (x: 4.0, y: 4.0),
+///     (x: 2.0, y: 4.0),
+///     (x: 2.0, y: 2.0)
+/// ];
+/// let intersection_matrix = rect.relate(&rect_boundary);
+/// assert!(intersection_matrix.is_intersects());
+/// assert!(!intersection_matrix.is_disjoint());
+/// // According to DE-9IM, polygons don't contain their own boundary
+/// assert!(!intersection_matrix.is_contains());
+/// assert!(!intersection_matrix.is_within());
+/// ```
+///
+/// Note: `Relate` must not be called on geometries containing `NaN` coordinates.
+pub trait Relate<F, T> {
+    fn relate(&self, other: &T) -> IntersectionMatrix;
+}
+
+impl<F: GeoFloat> Relate<F, GeometryCow<'_, F>> for GeometryCow<'_, F> {
+    fn relate(&self, other: &GeometryCow<F>) -> IntersectionMatrix {
+        let mut relate_computer = relate_operation::RelateOperation::new(self, other);
+        relate_computer.compute_intersection_matrix()
+    }
+}
+
+macro_rules! relate_impl {
+    ($k:ty, $t:ty) => {
+        relate_impl![($k, $t),];
+    };
+    ($(($k:ty, $t:ty),)*) => {
+        $(
+            impl<F: GeoFloat> Relate<F, $t> for $k {
+                fn relate(&self, other: &$t) -> IntersectionMatrix {
+                    GeometryCow::from(self).relate(&GeometryCow::from(other))
+                }
+            }
+        )*
+    };
+}
+
+/// Call the given macro with every pair of inputs
+///
+/// # Examples
+///
+/// ```no_run
+/// cartesian_pairs!(foo, [Bar, Baz, Qux]);
+/// ```
+/// Is akin to calling:
+/// ```no_run
+/// foo![(Bar, Bar), (Bar, Baz), (Bar, Qux), (Baz, Bar), (Baz, Baz), (Baz, Qux), (Qux, Bar), (Qux, Baz), (Qux, Qux)]);
+/// ```
+macro_rules! cartesian_pairs {
+    ($macro_name:ident, [$($a:ty),*]) => {
+        cartesian_pairs_helper! { [] [$($a,)*] [$($a,)*] [$($a,)*] $macro_name}
+    };
+}
+
+macro_rules! cartesian_pairs_helper {
+    // popped all a's - we're done. Use the accumulated output as the input to relate macro.
+    ([$($out_pairs:tt)*] [] [$($b:ty,)*] $init_b:tt $macro_name:ident) => {
+        $macro_name!{$($out_pairs)*}
+    };
+    // finished one loop of b, pop next a and reset b
+    ($out_pairs:tt [$a_car:ty, $($a_cdr:ty,)*] [] $init_b:tt $macro_name:ident) => {
+        cartesian_pairs_helper!{$out_pairs [$($a_cdr,)*] $init_b $init_b $macro_name}
+    };
+    // pop b through all of b with head of a
+    ([$($out_pairs:tt)*] [$a_car:ty, $($a_cdr:ty,)*] [$b_car:ty, $($b_cdr:ty,)*] $init_b:tt $macro_name:ident) => {
+        cartesian_pairs_helper!{[$($out_pairs)* ($a_car, $b_car),] [$a_car, $($a_cdr,)*] [$($b_cdr,)*] $init_b $macro_name}
+    };
+}
+
+// Implement Relate for every combination of Geometry. Alternatively we could do something like
+// `impl Relate<Into<GeometryCow>> for Into<GeometryCow> { }`
+// but I don't know that we want to make GeometryCow public (yet?).
+cartesian_pairs!(relate_impl, [Point<F>, Line<F>, LineString<F>, Polygon<F>, MultiPoint<F>, MultiLineString<F>, MultiPolygon<F>, Rect<F>, Triangle<F>, GeometryCollection<F>]);
+relate_impl!(Geometry<F>, Geometry<F>);

--- a/geo/src/algorithm/relate/relate_operation.rs
+++ b/geo/src/algorithm/relate/relate_operation.rs
@@ -1,0 +1,527 @@
+use super::{EdgeEndBuilder, IntersectionMatrix};
+use crate::algorithm::coordinate_position::CoordinatePosition;
+use crate::algorithm::dimensions::{Dimensions, HasDimensions};
+use crate::algorithm::relate::geomgraph::{
+    index::SegmentIntersector,
+    node_map::{NodeFactory, NodeMap},
+    CoordNode, CoordPos, Edge, EdgeEnd, EdgeEndBundleStar, GeometryGraph, LabeledEdgeEndBundleStar,
+    RobustLineIntersector,
+};
+use crate::{Coordinate, GeoFloat, GeometryCow};
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+/// Computes an [`IntersectionMatrix`] describing the topological relationship between two
+/// Geometries.
+///
+/// `RelateOperation` does not currently support [`GeometryCollection`]s with overlapping Polygons,
+/// and may provide surprising results in that case.
+///
+/// This implementation relies heavily on the functionality of [`GeometryGraph`].
+///
+/// Based on [JTS's `RelateComputer` as of 1.18.1](https://github.com/locationtech/jts/blob/jts-1.18.1/modules/core/src/main/java/org/locationtech/jts/operation/relate/RelateComputer.java)
+pub(crate) struct RelateOperation<'a, F>
+where
+    F: GeoFloat,
+{
+    graph_a: GeometryGraph<'a, F>,
+    graph_b: GeometryGraph<'a, F>,
+    nodes: NodeMap<F, RelateNodeFactory>,
+    line_intersector: RobustLineIntersector,
+    isolated_edges: Vec<Rc<RefCell<Edge<F>>>>,
+}
+
+pub(crate) struct RelateNodeFactory;
+impl<F> NodeFactory<F> for RelateNodeFactory
+where
+    F: GeoFloat,
+{
+    type Node = (CoordNode<F>, EdgeEndBundleStar<F>);
+    fn create_node(coordinate: Coordinate<F>) -> Self::Node {
+        (CoordNode::new(coordinate), EdgeEndBundleStar::new())
+    }
+}
+
+impl<'a, F> RelateOperation<'a, F>
+where
+    F: GeoFloat,
+{
+    pub(crate) fn new(
+        geom_a: &'a GeometryCow<'a, F>,
+        geom_b: &'a GeometryCow<'a, F>,
+    ) -> RelateOperation<'a, F> {
+        Self {
+            graph_a: GeometryGraph::new(0, geom_a),
+            graph_b: GeometryGraph::new(1, geom_b),
+            nodes: NodeMap::new(),
+            isolated_edges: vec![],
+            line_intersector: RobustLineIntersector::new(),
+        }
+    }
+
+    pub(crate) fn compute_intersection_matrix(&mut self) -> IntersectionMatrix {
+        let mut intersection_matrix = IntersectionMatrix::empty();
+        // since Geometries are finite and embedded in a 2-D space,
+        // the `(Outside, Outside)` element must always be 2-D
+        intersection_matrix.set(
+            CoordPos::Outside,
+            CoordPos::Outside,
+            Dimensions::TwoDimensional,
+        );
+
+        use crate::algorithm::bounding_rect::BoundingRect;
+        use crate::algorithm::intersects::Intersects;
+        match (
+            self.graph_a.geometry().bounding_rect(),
+            self.graph_b.geometry().bounding_rect(),
+        ) {
+            (Some(bounding_rect_a), Some(bounding_rect_b))
+                if bounding_rect_a.intersects(&bounding_rect_b) => {}
+            _ => {
+                // since Geometries don't overlap, we can skip most of the work
+                self.compute_disjoint_intersection_matrix(&mut intersection_matrix);
+                return intersection_matrix;
+            }
+        }
+
+        // Since changes to topology are inspected at nodes, we must crate a node for each
+        // intersection.
+        self.graph_a
+            .compute_self_nodes(Box::new(self.line_intersector.clone()));
+        self.graph_b
+            .compute_self_nodes(Box::new(self.line_intersector.clone()));
+
+        // compute intersections between edges of the two input geometries
+        let segment_intersector = self
+            .graph_a
+            .compute_edge_intersections(&self.graph_b, Box::new(self.line_intersector.clone()));
+
+        self.compute_intersection_nodes(0);
+        self.compute_intersection_nodes(1);
+        // Copy the labelling for the nodes in the parent Geometries.  These override any labels
+        // determined by intersections between the geometries.
+        self.copy_nodes_and_labels(0);
+        self.copy_nodes_and_labels(1);
+        // complete the labelling for any nodes which only have a label for a single geometry
+        self.label_isolated_nodes();
+        // If a proper intersection was found, we can set a lower bound on the IM.
+        self.compute_proper_intersection_im(&segment_intersector, &mut intersection_matrix);
+        // Now process improper intersections
+        // (eg where one or other of the geometries has a vertex at the intersection point)
+        // We need to compute the edge graph at all nodes to determine the IM.
+        let edge_end_builder = EdgeEndBuilder::new();
+        let edge_ends_a: Vec<_> = edge_end_builder.compute_ends_for_edges(self.graph_a.edges());
+        self.insert_edge_ends(edge_ends_a);
+        let edge_ends_b: Vec<_> = edge_end_builder.compute_ends_for_edges(self.graph_b.edges());
+        self.insert_edge_ends(edge_ends_b);
+
+        let mut nodes = NodeMap::new();
+        std::mem::swap(&mut self.nodes, &mut nodes);
+        let labeled_node_edges = nodes
+            .into_iter()
+            .map(|(node, edges)| (node, edges.into_labeled(&self.graph_a, &self.graph_b)))
+            .collect();
+
+        // Compute the labeling for "isolated" components
+        //
+        // Isolated components are components that do not touch any other components in the graph.
+        //
+        // They can be identified by the fact that their labels will have only one non-empty
+        // element, the one for their parent geometry.
+        //
+        // We only need to check components contained in the input graphs, since, by definition,
+        // isolated components will not have been replaced by new components formed by
+        // intersections.
+        self.label_isolated_edges(0, 1);
+        self.label_isolated_edges(1, 0);
+
+        debug!(
+            "before update_intersection_matrix: {:?}",
+            &intersection_matrix
+        );
+        self.update_intersection_matrix(labeled_node_edges, &mut intersection_matrix);
+
+        intersection_matrix
+    }
+
+    fn insert_edge_ends(&mut self, edge_ends: Vec<EdgeEnd<F>>) {
+        for edge_end in edge_ends {
+            let (_node, edges) = self
+                .nodes
+                .insert_node_with_coordinate(*edge_end.coordinate());
+            edges.insert(edge_end);
+        }
+    }
+
+    fn compute_proper_intersection_im(
+        &mut self,
+        segment_intersector: &SegmentIntersector<F>,
+        intersection_matrix: &mut IntersectionMatrix,
+    ) {
+        // If a proper intersection is found, we can set a lower bound on the IM.
+        let dim_a = self.graph_a.geometry().dimensions();
+        let dim_b = self.graph_b.geometry().dimensions();
+
+        let has_proper = segment_intersector.has_proper_intersection();
+        let has_proper_interior = segment_intersector.has_proper_interior_intersection();
+
+        debug_assert!(
+            (dim_a != Dimensions::ZeroDimensional && dim_b != Dimensions::ZeroDimensional)
+                || (!has_proper && !has_proper_interior)
+        );
+
+        match (dim_a, dim_b) {
+            // If edge segments of Areas properly intersect, the areas must properly overlap.
+            (Dimensions::TwoDimensional, Dimensions::TwoDimensional) => {
+                if has_proper {
+                    intersection_matrix
+                        .set_at_least_from_string("212101212")
+                        .expect("error in hardcoded dimensions");
+                }
+            }
+
+            // If a Line segment properly intersects an edge segment of an Area, it follows that
+            // the Interior of the Line intersects the Boundary of the Area.
+            // If the intersection is a proper *interior* intersection, then there is an
+            // Interior-Interior intersection too.
+            // Note that it does not follow that the Interior of the Line intersects the Exterior
+            // of the Area, since there may be another Area component which contains the rest of the Line.
+            (Dimensions::TwoDimensional, Dimensions::OneDimensional) => {
+                if has_proper {
+                    intersection_matrix
+                        .set_at_least_from_string("FFF0FFFF2")
+                        .expect("error in hardcoded dimensions");
+                }
+
+                if has_proper_interior {
+                    intersection_matrix
+                        .set_at_least_from_string("1FFFFF1FF")
+                        .expect("error in hardcoded dimensions");
+                }
+            }
+
+            (Dimensions::OneDimensional, Dimensions::TwoDimensional) => {
+                if has_proper {
+                    intersection_matrix
+                        .set_at_least_from_string("F0FFFFFF2")
+                        .expect("error in hardcoded dimensions");
+                }
+
+                if has_proper_interior {
+                    intersection_matrix
+                        .set_at_least_from_string("1F1FFFFFF")
+                        .expect("error in hardcoded dimensions");
+                }
+            }
+
+            // If edges of LineStrings properly intersect *in an interior point*, all we can deduce
+            // is that the interiors intersect.  (We can NOT deduce that the exteriors intersect,
+            // since some other segments in the geometries might cover the points in the
+            // neighbourhood of the intersection.)
+            // It is important that the point be known to be an interior point of both Geometries,
+            // since it is possible in a self-intersecting geometry to have a proper intersection
+            // on one segment that is also a boundary point of another segment.
+            (Dimensions::OneDimensional, Dimensions::OneDimensional) => {
+                if has_proper_interior {
+                    intersection_matrix
+                        .set_at_least_from_string("0FFFFFFFF")
+                        .expect("error in hardcoded dimensions");
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Copy all nodes from an arg geometry into this graph.
+    ///
+    /// The node label in the arg geometry overrides any previously computed label for that
+    /// argIndex.  (E.g. a node may be an intersection node with a computed label of BOUNDARY, but
+    /// in the original arg Geometry it is actually in the interior due to the Boundary
+    /// Determination Rule)
+    fn copy_nodes_and_labels(&mut self, geom_index: usize) {
+        let graph = if geom_index == 0 {
+            &self.graph_a
+        } else {
+            assert!(geom_index == 1);
+            &self.graph_b
+        };
+        for graph_node in graph.nodes_iter() {
+            let new_node = self
+                .nodes
+                .insert_node_with_coordinate(*graph_node.coordinate());
+
+            let on_position = graph_node
+                .label()
+                .on_position(geom_index)
+                .expect("node should have been labeled by now");
+
+            new_node.0.set_label_on_position(geom_index, on_position);
+        }
+    }
+
+    /// Insert nodes for all intersections on the edges of a Geometry.  
+    ///
+    /// Label the created nodes the same as the edge label if they do not already have a label.
+    /// This allows nodes created by either self-intersections or mutual intersections to be
+    /// labeled.
+    ///
+    /// Endpoint nodes will already be labeled from when they were inserted.
+    fn compute_intersection_nodes(&mut self, geom_index: usize) {
+        let graph = if geom_index == 0 {
+            &self.graph_a
+        } else {
+            assert!(geom_index == 1);
+            &self.graph_b
+        };
+
+        for edge in graph.edges() {
+            let edge = edge.borrow();
+
+            let edge_position = edge.label().on_position(geom_index);
+            for edge_intersection in edge.edge_intersections() {
+                let (new_node, _edges) = self
+                    .nodes
+                    .insert_node_with_coordinate(edge_intersection.coordinate());
+
+                if edge_position == Some(CoordPos::OnBoundary) {
+                    new_node.set_label_boundary(geom_index);
+                } else if new_node.label().is_empty(geom_index) {
+                    new_node.set_label_on_position(geom_index, CoordPos::Inside);
+                }
+            }
+        }
+    }
+
+    /// If the Geometries are disjoint, we need to enter their dimension and boundary dimension in
+    /// the `Outside` rows in the IM
+    fn compute_disjoint_intersection_matrix(&self, intersection_matrix: &mut IntersectionMatrix) {
+        {
+            let geometry_a = self.graph_a.geometry();
+            let dimensions = geometry_a.dimensions();
+            if dimensions != Dimensions::Empty {
+                intersection_matrix.set(CoordPos::Inside, CoordPos::Outside, dimensions);
+
+                let boundary_dimensions = geometry_a.boundary_dimensions();
+                if boundary_dimensions != Dimensions::Empty {
+                    intersection_matrix.set(
+                        CoordPos::OnBoundary,
+                        CoordPos::Outside,
+                        boundary_dimensions,
+                    );
+                }
+            }
+        }
+
+        {
+            let geometry_b = self.graph_b.geometry();
+            let dimensions = geometry_b.dimensions();
+            if dimensions != Dimensions::Empty {
+                intersection_matrix.set(CoordPos::Outside, CoordPos::Inside, dimensions);
+
+                let boundary_dimensions = geometry_b.boundary_dimensions();
+                if boundary_dimensions != Dimensions::Empty {
+                    intersection_matrix.set(
+                        CoordPos::Outside,
+                        CoordPos::OnBoundary,
+                        boundary_dimensions,
+                    );
+                }
+            }
+        }
+    }
+
+    fn update_intersection_matrix(
+        &self,
+        labeled_node_edges: Vec<(CoordNode<F>, LabeledEdgeEndBundleStar<F>)>,
+        intersection_matrix: &mut IntersectionMatrix,
+    ) {
+        debug!(
+            "before updated_intersection_matrix(isolated_edges): {:?}",
+            intersection_matrix
+        );
+        for isolated_edge in &self.isolated_edges {
+            let edge = isolated_edge.borrow();
+            Edge::<F>::update_intersection_matrix(edge.label(), intersection_matrix);
+            debug!(
+                "after updated_intersection_matrix(isolated_edge: {:?}, label: {:?}): {:?}",
+                edge,
+                edge.label(),
+                intersection_matrix
+            );
+        }
+
+        for (node, edges) in labeled_node_edges.iter() {
+            node.update_intersection_matrix(intersection_matrix);
+            edges.update_intersection_matrix(intersection_matrix);
+        }
+    }
+
+    /// Processes isolated edges by computing their labelling and adding them to the isolated edges
+    /// list.
+    ///
+    /// By definition, "isolated" edges are guaranteed not to touch the boundary of the target
+    /// (since if they did, they would have caused an intersection to be computed and hence would
+    /// not be isolated).
+    fn label_isolated_edges(&mut self, this_index: usize, target_index: usize) {
+        let (this_graph, target_graph) = if this_index == 0 {
+            (&self.graph_a, &self.graph_b)
+        } else {
+            (&self.graph_b, &self.graph_a)
+        };
+
+        for edge in this_graph.edges() {
+            let mut mut_edge = edge.borrow_mut();
+            if mut_edge.is_isolated() {
+                Self::label_isolated_edge(&mut mut_edge, target_index, target_graph.geometry());
+                self.isolated_edges.push(edge.clone());
+            }
+        }
+    }
+
+    /// Label an isolated edge of a graph with its relationship to the target geometry.
+    /// If the target has dim 2 or 1, the edge can either be in the interior or the exterior.
+    /// If the target has dim 0, the edge must be in the exterior
+    fn label_isolated_edge(edge: &mut Edge<F>, target_index: usize, target: &GeometryCow<F>) {
+        if target.dimensions() > Dimensions::ZeroDimensional {
+            // An isolated edge doesn't cross any boundary, so it's either wholly inside, or wholly
+            // outside of the geometry. As such, we can use any point from the edge to infer the
+            // position of the edge as a whole.
+            let coord = edge.coords().first().expect("can't create empty edge");
+            let position = target.coordinate_position(coord);
+            edge.label_mut().set_all_positions(target_index, position);
+        } else {
+            edge.label_mut()
+                .set_all_positions(target_index, CoordPos::Outside);
+        }
+    }
+
+    /// Isolated nodes are nodes whose labels are incomplete (e.g. the location for one Geometry is
+    /// null).  
+    /// This is the case because nodes in one graph which don't intersect nodes in the other
+    /// are not completely labeled by the initial process of adding nodes to the nodeList.  To
+    /// complete the labelling we need to check for nodes that lie in the interior of edges, and in
+    /// the interior of areas.
+    fn label_isolated_nodes(&mut self) {
+        let geometry_a = self.graph_a.geometry();
+        let geometry_b = self.graph_b.geometry();
+        for (node, _edges) in self.nodes.iter_mut() {
+            let label = node.label();
+            // isolated nodes should always have at least one geometry in their label
+            debug_assert!(label.geometry_count() > 0, "node with empty label found");
+            if node.is_isolated() {
+                if label.is_empty(0) {
+                    Self::label_isolated_node(node, 0, geometry_a)
+                } else {
+                    Self::label_isolated_node(node, 1, geometry_b)
+                }
+            }
+        }
+    }
+
+    fn label_isolated_node(
+        node: &mut CoordNode<F>,
+        target_index: usize,
+        geometry: &GeometryCow<F>,
+    ) {
+        let position = geometry.coordinate_position(node.coordinate());
+        node.label_mut().set_all_positions(target_index, position);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use geo_types::{polygon, Geometry};
+    use std::str::FromStr;
+
+    #[test]
+    fn test_disjoint() {
+        let square_a: Geometry<f64> = polygon![
+            (x: 0., y: 0.),
+            (x: 0., y: 20.),
+            (x: 20., y: 20.),
+            (x: 20., y: 0.),
+            (x: 0., y: 0.),
+        ]
+        .into();
+
+        let square_b: Geometry<f64> = polygon![
+            (x: 55., y: 55.),
+            (x: 50., y: 60.),
+            (x: 60., y: 60.),
+            (x: 60., y: 55.),
+            (x: 55., y: 55.),
+        ]
+        .into();
+
+        let gc1 = GeometryCow::from(&square_a);
+        let gc2 = GeometryCow::from(&square_b);
+        let mut relate_computer = RelateOperation::new(&gc1, &gc2);
+        let intersection_matrix = relate_computer.compute_intersection_matrix();
+        assert_eq!(
+            intersection_matrix,
+            IntersectionMatrix::from_str("FF2FF1212").unwrap()
+        );
+    }
+
+    #[test]
+    fn test_a_contains_b() {
+        let square_a: Geometry<f64> = polygon![
+            (x: 0., y: 0.),
+            (x: 0., y: 20.),
+            (x: 20., y: 20.),
+            (x: 20., y: 0.),
+            (x: 0., y: 0.),
+        ]
+        .into();
+
+        let square_b: Geometry<f64> = polygon![
+            (x: 5., y: 5.),
+            (x: 5., y: 10.),
+            (x: 10., y: 10.),
+            (x: 10., y: 5.),
+            (x: 5., y: 5.),
+        ]
+        .into();
+
+        let gca = GeometryCow::from(&square_a);
+        let gcb = GeometryCow::from(&square_b);
+        let mut relate_computer = RelateOperation::new(&gca, &gcb);
+        let intersection_matrix = relate_computer.compute_intersection_matrix();
+        assert_eq!(
+            intersection_matrix,
+            IntersectionMatrix::from_str("212FF1FF2").unwrap()
+        );
+    }
+
+    #[test]
+    fn test_a_overlaps_b() {
+        let square_a: Geometry<f64> = polygon![
+            (x: 0., y: 0.),
+            (x: 0., y: 20.),
+            (x: 20., y: 20.),
+            (x: 20., y: 0.),
+            (x: 0., y: 0.),
+        ]
+        .into();
+
+        let square_b: Geometry<f64> = polygon![
+            (x: 5., y: 5.),
+            (x: 5., y: 30.),
+            (x: 30., y: 30.),
+            (x: 30., y: 5.),
+            (x: 5., y: 5.),
+        ]
+        .into();
+
+        let gca = &GeometryCow::from(&square_a);
+        let gcb = &GeometryCow::from(&square_b);
+        let mut relate_computer = RelateOperation::new(gca, gcb);
+        let intersection_matrix = relate_computer.compute_intersection_matrix();
+        assert_eq!(
+            intersection_matrix,
+            IntersectionMatrix::from_str("212101212").unwrap()
+        );
+    }
+}

--- a/geo/src/geometry_cow.rs
+++ b/geo/src/geometry_cow.rs
@@ -1,0 +1,105 @@
+use crate::{
+    CoordNum, Geometry, GeometryCollection, Line, LineString, MultiLineString, MultiPoint,
+    MultiPolygon, Point, Polygon, Rect, Triangle,
+};
+use std::borrow::Cow;
+
+/// A `GeometryCow` is a "one of" enum, just like [`Geometry`], except it is possible for the inner
+/// type of a `GeometryCow` to be a reference rather than owned.
+///
+/// This is a way to "upgrade" an inner type to something like a `Geometry` without `moving` it.
+///
+/// As an example, see the [`Relate`] trait which uses `GeometryCow`.
+#[derive(PartialEq, Debug, Hash)]
+pub(crate) enum GeometryCow<'a, T>
+where
+    T: CoordNum,
+{
+    Point(Cow<'a, Point<T>>),
+    Line(Cow<'a, Line<T>>),
+    LineString(Cow<'a, LineString<T>>),
+    Polygon(Cow<'a, Polygon<T>>),
+    MultiPoint(Cow<'a, MultiPoint<T>>),
+    MultiLineString(Cow<'a, MultiLineString<T>>),
+    MultiPolygon(Cow<'a, MultiPolygon<T>>),
+    GeometryCollection(Cow<'a, GeometryCollection<T>>),
+    Rect(Cow<'a, Rect<T>>),
+    Triangle(Cow<'a, Triangle<T>>),
+}
+
+impl<'a, T: CoordNum> From<&'a Geometry<T>> for GeometryCow<'a, T> {
+    fn from(geometry: &'a Geometry<T>) -> Self {
+        match geometry {
+            Geometry::Point(g) => GeometryCow::Point(Cow::Borrowed(g)),
+            Geometry::Line(g) => GeometryCow::Line(Cow::Borrowed(g)),
+            Geometry::LineString(g) => GeometryCow::LineString(Cow::Borrowed(g)),
+            Geometry::Polygon(g) => GeometryCow::Polygon(Cow::Borrowed(g)),
+            Geometry::MultiPoint(g) => GeometryCow::MultiPoint(Cow::Borrowed(g)),
+            Geometry::MultiLineString(g) => GeometryCow::MultiLineString(Cow::Borrowed(g)),
+            Geometry::MultiPolygon(g) => GeometryCow::MultiPolygon(Cow::Borrowed(g)),
+            Geometry::GeometryCollection(g) => GeometryCow::GeometryCollection(Cow::Borrowed(g)),
+            Geometry::Rect(g) => GeometryCow::Rect(Cow::Borrowed(g)),
+            Geometry::Triangle(g) => GeometryCow::Triangle(Cow::Borrowed(g)),
+        }
+    }
+}
+
+impl<'a, T: CoordNum> From<&'a Point<T>> for GeometryCow<'a, T> {
+    fn from(point: &'a Point<T>) -> Self {
+        GeometryCow::Point(Cow::Borrowed(point))
+    }
+}
+
+impl<'a, T: CoordNum> From<&'a LineString<T>> for GeometryCow<'a, T> {
+    fn from(line_string: &'a LineString<T>) -> Self {
+        GeometryCow::LineString(Cow::Borrowed(line_string))
+    }
+}
+
+impl<'a, T: CoordNum> From<&'a Line<T>> for GeometryCow<'a, T> {
+    fn from(line: &'a Line<T>) -> Self {
+        GeometryCow::Line(Cow::Borrowed(line))
+    }
+}
+
+impl<'a, T: CoordNum> From<&'a Polygon<T>> for GeometryCow<'a, T> {
+    fn from(polygon: &'a Polygon<T>) -> Self {
+        GeometryCow::Polygon(Cow::Borrowed(polygon))
+    }
+}
+
+impl<'a, T: CoordNum> From<&'a MultiPoint<T>> for GeometryCow<'a, T> {
+    fn from(multi_point: &'a MultiPoint<T>) -> GeometryCow<'a, T> {
+        GeometryCow::MultiPoint(Cow::Borrowed(multi_point))
+    }
+}
+
+impl<'a, T: CoordNum> From<&'a MultiLineString<T>> for GeometryCow<'a, T> {
+    fn from(multi_line_string: &'a MultiLineString<T>) -> Self {
+        GeometryCow::MultiLineString(Cow::Borrowed(multi_line_string))
+    }
+}
+
+impl<'a, T: CoordNum> From<&'a MultiPolygon<T>> for GeometryCow<'a, T> {
+    fn from(multi_polygon: &'a MultiPolygon<T>) -> Self {
+        GeometryCow::MultiPolygon(Cow::Borrowed(multi_polygon))
+    }
+}
+
+impl<'a, T: CoordNum> From<&'a GeometryCollection<T>> for GeometryCow<'a, T> {
+    fn from(geometry_collection: &'a GeometryCollection<T>) -> Self {
+        GeometryCow::GeometryCollection(Cow::Borrowed(geometry_collection))
+    }
+}
+
+impl<'a, T: CoordNum> From<&'a Rect<T>> for GeometryCow<'a, T> {
+    fn from(rect: &'a Rect<T>) -> Self {
+        GeometryCow::Rect(Cow::Borrowed(rect))
+    }
+}
+
+impl<'a, T: CoordNum> From<&'a Triangle<T>> for GeometryCow<'a, T> {
+    fn from(triangle: &'a Triangle<T>) -> Self {
+        GeometryCow::Triangle(Cow::Borrowed(triangle))
+    }
+}

--- a/geo/src/lib.rs
+++ b/geo/src/lib.rs
@@ -86,6 +86,8 @@
 //!   another geometry
 //! - **[`line_intersection`](algorithm::line_intersection::line_intersection)**: Calculates the
 //!   intersection, if any, between two lines.
+//! - **[`Relate`](algorithm::relate::Relate)**: Topologically relate two geometries based on
+//!   [DE-9IM](https://en.wikipedia.org/wiki/DE-9IM) semantics.
 //!
 //! ## Winding
 //!
@@ -175,7 +177,7 @@ extern crate rstar;
 pub use crate::algorithm::*;
 #[allow(deprecated)]
 pub use crate::traits::ToGeo;
-pub use crate::types::*;
+pub use crate::types::Closest;
 
 pub use geo_types::{
     line_string, point, polygon, CoordFloat, CoordNum, Coordinate, Geometry, GeometryCollection,
@@ -184,13 +186,18 @@ pub use geo_types::{
 
 /// This module includes all the functions of geometric calculations
 pub mod algorithm;
+mod geometry_cow;
 mod traits;
 mod types;
 mod utils;
+pub(crate) use geometry_cow::GeometryCow;
 
 #[cfg(test)]
 #[macro_use]
 extern crate approx;
+
+#[macro_use]
+extern crate log;
 
 /// Mean radius of Earth in meters
 /// This is the value recommended by the IUGG:

--- a/geo/src/types.rs
+++ b/geo/src/types.rs
@@ -39,9 +39,8 @@ impl<F: GeoFloat> Closest<F> {
 
 /// Implements the common pattern where a Geometry enum simply delegates its trait impl to it's inner type.
 ///
-/// e.g.
 /// ```
-/// # use geo::{GeoNum, Polygon, Point, Coordinate, Line, Rect, Triangle, LineString, Geometry, MultiLineString, MultiPoint, MultiPolygon, GeometryCollection};
+/// # use geo::{GeoNum, Coordinate, Point, Line, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon, GeometryCollection, Rect, Triangle, Geometry};
 ///
 /// trait Foo<T: GeoNum> {
 ///     fn foo_1(&self, coord: Coordinate<T>)  -> bool;
@@ -51,43 +50,43 @@ impl<F: GeoFloat> Closest<F> {
 /// // Assuming we have an impl for all the inner types like this:
 /// impl<T: GeoNum> Foo<T> for Point<T> {
 ///     fn foo_1(&self, coord: Coordinate<T>)  -> bool { true }
-///     fn foo_2(&self)  -> i32 { 3 }
+///     fn foo_2(&self)  -> i32 { 1 }
+/// }
+/// impl<T: GeoNum> Foo<T> for Line<T> {
+///     fn foo_1(&self, coord: Coordinate<T>)  -> bool { false }
+///     fn foo_2(&self)  -> i32 { 2 }
 /// }
 /// impl<T: GeoNum> Foo<T> for LineString<T> {
 ///     fn foo_1(&self, coord: Coordinate<T>)  -> bool { true }
-///     fn foo_2(&self)  -> i32 { 9 }
+///     fn foo_2(&self)  -> i32 { 3 }
 /// }
-/// impl<T: GeoNum> Foo<T> for Line<T> {
+/// impl<T: GeoNum> Foo<T> for Polygon<T> {
+///     fn foo_1(&self, coord: Coordinate<T>)  -> bool { false }
+///     fn foo_2(&self)  -> i32 { 4 }
+/// }
+/// impl<T: GeoNum> Foo<T> for MultiPoint<T> {
 ///     fn foo_1(&self, coord: Coordinate<T>)  -> bool { true }
+///     fn foo_2(&self)  -> i32 { 5 }
+/// }
+/// impl<T: GeoNum> Foo<T> for MultiLineString<T> {
+///     fn foo_1(&self, coord: Coordinate<T>)  -> bool { false }
+///     fn foo_2(&self)  -> i32 { 6 }
+/// }
+/// impl<T: GeoNum> Foo<T> for MultiPolygon<T> {
+///     fn foo_1(&self, coord: Coordinate<T>)  -> bool { true }
+///     fn foo_2(&self)  -> i32 { 7 }
+/// }
+/// impl<T: GeoNum> Foo<T> for GeometryCollection<T> {
+///     fn foo_1(&self, coord: Coordinate<T>)  -> bool { false }
 ///     fn foo_2(&self)  -> i32 { 8 }
 /// }
 /// impl<T: GeoNum> Foo<T> for Rect<T> {
 ///     fn foo_1(&self, coord: Coordinate<T>)  -> bool { true }
-///     fn foo_2(&self)  -> i32 { 7 }
+///     fn foo_2(&self)  -> i32 { 9 }
 /// }
 /// impl<T: GeoNum> Foo<T> for Triangle<T> {
 ///     fn foo_1(&self, coord: Coordinate<T>)  -> bool { true }
-///     fn foo_2(&self)  -> i32 { 6 }
-/// }
-/// impl<T: GeoNum> Foo<T> for Polygon<T> {
-///     fn foo_1(&self, coord: Coordinate<T>)  -> bool { true }
-///     fn foo_2(&self)  -> i32 { 5 }
-/// }
-/// impl<T: GeoNum> Foo<T> for MultiPoint<T> {
-///     fn foo_1(&self, coord: Coordinate<T>)  -> bool { false }
-///     fn foo_2(&self)  -> i32 { 4 }
-/// }
-/// impl<T: GeoNum> Foo<T> for MultiPolygon<T> {
-///     fn foo_1(&self, coord: Coordinate<T>)  -> bool { false }
-///     fn foo_2(&self)  -> i32 { 3 }
-/// }
-/// impl<T: GeoNum> Foo<T> for GeometryCollection<T> {
-///     fn foo_1(&self, coord: Coordinate<T>)  -> bool { false }
-///     fn foo_2(&self)  -> i32 { 2 }
-/// }
-/// impl<T: GeoNum> Foo<T> for MultiLineString<T> {
-///     fn foo_1(&self, coord: Coordinate<T>)  -> bool { false }
-///     fn foo_2(&self)  -> i32 { 1 }
+///     fn foo_2(&self)  -> i32 { 10 }
 /// }
 ///
 /// // If we want the impl for Geometry to simply delegate to it's
@@ -98,7 +97,7 @@ impl<F: GeoFloat> Closest<F> {
 ///     //     match self {
 ///     //        Geometry::Point(g) => g.foo_1(coord),
 ///     //        Geometry::LineString(g) => g.foo_1(coord),
-///     //        _ => todo!("...etc for other cases")
+///     //        _ => unimplemented!("...etc for other cases")
 ///     //     }
 ///     // }
 ///     //
@@ -106,7 +105,7 @@ impl<F: GeoFloat> Closest<F> {
 ///     //     match self {
 ///     //        Geometry::Point(g) => g.foo_2(),
 ///     //        Geometry::LineString(g) => g.foo_2(),
-///     //        _ => todo!("...etc for other cases")
+///     //        _ => unimplemented!("...etc for other cases")
 ///     //     }
 ///     // }
 ///
@@ -119,7 +118,20 @@ impl<F: GeoFloat> Closest<F> {
 /// ```
 #[macro_export]
 macro_rules! geometry_delegate_impl {
+    ($($a:tt)*) => { $crate::__geometry_delegate_impl_helper!{ Geometry, $($a)* } }
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! geometry_cow_delegate_impl {
+    ($($a:tt)*) => { $crate::__geometry_delegate_impl_helper!{ GeometryCow, $($a)* } }
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __geometry_delegate_impl_helper {
     (
+        $enum:ident,
         $(
             $(#[$outer:meta])*
             fn $func_name: ident(&$($self_life:lifetime)?self $(, $arg_name: ident: $arg_type: ty)*) -> $return: ty;
@@ -129,16 +141,16 @@ macro_rules! geometry_delegate_impl {
                 $(#[$outer])*
                 fn $func_name(&$($self_life)? self, $($arg_name: $arg_type),*) -> $return {
                     match self {
-                        Geometry::Point(g) => g.$func_name($($arg_name),*).into(),
-                        Geometry::Line(g) =>  g.$func_name($($arg_name),*).into(),
-                        Geometry::LineString(g) => g.$func_name($($arg_name),*).into(),
-                        Geometry::Polygon(g) => g.$func_name($($arg_name),*).into(),
-                        Geometry::MultiPoint(g) => g.$func_name($($arg_name),*).into(),
-                        Geometry::MultiLineString(g) => g.$func_name($($arg_name),*).into(),
-                        Geometry::MultiPolygon(g) => g.$func_name($($arg_name),*).into(),
-                        Geometry::GeometryCollection(g) => g.$func_name($($arg_name),*).into(),
-                        Geometry::Rect(g) => g.$func_name($($arg_name),*).into(),
-                        Geometry::Triangle(g) => g.$func_name($($arg_name),*).into(),
+                        $enum::Point(g) => g.$func_name($($arg_name),*).into(),
+                        $enum::Line(g) =>  g.$func_name($($arg_name),*).into(),
+                        $enum::LineString(g) => g.$func_name($($arg_name),*).into(),
+                        $enum::Polygon(g) => g.$func_name($($arg_name),*).into(),
+                        $enum::MultiPoint(g) => g.$func_name($($arg_name),*).into(),
+                        $enum::MultiLineString(g) => g.$func_name($($arg_name),*).into(),
+                        $enum::MultiPolygon(g) => g.$func_name($($arg_name),*).into(),
+                        $enum::GeometryCollection(g) => g.$func_name($($arg_name),*).into(),
+                        $enum::Rect(g) => g.$func_name($($arg_name),*).into(),
+                        $enum::Triangle(g) => g.$func_name($($arg_name),*).into(),
                     }
                 }
             )+

--- a/geo/tests/jts_tests.rs
+++ b/geo/tests/jts_tests.rs
@@ -1,36 +1,17 @@
 use jts_test_runner::TestRunner;
 
-#[test]
-fn test_centroid() {
-    let mut runner = TestRunner::new().matching_filename_glob("*Centroid.xml");
-    runner.run().expect("test cases failed");
-
-    // sanity check that *something* was run
-    assert!(
-        runner.failures().len() + runner.successes().len() > 0,
-        "No tests were run."
-    );
-
-    if !runner.failures().is_empty() {
-        let failure_text = runner
-            .failures()
-            .iter()
-            .map(|failure| format!("{}", failure))
-            .collect::<Vec<String>>()
-            .join("\n");
-        panic!(
-            "{} failures / {} successes in JTS test suite:\n{}",
-            runner.failures().len(),
-            runner.successes().len(),
-            failure_text
-        );
-    }
+fn init_logging() {
+    use std::sync::Once;
+    static LOG_SETUP: Once = Once::new();
+    LOG_SETUP.call_once(|| {
+        pretty_env_logger::init();
+    });
 }
 
 #[test]
-// several of the ConvexHull tests are currently failing
-#[ignore]
 fn test_all_general() {
+    init_logging();
+
     let mut runner = TestRunner::new();
     runner.run().expect("test cases failed");
 
@@ -40,7 +21,12 @@ fn test_all_general() {
         "No tests were run."
     );
 
-    if !runner.failures().is_empty() {
+    if runner.failures().is_empty() {
+        log::info!(
+            "All {} cases succeeded in JTS test suite.",
+            runner.successes().len()
+        );
+    } else {
         let failure_text = runner
             .failures()
             .iter()


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Fixes #513, #515

(I'm sorry it's so large)

~~I'm going to leave it as a draft (edit: 🤦 I failed to actually open the PR as a draft) while I wait to merge #636 and #638 and then do some rebasing, but I don't anticipate doing other large changes before review.~~ *update: ready for review!*

Here's some of the earlier work in pursuit of this:

#514
#516
#523
#524 
#538
#552
#561
#611
#628
#629
#636 

Primarily, this introduces the geomgraph module for a DE-9IM `Relate` trait.

geomgraph implements a topology graph largely inspired by JTS's module of the same name:
https://github.com/locationtech/jts/tree/jts-1.18.1/modules/core/src/main/java/org/locationtech/jts/geomgraph

You can see some of the reference code if you omit the "REMOVE JTS COMMENTS" commit. In some places the implementation is quite close to the JTS source. 

The overall "flow" is pretty similar to that of JTS, but in the small, there were some divergences. It's not easy (or desirable) to literally translate a Java codebase making heavy use of inheritance and pointers to rust. Additionally, I chose to take advantage of `Option` and rust's enums with associated data to make some case analysis more explicit.

There is a corresponding PR in our [jts-test-runner](https://github.com/georust/jts-test-runner/pull/6) crate which includes the bulk of the tests for the new Relate trait.

## Algorithm Overview 

This functionality is accessed on geometries, via the `Relate` trait, e.g. `line.relate(point)` which returns a DE-9IM [`IntersectionMatrix`](https://en.wikipedia.org/wiki/DE-9IM#Matrix_model).

The `Relate` trait is driven by the `RelateOperation`. The `RelateOperation` builds a `GeometryGraph` for each of the two geometries being related. 

A `GeometryGraph` is a systematic way to organize the "interesting" parts of a geometry's structure - e.g. where its vertices, lines, and areas lie relative to one another.

Once the `RelateOperation` has built the two `GeometryGraph`s, it uses them to efficiently compare the two Geometries's structures, outputting the `IntesectionMatrix`.



