### PR TITLE
Minor: Remove test_all_general() from code coverage report.

### DIFF
--- a/geo/tests/jts_tests.rs
+++ b/geo/tests/jts_tests.rs
@@ -9,6 +9,7 @@ fn init_logging() {
 }
 
 #[test]
+#[cfg(not(tarpaulin_include))]
 fn test_all_general() {
     init_logging();
 


### PR DESCRIPTION
- [ x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
---

I was using `cargo tarpaulin -o Html` to generate a code coverage webpage.

All looks good this is a well tested crate.
 
But I noticed the report painted the test function test_all_general() red  --- as having no coverage

This is a minor oversight .. test harnesses and test infrastructure should be excluded for the consideration.

