### PR TITLE
New Feature "use-approx".

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* New Feaure 'use-approx' exports the implementation of the traits AbsDiffEq and RelativeEq
+  for various geometry types, for use in third party crates.
 * Add `ChaikinSmoothing` algorithm
 * Fix `rotate` for multipolygons to rotate around the collection's centroid, instead of rotating each individual polygon around its own centroid.
   * <https://github.com/georust/geo/pull/651>

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -18,6 +18,7 @@ travis-ci = { repository = "georust/geo" }
 num-traits = "0.2"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 rstar = { version = "0.8" }
+approx = { version = "0.4.0", optional= true }
 geographiclib-rs = { version = "0.2" }
 log = "0.4.11"
 
@@ -28,6 +29,7 @@ geo-types = { version = "0.7.2", features = ["approx", "use-rstar"] }
 robust = { version = "0.2.2" }
 
 [features]
+use-approx = ["approx"]
 use-proj = ["proj"]
 proj-network = ["use-proj", "proj/network"]
 use-serde = ["serde", "geo-types/serde"]


### PR DESCRIPTION
- [x ] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Exports various implementations of the traits "AbsDiffEq" and "RelativeEq" which were previously only visible in test build, so they can also be used in production code.

