### PR TITLE
Fixes the code example in the README file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,17 @@ let poly = polygon![
 // Calculate the polygon's convex hull
 let hull = poly.convex_hull();
 
-assert_eq!(hull.exterior(), line_string![
-    (x: 0.0, y: 0.0),
-    (x: 0.0, y: 4.0),
-    (x: 1.0, y: 4.0),
-    (x: 4.0, y: 1.0),
-    (x: 4.0, y: 0.0),
-    (x: 0.0, y: 0.0),
-]);
+assert_eq!(
+    hull.exterior(),
+    &line_string![
+        (x: 4.0, y: 0.0),
+        (x: 4.0, y: 1.0),
+        (x: 1.0, y: 4.0),
+        (x: 0.0, y: 4.0),
+        (x: 0.0, y: 0.0),
+        (x: 4.0, y: 0.0),
+    ]
+);
 ```
 
 ## Contributing


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

The code example in the README file does not compile. The problem is in the assertion 
```
can't compare `&geo::LineString<{float}>` with `geo::LineString<{float}>` the trait `PartialEq<geo::LineString<{float}>>` is not implemented for `&geo::LineString<{float}>`
```
To solve this issue, we could just borrow the right side.
Then, the assertion fails because the exterior of the convex hull has a different order.