### PR TITLE
Removes wrong calls to `clone()` on Copy types.

### DIFF
--- a/geo-types/src/lib.rs
+++ b/geo-types/src/lib.rs
@@ -160,7 +160,7 @@ mod tests {
     #[test]
     fn convert_types() {
         let p: Point<f32> = Point::new(0., 0.);
-        let p1 = p.clone();
+        let p1 = p;
         let g: Geometry<f32> = p.into();
         let p2 = Point::try_from(g).unwrap();
         assert_eq!(p1, p2);

--- a/geo/src/algorithm/centroid.rs
+++ b/geo/src/algorithm/centroid.rs
@@ -845,7 +845,7 @@ mod test {
     #[test]
     fn degenerate_triangle_like_ring() {
         let triangle = Triangle(c(0., 0.), c(1., 1.), c(2., 2.));
-        let poly: Polygon<_> = triangle.clone().into();
+        let poly: Polygon<_> = triangle.into();
 
         let line = Line::new(c(0., 1.), c(1., 3.));
 
@@ -857,7 +857,7 @@ mod test {
     #[test]
     fn degenerate_rect_like_ring() {
         let rect = Rect::new(c(0., 0.), c(0., 4.));
-        let poly: Polygon<_> = rect.clone().into();
+        let poly: Polygon<_> = rect.into();
 
         let line = Line::new(c(0., 1.), c(1., 3.));
 

--- a/geo/src/algorithm/coords_iter.rs
+++ b/geo/src/algorithm/coords_iter.rs
@@ -684,7 +684,7 @@ mod test {
         expected_coords.append(&mut coords.clone());
         expected_coords.append(&mut coords);
 
-        let actual_coords = MultiPoint(vec![point.clone(), point.clone()])
+        let actual_coords = MultiPoint(vec![point, point])
             .coords_iter()
             .collect::<Vec<_>>();
 


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

The only reason Copy types implement Clone is for generics.