### PR TITLE
Prepare for geo-types 0.7.3 release.

### DIFF
--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+*
+
+## 0.7.3
+
 * DEPRECATION: Deprecate `Point::lng`, `Point::lat`, `Point::set_lng` and `Point::set_lat`
   * <https://github.com/georust/geo/pull/711>
 * Support `rstar` version `0.9` in feature `use-rstar_0_9`

--- a/geo-types/Cargo.toml
+++ b/geo-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geo-types"
-version = "0.7.2"
+version = "0.7.3"
 authors = ["Corey Farwell <coreyf@rwell.org>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/georust/geo"


### PR DESCRIPTION
This is needed for a geo release, since geo relies on some of these changes.