### PR TITLE
A few noop code cleanups

### DIFF
--- a/geo/benches/frechet_distance.rs
+++ b/geo/benches/frechet_distance.rs
@@ -2,7 +2,6 @@
 extern crate criterion;
 extern crate geo;
 use geo::frechet_distance::FrechetDistance;
-use geo::{Coordinate, LineString};
 
 fn criterion_benchmark(c: &mut criterion::Criterion) {
     c.bench_function("frechet distance f32", |bencher| {

--- a/geo/benches/rotate.rs
+++ b/geo/benches/rotate.rs
@@ -4,7 +4,6 @@ extern crate geo;
 
 use criterion::Criterion;
 use geo::prelude::*;
-use geo::LineString;
 
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("rotate f32", |bencher| {

--- a/geo/src/algorithm/geodesic_intermediate.rs
+++ b/geo/src/algorithm/geodesic_intermediate.rs
@@ -58,10 +58,10 @@ impl GeodesicIntermediate<f64> for Point<f64> {
             g.inverse(self.y(), self.x(), other.y(), other.x());
 
         if total_distance <= max_dist {
-            if include_ends {
-                return vec![*self, *other];
+            return if include_ends {
+                vec![*self, *other]
             } else {
-                return vec![];
+                vec![]
             }
         }
 

--- a/geo/src/algorithm/haversine_intermediate.rs
+++ b/geo/src/algorithm/haversine_intermediate.rs
@@ -60,10 +60,10 @@ where
         let total_distance = d * T::from(MEAN_EARTH_RADIUS).unwrap();
 
         if total_distance <= max_dist {
-            if include_ends {
-                return vec![*self, *other];
+            return if include_ends {
+                vec![*self, *other]
             } else {
-                return vec![];
+                vec![]
             }
         }
 

--- a/geo/src/algorithm/intersects/mod.rs
+++ b/geo/src/algorithm/intersects/mod.rs
@@ -376,7 +376,7 @@ mod test {
         assert_eq!(true, bounding_rect_s2.intersects(&bounding_rect_sm));
     }
     #[test]
-    fn rect_interesection_consistent_with_poly_intersection_test() {
+    fn rect_intersection_consistent_with_poly_intersection_test() {
         let bounding_rect_xl = Rect::new(
             Coordinate { x: -100., y: -200. },
             Coordinate { x: 100., y: 200. },

--- a/geo/src/algorithm/relate/geomgraph/label.rs
+++ b/geo/src/algorithm/relate/geomgraph/label.rs
@@ -87,8 +87,8 @@ impl Label {
         self.geometry_topologies[geom_index].set_all_positions(position)
     }
 
-    pub fn set_all_positions_if_empty(&mut self, geom_index: usize, postion: CoordPos) {
-        self.geometry_topologies[geom_index].set_all_positions_if_empty(postion)
+    pub fn set_all_positions_if_empty(&mut self, geom_index: usize, position: CoordPos) {
+        self.geometry_topologies[geom_index].set_all_positions_if_empty(position)
     }
 
     pub fn geometry_count(&self) -> usize {

--- a/geo/src/algorithm/relate/mod.rs
+++ b/geo/src/algorithm/relate/mod.rs
@@ -88,7 +88,7 @@ macro_rules! relate_impl {
 /// ```
 /// Is akin to calling:
 /// ```no_run
-/// foo![(Bar, Bar), (Bar, Baz), (Bar, Qux), (Baz, Bar), (Baz, Baz), (Baz, Qux), (Qux, Bar), (Qux, Baz), (Qux, Qux)]);
+/// foo![(Bar, Bar), (Bar, Baz), (Bar, Qux), (Baz, Bar), (Baz, Baz), (Baz, Qux), (Qux, Bar), (Qux, Baz), (Qux, Qux)];
 /// ```
 macro_rules! cartesian_pairs {
     ($macro_name:ident, [$($a:ty),*]) => {

--- a/geo/src/algorithm/relate/relate_operation.rs
+++ b/geo/src/algorithm/relate/relate_operation.rs
@@ -243,7 +243,7 @@ where
         let graph = if geom_index == 0 {
             &self.graph_a
         } else {
-            assert!(geom_index == 1);
+            assert_eq!(geom_index, 1);
             &self.graph_b
         };
         for graph_node in graph.nodes_iter() {
@@ -271,7 +271,7 @@ where
         let graph = if geom_index == 0 {
             &self.graph_a
         } else {
-            assert!(geom_index == 1);
+            assert_eq!(geom_index, 1);
             &self.graph_b
         };
 

--- a/geo/src/algorithm/vincenty_distance.rs
+++ b/geo/src/algorithm/vincenty_distance.rs
@@ -95,12 +95,12 @@ where
                 .sqrt();
 
             if sinSigma.is_zero() {
-                if self == rhs {
+                return if self == rhs {
                     // coincident points
-                    return Ok(T::zero());
+                    Ok(T::zero())
                 } else {
-                    // anitpodal points, for which vincenty does not converge
-                    return Err(FailedToConvergeError);
+                    // antipodal points, for which vincenty does not converge
+                    Err(FailedToConvergeError)
                 }
             }
 


### PR DESCRIPTION
* Remove unused `use` from frechet_distance.rs and rotate.rs
* compacted `if ... {return a} else {return b}` into a single statement `return if ...{a} else {b}`
* rename misspelled fn param in label.rs
* renamed misspelled `#[test]` function
* fixed example code
* used `assert_eq!` instead of `assert!`
* reordered functions for `Rotate` trait implementations to match the order of the trait declaration

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

