### PR TITLE
Removes unnecessary call and improves readability.

### DIFF
--- a/geo/src/algorithm/convex_hull/mod.rs
+++ b/geo/src/algorithm/convex_hull/mod.rs
@@ -138,7 +138,7 @@ where
 // Utility function: swap idx to head(0th position), remove
 // head (modifies the slice), and return head as a reference
 fn swap_remove_to_first<'a, T>(slice: &mut &'a mut [T], idx: usize) -> &'a mut T {
-    let tmp = std::mem::replace(slice, &mut []);
+    let tmp = std::mem::take(slice);
     tmp.swap(0, idx);
     let (h, t) = tmp.split_first_mut().unwrap();
     *slice = t;

--- a/geo/src/algorithm/is_convex.rs
+++ b/geo/src/algorithm/is_convex.rs
@@ -189,13 +189,12 @@ where
 
     // Now we have a fixed orientation expected at the rest
     // of the coords. Loop to check everything matches it.
-    if ((i + 1)..n)
+    if !((i + 1)..n)
         .map(orientation_at)
-        .find(|&(_, orientation)| match orientation {
+        .any(|(_, orientation)| match orientation {
             Orientation::Collinear => !allow_collinear,
             orientation => orientation != first_non_collinear,
         })
-        .is_none()
     {
         Some(first_non_collinear)
     } else {

--- a/geo/src/algorithm/is_convex.rs
+++ b/geo/src/algorithm/is_convex.rs
@@ -189,12 +189,13 @@ where
 
     // Now we have a fixed orientation expected at the rest
     // of the coords. Loop to check everything matches it.
-    if !((i + 1)..n)
+    if ((i + 1)..n)
         .map(orientation_at)
-        .any(|(_, orientation)| match orientation {
+        .find(|&(_, orientation)| match orientation {
             Orientation::Collinear => !allow_collinear,
             orientation => orientation != first_non_collinear,
         })
+        .is_none()
     {
         Some(first_non_collinear)
     } else {

--- a/geo/src/algorithm/k_nearest_concave_hull.rs
+++ b/geo/src/algorithm/k_nearest_concave_hull.rs
@@ -338,7 +338,7 @@ mod tests {
             coord!(x: 1.0, y: 0.0),
         ];
 
-        let mut coords_mapped: Vec<&Coordinate<f32>> = coords.iter().map(|x| x).collect();
+        let mut coords_mapped: Vec<&Coordinate<f32>> = coords.iter().collect();
 
         let center = coord!(x: 0.0, y: 0.0);
         let prev_coord = coord!(x: 1.0, y: 1.0);


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

- Remove an unnecessary call to `map`.
- Use `std::mem::take` instead of `std::mem::replace` when the type `T` implements `Default`.
- Improve readability by using a negated `any` instead of `find` plus `is_none()`.
