### PR TITLE
ClosestPoint for Triangle, Rect, GeometryCollection types & Geometry enum

### DIFF
--- a/geo-types/src/rect.rs
+++ b/geo-types/src/rect.rs
@@ -1,4 +1,4 @@
-use crate::{polygon, CoordFloat, CoordNum, Coordinate, Polygon};
+use crate::{polygon, CoordFloat, CoordNum, Coordinate, Polygon, Line};
 
 #[cfg(any(feature = "approx", test))]
 use approx::{AbsDiffEq, RelativeEq};
@@ -224,6 +224,51 @@ impl<T: CoordNum> Rect<T> {
             (x: self.max.x, y: self.max.y),
             (x: self.max.x, y: self.min.y),
             (x: self.min.x, y: self.min.y),
+        ]
+    }
+
+    pub fn to_lines(&self) -> [Line<T>; 4] {
+        [
+            Line::new(
+                Coordinate {
+                    x: self.min.x,
+                    y: self.min.y,
+                },
+                Coordinate {
+                    x: self.min.x,
+                    y: self.max.y,
+                },
+            ),
+            Line::new(
+                Coordinate {
+                    x: self.min.x,
+                    y: self.max.y,
+                },
+                Coordinate {
+                    x: self.max.x,
+                    y: self.max.y,
+                },
+            ),
+            Line::new(
+                Coordinate {
+                    x: self.min.x,
+                    y: self.min.y,
+                },
+                Coordinate {
+                    x: self.max.x,
+                    y: self.min.y,
+                },
+            ),
+            Line::new(
+                Coordinate {
+                    x: self.max.x,
+                    y: self.min.y,
+                },
+                Coordinate {
+                    x: self.max.x,
+                    y: self.max.y,
+                },
+            ),
         ]
     }
 

--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -8,13 +8,10 @@
   * <https://github.com/georust/geo/pull/651>
 * Add KNearestConcaveHull algorithm
   * <https://github.com/georust/geo/pull/635>
-<<<<<<< HEAD
-* Implemented `ClosestPoint` method for types Triangle, Rect, GeometryCollection, Coordinate and the Geometry enum.
-  * <https://github.com/georust/geo/pull/675>
-=======
 * remove cargo-tarpaulin due to instability (#676, #677)
 * Fix: `ClosestPoint` for Polygon's handling of internal points
->>>>>>> b5d1a7f6b805ce12224390076fa338fb460e4632
+* Implemented `ClosestPoint` method for types Triangle, Rect, GeometryCollection, Coordinate and the Geometry enum.
+  * <https://github.com/georust/geo/pull/675>
 
 ## 0.18.0
 

--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -7,6 +7,8 @@
   * <https://github.com/georust/geo/pull/651>
 * Add KNearestConcaveHull algorithm
   * <https://github.com/georust/geo/pull/635>
+* Implemented `ClosestPoint` method for types Triangle, Rect, GeometryCollection, Coordinate and the Geometry enum.
+  * <https://github.com/georust/geo/pull/675>
 
 ## 0.18.0
 

--- a/geo/src/algorithm/closest_point.rs
+++ b/geo/src/algorithm/closest_point.rs
@@ -141,7 +141,7 @@ impl<F: GeoFloat> ClosestPoint<F> for Triangle<F> {
         if self.intersects(p) {
             return Closest::Intersection(*p);
         }
-        closest_of(self.to_lines(), *p)
+        closest_of(&self.to_lines(), *p)
     }
 }
 
@@ -150,7 +150,7 @@ impl<F: GeoFloat> ClosestPoint<F> for Rect<F> {
         if self.intersects(p) {
             return Closest::Intersection(*p);
         }
-        closest_of(self.to_lines(), *p)
+        closest_of(&self.to_lines(), *p)
     }
 }
 

--- a/geo/src/algorithm/closest_point.rs
+++ b/geo/src/algorithm/closest_point.rs
@@ -1,7 +1,8 @@
+use crate::coords_iter::CoordsIter;
 use crate::prelude::*;
 use crate::{
-    Closest, GeoFloat, Line, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon, 
-    Rect, Triangle, Geometry, GeometryCollection,
+    Closest, Coordinate, GeoFloat, Geometry, GeometryCollection, Line, LineString, MultiLineString,
+    MultiPoint, MultiPolygon, Point, Polygon, Rect, Triangle,
 };
 use std::iter;
 
