### PR TITLE
Fix macros not allowing trailing commas

### DIFF
--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-*
+* Macros `coord!`, `point!`, `line_string!`, and `polygon!` now support trailing commas such as `coord! { x: 181.2, y: 51.79, }`
+  * <https://github.com/georust/geo/pull/752> 
 
 ## 0.7.3
 

--- a/geo-types/src/macros.rs
+++ b/geo-types/src/macros.rs
@@ -22,7 +22,7 @@
 /// [`Point`]: ./struct.Point.html
 #[macro_export]
 macro_rules! point {
-    (x: $x:expr, y: $y:expr) => {
+    (x: $x:expr, y: $y:expr $(,)?) => {
         $crate::Point::new($x, $y)
     };
 }
@@ -48,7 +48,7 @@ macro_rules! point {
 /// [`Coordinate`]: ./struct.Point.html
 #[macro_export]
 macro_rules! coord {
-    (x: $x:expr, y: $y:expr) => {
+    (x: $x:expr, y: $y:expr $(,)?) => {
         $crate::Coordinate { x: $x, y: $y }
     };
 }
@@ -70,7 +70,7 @@ macro_rules! coord {
 ///     (x: -21.95156, y: 64.1446),
 ///     (x: -21.951, y: 64.14479),
 ///     (x: -21.95044, y: 64.14527),
-///     (x: -21.951445, y: 64.145508)
+///     (x: -21.951445, y: 64.145508),
 /// ];
 ///
 /// assert_eq!(ls[1], geo_types::Coordinate {
@@ -118,7 +118,7 @@ macro_rules! coord {
 macro_rules! line_string {
     () => { $crate::LineString(vec![]) };
     (
-        $((x: $x:expr, y: $y:expr)),*
+        $((x: $x:expr, y: $y:expr $(,)?)),*
         $(,)?
     ) => {
         line_string![
@@ -212,12 +212,12 @@ macro_rules! polygon {
     () => { $crate::Polygon::new(line_string![], vec![]) };
     (
         exterior: [
-            $((x: $exterior_x:expr, y: $exterior_y:expr)),*
+            $((x: $exterior_x:expr, y: $exterior_y:expr $(,)?)),*
             $(,)?
         ],
         interiors: [
             $([
-                $((x: $interior_x:expr, y: $interior_y:expr)),*
+                $((x: $interior_x:expr, y: $interior_y:expr $(,)?)),*
                 $(,)?
             ]),*
             $(,)?
@@ -234,7 +234,6 @@ macro_rules! polygon {
                 $([
                     $($crate::Coordinate { x: $interior_x, y: $interior_y }),*
                 ]),*
-
             ],
         )
     };
@@ -268,7 +267,7 @@ macro_rules! polygon {
         )
     };
     (
-        $((x: $x:expr, y: $y:expr)),*
+        $((x: $x:expr, y: $y:expr $(,)?)),*
         $(,)?
     ) => {
         polygon![


### PR DESCRIPTION
Macros like `coord!` need to support trailing comma cases:

```
coord! {
    x: 181.2,
    y: 51.79,  // <-- this one
}
```

More complex cases like `line_string!` also support trailing commas at all nesting levels

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

