### PR TITLE
Clean up rstar versioned dependencies

### DIFF
--- a/geo-test-fixtures/Cargo.toml
+++ b/geo-test-fixtures/Cargo.toml
@@ -4,8 +4,6 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 wkt = { version = "0.9", default-features = false }
 geo-types = { path = "../geo-types" }

--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -8,6 +8,8 @@
   * <https://github.com/georust/geo/pull/741>
 * Macros `coord!`, `point!`, `line_string!`, and `polygon!` now support trailing commas such as `coord! { x: 181.2, y: 51.79, }`
   * <https://github.com/georust/geo/pull/752>
+* Internal cleanup: Explicitly declare `rstar_0_8` and `rstar_0_9` features to be explicit which rstar version is being used. For backward compatibility, the `rstar` feature will still enable `rstar_0_8`.
+  * <https://github.com/georust/geo/pull/759>
 
 ## 0.7.3
 

--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -8,7 +8,7 @@
   * <https://github.com/georust/geo/pull/741>
 * Macros `coord!`, `point!`, `line_string!`, and `polygon!` now support trailing commas such as `coord! { x: 181.2, y: 51.79, }`
   * <https://github.com/georust/geo/pull/752>
-* Internal cleanup: Explicitly declare `rstar_0_8` and `rstar_0_9` features to be explicit which rstar version is being used. For backward compatibility, the `rstar` feature will still enable `rstar_0_8`.
+* Internal cleanup: Explicitly declare `use-rstar_0_8` and `use-rstar_0_9` features to be explicit which rstar version is being used. For backward compatibility, the `use-rstar` feature will still enable `use-rstar_0_8`.
   * <https://github.com/georust/geo/pull/759>
 
 ## 0.7.3

--- a/geo-types/Cargo.toml
+++ b/geo-types/Cargo.toml
@@ -11,17 +11,19 @@ description = "Geospatial primitive data types"
 edition = "2021"
 
 [features]
-use-rstar = ["rstar", "approx"]
+# Prefer `use-rstar` feature rather than enabling rstar directly.
+# rstar integration relies on the optional approx crate, but implicit features cannot yet enable other features.
+# See: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#namespaced-features
+rstar = ["rstar_0_8"]
+use-rstar = ["use-rstar_0_8"]
+use-rstar_0_8 = ["rstar_0_8", "approx"]
 use-rstar_0_9 = ["rstar_0_9", "approx"]
 
 [dependencies]
 approx = { version = "0.4.0", optional = true }
 arbitrary = { version = "1", optional = true }
 num-traits = "0.2"
-# Prefer `use-rstar` feature rather than enabling rstar directly.
-# rstar integration relies on the optional approx crate, but implicit features cannot yet enable other features.
-# See: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#namespaced-features
-rstar = { version = "0.8", optional = true }
+rstar_0_8 = { package = "rstar", version = "0.8", optional = true }
 rstar_0_9 = { package = "rstar", version = "0.9", optional = true }
 serde = { version = "1", optional = true, features = ["derive"] }
 

--- a/geo-types/src/coordinate.rs
+++ b/geo-types/src/coordinate.rs
@@ -285,10 +285,10 @@ where
     }
 }
 
-#[cfg(feature = "rstar")]
-impl<T> ::rstar::Point for Coordinate<T>
+#[cfg(feature = "rstar_0_8")]
+impl<T> ::rstar_0_8::Point for Coordinate<T>
 where
