### PR TITLE
Deprecate `Point::{lat,lng}` and friends

### DIFF
--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -2,13 +2,14 @@
 
 ## Unreleased
 
+* DEPRECATION: Deprecate `Point::lng`, `Point::lat`, `Point::set_lng` and `Point::set_lat`
+  * <https://github.com/georust/geo/pull/711>
 * Support `rstar` version `0.9` in feature `use-rstar_0_9`
   * <https://github.com/georust/geo/pull/682>
 * `Geometry` and `GeometryCollection` now support serde.
   * <https://github.com/georust/geo/pull/704>
-
-* add `Coordinate` iterators to LineString, regularise its iterator methods, and refactor its docs
-  * https://github.com/georust/geo/pull/705
+* Add `Coordinate` iterators to LineString, regularise its iterator methods, and refactor its docs
+  * <https://github.com/georust/geo/pull/705>
 
 ## 0.7.2
 

--- a/geo-types/src/point.rs
+++ b/geo-types/src/point.rs
@@ -173,6 +173,7 @@ where
     ///
     /// assert_eq!(p.lng(), 1.234);
     /// ```
+    #[deprecated = "use `Point::x` instead, it's less ambigous"]
     pub fn lng(self) -> T {
         self.x()
     }
@@ -189,6 +190,7 @@ where
     ///
     /// assert_eq!(p.lng(), 9.876);
     /// ```
+    #[deprecated = "use `Point::set_x` instead, it's less ambigous"]
     pub fn set_lng(&mut self, lng: T) -> &mut Point<T> {
         self.set_x(lng)
     }
@@ -204,6 +206,7 @@ where
     ///
     /// assert_eq!(p.lat(), 2.345);
     /// ```
+    #[deprecated = "use `Point::y` instead, it's less ambigous"]
     pub fn lat(self) -> T {
         self.y()
     }
@@ -219,6 +222,7 @@ where
     ///
     /// assert_eq!(p.lat(), 9.876);
     /// ```
+    #[deprecated = "use `Point::set_y` instead, it's less ambigous"]
     pub fn set_lat(&mut self, lat: T) -> &mut Point<T> {
         self.set_y(lat)
     }

--- a/geo-types/src/point.rs
+++ b/geo-types/src/point.rs
@@ -171,7 +171,7 @@ where
     ///
     /// let p = Point::new(1.234, 2.345);
     ///
-    /// assert_eq!(p.lng(), 1.234);
+    /// assert_eq!(p.x(), 1.234);
     /// ```
     #[deprecated = "use `Point::x` instead, it's less ambigous"]
     pub fn lng(self) -> T {
@@ -188,7 +188,7 @@ where
     /// let mut p = Point::new(1.234, 2.345);
     /// p.set_lng(9.876);
     ///
-    /// assert_eq!(p.lng(), 9.876);
+    /// assert_eq!(p.x(), 9.876);
     /// ```
     #[deprecated = "use `Point::set_x` instead, it's less ambigous"]
     pub fn set_lng(&mut self, lng: T) -> &mut Point<T> {
@@ -204,7 +204,7 @@ where
     ///
     /// let p = Point::new(1.234, 2.345);
     ///
-    /// assert_eq!(p.lat(), 2.345);
+    /// assert_eq!(p.y(), 2.345);
     /// ```
     #[deprecated = "use `Point::y` instead, it's less ambigous"]
     pub fn lat(self) -> T {
@@ -220,7 +220,7 @@ where
     /// let mut p = Point::new(1.234, 2.345);
     /// p.set_lat(9.876);
     ///
-    /// assert_eq!(p.lat(), 9.876);
+    /// assert_eq!(p.y(), 9.876);
     /// ```
     #[deprecated = "use `Point::set_y` instead, it's less ambigous"]
     pub fn set_lat(&mut self, lat: T) -> &mut Point<T> {

--- a/geo/src/algorithm/geodesic_distance.rs
+++ b/geo/src/algorithm/geodesic_distance.rs
@@ -41,6 +41,6 @@ pub trait GeodesicDistance<T, Rhs = Self> {
 
 impl GeodesicDistance<f64> for Point<f64> {
     fn geodesic_distance(&self, rhs: &Point<f64>) -> f64 {
-        Geodesic::wgs84().inverse(self.lat(), self.lng(), rhs.lat(), rhs.lng())
+        Geodesic::wgs84().inverse(self.y(), self.x(), rhs.y(), rhs.x())
     }
 }

--- a/geo/src/algorithm/geodesic_intermediate.rs
+++ b/geo/src/algorithm/geodesic_intermediate.rs
@@ -40,9 +40,9 @@ impl GeodesicIntermediate<f64> for Point<f64> {
     fn geodesic_intermediate(&self, other: &Point<f64>, f: f64) -> Point<f64> {
         let g = Geodesic::wgs84();
         let (total_distance, azi1, _azi2, _a12) =
-            g.inverse(self.lat(), self.lng(), other.lat(), other.lng());
+            g.inverse(self.y(), self.x(), other.y(), other.x());
         let distance = total_distance * f;
-        let (lat2, lon2) = g.direct(self.lat(), self.lng(), azi1, distance);
+        let (lat2, lon2) = g.direct(self.y(), self.x(), azi1, distance);
 
         Point::new(lon2, lat2)
     }
@@ -55,7 +55,7 @@ impl GeodesicIntermediate<f64> for Point<f64> {
     ) -> Vec<Point<f64>> {
         let g = Geodesic::wgs84();
         let (total_distance, azi1, _azi2, _a12) =
-            g.inverse(self.lat(), self.lng(), other.lat(), other.lng());
+            g.inverse(self.y(), self.x(), other.y(), other.x());
 
         if total_distance <= max_dist {
             if include_ends {
@@ -72,8 +72,7 @@ impl GeodesicIntermediate<f64> for Point<f64> {
         let mut points = if include_ends { vec![*self] } else { vec![] };
 
         while current_step < 1.0 {
-            let (lat2, lon2) =
-                g.direct(self.lat(), self.lng(), azi1, total_distance * current_step);
+            let (lat2, lon2) = g.direct(self.y(), self.x(), azi1, total_distance * current_step);
             let point = Point::new(lon2, lat2);
             points.push(point);
             current_step += interval;

--- a/geo/src/algorithm/vincenty_distance.rs
+++ b/geo/src/algorithm/vincenty_distance.rs
@@ -70,11 +70,11 @@ where
         let b = T::from(POLAR_EARTH_RADIUS).unwrap();
         let f = T::from(EARTH_FLATTENING).unwrap();
         // Difference in longitude
-        let L = (rhs.lng() - self.lng()).to_radians();
+        let L = (rhs.x() - self.x()).to_radians();
         // Reduced latitude (latitude on the auxiliary sphere)
-        let U1 = ((t_1 - f) * self.lat().to_radians().tan()).atan();
+        let U1 = ((t_1 - f) * self.y().to_radians().tan()).atan();
         // Reduced latitude (latitude on the auxiliary sphere)
-        let U2 = ((t_1 - f) * rhs.lat().to_radians().tan()).atan();
+        let U2 = ((t_1 - f) * rhs.y().to_radians().tan()).atan();
         let (sinU1, cosU1) = U1.sin_cos();
         let (sinU2, cosU2) = U2.sin_cos();
         let mut cosSqAlpha;


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Closes #710