### PR TITLE
Add `LinesIter` algorithm to iterate over lines in a geometry

### DIFF
--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Make `Rect::to_lines` return lines in winding order for `Rect::to_polygon`.
+* BREAKING: Make `Rect::to_lines` return lines in winding order for `Rect::to_polygon`.
   * <https://github.com/georust/geo/pull/757>
 * Macros `coord!`, `point!`, `line_string!`, and `polygon!` now support trailing commas such as `coord! { x: 181.2, y: 51.79, }`
   * <https://github.com/georust/geo/pull/752>

--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -2,8 +2,10 @@
 
 ## Unreleased
 
+* Make `Rect::to_lines` return lines in winding order for `Rect::to_polygon`.
+  * TODO: PR number TBD.
 * Macros `coord!`, `point!`, `line_string!`, and `polygon!` now support trailing commas such as `coord! { x: 181.2, y: 51.79, }`
-  * <https://github.com/georust/geo/pull/752> 
+  * <https://github.com/georust/geo/pull/752>
 
 ## 0.7.3
 

--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Make `Rect::to_lines` return lines in winding order for `Rect::to_polygon`.
-  * TODO: PR number TBD.
+  * <https://github.com/georust/geo/pull/757>
 * Macros `coord!`, `point!`, `line_string!`, and `polygon!` now support trailing commas such as `coord! { x: 181.2, y: 51.79, }`
   * <https://github.com/georust/geo/pull/752>
 

--- a/geo-types/src/rect.rs
+++ b/geo-types/src/rect.rs
@@ -248,8 +248,8 @@ impl<T: CoordNum> Rect<T> {
             ),
             Line::new(
                 Coordinate {
-                    x: self.min.x,
-                    y: self.min.y,
+                    x: self.max.x,
+                    y: self.max.y,
                 },
                 Coordinate {
                     x: self.max.x,
@@ -262,8 +262,8 @@ impl<T: CoordNum> Rect<T> {
                     y: self.min.y,
                 },
                 Coordinate {
-                    x: self.max.x,
-                    y: self.max.y,
+                    x: self.min.x,
+                    y: self.min.y,
                 },
             ),
         ]

--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-*
+* Add `LinesIter` algorithm to iterate over the lines in geometries.
+  * Very similar to `CoordsIter`, but only implemented where it makes sense (e.g., for `Polygon`, `Rect`, but not `Point`).
+  * TODO: PR ref TBD
 
 ## 0.19.0
 

--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -4,7 +4,7 @@
 
 * Add `LinesIter` algorithm to iterate over the lines in geometries.
   * Very similar to `CoordsIter`, but only implemented where it makes sense (e.g., for `Polygon`, `Rect`, but not `Point`).
-  * TODO: PR ref TBD
+  * <https://github.com/georust/geo/pull/757>
 
 ## 0.19.0
 

--- a/geo/src/algorithm/lines_iter.rs
+++ b/geo/src/algorithm/lines_iter.rs
@@ -1,5 +1,6 @@
-use crate::{CoordNum, Line, LineString};
-use std::iter::{self, FromFn};
+use crate::{Coordinate, CoordNum, Line, LineString};
+use core::slice;
+use std::iter;
 
 pub trait LinesIter<'a> {
     type Scalar: CoordNum;
@@ -21,39 +22,48 @@ impl<'a, T: CoordNum + 'a> LinesIter<'a> for Line<T> {
     }
 }
 
