### PR TITLE
Compact simple where clauses

### DIFF
--- a/geo-types/src/coordinate.rs
+++ b/geo-types/src/coordinate.rs
@@ -25,10 +25,7 @@ use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 /// [vector space]: //en.wikipedia.org/wiki/Vector_space
 #[derive(Eq, PartialEq, Clone, Copy, Debug, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct Coordinate<T>
-where
-    T: CoordNum,
-{
+pub struct Coordinate<T: CoordNum> {
     pub x: T,
     pub y: T,
 }
@@ -72,10 +69,7 @@ impl<T: CoordNum> From<Coordinate<T>> for [T; 2] {
     }
 }
 
-impl<T> Coordinate<T>
-where
-    T: CoordNum,
-{
+impl<T: CoordNum> Coordinate<T> {
     /// Returns a tuple that contains the x/horizontal & y/vertical component of the coordinate.
     ///
     /// # Examples
@@ -137,10 +131,7 @@ where
 /// assert_eq!(sum.x, 2.75);
 /// assert_eq!(sum.y, 5.0);
 /// ```
-impl<T> Add for Coordinate<T>
-where
-    T: CoordNum,
-{
+impl<T: CoordNum> Add for Coordinate<T> {
     type Output = Coordinate<T>;
 
     fn add(self, rhs: Coordinate<T>) -> Coordinate<T> {
@@ -162,10 +153,7 @@ where
 /// assert_eq!(diff.x, 0.25);
 /// assert_eq!(diff.y, 0.);
 /// ```
-impl<T> Sub for Coordinate<T>
-where
-    T: CoordNum,
-{
+impl<T: CoordNum> Sub for Coordinate<T> {
     type Output = Coordinate<T>;
 
     fn sub(self, rhs: Coordinate<T>) -> Coordinate<T> {
@@ -186,10 +174,7 @@ where
 /// assert_eq!(q.x, 5.0);
 /// assert_eq!(q.y, 10.0);
 /// ```
-impl<T> Mul<T> for Coordinate<T>
-where
-    T: CoordNum,
-{
+impl<T: CoordNum> Mul<T> for Coordinate<T> {
     type Output = Coordinate<T>;
 
     fn mul(self, rhs: T) -> Coordinate<T> {
@@ -210,10 +195,7 @@ where
 /// assert_eq!(q.x, 1.25);
 /// assert_eq!(q.y, 2.5);
 /// ```
-impl<T> Div<T> for Coordinate<T>
-where
-    T: CoordNum,
-{
+impl<T: CoordNum> Div<T> for Coordinate<T> {
     type Output = Coordinate<T>;
 
     fn div(self, rhs: T) -> Coordinate<T> {

--- a/geo-types/src/geometry.rs
+++ b/geo-types/src/geometry.rs
@@ -26,10 +26,7 @@ use std::convert::TryFrom;
 ///
 #[derive(Eq, PartialEq, Clone, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum Geometry<T>
-where
-    T: CoordNum,
-{
+pub enum Geometry<T: CoordNum> {
     Point(Point<T>),
     Line(Line<T>),
     LineString(LineString<T>),

--- a/geo-types/src/geometry_collection.rs
+++ b/geo-types/src/geometry_collection.rs
@@ -71,9 +71,7 @@ use std::ops::{Index, IndexMut};
 ///
 #[derive(Eq, PartialEq, Clone, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct GeometryCollection<T>(pub Vec<Geometry<T>>)
-where
-    T: CoordNum;
+pub struct GeometryCollection<T: CoordNum>(pub Vec<Geometry<T>>);
 
 // Implementing Default by hand because T does not have Default restriction
 // todo: consider adding Default as a CoordNum requirement

--- a/geo-types/src/line.rs
+++ b/geo-types/src/line.rs
@@ -11,18 +11,12 @@ use approx::{AbsDiffEq, RelativeEq};
 /// `LineString` with the two end points.
 #[derive(Eq, PartialEq, Clone, Copy, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct Line<T>
-where
-    T: CoordNum,
-{
+pub struct Line<T: CoordNum> {
     pub start: Coordinate<T>,
     pub end: Coordinate<T>,
 }
 
-impl<T> Line<T>
-where
-    T: CoordNum,
-{
+impl<T: CoordNum> Line<T> {
     /// Creates a new line segment.
     ///
     /// # Examples

--- a/geo-types/src/line_string.rs
+++ b/geo-types/src/line_string.rs
@@ -132,9 +132,7 @@ use std::ops::{Index, IndexMut};
 
 #[derive(Eq, PartialEq, Clone, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct LineString<T>(pub Vec<Coordinate<T>>)
-where
-    T: CoordNum;
+pub struct LineString<T: CoordNum>(pub Vec<Coordinate<T>>);
 
 /// A [`Point`] iterator returned by the `points` method
 #[derive(Debug)]

--- a/geo-types/src/multi_line_string.rs
+++ b/geo-types/src/multi_line_string.rs
@@ -33,9 +33,7 @@ use std::iter::FromIterator;
 /// of a closed `MultiLineString` is always empty.
 #[derive(Eq, PartialEq, Clone, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct MultiLineString<T>(pub Vec<LineString<T>>)
-where
-    T: CoordNum;
+pub struct MultiLineString<T: CoordNum>(pub Vec<LineString<T>>);
 
 impl<T: CoordNum> MultiLineString<T> {
     /// True if the MultiLineString is empty or if all of its LineStrings are closed - see

--- a/geo-types/src/multi_point.rs
+++ b/geo-types/src/multi_point.rs
@@ -30,9 +30,7 @@ use std::iter::FromIterator;
 /// ```
 #[derive(Eq, PartialEq, Clone, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct MultiPoint<T>(pub Vec<Point<T>>)
-where
-    T: CoordNum;
+pub struct MultiPoint<T: CoordNum>(pub Vec<Point<T>>);
 
 impl<T: CoordNum, IP: Into<Point<T>>> From<IP> for MultiPoint<T> {
     /// Convert a single `Point` (or something which can be converted to a `Point`) into a

--- a/geo-types/src/multi_polygon.rs
+++ b/geo-types/src/multi_polygon.rs
@@ -27,9 +27,7 @@ use std::iter::FromIterator;
 /// predicates that operate on it.
 #[derive(Eq, PartialEq, Clone, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct MultiPolygon<T>(pub Vec<Polygon<T>>)
-where
-    T: CoordNum;
+pub struct MultiPolygon<T: CoordNum>(pub Vec<Polygon<T>>);
 
 impl<T: CoordNum, IP: Into<Polygon<T>>> From<IP> for MultiPolygon<T> {
     fn from(x: IP) -> Self {

--- a/geo-types/src/point.rs
+++ b/geo-types/src/point.rs
@@ -28,9 +28,7 @@ use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssi
 /// ```
 #[derive(Eq, PartialEq, Clone, Copy, Debug, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct Point<T>(pub Coordinate<T>)
-where
-    T: CoordNum;
+pub struct Point<T: CoordNum>(pub Coordinate<T>);
 
 impl<T: CoordNum> From<Coordinate<T>> for Point<T> {
     fn from(x: Coordinate<T>) -> Point<T> {
@@ -62,10 +60,7 @@ impl<T: CoordNum> From<Point<T>> for [T; 2] {
     }
 }
 
-impl<T> Point<T>
-where
-    T: CoordNum,
-{
+impl<T: CoordNum> Point<T> {
     /// Creates a new point.
     ///
     /// # Examples
@@ -230,10 +225,7 @@ where
     }
 }
 
-impl<T> Point<T>
-where
-    T: CoordNum,
-{
+impl<T: CoordNum> Point<T> {
     /// Returns the dot product of the two points:
     /// `dot = x1 * x2 + y1 * y2`
     ///
@@ -274,10 +266,7 @@ where
     }
 }
 
-impl<T> Point<T>
-where
-    T: CoordFloat,
-{
+impl<T: CoordFloat> Point<T> {
     /// Converts the (x,y) components of Point to degrees
     ///
     /// # Example
@@ -338,10 +327,7 @@ where
     }
 }
 
-impl<T> Add for Point<T>
-where
-    T: CoordNum,
-{
+impl<T: CoordNum> Add for Point<T> {
     type Output = Point<T>;
 
     /// Add a point to the given point.
@@ -361,10 +347,7 @@ where
     }
 }
 
-impl<T> AddAssign for Point<T>
-where
-    T: CoordNum,
-{
+impl<T: CoordNum> AddAssign for Point<T> {
     /// Add a point to the given point and assign it to the original point.
     ///
     /// # Examples
@@ -383,10 +366,7 @@ where
     }
 }
 
-impl<T> Sub for Point<T>
-where
-    T: CoordNum,
-{
+impl<T: CoordNum> Sub for Point<T> {
     type Output = Point<T>;
 
     /// Subtract a point from the given point.
@@ -406,10 +386,7 @@ where
     }
 }
 
-impl<T> SubAssign for Point<T>
-where
-    T: CoordNum,
-{
+impl<T: CoordNum> SubAssign for Point<T> {
     /// Subtract a point from the given point and assign it to the original point.
     ///
     /// # Examples
@@ -428,10 +405,7 @@ where
     }
 }
 
-impl<T> Mul<T> for Point<T>
-where
-    T: CoordNum,
-{
+impl<T: CoordNum> Mul<T> for Point<T> {
     type Output = Point<T>;
 
     /// Scaler multiplication of a point
@@ -451,10 +425,7 @@ where
     }
 }
 
-impl<T> MulAssign<T> for Point<T>
-where
-    T: CoordNum,
-{
+impl<T: CoordNum> MulAssign<T> for Point<T> {
     /// Scaler multiplication of a point in place
     ///
     /// # Examples
@@ -473,10 +444,7 @@ where
     }
 }
 
-impl<T> Div<T> for Point<T>
-where
-    T: CoordNum,
-{
+impl<T: CoordNum> Div<T> for Point<T> {
     type Output = Point<T>;
 
     /// Scaler division of a point
@@ -496,10 +464,7 @@ where
     }
 }
 
-impl<T> DivAssign<T> for Point<T>
-where
-    T: CoordNum,
-{
+impl<T: CoordNum> DivAssign<T> for Point<T> {
     /// Scaler division of a point in place
     ///
     /// # Examples

--- a/geo-types/src/polygon.rs
+++ b/geo-types/src/polygon.rs
@@ -66,18 +66,12 @@ use approx::{AbsDiffEq, RelativeEq};
 /// [`LineString`]: line_string/struct.LineString.html
 #[derive(Eq, PartialEq, Clone, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct Polygon<T>
-where
-    T: CoordNum,
-{
+pub struct Polygon<T: CoordNum> {
     exterior: LineString<T>,
     interiors: Vec<LineString<T>>,
 }
 
-impl<T> Polygon<T>
-where
-    T: CoordNum,
-{
+impl<T: CoordNum> Polygon<T> {
     /// Create a new `Polygon` with the provided exterior `LineString` ring and
     /// interior `LineString` rings.
     ///
@@ -408,10 +402,7 @@ enum ListSign {
     Mixed,
 }
 
-impl<T> Polygon<T>
-where
-    T: CoordFloat + Signed,
-{
+impl<T: CoordFloat + Signed> Polygon<T> {
     /// Determine whether a Polygon is convex
     // For each consecutive pair of edges of the polygon (each triplet of points),
     // compute the z-component of the cross product of the vectors defined by the

--- a/geo-types/src/rect.rs
+++ b/geo-types/src/rect.rs
@@ -39,10 +39,7 @@ use approx::{AbsDiffEq, RelativeEq};
 /// ```
 #[derive(Eq, PartialEq, Clone, Copy, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct Rect<T>
-where
-    T: CoordNum,
-{
+pub struct Rect<T: CoordNum> {
     min: Coordinate<T>,
     max: Coordinate<T>,
 }


### PR DESCRIPTION
I think it gives relatively little value to use a verbose multiline `where T: CoordNum` form when it can be included in the impl declaration, e.g. `impl<T: CoordNum> Line<T> {` would be used instead of this long form:

```
impl<T> Line<T>
where
    T: CoordNum,
{
```

The more complex cases, as well as functions should keep the where clause separate as they are long enough as it is.

- [ ] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

