### PR TITLE
Run CI on pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,10 @@
 on:
   push:
+    branches:
+      - main
+      - master
+      - staging
+      - trying
   pull_request:
   schedule: [cron: "45 6 * * *"]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,6 @@
 on:
   push:
+  pull_request:
   schedule: [cron: "45 6 * * *"]
 
 name: Run tests


### PR DESCRIPTION
This ensures CI automatically runs on PRs, even if submitted from forks.

Doing this avoids a silly case of a PR being ready to merge and having a green "merge" button, only for the bors to start test&submitting it, realizing PR has bugs, and waiting for a fix from a user and another review from the maintainer.

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

fixes #747