### PR TITLE
Require Default on all num types

### DIFF
--- a/geo-types/src/coordinate.rs
+++ b/geo-types/src/coordinate.rs
@@ -1,5 +1,8 @@
 use crate::{coord, CoordNum, Point};
 
+#[cfg(any(feature = "rstar_0_8", feature = "rstar_0_9"))]
+use crate::CoordFloat;
+
 #[cfg(any(feature = "approx", test))]
 use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 
@@ -303,7 +306,7 @@ where
 #[cfg(feature = "rstar_0_8")]
 impl<T> ::rstar_0_8::Point for Coordinate<T>
 where
-    T: ::num_traits::Float + ::rstar_0_8::RTreeNum,
+    T: CoordFloat + ::rstar_0_8::RTreeNum,
 {
     type Scalar = T;
 
@@ -336,7 +339,7 @@ where
 #[cfg(feature = "rstar_0_9")]
 impl<T> ::rstar_0_9::Point for Coordinate<T>
 where
-    T: ::num_traits::Float + ::rstar_0_9::RTreeNum,
+    T: CoordFloat + ::rstar_0_9::RTreeNum,
 {
     type Scalar = T;
 

--- a/geo-types/src/geometry_collection.rs
+++ b/geo-types/src/geometry_collection.rs
@@ -69,17 +69,9 @@ use std::ops::{Index, IndexMut};
 /// println!("{:?}", gc[0]);
 /// ```
 ///
-#[derive(Eq, PartialEq, Clone, Debug, Hash)]
+#[derive(Eq, PartialEq, Clone, Debug, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct GeometryCollection<T: CoordNum>(pub Vec<Geometry<T>>);
-
-// Implementing Default by hand because T does not have Default restriction
-// todo: consider adding Default as a CoordNum requirement
-impl<T: CoordNum> Default for GeometryCollection<T> {
-    fn default() -> Self {
-        Self(Vec::new())
-    }
-}
 
 impl<T: CoordNum> GeometryCollection<T> {
     /// Return an empty GeometryCollection

--- a/geo-types/src/lib.rs
+++ b/geo-types/src/lib.rs
@@ -76,9 +76,9 @@ impl<T: Num + Copy + NumCast + PartialOrd + Debug> CoordinateType for T {}
 /// For algorithms which only make sense for floating point, like area or length calculations,
 /// see [CoordFloat](trait.CoordFloat.html).
 #[allow(deprecated)]
-pub trait CoordNum: CoordinateType + Debug {}
+pub trait CoordNum: CoordinateType + Debug + Default {}
 #[allow(deprecated)]
-impl<T: CoordinateType + Debug> CoordNum for T {}
+impl<T: CoordinateType + Debug + Default> CoordNum for T {}
 
 pub trait CoordFloat: CoordNum + Float {}
 impl<T: CoordNum + Float> CoordFloat for T {}

--- a/geo-types/src/line.rs
+++ b/geo-types/src/line.rs
@@ -1,3 +1,5 @@
+#[cfg(any(feature = "rstar_0_8", feature = "rstar_0_9"))]
+use crate::CoordFloat;
 use crate::{CoordNum, Coordinate, Point};
 #[cfg(any(feature = "approx", test))]
 use approx::{AbsDiffEq, RelativeEq};
@@ -226,7 +228,7 @@ macro_rules! impl_rstar_line {
     ($rstar:ident) => {
         impl<T> ::$rstar::RTreeObject for Line<T>
         where
-            T: ::num_traits::Float + ::$rstar::RTreeNum,
+            T: CoordFloat + ::$rstar::RTreeNum,
         {
             type Envelope = ::$rstar::AABB<Point<T>>;
 
@@ -238,7 +240,7 @@ macro_rules! impl_rstar_line {
 
         impl<T> ::$rstar::PointDistance for Line<T>
         where
-            T: ::num_traits::Float + ::$rstar::RTreeNum,
+            T: CoordFloat + ::$rstar::RTreeNum,
         {
             fn distance_2(&self, point: &Point<T>) -> T {
                 let d = crate::private_utils::point_line_euclidean_distance(*point, *self);

--- a/geo-types/src/line_string.rs
+++ b/geo-types/src/line_string.rs
@@ -1,3 +1,5 @@
+#[cfg(any(feature = "rstar_0_8", feature = "rstar_0_9"))]
+use crate::CoordFloat;
 #[cfg(any(feature = "approx", test))]
 use approx::{AbsDiffEq, RelativeEq};
 
@@ -483,7 +485,7 @@ macro_rules! impl_rstar_line_string {
     ($rstar:ident) => {
         impl<T> ::$rstar::RTreeObject for LineString<T>
         where
-            T: ::num_traits::Float + ::$rstar::RTreeNum,
+            T: CoordFloat + ::$rstar::RTreeNum,
         {
             type Envelope = ::$rstar::AABB<Point<T>>;
 
@@ -505,7 +507,7 @@ macro_rules! impl_rstar_line_string {
 
         impl<T> ::$rstar::PointDistance for LineString<T>
         where
-            T: ::num_traits::Float + ::$rstar::RTreeNum,
+            T: CoordFloat + ::$rstar::RTreeNum,
         {
             fn distance_2(&self, point: &Point<T>) -> T {
                 let d = crate::private_utils::point_line_string_euclidean_distance(*point, self);

--- a/geo-types/src/point.rs
+++ b/geo-types/src/point.rs
@@ -551,7 +551,7 @@ where
 // These are required for rstar RTree
 impl<T> ::rstar_0_8::Point for Point<T>
 where
-    T: ::num_traits::Float + ::rstar_0_8::RTreeNum,
+    T: CoordFloat + ::rstar_0_8::RTreeNum,
 {
     type Scalar = T;
 
@@ -580,7 +580,7 @@ where
 #[cfg(feature = "rstar_0_9")]
 impl<T> ::rstar_0_9::Point for Point<T>
 where
-    T: ::num_traits::Float + ::rstar_0_9::RTreeNum,
+    T: CoordFloat + ::rstar_0_9::RTreeNum,
 {
     type Scalar = T;
 

--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -5,6 +5,7 @@
 * Add `LinesIter` algorithm to iterate over the lines in geometries.
   * Very similar to `CoordsIter`, but only implemented where it makes sense (e.g., for `Polygon`, `Rect`, but not `Point`).
   * <https://github.com/georust/geo/pull/757>
+* BREAKING: Add `Default` constraint to all `CoordNum`/`CoordFloat` values.
 
 ## 0.19.0
 


### PR DESCRIPTION
This PR requires https://github.com/georust/proj/pull/110 or https://github.com/georust/proj/pull/111 to be released first. See https://github.com/georust/geo/discussions/746 of a potential solution.

* Add `Default` trait constraint to `CoordNum` and `CoordFloat`
* Use `CoordFloat` instead of `::num_traits::Float` for rstar
* A few minor conditional compilation cleanups

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

