### PR TITLE
#702 Geometry Collection now supports serde.

### DIFF
--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -4,6 +4,8 @@
 
 * Support `rstar` version `0.9` in feature `use-rstar_0_9`
   * <https://github.com/georust/geo/pull/682>
+* Geometry and GeometryCollection now support serde.
+  * <https://github.com/georust/geo/pull/704>
 
 ## 0.7.2
 

--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -4,7 +4,7 @@
 
 * Support `rstar` version `0.9` in feature `use-rstar_0_9`
   * <https://github.com/georust/geo/pull/682>
-* Geometry and GeometryCollection now support serde.
+* `Geometry` and `GeometryCollection` now support serde.
   * <https://github.com/georust/geo/pull/704>
 
 ## 0.7.2

--- a/geo-types/src/geometry.rs
+++ b/geo-types/src/geometry.rs
@@ -25,6 +25,7 @@ use std::convert::TryFrom;
 /// ```
 ///
 #[derive(Eq, PartialEq, Clone, Debug, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Geometry<T>
 where
     T: CoordNum,

--- a/geo-types/src/geometry_collection.rs
+++ b/geo-types/src/geometry_collection.rs
@@ -70,6 +70,7 @@ use std::ops::{Index, IndexMut};
 /// ```
 ///
 #[derive(Eq, PartialEq, Clone, Debug, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct GeometryCollection<T>(pub Vec<Geometry<T>>)
 where
     T: CoordNum;


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).

Initial version ... I want to discuss ways to test this, from what I can see serde support is not tested for geometry primitives like point, or line_string.. so I don't know how to confirm this works for all users.

