### PR TITLE
Versioned feature to support rstar 0.9

### DIFF
--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## Unreleased
+
+* Support `rstar` version `0.9` in feature `use-rstar_0_9`
+  * <https://github.com/georust/geo/pull/682>
+
 ## 0.7.2
 
 * Implement `RelativeEq` and `AbsDiffEq` for fuzzy comparison of remaining Geometry Types

--- a/geo-types/Cargo.toml
+++ b/geo-types/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 
 [features]
 use-rstar = ["rstar", "approx"]
+use-rstar-0_9 = ["rstar_0_9", "approx"]
 
 [dependencies]
 approx = { version = "0.4.0", optional = true }
@@ -22,6 +23,7 @@ serde = { version = "1", optional = true, features = ["derive"] }
 # rstar integration relies on the optional approx crate, but implicit features cannot yet enable other features.
 # See: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#namespaced-features
 rstar = { version = "0.8", optional = true }
+rstar_0_9 = { package = "rstar", version = "0.9", optional = true }
 
 [dev-dependencies]
 approx = "0.4.0"

--- a/geo-types/Cargo.toml
+++ b/geo-types/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [features]
 use-rstar = ["rstar", "approx"]
-use-rstar-0_9 = ["rstar_0_9", "approx"]
+use-rstar_0_9 = ["rstar_0_9", "approx"]
 
 [dependencies]
 approx = { version = "0.4.0", optional = true }

--- a/geo-types/src/coordinate.rs
+++ b/geo-types/src/coordinate.rs
@@ -344,3 +344,36 @@ where
         }
     }
 }
+
+#[cfg(feature = "rstar_0_9")]
+impl<T> ::rstar_0_9::Point for Coordinate<T>
+where
+    T: ::num_traits::Float + ::rstar_0_9::RTreeNum,
+{
+    type Scalar = T;
+
+    const DIMENSIONS: usize = 2;
+
+    fn generate(mut generator: impl FnMut(usize) -> Self::Scalar) -> Self {
+        Coordinate {
+            x: generator(0),
+            y: generator(1),
+        }
+    }
+
+    fn nth(&self, index: usize) -> Self::Scalar {
+        match index {
+            0 => self.x,
+            1 => self.y,
+            _ => unreachable!(),
+        }
+    }
+
+    fn nth_mut(&mut self, index: usize) -> &mut Self::Scalar {
+        match index {
+            0 => &mut self.x,
+            1 => &mut self.y,
+            _ => unreachable!(),
+        }
+    }
+}

--- a/geo-types/src/lib.rs
+++ b/geo-types/src/lib.rs
@@ -37,7 +37,8 @@
 //! - `approx`: Allows geometry types to be checked for approximate equality with [approx]
 //! - `arbitrary`: Allows geometry types to be created from unstructured input with [arbitrary]
 //! - `serde`: Allows geometry types to be serialized and deserialized with [Serde]
-//! - `use-rstar`: Allows geometry types to be inserted into [rstar] R*-trees
+//! - `use-rstar`: Allows geometry types to be inserted into [rstar] R*-trees (`rstar v0.8`)
+//! - `use-rstar_0_9`: Allows geometry types to be inserted into [rstar] R*-trees (`rstar v0.9`)
 //!
 //! [approx]: https://github.com/brendanzab/approx
 //! [arbitrary]: https://github.com/rust-fuzz/arbitrary
