### PR TITLE
Fixes several common cases of needless borrow.

### DIFF
--- a/geo-types/src/geometry_collection.rs
+++ b/geo-types/src/geometry_collection.rs
@@ -261,7 +261,7 @@ where
         }
 
         let mut mp_zipper = self.iter().zip(other.iter());
-        mp_zipper.all(|(lhs, rhs)| lhs.relative_eq(&rhs, epsilon, max_relative))
+        mp_zipper.all(|(lhs, rhs)| lhs.relative_eq(rhs, epsilon, max_relative))
     }
 }
 
@@ -298,6 +298,6 @@ where
         }
 
         let mut mp_zipper = self.into_iter().zip(other.into_iter());
-        mp_zipper.all(|(lhs, rhs)| lhs.abs_diff_eq(&rhs, epsilon))
+        mp_zipper.all(|(lhs, rhs)| lhs.abs_diff_eq(rhs, epsilon))
     }
 }

--- a/geo-types/src/multi_line_string.rs
+++ b/geo-types/src/multi_line_string.rs
@@ -148,7 +148,7 @@ where
         }
 
         let mut mp_zipper = self.iter().zip(other.iter());
-        mp_zipper.all(|(lhs, rhs)| lhs.relative_eq(&rhs, epsilon, max_relative))
+        mp_zipper.all(|(lhs, rhs)| lhs.relative_eq(rhs, epsilon, max_relative))
     }
 }
 
@@ -185,7 +185,7 @@ where
         }
 
         let mut mp_zipper = self.into_iter().zip(other.into_iter());
-        mp_zipper.all(|(lhs, rhs)| lhs.abs_diff_eq(&rhs, epsilon))
+        mp_zipper.all(|(lhs, rhs)| lhs.abs_diff_eq(rhs, epsilon))
     }
 }
 

--- a/geo-types/src/multi_point.rs
+++ b/geo-types/src/multi_point.rs
@@ -130,7 +130,7 @@ where
         }
 
         let mut mp_zipper = self.iter().zip(other.iter());
-        mp_zipper.all(|(lhs, rhs)| lhs.relative_eq(&rhs, epsilon, max_relative))
+        mp_zipper.all(|(lhs, rhs)| lhs.relative_eq(rhs, epsilon, max_relative))
     }
 }
 
@@ -167,7 +167,7 @@ where
         }
 
         let mut mp_zipper = self.into_iter().zip(other.into_iter());
-        mp_zipper.all(|(lhs, rhs)| lhs.abs_diff_eq(&rhs, epsilon))
+        mp_zipper.all(|(lhs, rhs)| lhs.abs_diff_eq(rhs, epsilon))
     }
 }
 

--- a/geo-types/src/multi_polygon.rs
+++ b/geo-types/src/multi_polygon.rs
@@ -123,7 +123,7 @@ where
         }
 
         let mut mp_zipper = self.iter().zip(other.iter());
-        mp_zipper.all(|(lhs, rhs)| lhs.relative_eq(&rhs, epsilon, max_relative))
+        mp_zipper.all(|(lhs, rhs)| lhs.relative_eq(rhs, epsilon, max_relative))
     }
 }
 
@@ -162,7 +162,7 @@ where
         }
 
         let mut mp_zipper = self.into_iter().zip(other.into_iter());
-        mp_zipper.all(|(lhs, rhs)| lhs.abs_diff_eq(&rhs, epsilon))
+        mp_zipper.all(|(lhs, rhs)| lhs.abs_diff_eq(rhs, epsilon))
     }
 }
 

--- a/geo-types/src/polygon.rs
+++ b/geo-types/src/polygon.rs
@@ -511,7 +511,7 @@ where
             return false;
         }
         let mut zipper = self.interiors.iter().zip(other.interiors.iter());
-        zipper.all(|(lhs, rhs)| lhs.relative_eq(&rhs, epsilon, max_relative))
+        zipper.all(|(lhs, rhs)| lhs.relative_eq(rhs, epsilon, max_relative))
     }
 }
 
@@ -546,6 +546,6 @@ impl<T: AbsDiffEq<Epsilon = T> + CoordNum> AbsDiffEq for Polygon<T> {
             return false;
         }
         let mut zipper = self.interiors.iter().zip(other.interiors.iter());
-        zipper.all(|(lhs, rhs)| lhs.abs_diff_eq(&rhs, epsilon))
+        zipper.all(|(lhs, rhs)| lhs.abs_diff_eq(rhs, epsilon))
     }
 }

