### PR TITLE
Minor: corrected "types".

### DIFF
--- a/geo/src/algorithm/kernels/simple.rs
+++ b/geo/src/algorithm/kernels/simple.rs
@@ -3,7 +3,7 @@ use crate::CoordNum;
 
 /// Simple kernel provides the direct implementation of the
 /// predicates. These are meant to be used with exact
-/// arithmetic signed tpyes (eg. i32, i64).
+/// arithmetic signed types (eg. i32, i64).
 #[derive(Default, Debug)]
 pub struct SimpleKernel;
 


### PR DESCRIPTION
typo in documentation.

