### PR TITLE
Fix `macro_use` and `unused_imports` cargo warnings 

### DIFF
--- a/geo-types/src/geometry.rs
+++ b/geo-types/src/geometry.rs
@@ -184,7 +184,6 @@ impl<T: CoordNum> Geometry<T> {
     }
 }
 
-#[macro_use]
 macro_rules! try_from_geometry_impl {
     ($($type: ident),+) => {
         $(

--- a/geo/src/algorithm/closest_point.rs
+++ b/geo/src/algorithm/closest_point.rs
@@ -1,4 +1,3 @@
-use crate::coords_iter::CoordsIter;
 use crate::prelude::*;
 use crate::{
     Closest, Coordinate, GeoFloat, Geometry, GeometryCollection, Line, LineString, MultiLineString,

--- a/geo/src/algorithm/intersects/mod.rs
+++ b/geo/src/algorithm/intersects/mod.rs
@@ -49,7 +49,6 @@ pub trait Intersects<Rhs = Self> {
 // when there is a blanket implementations (eg. Point from
 // Coordinate, MultiPoint from Point), we need to provide
 // the reverse (where Self is "simpler" than Rhs).
-#[macro_use]
 macro_rules! symmetric_intersects_impl {
     ($t:ty, $k:ty) => {
         impl<T> $crate::algorithm::intersects::Intersects<$k> for $t

--- a/geo/src/algorithm/kernels/mod.rs
+++ b/geo/src/algorithm/kernels/mod.rs
@@ -51,7 +51,6 @@ pub trait HasKernel: CoordNum {
 // `T` (first arg.) by assigning the second arg. It expects
 // the second arg. to be a type that takes one generic
 // parameter that is `T`.
-#[macro_use]
 macro_rules! has_kernel {
     ($t:ident, $k:ident) => {
         impl $crate::algorithm::kernels::HasKernel for $t {


### PR DESCRIPTION
These warnings are now gone:

```
callpraths_gmail_com@workstation:/mnt/data/source/geo$ cargo run --example concavehull-usage
warning: `#[macro_use]` only has an effect on `extern crate` and modules
   --> geo-types/src/geometry.rs:187:1
    |
187 | #[macro_use]
    | ^^^^^^^^^^^^
    |
    = note: `#[warn(unused_attributes)]` on by default

warning: `geo-types` (lib) generated 1 warning
warning: unused import: `crate::coords_iter::CoordsIter`
 --> geo/src/algorithm/closest_point.rs:1:5
  |
1 | use crate::coords_iter::CoordsIter;
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: `#[macro_use]` only has an effect on `extern crate` and modules
  --> geo/src/algorithm/kernels/mod.rs:54:1
   |
54 | #[macro_use]
   | ^^^^^^^^^^^^
   |
   = note: `#[warn(unused_attributes)]` on by default

warning: `#[macro_use]` only has an effect on `extern crate` and modules
  --> geo/src/algorithm/intersects/mod.rs:52:1
   |
52 | #[macro_use]
   | ^^^^^^^^^^^^

warning: `geo` (lib) generated 3 warnings
    Finished dev [unoptimized + debuginfo] target(s) in 0.08s
     Running `target/debug/examples/concavehull-usage`
```
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
  - *Not added* as I don't think this is a user visible change.
---

