### PR TITLE
Clippy: Simplify Duplicated code block.

### DIFF
--- a/geo/src/algorithm/polygon_distance_fast_path.rs
+++ b/geo/src/algorithm/polygon_distance_fast_path.rs
@@ -369,10 +369,10 @@ where
     let perpunit = unitpvector(p, punit);
     let mut obtuse = false;
     let left = leftturn(p, perpunit, Point(pnext));
+    if left == 0 {
+        obtuse = true;
+    }
     if clockwise {
-        if left == 0 {
-            obtuse = true;
-        }
         if left == -1 {
             angle = T::PI() / (T::one() + T::one());
         } else if !obtuse {
@@ -380,18 +380,14 @@ where
         } else {
             angle = T::PI() - (-sine).asin();
         }
+    } else if left == -1 {
+        angle = T::PI() / (T::one() + T::one());
+    } else if !obtuse {
+        angle = sine.asin();
     } else {
-        if left == 0 {
-            obtuse = true;
-        }
-        if left == -1 {
-            angle = T::PI() / (T::one() + T::one());
-        } else if !obtuse {
-            angle = sine.asin();
-        } else {
-            angle = T::PI() - sine.asin();
-        }
+        angle = T::PI() - sine.asin();
     }
+
     angle
 }
 


### PR DESCRIPTION
- [x ] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
---

Just clearing 2 clippy lint warnings. 

A) This conditional 

```
-        if left == 0 {
-            obtuse = true;
-        }

```

is considered duplicate code 

B) the remaining if statement can be simplified.
