### PR TITLE
Fixes more common cases of needless borrow.

### DIFF
--- a/geo/src/algorithm/euclidean_distance.rs
+++ b/geo/src/algorithm/euclidean_distance.rs
@@ -959,7 +959,7 @@ mod test {
             .collect::<Vec<_>>();
         let poly2 = Polygon::new(LineString::from(points2), vec![]);
         let dist = min_poly_dist(&poly1.convex_hull(), &poly2.convex_hull());
-        let dist2 = nearest_neighbour_distance(&poly1.exterior(), &poly2.exterior());
+        let dist2 = nearest_neighbour_distance(poly1.exterior(), poly2.exterior());
         assert_relative_eq!(dist, 21.0);
         assert_relative_eq!(dist2, 21.0);
     }
@@ -992,7 +992,7 @@ mod test {
             .collect::<Vec<_>>();
         let poly2 = Polygon::new(LineString::from(points2), vec![]);
         let dist = min_poly_dist(&poly1.convex_hull(), &poly2.convex_hull());
-        let dist2 = nearest_neighbour_distance(&poly1.exterior(), &poly2.exterior());
+        let dist2 = nearest_neighbour_distance(poly1.exterior(), poly2.exterior());
         assert_relative_eq!(dist, 29.274562336608895);
         assert_relative_eq!(dist2, 29.274562336608895);
     }
@@ -1025,7 +1025,7 @@ mod test {
             .collect::<Vec<_>>();
         let poly2 = Polygon::new(LineString::from(points2), vec![]);
         let dist = min_poly_dist(&poly1.convex_hull(), &poly2.convex_hull());
-        let dist2 = nearest_neighbour_distance(&poly1.exterior(), &poly2.exterior());
+        let dist2 = nearest_neighbour_distance(poly1.exterior(), poly2.exterior());
         assert_relative_eq!(dist, 12.0);
         assert_relative_eq!(dist2, 12.0);
     }

--- a/geo/src/algorithm/relate/geomgraph/edge_end.rs
+++ b/geo/src/algorithm/relate/geomgraph/edge_end.rs
@@ -154,7 +154,7 @@ mod test {
             fake_label.clone(),
         );
         assert_eq!(
-            edge_end_1.key().cmp(&edge_end_2.key()),
+            edge_end_1.key().cmp(edge_end_2.key()),
             std::cmp::Ordering::Equal
         );
 
@@ -165,11 +165,11 @@ mod test {
             fake_label.clone(),
         );
         assert_eq!(
-            edge_end_1.key().cmp(&edge_end_3.key()),
+            edge_end_1.key().cmp(edge_end_3.key()),
             std::cmp::Ordering::Less
         );
         assert_eq!(
-            edge_end_3.key().cmp(&edge_end_1.key()),
+            edge_end_3.key().cmp(edge_end_1.key()),
             std::cmp::Ordering::Greater
         );
     }

--- a/geo/src/algorithm/simplifyvw.rs
+++ b/geo/src/algorithm/simplifyvw.rs
@@ -746,7 +746,7 @@ mod test {
             min_points: 4,
             geomtype: GeomType::Line,
         };
-        let simplified = vwp_wrapper(&gt, &ls, None, &668.6);
+        let simplified = vwp_wrapper(gt, &ls, None, &668.6);
         // this is the correct, non-intersecting LineString
         let correct = vec![
             (10., 60.),
@@ -828,7 +828,7 @@ mod test {
             min_points: 4,
             geomtype: GeomType::Line,
         };
-        let simplified = vwp_wrapper(&gt, &points_ls.into(), None, &0.0005);
+        let simplified = vwp_wrapper(gt, &points_ls.into(), None, &0.0005);
         assert_eq!(simplified[0].len(), 3278);
     }
 


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

This is bad because it suggests that the receiver is borrowing the expression.