### PR TITLE
cargo: bump rstar dependency

### DIFF
--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+
+## Unreleased
+
+* Bump `rstar` dependency
+
 ## 0.7.2
 
 * Implement `RelativeEq` and `AbsDiffEq` for fuzzy comparison of remaining Geometry Types

--- a/geo-types/Cargo.toml
+++ b/geo-types/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1", optional = true, features = ["derive"] }
 # Prefer `use-rstar` feature rather than enabling rstar directly.
 # rstar integration relies on the optional approx crate, but implicit features cannot yet enable other features.
 # See: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#namespaced-features
-rstar = { version = "0.8", optional = true }
+rstar = { version = "0.9", optional = true }
 
 [dev-dependencies]
 approx = "0.4.0"

--- a/geo-types/src/coordinate.rs
+++ b/geo-types/src/coordinate.rs
@@ -309,7 +309,7 @@ where
 
     const DIMENSIONS: usize = 2;
 
-    fn generate(generator: impl Fn(usize) -> Self::Scalar) -> Self {
+    fn generate(mut generator: impl FnMut(usize) -> Self::Scalar) -> Self {
         Coordinate {
             x: generator(0),
             y: generator(1),

--- a/geo-types/src/point.rs
+++ b/geo-types/src/point.rs
@@ -486,7 +486,7 @@ where
 
     const DIMENSIONS: usize = 2;
 
-    fn generate(generator: impl Fn(usize) -> Self::Scalar) -> Self {
+    fn generate(mut generator: impl FnMut(usize) -> Self::Scalar) -> Self {
         Point::new(generator(0), generator(1))
     }
 

--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Bump `rstar` dependency
 * Add `ChaikinSmoothing` algorithm
 * Fix `rotate` for multipolygons to rotate around the collection's centroid, instead of rotating each individual polygon around its own centroid.
   * <https://github.com/georust/geo/pull/651>

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -17,7 +17,7 @@ travis-ci = { repository = "georust/geo" }
 [dependencies]
 num-traits = "0.2"
 serde = { version = "1.0", optional = true, features = ["derive"] }
-rstar = { version = "0.8" }
+rstar = { version = "0.9" }
 geographiclib-rs = { version = "0.2" }
 log = "0.4.11"
 


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Hey 👋 
A small PR  to update rstar and fix the possible conflit between geo-types definitions.

```rust
// Cargo.toml
// ...
// geo = "0.18"
// geo-types = { version = "0.7", features = ["use-rstar"] }
// rstar = "0.9"

impl From<XXX> for AABB<geo::Point<f32>> {
                   ^^^^^^^^^^^^^^^^^^^ the trait `rstar::Point` is not implemented for `geo::Point<f32>`
        ....
}
```
