### PR TITLE
More tidying of fast path algorithm

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -39,6 +39,8 @@
   * <https://github.com/georust/geo/pull/836>
 * BREAKING: MapCoords/MapCoordsInPlace now map `Coordinate`s rather than `(x,y)` tuples
   * <https://github.com/georust/geo/pull/837>
+* Tidy fast-path distance algorithm
+  * <https://github.com/georust/geo/pull/754>
 
 ## 0.20.1
 

--- a/geo/src/algorithm/euclidean_distance.rs
+++ b/geo/src/algorithm/euclidean_distance.rs
@@ -485,7 +485,7 @@ where
             // fall back to R* nearest neighbour method
             nearest_neighbour_distance(self.exterior(), poly2.exterior())
         } else {
-            min_poly_dist(self, poly2)
+            min_convex_poly_dist(self, poly2)
         }
     }
 }
@@ -958,7 +958,7 @@ mod test {
             .map(|e| Point::new(e.0, e.1))
             .collect::<Vec<_>>();
         let poly2 = Polygon::new(LineString::from(points2), vec![]);
-        let dist = min_poly_dist(&poly1.convex_hull(), &poly2.convex_hull());
+        let dist = min_convex_poly_dist(&poly1.convex_hull(), &poly2.convex_hull());
         let dist2 = nearest_neighbour_distance(poly1.exterior(), poly2.exterior());
         assert_relative_eq!(dist, 21.0);
         assert_relative_eq!(dist2, 21.0);
@@ -991,7 +991,7 @@ mod test {
             .map(|e| Point::new(e.0, e.1))
             .collect::<Vec<_>>();
         let poly2 = Polygon::new(LineString::from(points2), vec![]);
-        let dist = min_poly_dist(&poly1.convex_hull(), &poly2.convex_hull());
+        let dist = min_convex_poly_dist(&poly1.convex_hull(), &poly2.convex_hull());
         let dist2 = nearest_neighbour_distance(poly1.exterior(), poly2.exterior());
         assert_relative_eq!(dist, 29.274562336608895);
         assert_relative_eq!(dist2, 29.274562336608895);
@@ -1024,7 +1024,7 @@ mod test {
             .map(|e| Point::new(e.0, e.1))
             .collect::<Vec<_>>();
         let poly2 = Polygon::new(LineString::from(points2), vec![]);
-        let dist = min_poly_dist(&poly1.convex_hull(), &poly2.convex_hull());
+        let dist = min_convex_poly_dist(&poly1.convex_hull(), &poly2.convex_hull());
         let dist2 = nearest_neighbour_distance(poly1.exterior(), poly2.exterior());
         assert_relative_eq!(dist, 12.0);
         assert_relative_eq!(dist2, 12.0);
@@ -1034,7 +1034,7 @@ mod test {
     fn test_minimum_polygon_distance_4() {
         let poly1 = Rect::new((0., 0.), (1., 1.)).to_polygon();
         let poly2 = Rect::new((2., 2.), (3., 3.)).to_polygon();
-        let dist = min_poly_dist(&poly1, &poly2);
+        let dist = min_convex_poly_dist(&poly1, &poly2);
         let dist2 = nearest_neighbour_distance(poly1.exterior(), poly2.exterior());
         assert_eq!(dist, dist2);
     }
@@ -1063,7 +1063,7 @@ mod test {
                 ],
                 interiors: []
             );
-        let dist = min_poly_dist(&poly1, &poly2);
+        let dist = min_convex_poly_dist(&poly1, &poly2);
         let dist2 = nearest_neighbour_distance(poly1.exterior(), poly2.exterior());
         assert_eq!(dist, dist2);
     }


### PR DESCRIPTION
Use built-in cross product instead of "left turn"
Simplify vertex line angle logic
Use accumulated caliper angle as a stopping condition
Use epsilon from num-traits instead of "small number"
Simplify bounds
Add link to original paper

I still don't understand why the magic "100" number works, but at least we're down to a single magic number, and I couldn't trigger a condition that causes it to diverge from the rtree-based result.

If anyone's got an idea for an algorithm that can generate valid polygons, this would be a good candidate for a property-based test:

1. generate two valid polygons 
2. generate their convex hulls 
3. calculate distance using fast path4 
4. compare to rtree-based version



- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

