### PR TITLE
bump MSRV to 1.55, add rust-1.58

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,10 +39,10 @@ jobs:
           # giving us about 6 months of coverage.
           #
           # Minimum supported rust version (MSRV)
-          - "georust/geo-ci:rust-1.51"
+          - "georust/geo-ci:rust-1.55"
           # Two most recent releases - we omit older ones for expedient CI
-          - "georust/geo-ci:rust-1.56"
           - "georust/geo-ci:rust-1.57"
+          - "georust/geo-ci:rust-1.58"
     container:
       image: ${{ matrix.container_image }}
     steps:
@@ -65,10 +65,10 @@ jobs:
           # giving us about 6 months of coverage.
           #
           # Minimum supported rust version (MSRV)
-          - "georust/geo-ci:rust-1.51"
+          - "georust/geo-ci:rust-1.55"
           # Two most recent releases - we omit older ones for expedient CI
-          - "georust/geo-ci:rust-1.56"
           - "georust/geo-ci:rust-1.57"
+          - "georust/geo-ci:rust-1.58"
     container:
       image: ${{ matrix.container_image }}
     steps:
@@ -92,10 +92,10 @@ jobs:
           # giving us about 6 months of coverage.
           #
           # Minimum supported rust version (MSRV)
-          - "georust/geo-ci:rust-1.51"
+          - "georust/geo-ci:rust-1.55"
           # Two most recent releases - we omit older ones for expedient CI
-          - "georust/geo-ci:rust-1.56"
           - "georust/geo-ci:rust-1.57"
+          - "georust/geo-ci:rust-1.58"
     container:
       image: ${{ matrix.container_image }}
     steps:

--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -12,6 +12,8 @@
   * <https://github.com/georust/geo/pull/705>
 * Add +=, -=, \*=, and /= for Point
   * <https://github.com/georust/geo/pull/715>
+* Note: The MSRV when installing latest dependencies has increased to 1.55
+  * <https://github.com/georust/geo/pull/726>
 
 ## 0.7.2
 

--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -20,6 +20,8 @@
   * <https://github.com/georust/geo/issues/722>
 * Add `Transform` algorithm
   * <https://github.com/georust/geo/pull/718>
+* Note: The MSRV when installing latest dependencies has increased to 1.55
+  * <https://github.com/georust/geo/pull/726>
 
 ## 0.18.0
 


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

MSRV for latest 'arbitrary' crate is 1.55

Alternatively, we **could** pin to an older version of `arbitrary` to keep our old MSRV, but in [previous discussion](https://github.com/georust/geo/pull/680#discussion_r753412550) we said we'd do our best to support stable + 3 releases, so I guess "onward" we should go.

FIXES https://github.com/georust/geo/pull/725#issuecomment-1034398133