### PR TITLE
More LineString iterators

### DIFF
--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -7,6 +7,9 @@
 * `Geometry` and `GeometryCollection` now support serde.
   * <https://github.com/georust/geo/pull/704>
 
+* add `Coordinate` iterators to LineString, regularise its iterator methods, and refactor its docs
+  * https://github.com/georust/geo/pull/705
+
 ## 0.7.2
 
 * Implement `RelativeEq` and `AbsDiffEq` for fuzzy comparison of remaining Geometry Types

--- a/geo-types/src/line_string.rs
+++ b/geo-types/src/line_string.rs
@@ -78,7 +78,7 @@ use std::ops::{Index, IndexMut};
 /// let line_string: LineString<f32> = coords_iter.collect();
 /// ```
 ///
-/// You can iterate over the coordinates in the `LineString`:
+/// You can iterate and loop over the coordinates in the `LineString`, yielding [Coordinate]s:
 ///
 /// ```
 /// use geo_types::{Coordinate, LineString};
@@ -87,6 +87,8 @@ use std::ops::{Index, IndexMut};
 ///     Coordinate { x: 0., y: 0. },
 ///     Coordinate { x: 10., y: 0. },
 /// ]);
+///
+/// line_string.iter().for_each(|coord| println!("Coordinate x = {}, y = {}", coord.x, coord.y));
 ///
 /// for coord in line_string {
 ///     println!("Coordinate x = {}, y = {}", coord.x, coord.y);
@@ -132,15 +134,47 @@ impl<'a, T: CoordNum> DoubleEndedIterator for PointsIter<'a, T> {
     }
 }
 
