### PR TITLE
Tidy benches

### DIFF
--- a/geo/benches/rotate.rs
+++ b/geo/benches/rotate.rs
@@ -13,7 +13,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         bencher.iter(|| {
             criterion::black_box(
-                criterion::black_box(&line_string).rotate(criterion::black_box(180.)),
+                criterion::black_box(&line_string).rotate_around_centroid(criterion::black_box(180.)),
             );
         });
     });
@@ -24,7 +24,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         bencher.iter(|| {
             criterion::black_box(
-                criterion::black_box(&line_string).rotate(criterion::black_box(180.)),
+                criterion::black_box(&line_string).rotate_around_centroid(criterion::black_box(180.)),
             );
         });
     });

--- a/geo/benches/simplify.rs
+++ b/geo/benches/simplify.rs
@@ -11,7 +11,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         let points = include!("../src/algorithm/test_fixtures/louisiana.rs");
         let ls: LineString<f32> = points.into();
         bencher.iter(|| {
-            criterion::black_box(criterion::black_box(&ls).simplify(criterion::black_box(&0.0005)));
+            criterion::black_box(criterion::black_box(&ls).simplify(criterion::black_box(&0.01)));
         });
     });
 
@@ -19,7 +19,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         let points = include!("../src/algorithm/test_fixtures/louisiana.rs");
         let ls: LineString<f64> = points.into();
         bencher.iter(|| {
-            criterion::black_box(criterion::black_box(&ls).simplify(criterion::black_box(&0.0005)));
+            criterion::black_box(criterion::black_box(&ls).simplify(criterion::black_box(&0.01)));
         });
     });
 }


### PR DESCRIPTION
- We don't use `rotate` anymore, so I've swapped it for `rotate_around_centroid` in the benchmark. Happy to switch it to `rotate_around_center` if people prefer.

- I've modified the `simplify` benchmarks so that they're more directly comparable with the `simplifyvw` benchmarks.

We're also left with a deprecation warning in `rotate`'s [test suite](https://github.com/georust/geo/blob/master/geo/src/algorithm/rotate.rs#L475) as we still use `rotate` there (even though we modified the test in 1d2c970fe), but swapping in either of the new methods causes a failure, so this will have to be re-written – do people have a preference?

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

