### PR TITLE
Use automatic default implementation

### DIFF
--- a/geo-types/src/coordinate.rs
+++ b/geo-types/src/coordinate.rs
@@ -23,7 +23,7 @@ use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 /// (for eg. not `f64::NAN`).
 ///
 /// [vector space]: //en.wikipedia.org/wiki/Vector_space
-#[derive(Eq, PartialEq, Clone, Copy, Debug, Hash)]
+#[derive(Eq, PartialEq, Clone, Copy, Debug, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Coordinate<T>
 where
@@ -31,15 +31,6 @@ where
 {
     pub x: T,
     pub y: T,
-}
-
-impl<T: Default + CoordNum> Default for Coordinate<T> {
-    fn default() -> Coordinate<T> {
-        Coordinate {
-            x: T::default(),
-            y: T::default(),
-        }
-    }
 }
 
 impl<T: CoordNum> From<(T, T)> for Coordinate<T> {

--- a/geo-types/src/geometry_collection.rs
+++ b/geo-types/src/geometry_collection.rs
@@ -69,11 +69,19 @@ use std::ops::{Index, IndexMut};
 /// println!("{:?}", gc[0]);
 /// ```
 ///
-#[derive(Eq, PartialEq, Clone, Debug, Hash, Default)]
+#[derive(Eq, PartialEq, Clone, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct GeometryCollection<T>(pub Vec<Geometry<T>>)
 where
     T: CoordNum;
+
+// Implementing Default by hand because T does not have Default restriction
+// todo: consider adding Default as a CoordNum requirement
+impl<T: CoordNum> Default for GeometryCollection<T> {
+    fn default() -> Self {
+        GeometryCollection(Vec::new())
+    }
+}
 
 impl<T: CoordNum> GeometryCollection<T> {
     /// Return an empty GeometryCollection

--- a/geo-types/src/geometry_collection.rs
+++ b/geo-types/src/geometry_collection.rs
@@ -69,22 +69,16 @@ use std::ops::{Index, IndexMut};
 /// println!("{:?}", gc[0]);
 /// ```
 ///
-#[derive(Eq, PartialEq, Clone, Debug, Hash)]
+#[derive(Eq, PartialEq, Clone, Debug, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct GeometryCollection<T>(pub Vec<Geometry<T>>)
 where
     T: CoordNum;
 
-impl<T: CoordNum> Default for GeometryCollection<T> {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl<T: CoordNum> GeometryCollection<T> {
     /// Return an empty GeometryCollection
     pub fn new() -> GeometryCollection<T> {
-        GeometryCollection(Vec::new())
+        GeometryCollection::default()
     }
 
     /// Number of geometries in this GeometryCollection


### PR DESCRIPTION
Make the code just a bit shorter by using the automatically generated `default` implementation (`#derive(Default)`)

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