@@ -214,6 +215,21 @@ mod tests {
     fn line_test() {
         use rstar::primitives::Line as RStarLine;
         use rstar::{PointDistance, RTreeObject};
+
+        let rl = RStarLine::new(Point::new(0.0, 0.0), Point::new(5.0, 5.0));
+        let l = Line::new(Coordinate { x: 0.0, y: 0.0 }, Coordinate { x: 5., y: 5. });
+        assert_eq!(rl.envelope(), l.envelope());
+        // difference in 15th decimal place
+        assert_relative_eq!(26.0, rl.distance_2(&Point::new(4.0, 10.0)));
+        assert_relative_eq!(25.999999999999996, l.distance_2(&Point::new(4.0, 10.0)));
+    }
+
+    #[cfg(feature = "rstar_0_9")]
+    #[test]
+    /// ensure Line's SpatialObject impl is correct
+    fn line_test_0_9() {
+        use rstar_0_9::primitives::Line as RStarLine;
+        use rstar_0_9::{PointDistance, RTreeObject};
 
         let rl = RStarLine::new(Point::new(0.0, 0.0), Point::new(5.0, 5.0));
         let l = Line::new(Coordinate { x: 0.0, y: 0.0 }, Coordinate { x: 5., y: 5. });

--- a/geo-types/src/line.rs
+++ b/geo-types/src/line.rs
@@ -227,29 +227,38 @@ impl<T: AbsDiffEq<Epsilon = T> + CoordNum> AbsDiffEq for Line<T> {
     }
 }
 
-#[cfg(feature = "rstar")]
-impl<T> ::rstar::RTreeObject for Line<T>
-where
-    T: ::num_traits::Float + ::rstar::RTreeNum,
-{
-    type Envelope = ::rstar::AABB<Point<T>>;
+macro_rules! impl_rstar_line {
+	  ($rstar:ident) => {
+        impl<T> ::$rstar::RTreeObject for Line<T>
+        where
+            T: ::num_traits::Float + ::$rstar::RTreeNum,
+        {
+            type Envelope = ::$rstar::AABB<Point<T>>;
 
-    fn envelope(&self) -> Self::Envelope {
-        let bounding_rect = crate::private_utils::line_bounding_rect(*self);
-        ::rstar::AABB::from_corners(bounding_rect.min().into(), bounding_rect.max().into())
-    }
+            fn envelope(&self) -> Self::Envelope {
+                let bounding_rect = crate::private_utils::line_bounding_rect(*self);
+                ::$rstar::AABB::from_corners(bounding_rect.min().into(), bounding_rect.max().into())
+            }
+        }
+
+        impl<T> ::$rstar::PointDistance for Line<T>
+        where
+            T: ::num_traits::Float + ::$rstar::RTreeNum,
+        {
+            fn distance_2(&self, point: &Point<T>) -> T {
+                let d = crate::private_utils::point_line_euclidean_distance(*point, *self);
+                d.powi(2)
+            }
+        }
+	  };
 }
 
 #[cfg(feature = "rstar")]
-impl<T> ::rstar::PointDistance for Line<T>
-where
-    T: ::num_traits::Float + ::rstar::RTreeNum,
-{
-    fn distance_2(&self, point: &Point<T>) -> T {
-        let d = crate::private_utils::point_line_euclidean_distance(*point, *self);
-        d.powi(2)
-    }
-}
+impl_rstar_line!(rstar);
+
+
+#[cfg(feature = "rstar_0_9")]
+impl_rstar_line!(rstar_0_9);
 
 #[cfg(test)]
 mod test {

--- a/geo-types/src/point.rs
+++ b/geo-types/src/point.rs
@@ -518,6 +518,35 @@ where
     }
 }
 
+#[cfg(feature = "rstar_0_9")]
+impl<T> ::rstar_0_9::Point for Point<T>
+where
+    T: ::num_traits::Float + ::rstar_0_9::RTreeNum,
+{
+    type Scalar = T;
+
+    const DIMENSIONS: usize = 2;
+
+    fn generate(mut generator: impl FnMut(usize) -> Self::Scalar) -> Self {
+        Point::new(generator(0), generator(1))
+    }
+
+    fn nth(&self, index: usize) -> Self::Scalar {
+        match index {
+            0 => self.0.x,
+            1 => self.0.y,
+            _ => unreachable!(),
+        }
+    }
+    fn nth_mut(&mut self, index: usize) -> &mut Self::Scalar {
+        match index {
+            0 => &mut self.0.x,
+            1 => &mut self.0.y,
+            _ => unreachable!(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Another approach to solve resolve #660 .  It seems this approach is not uncommon: eg. https://docs.rs/tokio-postgres/0.7.5/tokio_postgres/#features .  It does involve a bit of boiler-plate macros though :(