-/*
+
 // ┌──────────────────────────────────┐
 // │ Implementation for LineString    │
 // └──────────────────────────────────┘
 
-impl<'a, T: CoordNum + 'a> LinesIter<'a, T> for LineString<T> {
-    type Iter = iter::Map<iter::Windows<'a, Coordinate<T>>>;
+impl<'a, T: CoordNum + 'a> LinesIter<'a> for LineString<T> {
+    type Scalar = T;
+    type Iter = LineStringLinesIter<'a, T>;
 
     fn lines_iter(&'a self) -> Self::Iter {
-        self.0.windows(2).map(|w| {
-            // slice::windows(N) is guaranteed to yield a slice with exactly N elements
+        LineStringLinesIter::new(self)
+    }
+}
+
+pub struct LineStringLinesIter<'a, T: CoordNum>(slice::Windows<'a, Coordinate<T>>);
+
+impl<'a, T: CoordNum> LineStringLinesIter<'a, T> {
+    fn new(line_string: &'a LineString<T>) -> Self {
+        Self(line_string.0.windows(2))
+    }
+}
+
+impl<'a, T: CoordNum> Iterator for LineStringLinesIter<'a, T> {
+    type Item = Line<T>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // Can't use LineString::lines() because it returns an `impl Trait`
+        // and there is no way to name that type in `LinesIter::Iter` until [RFC 2071] is stabilized.
+        //
+        // [RFC 2071]: https://rust-lang.github.io/rfcs/2071-impl-trait-existential-types.html
+        self.0.next().map(|w| {
+            // slice::windows(2) is guaranteed to yield a slice with exactly 2 elements
             unsafe { Line::new(*w.get_unchecked(0), *w.get_unchecked(1)) }
         })
     }
 }
 
-pub struct LinesIterIter<'a, T,
-
-struct LineStringLinesIterator<T: CoordNum, Iter: Iterator<Item=Line<T>>> (Iter);
-
-impl<T: CoordNum, Iter: Iterator<Item=Line<T>>> Iterator for LineStringLinesIterator<T, Iter> {
-    type Item = Line<T>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.0.next()
-    }
-}
- */
 #[cfg(test)]
 mod test {
 
     use super::LinesIter;
-    use crate::{Coordinate, Line};
+    use crate::{line_string, Coordinate, Line, LineString};
 
     #[test]
     fn test_line() {
@@ -63,5 +73,33 @@ mod test {
             Coordinate { x: 5., y: 10. },
         )];
         assert_eq!(want, line.lines_iter().collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn test_empty_line_string() {
+        let ls: LineString<f64> = line_string![];
+        assert_eq!(Vec::<Line<f64>>::new(), ls.lines_iter().collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn test_open_line_string() {
+        let ls = line_string![(x: 0., y: 0.), (x: 1., y: 1.), (x:2., y: 2.)];
+        let want = vec![
+            Line::new(Coordinate { x: 0., y: 0. }, Coordinate { x: 1., y: 1. }),
+            Line::new(Coordinate { x: 1., y: 1. }, Coordinate { x: 2., y: 2. }),
+        ];
+        assert_eq!(want, ls.lines_iter().collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn test_closed_line_string() {
+        let mut ls = line_string![(x: 0., y: 0.), (x: 1., y: 1.), (x:2., y: 2.)];
+        ls.close();
+        let want = vec![
+            Line::new(Coordinate { x: 0., y: 0. }, Coordinate { x: 1., y: 1. }),
+            Line::new(Coordinate { x: 1., y: 1. }, Coordinate { x: 2., y: 2. }),
+            Line::new(Coordinate { x: 2., y: 2. }, Coordinate { x: 0., y: 0. }),
+        ];
+        assert_eq!(want, ls.lines_iter().collect::<Vec<_>>());
     }
 }

--- a/geo/src/algorithm/lines_iter.rs
+++ b/geo/src/algorithm/lines_iter.rs
@@ -1,4 +1,4 @@
-use crate::{CoordNum, Coordinate, Line, LineString, MultiLineString, MultiPolygon, Polygon, Rect};
+use crate::{CoordNum, Coordinate, Line, LineString, MultiLineString, MultiPolygon, Polygon, Rect, Triangle};
 use core::slice;
 use std::iter;
 
@@ -131,12 +131,29 @@ impl<'a, T: CoordNum + 'a> LinesIter<'a> for Rect<T> {
     }
 }
 
+
+// ┌────────────────────────────────┐
+// │ Implementation for Triangle    │
+// └────────────────────────────────┘
+
+
+impl<'a, T: CoordNum + 'a> LinesIter<'a> for Triangle<T> {
+    type Scalar = T;
+    type Iter = <[Line<T>; 3] as IntoIterator>::IntoIter;
+
+    fn lines_iter(&'a self) -> Self::Iter {
+        // Explicitly iterate by value so this works for pre-2021 rust editions.
+        // See https://doc.rust-lang.org/std/primitive.array.html#editions
+        IntoIterator::into_iter(self.to_lines())
+    }
+}
+
 #[cfg(test)]
 mod test {
 
     use super::LinesIter;
     use crate::{
-        line_string, polygon, Coordinate, Line, LineString, MultiLineString, MultiPolygon, Rect,
+        line_string, polygon, Coordinate, Line, LineString, MultiLineString, MultiPolygon, Rect, Triangle
     };
 
     #[test]
@@ -258,5 +275,12 @@ mod test {
         let rect = Rect::new(Coordinate { x: 0., y: 0. }, Coordinate { x: 1., y: 2. });
         let want = rect.to_polygon().lines_iter().collect::<Vec<_>>();
         assert_eq!(want, rect.lines_iter().collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn test_triangle() {
+        let triangle = Triangle(Coordinate { x: 0., y: 0. }, Coordinate { x: 1., y: 2. }, Coordinate { x: 2., y: 3.});
+        let want = triangle.to_polygon().lines_iter().collect::<Vec<_>>();
+        assert_eq!(want, triangle.lines_iter().collect::<Vec<_>>());
     }
 }

--- a/geo/src/algorithm/lines_iter.rs
+++ b/geo/src/algorithm/lines_iter.rs
@@ -135,6 +135,10 @@ impl<'a, T: CoordNum + 'a> LinesIter<'a> for Rect<T> {
     fn lines_iter(&'a self) -> Self::Iter {
         // Explicitly iterate by value so this works for pre-2021 rust editions.
         // See https://doc.rust-lang.org/std/primitive.array.html#editions
+        //
+        // TODO: Simplify once [#741] bumps MSRV.
+        //
+        // [#741]: https://github.com/georust/geo/pull/741
         IntoIterator::into_iter(self.to_lines())
     }
 }
@@ -146,11 +150,15 @@ impl<'a, T: CoordNum + 'a> LinesIter<'a> for Triangle<T> {
     fn lines_iter(&'a self) -> Self::Iter {
         // Explicitly iterate by value so this works for pre-2021 rust editions.
         // See https://doc.rust-lang.org/std/primitive.array.html#editions
+        //
+        // TODO: Simplify once [#741] bumps MSRV.
+        //
+        // [#741]: https://github.com/georust/geo/pull/741
         IntoIterator::into_iter(self.to_lines())
     }
 }
 
-/// An iterator that transform Iterator<LinesIter> into Iterator<Iterator<Line>>
+/// Utility to transform Iterator<LinesIter> into Iterator<Iterator<Line>>.
 #[derive(Debug)]
 pub struct MapLinesIter<'a, Iter1: Iterator<Item = &'a Iter2>, Iter2: 'a + LinesIter<'a>>(Iter1);
 

--- a/geo/src/algorithm/lines_iter.rs
+++ b/geo/src/algorithm/lines_iter.rs
@@ -133,13 +133,7 @@ impl<'a, T: CoordNum + 'a> LinesIter<'a> for Rect<T> {
     type Iter = <[Line<Self::Scalar>; 4] as IntoIterator>::IntoIter;
 
     fn lines_iter(&'a self) -> Self::Iter {
-        // Explicitly iterate by value so this works for pre-2021 rust editions.
-        // See https://doc.rust-lang.org/std/primitive.array.html#editions
-        //
-        // TODO: Simplify once [#741] bumps MSRV.
-        //
-        // [#741]: https://github.com/georust/geo/pull/741
-        IntoIterator::into_iter(self.to_lines())
+        self.to_lines().into_iter()
     }
 }
 
@@ -148,13 +142,7 @@ impl<'a, T: CoordNum + 'a> LinesIter<'a> for Triangle<T> {
     type Iter = <[Line<Self::Scalar>; 3] as IntoIterator>::IntoIter;
 
     fn lines_iter(&'a self) -> Self::Iter {
-        // Explicitly iterate by value so this works for pre-2021 rust editions.
-        // See https://doc.rust-lang.org/std/primitive.array.html#editions
-        //
-        // TODO: Simplify once [#741] bumps MSRV.
-        //
-        // [#741]: https://github.com/georust/geo/pull/741
-        IntoIterator::into_iter(self.to_lines())
+        self.to_lines().into_iter()
     }
 }
 