--- a/geo/src/algorithm/convex_hull/qhull.rs
+++ b/geo/src/algorithm/convex_hull/qhull.rs
@@ -30,7 +30,7 @@ where
 
     use crate::utils::least_and_greatest_index;
     let (min, max) = {
-        let (min_idx, mut max_idx) = least_and_greatest_index(&points);
+        let (min_idx, mut max_idx) = least_and_greatest_index(points);
         let min = swap_remove_to_first(&mut points, min_idx);
 
         // Two special cases to consider:

--- a/geo/src/algorithm/euclidean_distance.rs
+++ b/geo/src/algorithm/euclidean_distance.rs
@@ -395,7 +395,7 @@ where
             }
             mindist
         } else {
-            nearest_neighbour_distance(self, &other.exterior())
+            nearest_neighbour_distance(self, other.exterior())
         }
     }
 }
@@ -465,7 +465,7 @@ where
             // check each ring distance, returning the minimum
             let mut mindist: T = Float::max_value();
             for ring in self.interiors() {
-                mindist = mindist.min(nearest_neighbour_distance(&poly2.exterior(), ring))
+                mindist = mindist.min(nearest_neighbour_distance(poly2.exterior(), ring))
             }
             return mindist;
         } else if !poly2.interiors().is_empty()
@@ -473,14 +473,14 @@ where
         {
             let mut mindist: T = Float::max_value();
             for ring in poly2.interiors() {
-                mindist = mindist.min(nearest_neighbour_distance(&self.exterior(), ring))
+                mindist = mindist.min(nearest_neighbour_distance(self.exterior(), ring))
             }
             return mindist;
         }
         use super::is_convex::IsConvex;
         if !poly2.exterior().is_convex() || !self.exterior().is_convex() {
             // fall back to R* nearest neighbour method
-            nearest_neighbour_distance(&self.exterior(), &poly2.exterior())
+            nearest_neighbour_distance(self.exterior(), poly2.exterior())
         } else {
             min_poly_dist(self, poly2)
         }
@@ -543,7 +543,7 @@ fn ring_contains_point<T>(poly: &Polygon<T>, p: Point<T>) -> bool
 where
     T: GeoNum,
 {
-    match coord_pos_relative_to_ring(p.0, &poly.exterior()) {
+    match coord_pos_relative_to_ring(p.0, poly.exterior()) {
         CoordPos::Inside => true,
         CoordPos::OnBoundary | CoordPos::Outside => false,
     }

--- a/geo/src/algorithm/haversine_intermediate.rs
+++ b/geo/src/algorithm/haversine_intermediate.rs
@@ -44,7 +44,7 @@ where
     T: CoordFloat + FromPrimitive,
 {
     fn haversine_intermediate(&self, other: &Point<T>, f: T) -> Point<T> {
-        let params = get_params(&self, &other);
+        let params = get_params(self, other);
         get_point(&params, f)
     }
 
@@ -54,7 +54,7 @@ where
         max_dist: T,
         include_ends: bool,
     ) -> Vec<Point<T>> {
-        let params = get_params(&self, &other);
+        let params = get_params(self, other);
         let HaversineParams { d, .. } = params;
 
         let total_distance = d * T::from(MEAN_EARTH_RADIUS).unwrap();

--- a/geo/src/algorithm/intersects/polygon.rs
+++ b/geo/src/algorithm/intersects/polygon.rs
@@ -10,7 +10,7 @@ where
     T: GeoNum,
 {
     fn intersects(&self, p: &Coordinate<T>) -> bool {
-        coord_pos_relative_to_ring(*p, &self.exterior()) != CoordPos::Outside
+        coord_pos_relative_to_ring(*p, self.exterior()) != CoordPos::Outside
             && self
                 .interiors()
                 .iter()

--- a/geo/src/algorithm/simplifyvw.rs
+++ b/geo/src/algorithm/simplifyvw.rs
@@ -232,13 +232,11 @@ where
     );
 
     // Simplify shell
-    rings.push(visvalingam_preserve(
-        geomtype, &exterior, epsilon, &mut tree,
-    ));
+    rings.push(visvalingam_preserve(geomtype, exterior, epsilon, &mut tree));
     // Simplify interior rings, if any
     if let Some(interior_rings) = interiors {
         for ring in interior_rings {
-            rings.push(visvalingam_preserve(geomtype, &ring, epsilon, &mut tree))
+            rings.push(visvalingam_preserve(geomtype, ring, epsilon, &mut tree))
         }
     }
     rings


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Fixes several _common_ cases of needless borrow suggested by `clippy`. This is a warning example

```
warning: this expression borrows a reference (`&point::Point<T>`) that is immediately dereferenced by the compiler
   --> geo-types/src/multi_point.rs:133:52
    |
133 |         mp_zipper.all(|(lhs, rhs)| lhs.relative_eq(&rhs, epsilon, max_relative))
    |                                                    ^^^^ help: change this to: `rhs`
    |
    = note: `#[warn(clippy::needless_borrow)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
```