@@ -122,15 +123,21 @@ impl<F: GeoFloat> ClosestPoint<F> for Polygon<F> {
     }
 }
 
+impl<F: GeoFloat> ClosestPoint<F> for Coordinate<F> {
+    fn closest_point(&self, p: &Point<F>) -> Closest<F> {
+        Point(*self).closest_point(p)
+    }
+}
+
 impl<F: GeoFloat> ClosestPoint<F> for Triangle<F> {
     fn closest_point(&self, p: &Point<F>) -> Closest<F> {
-        self.to_polygon().closest_point(p)
+        closest_of(self.coords_iter(), *p)
     }
 }
 
 impl<F: GeoFloat> ClosestPoint<F> for Rect<F> {
     fn closest_point(&self, p: &Point<F>) -> Closest<F> {
-        self.to_polygon().closest_point(p)
+        closest_of(self.coords_iter(), *p)
     }
 }
 

--- a/geo/src/algorithm/closest_point.rs
+++ b/geo/src/algorithm/closest_point.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
 use crate::{
-    Closest, GeoFloat, Line, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon,
+    Closest, GeoFloat, Line, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon, 
+    Rect, Triangle, Geometry, GeometryCollection,
 };
 use std::iter;
 
@@ -121,6 +122,18 @@ impl<F: GeoFloat> ClosestPoint<F> for Polygon<F> {
     }
 }
 
+impl<F: GeoFloat> ClosestPoint<F> for Triangle<F> {
+    fn closest_point(&self, p: &Point<F>) -> Closest<F> {
+        self.to_polygon().closest_point(p)
+    }
+}
+
+impl<F: GeoFloat> ClosestPoint<F> for Rect<F> {
+    fn closest_point(&self, p: &Point<F>) -> Closest<F> {
+        self.to_polygon().closest_point(p)
+    }
+}
+
 impl<F: GeoFloat> ClosestPoint<F> for MultiPolygon<F> {
     fn closest_point(&self, p: &Point<F>) -> Closest<F> {
         closest_of(self.iter(), *p)
@@ -136,6 +149,17 @@ impl<F: GeoFloat> ClosestPoint<F> for MultiPoint<F> {
 impl<F: GeoFloat> ClosestPoint<F> for MultiLineString<F> {
     fn closest_point(&self, p: &Point<F>) -> Closest<F> {
         closest_of(self.iter(), *p)
+    }
+}
+
+impl<F: GeoFloat> ClosestPoint<F> for GeometryCollection<F> {
+    fn closest_point(&self, p: &Point<F>) -> Closest<F> {
+        closest_of(self.iter(), *p)
+    }
+}
+impl<F: GeoFloat> ClosestPoint<F> for Geometry<F> {
+    crate::geometry_delegate_impl! {
+        fn closest_point(&self, p: &Point<F>) -> Closest<F>;
     }
 }
 

--- a/geo/src/algorithm/closest_point.rs
+++ b/geo/src/algorithm/closest_point.rs
@@ -138,13 +138,19 @@ impl<F: GeoFloat> ClosestPoint<F> for Coordinate<F> {
 
 impl<F: GeoFloat> ClosestPoint<F> for Triangle<F> {
     fn closest_point(&self, p: &Point<F>) -> Closest<F> {
-        closest_of(self.coords_iter(), *p)
+        if self.intersects(p) {
+            return Closest::Intersection(*p);
+        }
+        closest_of(self.to_lines(), *p)
     }
 }
 
 impl<F: GeoFloat> ClosestPoint<F> for Rect<F> {
     fn closest_point(&self, p: &Point<F>) -> Closest<F> {
-        closest_of(self.coords_iter(), *p)
+        if self.intersects(p) {
+            return Closest::Intersection(*p);
+        }
+        closest_of(self.to_lines(), *p)
     }
 }
 


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

This pull request addresses issue #544 
The ClosestPoint method was implemented for the remaining members of the `Geometry` enum ie., `Triangle, Rect and GeometryCollection` and then implemented for the enum itself.