### PR TITLE
Bumps the two most recent Rust versions in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,8 +41,8 @@ jobs:
           # Minimum supported rust version (MSRV)
           - "georust/geo-ci:rust-1.51"
           # Two most recent releases - we omit older ones for expedient CI
-          - "georust/geo-ci:rust-1.55"
           - "georust/geo-ci:rust-1.56"
+          - "georust/geo-ci:rust-1.57"
     container:
       image: ${{ matrix.container_image }}
     steps:
@@ -67,8 +67,8 @@ jobs:
           # Minimum supported rust version (MSRV)
           - "georust/geo-ci:rust-1.51"
           # Two most recent releases - we omit older ones for expedient CI
-          - "georust/geo-ci:rust-1.55"
           - "georust/geo-ci:rust-1.56"
+          - "georust/geo-ci:rust-1.57"
     container:
       image: ${{ matrix.container_image }}
     steps:
@@ -94,8 +94,8 @@ jobs:
           # Minimum supported rust version (MSRV)
           - "georust/geo-ci:rust-1.51"
           # Two most recent releases - we omit older ones for expedient CI
-          - "georust/geo-ci:rust-1.55"
           - "georust/geo-ci:rust-1.56"
+          - "georust/geo-ci:rust-1.57"
     container:
       image: ${{ matrix.container_image }}
     steps:
@@ -115,7 +115,7 @@ jobs:
       matrix:
         container_image:
           # Fuzz only on latest
-          - "georust/geo-ci:rust-1.56"
+          - "georust/geo-ci:rust-1.57"
     container:
       image: ${{ matrix.container_image }}
     steps:


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Only bumps the two most recent Rust versions in the CI config. @michaelkirk, maybe it would be necessary to also increase the minimum supported Rust version?