### PR TITLE
Minor: Add get() to IntersectionMatrix

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -14,6 +14,7 @@
   * <https://github.com/georust/geo/pull/675>
 * BREAKING: `TryMapCoords` Result is now generic rather than a Box<dyn Error>.
   * <https://github.com/georust/geo/issues/722>
+* Add `get()` to `IntersectionMatrix` for directly querying DE-9IM matrices
 
 ## 0.18.0
 

--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -15,6 +15,7 @@
 * BREAKING: `TryMapCoords` Result is now generic rather than a Box<dyn Error>.
   * <https://github.com/georust/geo/issues/722>
 * Add `get()` to `IntersectionMatrix` for directly querying DE-9IM matrices
+  * <https://github.com/georust/geo/pull/714>
 
 ## 0.18.0
 

--- a/geo/src/algorithm/relate/geomgraph/intersection_matrix.rs
+++ b/geo/src/algorithm/relate/geomgraph/intersection_matrix.rs
@@ -220,6 +220,12 @@ impl IntersectionMatrix {
             && self.0[CoordPos::Outside][CoordPos::Inside] == Dimensions::Empty
             && self.0[CoordPos::Outside][CoordPos::OnBoundary] == Dimensions::Empty
     }
+
+    /// Directly accesses this matrix
+    ///
+    pub fn get(&self, lhs: CoordPos, rhs: CoordPos) -> Dimensions {
+        self.0[lhs][rhs]
+    }
 }
 
 impl std::str::FromStr for IntersectionMatrix {

--- a/geo/src/algorithm/relate/geomgraph/intersection_matrix.rs
+++ b/geo/src/algorithm/relate/geomgraph/intersection_matrix.rs
@@ -255,7 +255,7 @@ impl IntersectionMatrix {
     /// // The intersection of the line's exteror with the rect's boundary is one-dimensional, because it's the rect's edges (minus where the string overlaps it)
     /// assert_eq!(intersection.get(CoordPos::Outside, CoordPos::OnBoundary), Dimensions::OneDimensional);
     ///
-    /// // The intersection of the two exterors is two-dimensional, because it's the whole plane around the two shapes
+    /// // The intersection of the two exteriors is two-dimensional, because it's the whole plane around the two shapes
     /// assert_eq!(intersection.get(CoordPos::Outside, CoordPos::Outside), Dimensions::TwoDimensional);
     /// ```
     pub fn get(&self, lhs: CoordPos, rhs: CoordPos) -> Dimensions {

--- a/geo/src/algorithm/relate/geomgraph/intersection_matrix.rs
+++ b/geo/src/algorithm/relate/geomgraph/intersection_matrix.rs
@@ -252,7 +252,7 @@ impl IntersectionMatrix {
     /// // The intersection of the the line's exterior with the rect's interior is two-dimensional, because it's simply the rect's interior
     /// assert_eq!(intersection.get(CoordPos::Outside, CoordPos::Inside), Dimensions::TwoDimensional);
     ///
-    /// // The intersection of the line's exteror with the rect's boundary is one-dimensional, because it's the rect's edges (minus where the string overlaps it)
+    /// // The intersection of the line's exterior with the rect's boundary is one-dimensional, because it's the rect's edges (minus where the string overlaps it)
     /// assert_eq!(intersection.get(CoordPos::Outside, CoordPos::OnBoundary), Dimensions::OneDimensional);
     ///
     /// // The intersection of the two exteriors is two-dimensional, because it's the whole plane around the two shapes

--- a/geo/src/algorithm/relate/geomgraph/intersection_matrix.rs
+++ b/geo/src/algorithm/relate/geomgraph/intersection_matrix.rs
@@ -1,5 +1,4 @@
-use crate::algorithm::coordinate_position::CoordPos;
-use crate::algorithm::dimensions::Dimensions;
+use crate::algorithm::{coordinate_position::CoordPos, dimensions::Dimensions};
 
 /// Models a *Dimensionally Extended Nine-Intersection Model (DE-9IM)* matrix.
 ///
@@ -222,6 +221,43 @@ impl IntersectionMatrix {
     }
 
     /// Directly accesses this matrix
+    ///
+    /// ```
+    /// use geo_types::{LineString, Rect, line_string};
+    /// use geo::algorithm::{coordinate_position::CoordPos, dimensions::Dimensions, relate::Relate};
+    ///
+    /// let line_string: LineString<f64> = line_string![(x: 0.0, y: 0.0), (x: 10.0, y: 0.0), (x: 5.0, y: 5.0)];
+    /// let rect = Rect::new((0.0, 0.0), (5.0, 5.0));
+    ///
+    /// let intersection = line_string.relate(&rect);
+    ///
+    /// // The intersection of the two interiors is empty, because no part of the string is inside the rect
+    /// assert_eq!(intersection.get(CoordPos::Inside, CoordPos::Inside), Dimensions::Empty);
+    ///
+    /// // The intersection of the two string's interior with the rect's boundary is one-dimensoinal, because part of the first line overlaps one of the rect's edges
+    /// assert_eq!(intersection.get(CoordPos::Inside, CoordPos::OnBoundary), Dimensions::OneDimensional);
+    ///
+    /// // The intersection of the line string's interior with the rect's exterior is one-dimensional, because part of the string is outside the rect
+    /// assert_eq!(intersection.get(CoordPos::Inside, CoordPos::Outside), Dimensions::OneDimensional);
+    ///
+    /// // The intersection of the line string's boundary with the rect's interior is empty, because neither of its end points are inside the rect
+    /// assert_eq!(intersection.get(CoordPos::OnBoundary, CoordPos::Inside), Dimensions::Empty);
+    ///
+    /// // The intersection of the line string's boundary with the rect's boundary is zero-dimensional, because the string's start and end points are on the rect's edges
+    /// assert_eq!(intersection.get(CoordPos::OnBoundary, CoordPos::OnBoundary), Dimensions::ZeroDimensional);
+    ///
+    /// // The intersection of the line string's boundary with the rect's exterior is empty, because neither of its end points are outside the rect
+    /// assert_eq!(intersection.get(CoordPos::OnBoundary, CoordPos::Outside), Dimensions::Empty);
+    ///
+    /// // The intersection of the the line's exteror with the rect's interior is two-dimensional, because it's simply the rect's interior
+    /// assert_eq!(intersection.get(CoordPos::Outside, CoordPos::Inside), Dimensions::TwoDimensional);
+    ///
+    /// // The intersection of the line's exteror with the rect's boundary is one-dimensional, because it's the rect's edges (minus where the string overlaps it)
+    /// assert_eq!(intersection.get(CoordPos::Outside, CoordPos::OnBoundary), Dimensions::OneDimensional);
+    ///
+    /// // The intersection of the two exterors is two-dimensional, because it's the whole plane around the two shapes
+    /// assert_eq!(intersection.get(CoordPos::Outside, CoordPos::Outside), Dimensions::TwoDimensional);
+    /// ```
     pub fn get(&self, lhs: CoordPos, rhs: CoordPos) -> Dimensions {
         self.0[lhs][rhs]
     }

--- a/geo/src/algorithm/relate/geomgraph/intersection_matrix.rs
+++ b/geo/src/algorithm/relate/geomgraph/intersection_matrix.rs
@@ -222,7 +222,6 @@ impl IntersectionMatrix {
     }
 
     /// Directly accesses this matrix
-    ///
     pub fn get(&self, lhs: CoordPos, rhs: CoordPos) -> Dimensions {
         self.0[lhs][rhs]
     }

--- a/geo/src/algorithm/relate/geomgraph/intersection_matrix.rs
+++ b/geo/src/algorithm/relate/geomgraph/intersection_matrix.rs
@@ -249,7 +249,7 @@ impl IntersectionMatrix {
     /// // The intersection of the line string's boundary with the rect's exterior is empty, because neither of its end points are outside the rect
     /// assert_eq!(intersection.get(CoordPos::OnBoundary, CoordPos::Outside), Dimensions::Empty);
     ///
-    /// // The intersection of the the line's exteror with the rect's interior is two-dimensional, because it's simply the rect's interior
+    /// // The intersection of the the line's exterior with the rect's interior is two-dimensional, because it's simply the rect's interior
     /// assert_eq!(intersection.get(CoordPos::Outside, CoordPos::Inside), Dimensions::TwoDimensional);
     ///
     /// // The intersection of the line's exteror with the rect's boundary is one-dimensional, because it's the rect's edges (minus where the string overlaps it)

--- a/geo/src/algorithm/relate/geomgraph/intersection_matrix.rs
+++ b/geo/src/algorithm/relate/geomgraph/intersection_matrix.rs
@@ -234,7 +234,7 @@ impl IntersectionMatrix {
     /// // The intersection of the two interiors is empty, because no part of the string is inside the rect
     /// assert_eq!(intersection.get(CoordPos::Inside, CoordPos::Inside), Dimensions::Empty);
     ///
-    /// // The intersection of the two string's interior with the rect's boundary is one-dimensoinal, because part of the first line overlaps one of the rect's edges
+    /// // The intersection of the line string's interior with the rect's boundary is one-dimensoinal, because part of the first line overlaps one of the rect's edges
     /// assert_eq!(intersection.get(CoordPos::Inside, CoordPos::OnBoundary), Dimensions::OneDimensional);
     ///
     /// // The intersection of the line string's interior with the rect's exterior is one-dimensional, because part of the string is outside the rect


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Currently there doesn't seem to be any way to directly access the values inside of an `IntersectionMatrix`.
This PR adds a simple accessor.

Related to https://github.com/georust/geo/issues/515