-    T: ::num_traits::Float + ::rstar::RTreeNum,
+    T: ::num_traits::Float + ::rstar_0_8::RTreeNum,
 {
     type Scalar = T;
 

--- a/geo-types/src/lib.rs
+++ b/geo-types/src/lib.rs
@@ -58,7 +58,7 @@ use std::fmt::Debug;
 extern crate serde;
 
 #[cfg(feature = "rstar")]
-extern crate rstar;
+extern crate rstar_0_8;
 
 #[cfg(test)]
 #[macro_use]
@@ -213,8 +213,8 @@ mod tests {
     #[test]
     /// ensure Line's SpatialObject impl is correct
     fn line_test() {
-        use rstar::primitives::Line as RStarLine;
-        use rstar::{PointDistance, RTreeObject};
+        use rstar_0_8::primitives::Line as RStarLine;
+        use rstar_0_8::{PointDistance, RTreeObject};
 
         let rl = RStarLine::new(Point::new(0.0, 0.0), Point::new(5.0, 5.0));
         let l = Line::new(Coordinate { x: 0.0, y: 0.0 }, Coordinate { x: 5., y: 5. });

--- a/geo-types/src/lib.rs
+++ b/geo-types/src/lib.rs
@@ -37,7 +37,7 @@
 //! - `approx`: Allows geometry types to be checked for approximate equality with [approx]
 //! - `arbitrary`: Allows geometry types to be created from unstructured input with [arbitrary]
 //! - `serde`: Allows geometry types to be serialized and deserialized with [Serde]
-//! - `use-rstar`: Allows geometry types to be inserted into [rstar] R*-trees (`rstar v0.8`)
+//! - `use-rstar_0_8`: Allows geometry types to be inserted into [rstar] R*-trees (`rstar v0.8`)
 //! - `use-rstar_0_9`: Allows geometry types to be inserted into [rstar] R*-trees (`rstar v0.9`)
 //!
 //! [approx]: https://github.com/brendanzab/approx
@@ -57,7 +57,7 @@ use std::fmt::Debug;
 #[macro_use]
 extern crate serde;
 
-#[cfg(feature = "rstar")]
+#[cfg(feature = "rstar_0_8")]
 extern crate rstar_0_8;
 
 #[cfg(test)]
@@ -129,7 +129,7 @@ mod macros;
 #[cfg(feature = "arbitrary")]
 mod arbitrary;
 
-#[cfg(feature = "rstar")]
+#[cfg(feature = "rstar_0_8")]
 #[doc(hidden)]
 pub mod private_utils;
 
@@ -209,7 +209,7 @@ mod tests {
         assert_eq!(p.x(), 1_000_000i64);
     }
 
-    #[cfg(feature = "rstar")]
+    #[cfg(feature = "rstar_0_8")]
     #[test]
     /// ensure Line's SpatialObject impl is correct
     fn line_test() {

--- a/geo-types/src/line.rs
+++ b/geo-types/src/line.rs
@@ -221,7 +221,7 @@ impl<T: AbsDiffEq<Epsilon = T> + CoordNum> AbsDiffEq for Line<T> {
     }
 }
 
-#[cfg(any(feature = "rstar", feature = "rstar_0_9"))]
+#[cfg(any(feature = "rstar_0_8", feature = "rstar_0_9"))]
 macro_rules! impl_rstar_line {
     ($rstar:ident) => {
         impl<T> ::$rstar::RTreeObject for Line<T>

--- a/geo-types/src/line.rs
+++ b/geo-types/src/line.rs
@@ -221,6 +221,7 @@ impl<T: AbsDiffEq<Epsilon = T> + CoordNum> AbsDiffEq for Line<T> {
     }
 }
 
+#[cfg(any(feature = "rstar", feature = "rstar_0_9"))]
 macro_rules! impl_rstar_line {
     ($rstar:ident) => {
         impl<T> ::$rstar::RTreeObject for Line<T>
@@ -247,8 +248,8 @@ macro_rules! impl_rstar_line {
     };
 }
 
-#[cfg(feature = "rstar")]
-impl_rstar_line!(rstar);
+#[cfg(feature = "rstar_0_8")]
+impl_rstar_line!(rstar_0_8);
 
 #[cfg(feature = "rstar_0_9")]
 impl_rstar_line!(rstar_0_9);

--- a/geo-types/src/line_string.rs
+++ b/geo-types/src/line_string.rs
@@ -459,6 +459,7 @@ impl<T: AbsDiffEq<Epsilon = T> + CoordNum> AbsDiffEq for LineString<T> {
     }
 }
 
+#[cfg(any(feature = "rstar_0_8", feature = "rstar_0_9"))]
 macro_rules! impl_rstar_line_string {
     ($rstar:ident) => {
         impl<T> ::$rstar::RTreeObject for LineString<T>
@@ -499,8 +500,8 @@ macro_rules! impl_rstar_line_string {
     };
 }
 
-#[cfg(feature = "rstar")]
-impl_rstar_line_string!(rstar);
+#[cfg(feature = "rstar_0_8")]
+impl_rstar_line_string!(rstar_0_8);
 
 #[cfg(feature = "rstar_0_9")]
 impl_rstar_line_string!(rstar_0_9);

--- a/geo-types/src/point.rs
+++ b/geo-types/src/point.rs
@@ -547,11 +547,11 @@ where
     }
 }
 
-#[cfg(feature = "rstar")]
+#[cfg(feature = "rstar_0_8")]
 // These are required for rstar RTree
-impl<T> ::rstar::Point for Point<T>
+impl<T> ::rstar_0_8::Point for Point<T>
 where
-    T: ::num_traits::Float + ::rstar::RTreeNum,
+    T: ::num_traits::Float + ::rstar_0_8::RTreeNum,
 {
     type Scalar = T;
 

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -18,17 +18,17 @@ use-serde = ["serde", "geo-types/serde"]
 
 [dependencies]
 geo-types = { version = "0.7.3", features = ["approx", "use-rstar"] }
-geographiclib-rs = { version = "0.2" }
+geographiclib-rs = "0.2"
 log = "0.4.11"
 num-traits = "0.2"
 proj = { version = "0.25.2", optional = true }
-robust = { version = "0.2.2" }
-rstar = { version = "0.8" }
+robust = "0.2.2"
+rstar = "0.8"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 approx = "0.4.0"
-criterion = { version = "0.3" }
+criterion = "0.3"
 geo-test-fixtures = { path = "../geo-test-fixtures" }
 # jts-test-runner is an internal crate which exists only to be part of the geo test suite.
 # As such it's kept unpublished. It's in a separate repo primarily because it's kind of large.


### PR DESCRIPTION
Explicitly declare `rstar_0_8` and `rstar_0_9` to make it clearer which version is being used.  For backward compatibility, the `rstar` is now a feature that enables `rstar_0_8`

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

