### PR TITLE
Clean up trailing spaces at EOL

### DIFF
--- a/geo/src/algorithm/relate/relate_operation.rs
+++ b/geo/src/algorithm/relate/relate_operation.rs
@@ -260,7 +260,7 @@ where
         }
     }
 
-    /// Insert nodes for all intersections on the edges of a Geometry.  
+    /// Insert nodes for all intersections on the edges of a Geometry.
     ///
     /// Label the created nodes the same as the edge label if they do not already have a label.
     /// This allows nodes created by either self-intersections or mutual intersections to be
@@ -397,7 +397,7 @@ where
     }
 
     /// Isolated nodes are nodes whose labels are incomplete (e.g. the location for one Geometry is
-    /// null).  
+    /// null).
     /// This is the case because nodes in one graph which don't intersect nodes in the other
     /// are not completely labeled by the initial process of adding nodes to the nodeList.  To
     /// complete the labelling we need to check for nodes that lie in the interior of edges, and in

--- a/geo/src/algorithm/rotate.rs
+++ b/geo/src/algorithm/rotate.rs
@@ -82,9 +82,9 @@ pub trait Rotate<T> {
         T: CoordFloat;
 
     #[deprecated(
-        note = "Equivalent to `rotate_around_centroid` except for `Polygon<T>`, 
-                    where it is equivalent to rotating around the polygon's outer ring. 
-                    Call that instead, or `rotate_around_center` if you'd like to rotate 
+        note = "Equivalent to `rotate_around_centroid` except for `Polygon<T>`,
+                    where it is equivalent to rotating around the polygon's outer ring.
+                    Call that instead, or `rotate_around_center` if you'd like to rotate
                     around the geometry's bounding box center."
     )]
     fn rotate(&self, angle: T) -> Self


### PR DESCRIPTION
This should be a noop

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