--- a/geo/src/algorithm/lines_iter.rs
+++ b/geo/src/algorithm/lines_iter.rs
@@ -1,0 +1,67 @@
+use crate::{CoordNum, Line, LineString};
+use std::iter::{self, FromFn};
+
+pub trait LinesIter<'a> {
+    type Scalar: CoordNum;
+    type Iter: Iterator<Item = Line<Self::Scalar>>;
+
+    fn lines_iter(&'a self) -> Self::Iter;
+}
+
+// ┌────────────────────────────┐
+// │ Implementation for Line    │
+// └────────────────────────────┘
+
+impl<'a, T: CoordNum + 'a> LinesIter<'a> for Line<T> {
+    type Scalar = T;
+    type Iter = iter::Copied<iter::Once<&'a Line<T>>>;
+
+    fn lines_iter(&'a self) -> Self::Iter {
+        iter::once(self).copied()
+    }
+}
+
+/*
+// ┌──────────────────────────────────┐
+// │ Implementation for LineString    │
+// └──────────────────────────────────┘
+
+impl<'a, T: CoordNum + 'a> LinesIter<'a, T> for LineString<T> {
+    type Iter = iter::Map<iter::Windows<'a, Coordinate<T>>>;
+
+    fn lines_iter(&'a self) -> Self::Iter {
+        self.0.windows(2).map(|w| {
+            // slice::windows(N) is guaranteed to yield a slice with exactly N elements
+            unsafe { Line::new(*w.get_unchecked(0), *w.get_unchecked(1)) }
+        })
+    }
+}
+
+pub struct LinesIterIter<'a, T,
+
+struct LineStringLinesIterator<T: CoordNum, Iter: Iterator<Item=Line<T>>> (Iter);
+
+impl<T: CoordNum, Iter: Iterator<Item=Line<T>>> Iterator for LineStringLinesIterator<T, Iter> {
+    type Item = Line<T>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+ */
+#[cfg(test)]
+mod test {
+
+    use super::LinesIter;
+    use crate::{Coordinate, Line};
+
+    #[test]
+    fn test_line() {
+        let line = Line::new(Coordinate { x: 0., y: 0. }, Coordinate { x: 5., y: 10. });
+        let want = vec![Line::new(
+            Coordinate { x: 0., y: 0. },
+            Coordinate { x: 5., y: 10. },
+        )];
+        assert_eq!(want, line.lines_iter().collect::<Vec<_>>());
+    }
+}

