### PR TITLE
FIX: geo tests not running in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,7 @@ jobs:
         uses: actions/checkout@v2
       - run: cargo check --all-targets --no-default-features
       # we don't want to test `proj-network` because it only enables the `proj` feature
-      - run: cargo test --features use-proj use-serde
+      - run: cargo test --features "use-proj use-serde"
 
   geo_postgis:
     name: geo-postgis


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Due to the lack of quoting, the "use-serde" feature was incorrectly
being interpreted as a filter on which tests to run.

e.g. compare

previously working:
https://github.com/georust/geo/runs/3929823924?check_suite_focus=true#step:6:72

broken here:
https://github.com/georust/geo/runs/3929868700?check_suite_focus=true#step:5:184

and now working again:
https://github.com/georust/geo/runs/4694596622?check_suite_focus=true#step:5:145