### PR TITLE
Add Into implementation for Coordinate and Point

### DIFF
--- a/geo-types/src/coordinate.rs
+++ b/geo-types/src/coordinate.rs
@@ -69,6 +69,18 @@ impl<T: CoordNum> From<Point<T>> for Coordinate<T> {
     }
 }
 
+impl<T: CoordNum> From<Coordinate<T>> for (T, T) {
+    fn from(coord: Coordinate<T>) -> Self {
+        (coord.x, coord.y)
+    }
+}
+
+impl<T: CoordNum> From<Coordinate<T>> for [T; 2] {
+    fn from(coord: Coordinate<T>) -> Self {
+        [coord.x, coord.y]
+    }
+}
+
 impl<T> Coordinate<T>
 where
     T: CoordNum,

--- a/geo-types/src/point.rs
+++ b/geo-types/src/point.rs
@@ -50,6 +50,18 @@ impl<T: CoordNum> From<[T; 2]> for Point<T> {
     }
 }
 
+impl<T: CoordNum> From<Point<T>> for (T, T) {
+    fn from(point: Point<T>) -> Self {
+        point.0.into()
+    }
+}
+
+impl<T: CoordNum> From<Point<T>> for [T; 2] {
+    fn from(point: Point<T>) -> Self {
+        point.0.into()
+    }
+}
+
 impl<T> Point<T>
 where
     T: CoordNum,


### PR DESCRIPTION
This PR adds two implementations of the `Into` trait for `Coordinate` and `Point`.

As these structs can already be constructed from tuples and arrays it is expected that they can also be converted back.

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.