--- a/geo/src/algorithm/lines_iter.rs
+++ b/geo/src/algorithm/lines_iter.rs
@@ -1,4 +1,4 @@
-use crate::{CoordNum, Coordinate, Line, LineString, MultiLineString, MultiPolygon, Polygon};
+use crate::{CoordNum, Coordinate, Line, LineString, MultiLineString, MultiPolygon, Polygon, Rect};
 use core::slice;
 use std::iter;
 
@@ -116,12 +116,27 @@ impl<'a, T: CoordNum + 'a> LinesIter<'a> for MultiPolygon<T> {
     }
 }
 
+// ┌────────────────────────────┐
+// │ Implementation for Rect    │
+// └────────────────────────────┘
+
+impl<'a, T: CoordNum + 'a> LinesIter<'a> for Rect<T> {
+    type Scalar = T;
+    type Iter = <[Line<T>; 4] as IntoIterator>::IntoIter;
+
+    fn lines_iter(&'a self) -> Self::Iter {
+        // Explicitly iterate by value so this works for pre-2021 rust editions.
+        // See https://doc.rust-lang.org/std/primitive.array.html#editions
+        IntoIterator::into_iter(self.to_lines())
+    }
+}
+
 #[cfg(test)]
 mod test {
 
     use super::LinesIter;
     use crate::{
-        line_string, polygon, Coordinate, Line, LineString, MultiLineString, MultiPolygon,
+        line_string, polygon, Coordinate, Line, LineString, MultiLineString, MultiPolygon, Rect,
     };
 
     #[test]
@@ -236,5 +251,12 @@ mod test {
             Line::new(Coordinate { x: 3., y: 5. }, Coordinate { x: 3., y: 3. }),
         ];
         assert_eq!(want, mp.lines_iter().collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn test_rect() {
+        let rect = Rect::new(Coordinate { x: 0., y: 0. }, Coordinate { x: 1., y: 2. });
+        let want = rect.to_polygon().lines_iter().collect::<Vec<_>>();
+        assert_eq!(want, rect.lines_iter().collect::<Vec<_>>());
     }
 }

--- a/geo/src/algorithm/mod.rs
+++ b/geo/src/algorithm/mod.rs
@@ -61,6 +61,8 @@ pub mod line_interpolate_point;
 pub mod line_intersection;
 /// Locate a point along a `Line` or `LineString`.
 pub mod line_locate_point;
+/// Iterate over the lines in a geometry.
+pub mod lines_iter;
 /// Apply a function to all `Coordinates` of a `Geometry`.
 pub mod map_coords;
 /// Orient a `Polygon`'s exterior and interior rings.

--- a/geo/src/lib.rs
+++ b/geo/src/lib.rs
@@ -103,6 +103,7 @@
 //!   coordinates in a geometry in-place
 //! - **[`TryMapCoords`](algorithm::map_coords::TryMapCoords)**: Map a fallible function over all
 //!   the coordinates in a geometry, returning a new geometry wrapped in a `Result`
+//! - **[`LinesIter`](algorithm::lines_iter::LinesIter)**: Iterate over lines of a geometry
 //!
 //! ## Boundary
 //!


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Newly introduced `LinesIter` is very similar to `CoordsIter`, but is implemented for only a subset of types (e.g., not for `Point`, and hence not for `Geometry`).

This PR also includes a small tweak to the order in which `Rect::to_lines()` returns the lines -- it now matches the winding order of the polygon created by `Rect::to_polygon()`.

Closes #708 