### PR TITLE
Gracefully handle rotation of empty linestring and polygon

### DIFF
--- a/geo/src/algorithm/rotate.rs
+++ b/geo/src/algorithm/rotate.rs
@@ -164,7 +164,16 @@ where
     fn rotate(&self, angle: T) -> Self {
         match self.centroid() {
             Some(centroid) => rotate_many(angle, centroid, self.points_iter()).collect(),
-            None => self.clone(),
+            None => {
+                // LineString was empty and had no computable centroid
+                let points = self.clone().into_points();
+                debug_assert!(
+                    points.len() == 0,
+                    "Expected `None` centroid to only occur for an empty LineString, but this LineString has {} points", 
+                    points.len()
+                );
+                self.clone()
+            }
         }
     }
 }

--- a/geo/src/algorithm/rotate.rs
+++ b/geo/src/algorithm/rotate.rs
@@ -165,13 +165,7 @@ where
         match self.centroid() {
             Some(centroid) => rotate_many(angle, centroid, self.points_iter()).collect(),
             None => {
-                // LineString was empty and had no computable centroid
-                let points = self.clone().into_points();
-                debug_assert!(
-                    points.len() == 0,
-                    "Expected `None` centroid to only occur for an empty LineString, but this LineString has {} points", 
-                    points.len()
-                );
+                // LineString was empty or otherwise degenerate and had no computable centroid
                 self.clone()
             }
         }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Resolves #652 