+/// A [Coordinate] iterator returned by the `iter` method over a [LineString]
+#[derive(Debug)]
+pub struct CoordinatesIter<'a, T: CoordNum + 'a>(::std::slice::Iter<'a, Coordinate<T>>);
+
+impl<'a, T: CoordNum> Iterator for CoordinatesIter<'a, T> {
+    type Item = &'a Coordinate<T>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+impl<'a, T: CoordNum> DoubleEndedIterator for CoordinatesIter<'a, T> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.0.next_back()
+    }
+}
+
 impl<T: CoordNum> LineString<T> {
     /// Return an iterator yielding the coordinates of a `LineString` as `Point`s
     pub fn points_iter(&self) -> PointsIter<T> {
         PointsIter(self.0.iter())
     }
 
+    /// Return an iterator yielding the members of a [LineString] as [Coordinate]s
+    pub fn iter(&self) -> CoordinatesIter<T> {
+        CoordinatesIter(self.0.iter())
+    }
+    /// Return an iterator yielding the coordinates of a [LineString] as mutable [Coordinate]s
+    pub fn iter_mut(&mut self) -> CoordinatesIter<T> {
+        CoordinatesIter(self.0.iter())
+    }
+
     /// Return the coordinates of a `LineString` as a `Vec` of `Point`s
     pub fn into_points(self) -> Vec<Point<T>> {
         self.0.into_iter().map(Point).collect()
+    }
+
+    /// Return the coordinates of a [LineString] as a `Vec` of [Coordinate]s
+    pub fn into_coordinates(self) -> Vec<Coordinate<T>> {
+        self.0.into_iter().collect()
     }
 
     /// Return an iterator yielding one `Line` for each line segment

--- a/geo-types/src/line_string.rs
+++ b/geo-types/src/line_string.rs
@@ -163,8 +163,8 @@ impl<T: CoordNum> LineString<T> {
     }
 
     /// Return an iterator yielding the members of a [LineString] as [Coordinate]s
-    pub fn iter(&self) -> CoordinatesIter<T> {
-        CoordinatesIter(self.0.iter())
+    pub fn iter(&self) -> impl Iterator<Item = &Coordinate<T>> {
+        self.0.iter()
     }
 
     /// Return an iterator yielding the coordinates of a [LineString] as mutable [Coordinate]s

--- a/geo-types/src/line_string.rs
+++ b/geo-types/src/line_string.rs
@@ -5,7 +5,7 @@ use crate::{CoordNum, Coordinate, Line, Point, Triangle};
 use std::iter::FromIterator;
 use std::ops::{Index, IndexMut};
 
-/// An ordered collection of two or more [`Coordinate`]s, representing a
+/// An ordered collection of two or more [Coordinate]s, representing a
 /// path between locations.
 ///
 /// # Semantics
@@ -25,9 +25,9 @@ use std::ops::{Index, IndexMut};
 ///
 /// A `LineString` is valid if it is either empty or
 /// contains 2 or more coordinates. Further, a closed
-/// `LineString` must not self intersect. Note that the
-/// validity is not enforced, and the operations and
-/// predicates are undefined on invalid linestrings.
+/// `LineString` must not self-intersect. Note that its
+/// validity is **not** enforced, and operations and
+/// predicates are **undefined** on invalid `LineString`s.
 ///
 /// # Examples
 ///
@@ -53,7 +53,7 @@ use std::ops::{Index, IndexMut};
 /// ];
 /// ```
 ///
-/// Converting a `Vec` of `Coordinate`-like things:
+/// Converting from a `Vec` of [Coordinate]-like things:
 ///
 /// ```
 /// use geo_types::LineString;
@@ -67,7 +67,7 @@ use std::ops::{Index, IndexMut};
 /// let line_string: LineString<f64> = vec![[0., 0.], [10., 0.]].into();
 /// ```
 //
-/// Or `collect`ing from a `Coordinate` iterator
+/// Or `collect`ing from a [Coordinate] iterator
 ///
 /// ```
 /// use geo_types::{Coordinate, LineString};
@@ -78,7 +78,7 @@ use std::ops::{Index, IndexMut};
 /// let line_string: LineString<f32> = coords_iter.collect();
 /// ```
 ///
-/// You can iterate and loop over the coordinates in the `LineString`, yielding [Coordinate]s:
+/// You can iterate and loop over the coordinates in the [LineString], yielding [Coordinate]s:
 ///
 /// ```
 /// use geo_types::{Coordinate, LineString};
@@ -90,12 +90,16 @@ use std::ops::{Index, IndexMut};
 ///
 /// line_string.iter().for_each(|coord| println!("Coordinate x = {}, y = {}", coord.x, coord.y));
 ///
+/// for coord in &line_string {
+///     println!("Coordinate x = {}, y = {}", coord.x, coord.y);
+/// }
+///
 /// for coord in line_string {
 ///     println!("Coordinate x = {}, y = {}", coord.x, coord.y);
 /// }
 /// ```
 ///
-/// You can also iterate over the coordinates in the `LineString` as `Point`s:
+/// You can also iterate over the coordinates in the [LineString] as [Point]s:
 ///
 /// ```
 /// use geo_types::{Coordinate, LineString};
@@ -116,7 +120,7 @@ pub struct LineString<T>(pub Vec<Coordinate<T>>)
 where
     T: CoordNum;
 
-/// A `Point` iterator returned by the `points_iter` method
+/// A [Point] iterator returned by the `points_iter` method
 #[derive(Debug)]
 pub struct PointsIter<'a, T: CoordNum + 'a>(::std::slice::Iter<'a, Coordinate<T>>);
 
@@ -134,7 +138,7 @@ impl<'a, T: CoordNum> DoubleEndedIterator for PointsIter<'a, T> {
     }
 }
 
-/// A [Coordinate] iterator returned by the `iter` method over a [LineString]
+/// A [Coordinate] iterator returned by the `iter` method on a [LineString]
 #[derive(Debug)]
 pub struct CoordinatesIter<'a, T: CoordNum + 'a>(::std::slice::Iter<'a, Coordinate<T>>);
 
@@ -153,7 +157,7 @@ impl<'a, T: CoordNum> DoubleEndedIterator for CoordinatesIter<'a, T> {
 }
 
 impl<T: CoordNum> LineString<T> {
-    /// Return an iterator yielding the coordinates of a `LineString` as `Point`s
+    /// Return an iterator yielding the coordinates of a [LineString] as [Point]s
     pub fn points_iter(&self) -> PointsIter<T> {
         PointsIter(self.0.iter())
     }
@@ -167,7 +171,7 @@ impl<T: CoordNum> LineString<T> {
         CoordinatesIter(self.0.iter())
     }
 
-    /// Return the coordinates of a `LineString` as a `Vec` of `Point`s
+    /// Return the coordinates of a [LineString] as a `Vec` of [Point]s
     pub fn into_points(self) -> Vec<Point<T>> {
         self.0.into_iter().map(Point).collect()
     }
@@ -177,8 +181,8 @@ impl<T: CoordNum> LineString<T> {
         self.0.into_iter().collect()
     }
 
-    /// Return an iterator yielding one `Line` for each line segment
-    /// in the `LineString`.
+    /// Return an iterator yielding one [Line] for each line segment
+    /// in the [LineString].
     ///
     /// # Examples
     ///
@@ -212,7 +216,7 @@ impl<T: CoordNum> LineString<T> {
         })
     }
 
-    /// An iterator which yields the coordinates of a `LineString` as `Triangle`s
+    /// An iterator which yields the coordinates of a [LineString] as [Triangle]s
     pub fn triangles(&'_ self) -> impl ExactSizeIterator + Iterator<Item = Triangle<T>> + '_ {
         self.0.windows(3).map(|w| {
             // slice::windows(N) is guaranteed to yield a slice with exactly N elements
@@ -226,7 +230,7 @@ impl<T: CoordNum> LineString<T> {
         })
     }
 
-    /// Close the `LineString`. Specifically, if the `LineString` has at least one coordinate, and
+    /// Close the [LineString]. Specifically, if the [LineString] has at least one coordinate, and
     /// the value of the first coordinate does not equal the value of the last coordinate, then a
     /// new coordinate is added to the end with the value of the first coordinate.
     pub fn close(&mut self) {
@@ -237,7 +241,7 @@ impl<T: CoordNum> LineString<T> {
         }
     }
 
-    /// Return the number of coordinates in the `LineString`.
+    /// Return the number of coordinates in the [LineString].
     ///
     /// # Examples
     ///
@@ -281,7 +285,7 @@ impl<T: CoordNum> LineString<T> {
     }
 }
 
-/// Turn a `Vec` of `Point`-like objects into a `LineString`.
+/// Turn a `Vec` of [Point]-like objects into a [LineString].
 impl<T: CoordNum, IC: Into<Coordinate<T>>> From<Vec<IC>> for LineString<T> {
     fn from(v: Vec<IC>) -> Self {
         LineString(v.into_iter().map(|c| c.into()).collect())
@@ -294,14 +298,14 @@ impl<T: CoordNum> From<Line<T>> for LineString<T> {
     }
 }
 
-/// Turn an iterator of `Point`-like objects into a `LineString`.
+/// Turn an iterator of [Point]-like objects into a [LineString].
 impl<T: CoordNum, IC: Into<Coordinate<T>>> FromIterator<IC> for LineString<T> {
     fn from_iter<I: IntoIterator<Item = IC>>(iter: I) -> Self {
         LineString(iter.into_iter().map(|c| c.into()).collect())
     }
 }
 
-/// Iterate over all the [Coordinate](struct.Coordinates.html)s in this `LineString`.
+/// Iterate over all the [Coordinate](struct.Coordinates.html)s in this [LineString].
 impl<T: CoordNum> IntoIterator for LineString<T> {
     type Item = Coordinate<T>;
     type IntoIter = ::std::vec::IntoIter<Coordinate<T>>;

--- a/geo-types/src/line_string.rs
+++ b/geo-types/src/line_string.rs
@@ -311,7 +311,16 @@ impl<T: CoordNum> IntoIterator for LineString<T> {
     }
 }
 
-/// Mutably iterate over all the [Coordinate](struct.Coordinates.html)s in this `LineString`.
+impl<'a, T: CoordNum> IntoIterator for &'a LineString<T> {
+    type Item = &'a Coordinate<T>;
+    type IntoIter = CoordinatesIter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        CoordinatesIter(self.0.iter())
+    }
+}
+
+/// Mutably iterate over all the [Coordinate](struct.Coordinates.html)s in this [LineString].
 impl<'a, T: CoordNum> IntoIterator for &'a mut LineString<T> {
     type Item = &'a mut Coordinate<T>;
     type IntoIter = ::std::slice::IterMut<'a, Coordinate<T>>;

--- a/geo-types/src/line_string.rs
+++ b/geo-types/src/line_string.rs
@@ -5,7 +5,7 @@ use crate::{CoordNum, Coordinate, Line, Point, Triangle};
 use std::iter::FromIterator;
 use std::ops::{Index, IndexMut};
 
-/// An ordered collection of two or more [Coordinate]s, representing a
+/// An ordered collection of two or more [`Coordinate`]s, representing a
 /// path between locations.
 ///
 /// # Semantics

--- a/geo-types/src/line_string.rs
+++ b/geo-types/src/line_string.rs
@@ -10,22 +10,20 @@ use std::ops::{Index, IndexMut};
 ///
 /// # Semantics
 ///
-/// A [`LineString`] is _closed_ if it is empty, or if the
-/// first and last coordinates are the same. The _boundary_
-/// of a [`LineString`] is empty if closed, and otherwise the
-/// end points. The _interior_ is the (infinite) set of all
-/// points along the linestring _not including_ the
-/// boundary. A [`LineString`] is _simple_ if it does not
-/// intersect except possibly at the first and last
-/// coordinates. A simple and closed [`LineString`] is a
-/// `LinearRing` as defined in the OGC-SFA (but is not a
-/// separate type here).
+/// 1. A [`LineString`] is _closed_ if it is empty, **or** if the first and last coordinates are the same.
+/// 2. The _boundary_ of a [`LineString`] is either:
+///     - **empty** if it is closed **or**
+///     - contains the **start** and **end** coordinates.
+/// 3. The _interior_ is the (infinite) set of all coordinates along the [`LineString`], _not including_ the boundary.
+/// 4. A [`LineString`] is _simple_ if it does not intersect except **optionally** at the first and last coordinates (in which case it is also _closed_, see **1**).
+/// 5. A _simple_ **and** _closed_ [`LineString`] is a `LinearRing` as defined in the OGC-SFA (but is not defined as a separate type in this crate).
 ///
 /// # Validity
 ///
 /// A [`LineString`] is valid if it is either empty or
-/// contains 2 or more coordinates. Further, a closed
-/// [`LineString`] must not self-intersect. Note that its
+/// contains 2 or more coordinates.
+///
+/// Further, a closed [`LineString`] **must not** self-intersect. Note that its
 /// validity is **not** enforced, and operations and
 /// predicates are **undefined** on invalid `LineString`s.
 ///
@@ -261,9 +259,9 @@ impl<T: CoordNum> LineString<T> {
         })
     }
 
-    /// Close the [`LineString`]. Specifically, if the [`LineString`] has at least one coordinate, and
-    /// the value of the first coordinate does not equal the value of the last coordinate, then a
-    /// new coordinate is added to the end with the value of the first coordinate.
+    /// Close the [`LineString`]. Specifically, if the [`LineString`] has at least one [`Coordinate`], and
+    /// the value of the first [`Coordinate`] **does not** equal the value of the last [`Coordinate`], then a
+    /// new [`Coordinate`] is added to the end with the value of the first [`Coordinate`].
     pub fn close(&mut self) {
         if !self.is_closed() {
             // by definition, we treat empty LineString's as closed.
@@ -302,15 +300,15 @@ impl<T: CoordNum> LineString<T> {
     /// assert!(line_string.is_closed());
     /// ```
     ///
-    /// Note that we diverge from some libraries (JTS et al), which have a LinearRing type,
-    /// separate from LineString. Those libraries treat an empty LinearRing as closed, by
-    /// definition, while treating an empty LineString as open. Since we don't have a separate
-    /// LinearRing type, and use a LineString in its place, we adopt the JTS LinearRing `is_closed`
-    /// behavior in all places, that is, we consider an empty LineString as closed.
+    /// Note that we diverge from some libraries ([JTS](https://locationtech.github.io/jts/javadoc/org/locationtech/jts/geom/LinearRing.html) et al), which have a `LinearRing` type,
+    /// separate from [`LineString`]. Those libraries treat an empty `LinearRing` as **closed** by
+    /// definition, while treating an empty `LineString` as **open**. Since we don't have a separate
+    /// `LinearRing` type, and use a [`LineString`] in its place, we adopt the JTS `LinearRing` `is_closed`
+    /// behavior in all places: that is, **we consider an empty [`LineString`] as closed**.
     ///
     /// This is expected when used in the context of a [`Polygon.exterior`](crate::Polygon::exterior) and elsewhere; And there
-    /// seems to be no reason to maintain the separate behavior for LineStrings used in
-    /// non-LinearRing contexts.
+    /// seems to be no reason to maintain the separate behavior for [`LineString`]s used in
+    /// non-`LinearRing` contexts.
     pub fn is_closed(&self) -> bool {
         self.0.first() == self.0.last()
     }

--- a/geo-types/src/line_string.rs
+++ b/geo-types/src/line_string.rs
@@ -138,7 +138,7 @@ impl<'a, T: CoordNum> DoubleEndedIterator for PointsIter<'a, T> {
     }
 }
 
-/// A [Coordinate] iterator returned by the `iter` method on a [LineString]
+/// A [Coordinate] iterator used by the `into_iter` method on a [LineString]
 #[derive(Debug)]
 pub struct CoordinatesIter<'a, T: CoordNum + 'a>(::std::slice::Iter<'a, Coordinate<T>>);
 

--- a/geo-types/src/line_string.rs
+++ b/geo-types/src/line_string.rs
@@ -12,7 +12,7 @@ use std::ops::{Index, IndexMut};
 ///
 /// 1. A [`LineString`] is _closed_ if it is empty, **or** if the first and last coordinates are the same.
 /// 2. The _boundary_ of a [`LineString`] is either:
-///     - **empty** if it is closed **or**
+///     - **empty** if it is _closed_ (see **1**) **or**
 ///     - contains the **start** and **end** coordinates.
 /// 3. The _interior_ is the (infinite) set of all coordinates along the [`LineString`], _not including_ the boundary.
 /// 4. A [`LineString`] is _simple_ if it does not intersect except **optionally** at the first and last coordinates (in which case it is also _closed_, see **1**).

--- a/geo-types/src/line_string.rs
+++ b/geo-types/src/line_string.rs
@@ -166,9 +166,10 @@ impl<T: CoordNum> LineString<T> {
     pub fn iter(&self) -> CoordinatesIter<T> {
         CoordinatesIter(self.0.iter())
     }
+
     /// Return an iterator yielding the coordinates of a [LineString] as mutable [Coordinate]s
-    pub fn iter_mut(&mut self) -> CoordinatesIter<T> {
-        CoordinatesIter(self.0.iter())
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Coordinate<T>> {
+        self.0.iter_mut()
     }
 
     /// Return the coordinates of a [LineString] as a `Vec` of [Point]s

--- a/geo-types/src/line_string.rs
+++ b/geo-types/src/line_string.rs
@@ -10,28 +10,28 @@ use std::ops::{Index, IndexMut};
 ///
 /// # Semantics
 ///
-/// A `LineString` is _closed_ if it is empty, or if the
+/// A [`LineString`] is _closed_ if it is empty, or if the
 /// first and last coordinates are the same. The _boundary_
-/// of a `LineString` is empty if closed, and otherwise the
+/// of a [`LineString`] is empty if closed, and otherwise the
 /// end points. The _interior_ is the (infinite) set of all
 /// points along the linestring _not including_ the
-/// boundary. A `LineString` is _simple_ if it does not
+/// boundary. A [`LineString`] is _simple_ if it does not
 /// intersect except possibly at the first and last
-/// coordinates. A simple and closed `LineString` is a
+/// coordinates. A simple and closed [`LineString`] is a
 /// `LinearRing` as defined in the OGC-SFA (but is not a
 /// separate type here).
 ///
 /// # Validity
 ///
-/// A `LineString` is valid if it is either empty or
+/// A [`LineString`] is valid if it is either empty or
 /// contains 2 or more coordinates. Further, a closed
-/// `LineString` must not self-intersect. Note that its
+/// [`LineString`] must not self-intersect. Note that its
 /// validity is **not** enforced, and operations and
 /// predicates are **undefined** on invalid `LineString`s.
 ///
 /// # Examples
 ///
-/// Create a `LineString` by calling it directly:
+/// Create a [`LineString`] by calling it directly:
 ///
 /// ```
 /// use geo_types::{Coordinate, LineString};
@@ -42,7 +42,7 @@ use std::ops::{Index, IndexMut};
 /// ]);
 /// ```
 ///
-/// Create a `LineString` with the [`line_string!`] macro:
+/// Create a [`LineString`] with the [`line_string!`] macro:
 ///
 /// ```
 /// use geo_types::line_string;
@@ -53,7 +53,7 @@ use std::ops::{Index, IndexMut};
 /// ];
 /// ```
 ///
-/// Converting from a `Vec` of [Coordinate]-like things:
+/// Converting from a [`Vec`] of [`Coordinate`]-like things:
 ///
 /// ```
 /// use geo_types::LineString;
@@ -67,7 +67,7 @@ use std::ops::{Index, IndexMut};
 /// let line_string: LineString<f64> = vec![[0., 0.], [10., 0.]].into();
 /// ```
 //
-/// Or `collect`ing from a [Coordinate] iterator
+/// Or `collect`ing from a [`Coordinate`] iterator
 ///
 /// ```
 /// use geo_types::{Coordinate, LineString};
@@ -78,7 +78,7 @@ use std::ops::{Index, IndexMut};
 /// let line_string: LineString<f32> = coords_iter.collect();
 /// ```
 ///
-/// You can iterate and loop over the coordinates in the [LineString], yielding [Coordinate]s:
+/// You can iterate and loop over the coordinates in the [`LineString`], yielding [`Coordinate`]s by default:
 ///
 /// ```
 /// use geo_types::{Coordinate, LineString};
@@ -99,7 +99,7 @@ use std::ops::{Index, IndexMut};
 /// }
 /// ```
 ///
-/// You can also iterate over the coordinates in the [LineString] as [Point]s:
+/// …or yielding [`Point`]s:
 ///
 /// ```
 /// use geo_types::{Coordinate, LineString};
@@ -120,7 +120,7 @@ pub struct LineString<T>(pub Vec<Coordinate<T>>)
 where
     T: CoordNum;
 
-/// A [Point] iterator returned by the `points_iter` method
+/// A [`Point`] iterator returned by the `points_iter` method
 #[derive(Debug)]
 pub struct PointsIter<'a, T: CoordNum + 'a>(::std::slice::Iter<'a, Coordinate<T>>);
 
@@ -138,7 +138,7 @@ impl<'a, T: CoordNum> DoubleEndedIterator for PointsIter<'a, T> {
     }
 }
 
-/// A [Coordinate] iterator used by the `into_iter` method on a [LineString]
+/// A [`Coordinate`] iterator used by the `into_iter` method on a [`LineString`]
 #[derive(Debug)]
 pub struct CoordinatesIter<'a, T: CoordNum + 'a>(::std::slice::Iter<'a, Coordinate<T>>);
 
@@ -150,6 +150,12 @@ impl<'a, T: CoordNum> Iterator for CoordinatesIter<'a, T> {
     }
 }
 
+impl<'a, T: CoordNum> ExactSizeIterator for CoordinatesIter<'a, T> {
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
 impl<'a, T: CoordNum> DoubleEndedIterator for CoordinatesIter<'a, T> {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.0.next_back()
@@ -157,33 +163,33 @@ impl<'a, T: CoordNum> DoubleEndedIterator for CoordinatesIter<'a, T> {
 }
 
 impl<T: CoordNum> LineString<T> {
-    /// Return an iterator yielding the coordinates of a [LineString] as [Point]s
+    /// Return an iterator yielding the coordinates of a [`LineString`] as [`Point`]s
     pub fn points_iter(&self) -> PointsIter<T> {
         PointsIter(self.0.iter())
     }
 
-    /// Return an iterator yielding the members of a [LineString] as [Coordinate]s
+    /// Return an iterator yielding the members of a [`LineString`] as [`Coordinate`]s
     pub fn iter(&self) -> impl Iterator<Item = &Coordinate<T>> {
         self.0.iter()
     }
 
-    /// Return an iterator yielding the coordinates of a [LineString] as mutable [Coordinate]s
+    /// Return an iterator yielding the coordinates of a [`LineString`] as mutable [`Coordinate`]s
     pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Coordinate<T>> {
         self.0.iter_mut()
     }
 
-    /// Return the coordinates of a [LineString] as a `Vec` of [Point]s
+    /// Return the coordinates of a [`LineString`] as a [`Vec`] of [`Point`]s
     pub fn into_points(self) -> Vec<Point<T>> {
         self.0.into_iter().map(Point).collect()
     }
 
-    /// Return the coordinates of a [LineString] as a `Vec` of [Coordinate]s
-    pub fn into_coordinates(self) -> Vec<Coordinate<T>> {
-        self.0.into_iter().collect()
+    /// Return the coordinates of a [`LineString`] as a [`Vec`] of [`Coordinate`]s
+    pub fn into_inner(self) -> Vec<Coordinate<T>> {
+        self.0
     }
 
     /// Return an iterator yielding one [Line] for each line segment
-    /// in the [LineString].
+    /// in the [`LineString`].
     ///
     /// # Examples
     ///
@@ -217,7 +223,7 @@ impl<T: CoordNum> LineString<T> {
         })
     }
 
-    /// An iterator which yields the coordinates of a [LineString] as [Triangle]s
+    /// An iterator which yields the coordinates of a [`LineString`] as [Triangle]s
     pub fn triangles(&'_ self) -> impl ExactSizeIterator + Iterator<Item = Triangle<T>> + '_ {
         self.0.windows(3).map(|w| {
             // slice::windows(N) is guaranteed to yield a slice with exactly N elements
@@ -231,7 +237,7 @@ impl<T: CoordNum> LineString<T> {
         })
     }
 
-    /// Close the [LineString]. Specifically, if the [LineString] has at least one coordinate, and
+    /// Close the [`LineString`]. Specifically, if the [`LineString`] has at least one coordinate, and
     /// the value of the first coordinate does not equal the value of the last coordinate, then a
     /// new coordinate is added to the end with the value of the first coordinate.
     pub fn close(&mut self) {
@@ -242,7 +248,7 @@ impl<T: CoordNum> LineString<T> {
         }
     }
 
-    /// Return the number of coordinates in the [LineString].
+    /// Return the number of coordinates in the [`LineString`].
     ///
     /// # Examples
     ///
@@ -286,7 +292,7 @@ impl<T: CoordNum> LineString<T> {
     }
 }
 
-/// Turn a `Vec` of [Point]-like objects into a [LineString].
+/// Turn a [`Vec`] of [`Point`]-like objects into a [`LineString`].
 impl<T: CoordNum, IC: Into<Coordinate<T>>> From<Vec<IC>> for LineString<T> {
     fn from(v: Vec<IC>) -> Self {
         LineString(v.into_iter().map(|c| c.into()).collect())
@@ -299,14 +305,14 @@ impl<T: CoordNum> From<Line<T>> for LineString<T> {
     }
 }
 
-/// Turn an iterator of [Point]-like objects into a [LineString].
+/// Turn an iterator of [`Point`]-like objects into a [`LineString`].
 impl<T: CoordNum, IC: Into<Coordinate<T>>> FromIterator<IC> for LineString<T> {
     fn from_iter<I: IntoIterator<Item = IC>>(iter: I) -> Self {
         LineString(iter.into_iter().map(|c| c.into()).collect())
     }
 }
 
-/// Iterate over all the [Coordinate](struct.Coordinates.html)s in this [LineString].
+/// Iterate over all the [`Coordinate`]s in this [`LineString`].
 impl<T: CoordNum> IntoIterator for LineString<T> {
     type Item = Coordinate<T>;
     type IntoIter = ::std::vec::IntoIter<Coordinate<T>>;
@@ -325,7 +331,7 @@ impl<'a, T: CoordNum> IntoIterator for &'a LineString<T> {
     }
 }
 
-/// Mutably iterate over all the [Coordinate](struct.Coordinates.html)s in this [LineString].
+/// Mutably iterate over all the [`Coordinate`]s in this [`LineString`]
 impl<'a, T: CoordNum> IntoIterator for &'a mut LineString<T> {
     type Item = &'a mut Coordinate<T>;
     type IntoIter = ::std::slice::IterMut<'a, Coordinate<T>>;

--- a/geo-types/src/polygon.rs
+++ b/geo-types/src/polygon.rs
@@ -433,8 +433,8 @@ where
             .map(|(idx, _)| {
                 let prev_1 = self.previous_vertex(idx);
                 let prev_2 = self.previous_vertex(prev_1);
-                Point(self.exterior.0[prev_2])
-                    .cross_prod(Point(self.exterior.0[prev_1]), Point(self.exterior.0[idx]))
+                Point(self.exterior[prev_2])
+                    .cross_prod(Point(self.exterior[prev_1]), Point(self.exterior[idx]))
             })
             // accumulate and check cross-product result signs in a single pass
             // positive implies ccw convexity, negative implies cw convexity

--- a/geo-types/src/private_utils.rs
+++ b/geo-types/src/private_utils.rs
@@ -9,7 +9,7 @@ pub fn line_string_bounding_rect<T>(line_string: &LineString<T>) -> Option<Rect<
 where
     T: CoordNum,
 {
-    get_bounding_rect(line_string.0.iter().cloned())
+    get_bounding_rect(line_string.iter().cloned())
 }
 
 pub fn line_bounding_rect<T>(line: Line<T>) -> Rect<T>
@@ -132,7 +132,7 @@ where
     }
     // LineString with one point equal p
     if line_string.0.len() == 1 {
-        return point_contains_point(Point(line_string.0[0]), point);
+        return point_contains_point(Point(line_string[0]), point);
     }
     // check if point is a vertex
     if line_string.0.contains(&point.0) {

--- a/geo-types/src/private_utils.rs
+++ b/geo-types/src/private_utils.rs
@@ -9,7 +9,7 @@ pub fn line_string_bounding_rect<T>(line_string: &LineString<T>) -> Option<Rect<
 where
     T: CoordNum,
 {
-    get_bounding_rect(line_string.iter().cloned())
+    get_bounding_rect(line_string.coords().cloned())
 }
 
 pub fn line_bounding_rect<T>(line: Line<T>) -> Rect<T>

--- a/geo/src/algorithm/euclidean_distance.rs
+++ b/geo/src/algorithm/euclidean_distance.rs
@@ -559,19 +559,15 @@ where
     let tree_b: RTree<Line<_>> = RTree::bulk_load(geom2.lines().collect::<Vec<_>>());
     // Return minimum distance between all geom a points and all geom b points
     geom2
-        .points_iter()
+        .points()
         .fold(<T as Bounded>::max_value(), |acc, point| {
             let nearest = tree_a.nearest_neighbor(&point).unwrap();
             acc.min(nearest.euclidean_distance(&point))
         })
-        .min(
-            geom1
-                .points_iter()
-                .fold(Bounded::max_value(), |acc, point| {
-                    let nearest = tree_b.nearest_neighbor(&point).unwrap();
-                    acc.min(nearest.euclidean_distance(&point))
-                }),
-        )
+        .min(geom1.points().fold(Bounded::max_value(), |acc, point| {
+            let nearest = tree_b.nearest_neighbor(&point).unwrap();
+            acc.min(nearest.euclidean_distance(&point))
+        }))
 }
 
 #[cfg(test)]

--- a/geo/src/algorithm/line_interpolate_point.rs
+++ b/geo/src/algorithm/line_interpolate_point.rs
@@ -240,11 +240,11 @@ mod test {
         // fraction is nan or inf
         assert_eq!(
             linestring.line_interpolate_point(Float::infinity()),
-            linestring.points_iter().last()
+            linestring.points().last()
         );
         assert_eq!(
             linestring.line_interpolate_point(Float::neg_infinity()),
-            linestring.points_iter().next()
+            linestring.points().next()
         );
         assert_eq!(linestring.line_interpolate_point(Float::nan()), None);
 

--- a/geo/src/algorithm/map_coords.rs
+++ b/geo/src/algorithm/map_coords.rs
@@ -236,7 +236,7 @@ impl<T: CoordNum, NT: CoordNum> MapCoords<T, NT> for LineString<T> {
 
     fn map_coords(&self, func: impl Fn(&(T, T)) -> (NT, NT) + Copy) -> Self::Output {
         LineString::from(
-            self.points_iter()
+            self.points()
                 .map(|p| p.map_coords(func))
                 .collect::<Vec<_>>(),
         )
@@ -251,7 +251,7 @@ impl<T: CoordNum, NT: CoordNum> TryMapCoords<T, NT> for LineString<T> {
         func: impl Fn(&(T, T)) -> Result<(NT, NT), Box<dyn Error + Send + Sync>> + Copy,
     ) -> Result<Self::Output, Box<dyn Error + Send + Sync>> {
         Ok(LineString::from(
-            self.points_iter()
+            self.points()
                 .map(|p| p.try_map_coords(func))
                 .collect::<Result<Vec<_>, Box<dyn Error + Send + Sync>>>()?,
         ))

--- a/geo/src/algorithm/rotate.rs
+++ b/geo/src/algorithm/rotate.rs
@@ -222,10 +222,10 @@ where
         // return a rotated polygon, or a clone if no centroid is computable
         if let Some(centroid) = centroid {
             Polygon::new(
-                rotate_many(angle, centroid, self.exterior().points_iter()).collect(),
+                rotate_many(angle, centroid, self.exterior().points()).collect(),
                 self.interiors()
                     .iter()
-                    .map(|ring| rotate_many(angle, centroid, ring.points_iter()).collect())
+                    .map(|ring| rotate_many(angle, centroid, ring.points()).collect())
                     .collect(),
             )
         } else {

--- a/geo/src/algorithm/winding_order.rs
+++ b/geo/src/algorithm/winding_order.rs
@@ -157,8 +157,8 @@ where
     /// order, so that the resultant order makes it appear clockwise
     fn points_cw(&self) -> Points<Self::Scalar> {
         match self.winding_order() {
-            Some(WindingOrder::CounterClockwise) => Points(EitherIter::B(self.points_iter().rev())),
-            _ => Points(EitherIter::A(self.points_iter())),
+            Some(WindingOrder::CounterClockwise) => Points(EitherIter::B(self.points().rev())),
+            _ => Points(EitherIter::A(self.points())),
         }
     }
 
@@ -168,8 +168,8 @@ where
     /// order, so that the resultant order makes it appear counter-clockwise
     fn points_ccw(&self) -> Points<Self::Scalar> {
         match self.winding_order() {
-            Some(WindingOrder::Clockwise) => Points(EitherIter::B(self.points_iter().rev())),
-            _ => Points(EitherIter::A(self.points_iter())),
+            Some(WindingOrder::Clockwise) => Points(EitherIter::B(self.points().rev())),
+            _ => Points(EitherIter::A(self.points())),
         }
     }
 


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

This PR adds the `iter` and `iter_mut` methods on `LineString` (previously only available via its public `.0` field), yielding `Coordinate`s, and adds an `into_coordinates` method, complementing `into_points`. It also adds `into_iter` for **borrowed** `LineString`s.

Some of these methods overlap with those available in `geo`s [CoordsIter](https://docs.rs/geo/0.18.0/geo/algorithm/coords_iter/trait.CoordsIter.html) trait, but:

- Not all `geo-types` library users are _necessarily_ `geo` users
- The lack of direct `iter` methods is a constant papercut in my opinion.