### PR TITLE
Use coord! macro instead of Coordinate ctor

### DIFF
--- a/geo-types/src/arbitrary.rs
+++ b/geo-types/src/arbitrary.rs
@@ -8,7 +8,7 @@ impl<'a, T: arbitrary::Arbitrary<'a> + CoordFloat> arbitrary::Arbitrary<'a> for 
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let x = u.arbitrary::<T>()?;
         let y = u.arbitrary::<T>()?;
-        Ok(Coordinate { x, y })
+        Ok(coord! { x: x, y: y })
     }
 }
 

--- a/geo-types/src/coordinate.rs
+++ b/geo-types/src/coordinate.rs
@@ -1,4 +1,4 @@
-use crate::{CoordNum, Point};
+use crate::{coord, CoordNum, Point};
 
 #[cfg(any(feature = "approx", test))]
 use approx::{AbsDiffEq, RelativeEq, UlpsEq};
@@ -32,7 +32,7 @@ pub struct Coordinate<T: CoordNum> {
 
 impl<T: CoordNum> From<(T, T)> for Coordinate<T> {
     fn from(coords: (T, T)) -> Self {
-        Coordinate {
+        coord! {
             x: coords.0,
             y: coords.1,
         }
@@ -41,7 +41,7 @@ impl<T: CoordNum> From<(T, T)> for Coordinate<T> {
 
 impl<T: CoordNum> From<[T; 2]> for Coordinate<T> {
     fn from(coords: [T; 2]) -> Self {
-        Coordinate {
+        coord! {
             x: coords[0],
             y: coords[1],
         }
@@ -50,7 +50,7 @@ impl<T: CoordNum> From<[T; 2]> for Coordinate<T> {
 
 impl<T: CoordNum> From<Point<T>> for Coordinate<T> {
     fn from(point: Point<T>) -> Self {
-        Coordinate {
+        coord! {
             x: point.x(),
             y: point.y(),
         }
@@ -75,9 +75,9 @@ impl<T: CoordNum> Coordinate<T> {
     /// # Examples
     ///
     /// ```
-    /// use geo_types::Coordinate;
+    /// use geo_types::coord;
     ///
-    /// let c = Coordinate {
+    /// let c = coord! {
     ///     x: 40.02f64,
     ///     y: 116.34,
     /// };
@@ -328,7 +328,7 @@ where
     const DIMENSIONS: usize = 2;
 
     fn generate(mut generator: impl FnMut(usize) -> Self::Scalar) -> Self {
-        Coordinate {
+        coord! {
             x: generator(0),
             y: generator(1),
         }

--- a/geo-types/src/lib.rs
+++ b/geo-types/src/lib.rs
@@ -140,7 +140,7 @@ mod tests {
 
     #[test]
     fn type_test() {
-        let c = Coordinate {
+        let c = coord! {
             x: 40.02f64,
             y: 116.34,
         };
@@ -169,16 +169,16 @@ mod tests {
     #[test]
     fn polygon_new_test() {
         let exterior = LineString(vec![
-            Coordinate { x: 0., y: 0. },
-            Coordinate { x: 1., y: 1. },
-            Coordinate { x: 1., y: 0. },
-            Coordinate { x: 0., y: 0. },
+            coord! { x: 0., y: 0. },
+            coord! { x: 1., y: 1. },
+            coord! { x: 1., y: 0. },
+            coord! { x: 0., y: 0. },
         ]);
         let interiors = vec![LineString(vec![
-            Coordinate { x: 0.1, y: 0.1 },
-            Coordinate { x: 0.9, y: 0.9 },
-            Coordinate { x: 0.9, y: 0.1 },
-            Coordinate { x: 0.1, y: 0.1 },
+            coord! { x: 0.1, y: 0.1 },
+            coord! { x: 0.9, y: 0.9 },
+            coord! { x: 0.9, y: 0.1 },
+            coord! { x: 0.1, y: 0.1 },
         ])];
         let p = Polygon::new(exterior.clone(), interiors.clone());
 
@@ -192,11 +192,11 @@ mod tests {
         let _: MultiPoint<_> = vec![(0., 0.), (1., 2.)].into_iter().collect();
 
         let mut l1: LineString<_> = vec![(0., 0.), (1., 2.)].into();
-        assert_eq!(l1[1], Coordinate { x: 1., y: 2. }); // index into linestring
+        assert_eq!(l1[1], coord! { x: 1., y: 2. }); // index into linestring
         let _: LineString<_> = vec![(0., 0.), (1., 2.)].into_iter().collect();
 
         // index mutably into a linestring
-        l1[0] = Coordinate { x: 1., y: 1. };
+        l1[0] = coord! { x: 1., y: 1. };
         assert_eq!(l1, vec![(1., 1.), (1., 2.)].into());
     }
 
@@ -217,7 +217,7 @@ mod tests {
         use rstar::{PointDistance, RTreeObject};
 
         let rl = RStarLine::new(Point::new(0.0, 0.0), Point::new(5.0, 5.0));
-        let l = Line::new(Coordinate { x: 0.0, y: 0.0 }, Coordinate { x: 5., y: 5. });
+        let l = Line::new(coord! { x: 0.0, y: 0.0 }, coord! { x: 5., y: 5. });
         assert_eq!(rl.envelope(), l.envelope());
         // difference in 15th decimal place
         assert_relative_eq!(26.0, rl.distance_2(&Point::new(4.0, 10.0)));
@@ -232,7 +232,7 @@ mod tests {
         use rstar_0_9::{PointDistance, RTreeObject};
 
         let rl = RStarLine::new(Point::new(0.0, 0.0), Point::new(5.0, 5.0));
-        let l = Line::new(Coordinate { x: 0.0, y: 0.0 }, Coordinate { x: 5., y: 5. });
+        let l = Line::new(coord! { x: 0.0, y: 0.0 }, coord! { x: 5., y: 5. });
         assert_eq!(rl.envelope(), l.envelope());
         // difference in 15th decimal place
         assert_relative_eq!(26.0, rl.distance_2(&Point::new(4.0, 10.0)));
@@ -241,7 +241,7 @@ mod tests {
 
     #[test]
     fn test_rects() {
-        let r = Rect::new(Coordinate { x: -1., y: -1. }, Coordinate { x: 1., y: 1. });
+        let r = Rect::new(coord! { x: -1., y: -1. }, coord! { x: 1., y: 1. });
         let p: Polygon<_> = r.into();
         assert_eq!(
             p,

--- a/geo-types/src/line.rs
+++ b/geo-types/src/line.rs
@@ -22,12 +22,12 @@ impl<T: CoordNum> Line<T> {
     /// # Examples
     ///
     /// ```
-    /// use geo_types::{Coordinate, Line};
+    /// use geo_types::{coord, Line};
     ///
-    /// let line = Line::new(Coordinate { x: 0., y: 0. }, Coordinate { x: 1., y: 2. });
+    /// let line = Line::new(coord! { x: 0., y: 0. }, coord! { x: 1., y: 2. });
     ///
-    /// assert_eq!(line.start, Coordinate { x: 0., y: 0. });
-    /// assert_eq!(line.end, Coordinate { x: 1., y: 2. });
+    /// assert_eq!(line.start, coord! { x: 0., y: 0. });
+    /// assert_eq!(line.end, coord! { x: 1., y: 2. });
     /// ```
     pub fn new<C>(start: C, end: C) -> Line<T>
     where
@@ -49,10 +49,10 @@ impl<T: CoordNum> Line<T> {
     /// Equivalent to:
     ///
     /// ```rust
-    /// # use geo_types::{Line, Coordinate, Point};
+    /// # use geo_types::{Line, coord, Point};
     /// # let line = Line::new(
-    /// #     Point(Coordinate { x: 4., y: -12. }),
-    /// #     Point(Coordinate { x: 0., y: 9. }),
+    /// #     Point(coord! { x: 4., y: -12. }),
+    /// #     Point(coord! { x: 0., y: 9. }),
     /// # );
     /// # assert_eq!(
     /// #     line.dx(),
@@ -68,10 +68,10 @@ impl<T: CoordNum> Line<T> {
     /// Equivalent to:
     ///
     /// ```rust
-    /// # use geo_types::{Line, Coordinate, Point};
+    /// # use geo_types::{Line, coord, Point};
     /// # let line = Line::new(
-    /// #     Point(Coordinate { x: 4., y: -12. }),
-    /// #     Point(Coordinate { x: 0., y: 9. }),
+    /// #     Point(coord! { x: 4., y: -12. }),
+    /// #     Point(coord! { x: 0., y: 9. }),
     /// # );
     /// # assert_eq!(
     /// #     line.dy(),
@@ -87,10 +87,10 @@ impl<T: CoordNum> Line<T> {
     /// Equivalent to:
     ///
     /// ```rust
-    /// # use geo_types::{Line, Coordinate, Point};
+    /// # use geo_types::{Line, coord, Point};
     /// # let line = Line::new(
-    /// #     Point(Coordinate { x: 4., y: -12. }),
-    /// #     Point(Coordinate { x: 0., y: 9. }),
+    /// #     Point(coord! { x: 4., y: -12. }),
+    /// #     Point(coord! { x: 0., y: 9. }),
     /// # );
     /// # assert_eq!(
     /// #     line.slope(),
@@ -101,9 +101,9 @@ impl<T: CoordNum> Line<T> {
     /// Note that:
     ///
     /// ```rust
-    /// # use geo_types::{Line, Coordinate, Point};
-    /// # let a = Point(Coordinate { x: 4., y: -12. });
-    /// # let b = Point(Coordinate { x: 0., y: 9. });
+    /// # use geo_types::{Line, coord, Point};
+    /// # let a = Point(coord! { x: 4., y: -12. });
+    /// # let b = Point(coord! { x: 0., y: 9. });
     /// # assert!(
     /// Line::new(a, b).slope() == Line::new(b, a).slope()
     /// # );
@@ -117,10 +117,10 @@ impl<T: CoordNum> Line<T> {
     /// Equivalent to:
     ///
     /// ```rust
-    /// # use geo_types::{Line, Coordinate, Point};
+    /// # use geo_types::{Line, coord, Point};
     /// # let line = Line::new(
-    /// #     Point(Coordinate { x: 4., y: -12. }),
-    /// #     Point(Coordinate { x: 0., y: 9. }),
+    /// #     Point(coord! { x: 4., y: -12. }),
+    /// #     Point(coord! { x: 0., y: 9. }),
     /// # );
     /// # assert_eq!(
     /// #     line.determinant(),
@@ -131,9 +131,9 @@ impl<T: CoordNum> Line<T> {
     /// Note that:
     ///
     /// ```rust
-    /// # use geo_types::{Line, Coordinate, Point};
-    /// # let a = Point(Coordinate { x: 4., y: -12. });
-    /// # let b = Point(Coordinate { x: 0., y: 9. });
+    /// # use geo_types::{Line, coord, Point};
+    /// # let a = Point(coord! { x: 4., y: -12. });
+    /// # let b = Point(coord! { x: 0., y: 9. });
     /// # assert!(
     /// Line::new(a, b).determinant() == -Line::new(b, a).determinant()
     /// # );
@@ -175,10 +175,10 @@ where
     /// # Examples
     ///
     /// ```
-    /// use geo_types::{Coordinate, Line};
+    /// use geo_types::{coord, Line};
     ///
-    /// let a = Line::new(Coordinate { x: 0., y: 0. }, Coordinate { x: 1., y: 1. });
-    /// let b = Line::new(Coordinate { x: 0., y: 0. }, Coordinate { x: 1.001, y: 1. });
+    /// let a = Line::new(coord! { x: 0., y: 0. }, coord! { x: 1., y: 1. });
+    /// let b = Line::new(coord! { x: 0., y: 0. }, coord! { x: 1.001, y: 1. });
     ///
     /// approx::assert_relative_eq!(a, b, max_relative=0.1);
     /// ```
@@ -208,10 +208,10 @@ impl<T: AbsDiffEq<Epsilon = T> + CoordNum> AbsDiffEq for Line<T> {
     /// # Examples
     ///
     /// ```
-    /// use geo_types::{Coordinate, Line};
+    /// use geo_types::{coord, Line};
     ///
-    /// let a = Line::new(Coordinate { x: 0., y: 0. }, Coordinate { x: 1., y: 1. });
-    /// let b = Line::new(Coordinate { x: 0., y: 0. }, Coordinate { x: 1.001, y: 1. });
+    /// let a = Line::new(coord! { x: 0., y: 0. }, coord! { x: 1., y: 1. });
+    /// let b = Line::new(coord! { x: 0., y: 0. }, coord! { x: 1.001, y: 1. });
     ///
     /// approx::assert_abs_diff_eq!(a, b, epsilon=0.1);
     /// ```
@@ -256,34 +256,35 @@ impl_rstar_line!(rstar_0_9);
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::coord;
 
     #[test]
     fn test_abs_diff_eq() {
         let delta = 1e-6;
-        let line = Line::new(Coordinate { x: 0., y: 0. }, Coordinate { x: 1., y: 1. });
+        let line = Line::new(coord! { x: 0., y: 0. }, coord! { x: 1., y: 1. });
         let line_start_x = Line::new(
-            Point(Coordinate {
+            Point(coord! {
                 x: 0. + delta,
                 y: 0.,
             }),
-            Point(Coordinate { x: 1., y: 1. }),
+            Point(coord! { x: 1., y: 1. }),
         );
         assert!(line.abs_diff_eq(&line_start_x, 1e-2));
         assert!(line.abs_diff_ne(&line_start_x, 1e-12));
 
         let line_start_y = Line::new(
-            Coordinate {
+            coord! {
                 x: 0.,
                 y: 0. + delta,
             },
-            Coordinate { x: 1., y: 1. },
+            coord! { x: 1., y: 1. },
         );
         assert!(line.abs_diff_eq(&line_start_y, 1e-2));
         assert!(line.abs_diff_ne(&line_start_y, 1e-12));
 
         let line_end_x = Line::new(
-            Coordinate { x: 0., y: 0. },
-            Coordinate {
+            coord! { x: 0., y: 0. },
+            coord! {
                 x: 1. + delta,
                 y: 1.,
             },
@@ -293,8 +294,8 @@ mod test {
         assert!(line.abs_diff_ne(&line_end_x, 1e-12));
 
         let line_end_y = Line::new(
-            Coordinate { x: 0., y: 0. },
-            Coordinate {
+            coord! { x: 0., y: 0. },
+            coord! {
                 x: 1.,
                 y: 1. + delta,
             },
@@ -308,20 +309,20 @@ mod test {
     fn test_relative_eq() {
         let delta = 1e-6;
 
-        let line = Line::new(Coordinate { x: 0., y: 0. }, Coordinate { x: 1., y: 1. });
+        let line = Line::new(coord! { x: 0., y: 0. }, coord! { x: 1., y: 1. });
         let line_start_x = Line::new(
-            Point(Coordinate {
+            Point(coord! {
                 x: 0. + delta,
                 y: 0.,
             }),
-            Point(Coordinate { x: 1., y: 1. }),
+            Point(coord! { x: 1., y: 1. }),
         );
         let line_start_y = Line::new(
-            Coordinate {
+            coord! {
                 x: 0.,
                 y: 0. + delta,
             },
-            Coordinate { x: 1., y: 1. },
+            coord! { x: 1., y: 1. },
         );
 
         assert!(line.relative_eq(&line_start_x, 1e-2, 1e-2));

--- a/geo-types/src/line_string.rs
+++ b/geo-types/src/line_string.rs
@@ -33,11 +33,11 @@ use std::ops::{Index, IndexMut};
 /// Create a [`LineString`] by calling it directly:
 ///
 /// ```
-/// use geo_types::{Coordinate, LineString};
+/// use geo_types::{coord, LineString};
 ///
 /// let line_string = LineString(vec![
-///     Coordinate { x: 0., y: 0. },
-///     Coordinate { x: 10., y: 0. },
+///     coord! { x: 0., y: 0. },
+///     coord! { x: 10., y: 0. },
 /// ]);
 /// ```
 ///
@@ -69,10 +69,10 @@ use std::ops::{Index, IndexMut};
 /// Or by `collect`ing from a [`Coordinate`] iterator
 ///
 /// ```
-/// use geo_types::{Coordinate, LineString};
+/// use geo_types::{coord, LineString};
 ///
 /// let mut coords_iter =
-///     vec![Coordinate { x: 0., y: 0. }, Coordinate { x: 10., y: 0. }].into_iter();
+///     vec![coord! { x: 0., y: 0. }, coord! { x: 10., y: 0. }].into_iter();
 ///
 /// let line_string: LineString<f32> = coords_iter.collect();
 /// ```
@@ -81,11 +81,11 @@ use std::ops::{Index, IndexMut};
 /// [`LineString`] provides five iterators: [`coords`](LineString::coords), [`coords_mut`](LineString::coords_mut), [`points`](LineString::points), [`lines`](LineString::lines), and [`triangles`](LineString::triangles):
 ///
 /// ```
-/// use geo_types::{Coordinate, LineString};
+/// use geo_types::{coord, LineString};
 ///
 /// let line_string = LineString(vec![
-///     Coordinate { x: 0., y: 0. },
-///     Coordinate { x: 10., y: 0. },
+///     coord! { x: 0., y: 0. },
+///     coord! { x: 10., y: 0. },
 /// ]);
 ///
 /// line_string.coords().for_each(|coord| println!("{:?}", coord));
@@ -98,11 +98,11 @@ use std::ops::{Index, IndexMut};
 /// Note that its [`IntoIterator`] impl yields [`Coordinate`]s when looping:
 ///
 /// ```
-/// use geo_types::{Coordinate, LineString};
+/// use geo_types::{coord, LineString};
 ///
 /// let line_string = LineString(vec![
-///     Coordinate { x: 0., y: 0. },
-///     Coordinate { x: 10., y: 0. },
+///     coord! { x: 0., y: 0. },
+///     coord! { x: 10., y: 0. },
 /// ]);
 ///
 /// for coord in &line_string {
@@ -118,11 +118,11 @@ use std::ops::{Index, IndexMut};
 ///
 /// You can decompose a [`LineString`] into a [`Vec`] of [`Coordinate`]s or [`Point`]s:
 /// ```
-/// use geo_types::{Coordinate, LineString, Point};
+/// use geo_types::{coord, LineString, Point};
 ///
 /// let line_string = LineString(vec![
-///     Coordinate { x: 0., y: 0. },
-///     Coordinate { x: 10., y: 0. },
+///     coord! { x: 0., y: 0. },
+///     coord! { x: 10., y: 0. },
 /// ]);
 ///
 /// let coordinate_vec = line_string.clone().into_inner();
@@ -214,7 +214,7 @@ impl<T: CoordNum> LineString<T> {
     /// # Examples
     ///
     /// ```
-    /// use geo_types::{Coordinate, Line, LineString};
+    /// use geo_types::{coord, Line, LineString};
     ///
     /// let mut coords = vec![(0., 0.), (5., 0.), (7., 9.)];
     /// let line_string: LineString<f32> = coords.into_iter().collect();
@@ -222,15 +222,15 @@ impl<T: CoordNum> LineString<T> {
     /// let mut lines = line_string.lines();
     /// assert_eq!(
     ///     Some(Line::new(
-    ///         Coordinate { x: 0., y: 0. },
-    ///         Coordinate { x: 5., y: 0. }
+    ///         coord! { x: 0., y: 0. },
+    ///         coord! { x: 5., y: 0. }
     ///     )),
     ///     lines.next()
     /// );
     /// assert_eq!(
     ///     Some(Line::new(
-    ///         Coordinate { x: 5., y: 0. },
-    ///         Coordinate { x: 7., y: 9. }
+    ///         coord! { x: 5., y: 0. },
+    ///         coord! { x: 7., y: 9. }
     ///     )),
     ///     lines.next()
     /// );
@@ -508,7 +508,7 @@ impl_rstar_line_string!(rstar_0_9);
 #[cfg(test)]
 mod test {
     use super::*;
-
+    use crate::coord;
     use approx::AbsDiffEq;
 
     #[test]
@@ -569,15 +569,15 @@ mod test {
 
     #[test]
     fn should_be_built_from_line() {
-        let start = Coordinate { x: 0, y: 0 };
-        let end = Coordinate { x: 10, y: 10 };
+        let start = coord! { x: 0, y: 0 };
+        let end = coord! { x: 10, y: 10 };
         let line = Line::new(start, end);
         let expected = LineString(vec![start, end]);
 
         assert_eq!(expected, LineString::from(line));
 
-        let start = Coordinate { x: 10., y: 0.5 };
-        let end = Coordinate { x: 10000., y: 10.4 };
+        let start = coord! { x: 10., y: 0.5 };
+        let end = coord! { x: 10000., y: 10.4 };
         let line = Line::new(start, end);
         let expected = LineString(vec![start, end]);
 

--- a/geo-types/src/macros.rs
+++ b/geo-types/src/macros.rs
@@ -13,7 +13,7 @@
 ///
 /// let p = point!(x: 181.2, y: 51.79);
 ///
-/// assert_eq!(p, geo_types::Point(geo_types::Coordinate {
+/// assert_eq!(p, geo_types::Point(geo_types::coord! {
 ///     x: 181.2,
 ///     y: 51.79,
 /// }));
@@ -42,7 +42,7 @@ macro_rules! point {
 ///
 /// let c = coord!(x: 181.2, y: 51.79);
 ///
-/// assert_eq!(c, geo_types::Coordinate { x: 181.2, y: 51.79 });
+/// assert_eq!(c, geo_types::coord! { x: 181.2, y: 51.79 });
 /// ```
 ///
 /// [`Coordinate`]: ./struct.Point.html
@@ -73,7 +73,7 @@ macro_rules! coord {
 ///     (x: -21.951445, y: 64.145508),
 /// ];
 ///
-/// assert_eq!(ls[1], geo_types::Coordinate {
+/// assert_eq!(ls[1], geo_types::coord! {
 ///     x: -21.951,
 ///     y: 64.14479
 /// });
@@ -84,19 +84,19 @@ macro_rules! coord {
 /// ```
 /// use geo_types::line_string;
 ///
-/// let coord1 = geo_types::Coordinate {
+/// let coord1 = geo_types::coord! {
 ///     x: -21.95156,
 ///     y: 64.1446,
 /// };
-/// let coord2 = geo_types::Coordinate {
+/// let coord2 = geo_types::coord! {
 ///     x: -21.951,
 ///     y: 64.14479,
 /// };
-/// let coord3 = geo_types::Coordinate {
+/// let coord3 = geo_types::coord! {
 ///     x: -21.95044,
 ///     y: 64.14527,
 /// };
-/// let coord4 = geo_types::Coordinate {
+/// let coord4 = geo_types::coord! {
 ///     x: -21.951445,
 ///     y: 64.145508,
 /// };
@@ -105,7 +105,7 @@ macro_rules! coord {
 ///
 /// assert_eq!(
 ///     ls[1],
-///     geo_types::Coordinate {
+///     geo_types::coord! {
 ///         x: -21.951,
 ///         y: 64.14479
 ///     }
@@ -123,7 +123,7 @@ macro_rules! line_string {
     ) => {
         line_string![
             $(
-                $crate::Coordinate { x: $x, y: $y },
+                $crate::coord! { x: $x, y: $y },
             )*
         ]
     };
@@ -173,7 +173,7 @@ macro_rules! line_string {
 ///
 /// assert_eq!(
 ///     poly.exterior()[1],
-///     geo_types::Coordinate { x: -111., y: 41. },
+///     geo_types::coord! { x: -111., y: 41. },
 /// );
 /// ```
 ///
@@ -201,7 +201,7 @@ macro_rules! line_string {
 ///
 /// assert_eq!(
 ///     poly.exterior()[1],
-///     geo_types::Coordinate { x: -111., y: 41. },
+///     geo_types::coord! { x: -111., y: 41. },
 /// );
 /// ```
 ///
@@ -227,12 +227,12 @@ macro_rules! polygon {
         polygon!(
             exterior: [
                 $(
-                    $crate::Coordinate { x: $exterior_x, y: $exterior_y },
+                    $crate::coord! { x: $exterior_x, y: $exterior_y },
                 )*
             ],
             interiors: [
                 $([
-                    $($crate::Coordinate { x: $interior_x, y: $interior_y }),*
+                    $($crate::coord! { x: $interior_x, y: $interior_y }),*
                 ]),*
             ],
         )
@@ -271,7 +271,7 @@ macro_rules! polygon {
         $(,)?
     ) => {
         polygon![
-            $($crate::Coordinate { x: $x, y: $y }),*
+            $($crate::coord! { x: $x, y: $y }),*
         ]
     };
     (

--- a/geo-types/src/point.rs
+++ b/geo-types/src/point.rs
@@ -232,10 +232,10 @@ impl<T: CoordNum> Point<T> {
     /// # Examples
     ///
     /// ```
-    /// use geo_types::Point;
+    /// use geo_types::{coord, Point};
     ///
-    /// let point = Point::new(1.5, 0.5);
-    /// let dot = point.dot(Point::new(2.0, 4.5);
+    /// let point = Point(coord! { x: 1.5, y: 0.5 });
+    /// let dot = point.dot(Point(coord! { x: 2.0, y: 4.5 }));
     ///
     /// assert_eq!(dot, 5.25);
     /// ```
@@ -250,11 +250,11 @@ impl<T: CoordNum> Point<T> {
     /// # Examples
     ///
     /// ```
-    /// use geo_types::Point;
+    /// use geo_types::{coord, Point};
     ///
-    /// let point_a = Point::new(1., 2.);
-    /// let point_b = Point::new(3., 5.);
-    /// let point_c = Point::new(7., 12.);
+    /// let point_a = Point(coord! { x: 1., y: 2. });
+    /// let point_b = Point(coord! { x: 3., y: 5. });
+    /// let point_c = Point(coord! { x: 7., y: 12. });
     ///
     /// let cross = point_a.cross_prod(point_b, point_c);
     ///

--- a/geo-types/src/point.rs
+++ b/geo-types/src/point.rs
@@ -1,4 +1,4 @@
-use crate::{CoordFloat, CoordNum, Coordinate, coord};
+use crate::{coord, CoordFloat, CoordNum, Coordinate};
 
 #[cfg(any(feature = "approx", test))]
 use approx::{AbsDiffEq, RelativeEq};

--- a/geo-types/src/point.rs
+++ b/geo-types/src/point.rs
@@ -232,10 +232,10 @@ impl<T: CoordNum> Point<T> {
     /// # Examples
     ///
     /// ```
-    /// use geo_types::{coord, Point};
+    /// use geo_types::Point;
     ///
-    /// let point = Point(coord! { x: 1.5, y: 0.5 });
-    /// let dot = point.dot(Point(coord! { x: 2.0, y: 4.5 }));
+    /// let point = Point::new(1.5, 0.5);
+    /// let dot = point.dot(Point::new(2.0, 4.5);
     ///
     /// assert_eq!(dot, 5.25);
     /// ```
@@ -250,11 +250,11 @@ impl<T: CoordNum> Point<T> {
     /// # Examples
     ///
     /// ```
-    /// use geo_types::{coord, Point};
+    /// use geo_types::Point;
     ///
-    /// let point_a = Point(coord! { x: 1., y: 2. });
-    /// let point_b = Point(coord! { x: 3., y: 5. });
-    /// let point_c = Point(coord! { x: 7., y: 12. });
+    /// let point_a = Point::new(1., 2.);
+    /// let point_b = Point::new(3., 5.);
+    /// let point_c = Point::new(7., 12.);
     ///
     /// let cross = point_a.cross_prod(point_b, point_c);
     ///

--- a/geo-types/src/point.rs
+++ b/geo-types/src/point.rs
@@ -1,4 +1,4 @@
-use crate::{CoordFloat, CoordNum, Coordinate};
+use crate::{CoordFloat, CoordNum, Coordinate, coord};
 
 #[cfg(any(feature = "approx", test))]
 use approx::{AbsDiffEq, RelativeEq};
@@ -21,9 +21,9 @@ use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssi
 /// # Examples
 ///
 /// ```
-/// use geo_types::{Coordinate, Point};
+/// use geo_types::{coord, Point};
 /// let p1: Point<f64> = (0., 1.).into();
-/// let c = Coordinate { x: 10., y: 20. };
+/// let c = coord! { x: 10., y: 20. };
 /// let p2: Point<f64> = c.into();
 /// ```
 #[derive(Eq, PartialEq, Clone, Copy, Debug, Hash, Default)]
@@ -74,7 +74,7 @@ impl<T: CoordNum> Point<T> {
     /// assert_eq!(p.y(), 2.345);
     /// ```
     pub fn new(x: T, y: T) -> Point<T> {
-        Point(Coordinate { x, y })
+        Point(coord! { x: x, y: y })
     }
 
     /// Returns the x/horizontal component of the point.
@@ -232,10 +232,10 @@ impl<T: CoordNum> Point<T> {
     /// # Examples
     ///
     /// ```
-    /// use geo_types::{Coordinate, Point};
+    /// use geo_types::{coord, Point};
     ///
-    /// let point = Point(Coordinate { x: 1.5, y: 0.5 });
-    /// let dot = point.dot(Point(Coordinate { x: 2.0, y: 4.5 }));
+    /// let point = Point(coord! { x: 1.5, y: 0.5 });
+    /// let dot = point.dot(Point(coord! { x: 2.0, y: 4.5 }));
     ///
     /// assert_eq!(dot, 5.25);
     /// ```
@@ -250,11 +250,11 @@ impl<T: CoordNum> Point<T> {
     /// # Examples
     ///
     /// ```
-    /// use geo_types::{Coordinate, Point};
+    /// use geo_types::{coord, Point};
     ///
-    /// let point_a = Point(Coordinate { x: 1., y: 2. });
-    /// let point_b = Point(Coordinate { x: 3., y: 5. });
-    /// let point_c = Point(Coordinate { x: 7., y: 12. });
+    /// let point_a = Point(coord! { x: 1., y: 2. });
+    /// let point_b = Point(coord! { x: 3., y: 5. });
+    /// let point_c = Point(coord! { x: 7., y: 12. });
     ///
     /// let cross = point_a.cross_prod(point_b, point_c);
     ///

--- a/geo-types/src/polygon.rs
+++ b/geo-types/src/polygon.rs
@@ -113,7 +113,7 @@ impl<T: CoordNum> Polygon<T> {
     /// `LineString`s no longer match, those `LineString`s [will be closed]:
     ///
     /// ```
-    /// use geo_types::{Coordinate, LineString, Polygon};
+    /// use geo_types::{coord, LineString, Polygon};
     ///
     /// let mut polygon = Polygon::new(LineString::from(vec![(0., 0.), (1., 1.), (1., 0.)]), vec![]);
     ///
@@ -197,7 +197,7 @@ impl<T: CoordNum> Polygon<T> {
     /// # Examples
     ///
     /// ```
-    /// use geo_types::{Coordinate, LineString, Polygon};
+    /// use geo_types::{coord, LineString, Polygon};
     ///
     /// let mut polygon = Polygon::new(
     ///     LineString::from(vec![(0., 0.), (1., 1.), (1., 0.), (0., 0.)]),
@@ -205,7 +205,7 @@ impl<T: CoordNum> Polygon<T> {
     /// );
     ///
     /// polygon.exterior_mut(|exterior| {
-    ///     exterior.0[1] = Coordinate { x: 1., y: 2. };
+    ///     exterior.0[1] = coord! { x: 1., y: 2. };
     /// });
     ///
     /// assert_eq!(
@@ -218,7 +218,7 @@ impl<T: CoordNum> Polygon<T> {
     /// longer match, the `LineString` [will be closed]:
     ///
     /// ```
-    /// use geo_types::{Coordinate, LineString, Polygon};
+    /// use geo_types::{coord, LineString, Polygon};
     ///
     /// let mut polygon = Polygon::new(
     ///     LineString::from(vec![(0., 0.), (1., 1.), (1., 0.), (0., 0.)]),
@@ -226,7 +226,7 @@ impl<T: CoordNum> Polygon<T> {
     /// );
     ///
     /// polygon.exterior_mut(|exterior| {
-    ///     exterior.0[0] = Coordinate { x: 0., y: 1. };
+    ///     exterior.0[0] = coord! { x: 0., y: 1. };
     /// });
     ///
     /// assert_eq!(
@@ -249,7 +249,7 @@ impl<T: CoordNum> Polygon<T> {
     /// # Examples
     ///
     /// ```
-    /// use geo_types::{Coordinate, LineString, Polygon};
+    /// use geo_types::{coord, LineString, Polygon};
     ///
     /// let interiors = vec![LineString::from(vec![
     ///     (0.1, 0.1),
@@ -278,7 +278,7 @@ impl<T: CoordNum> Polygon<T> {
     /// # Examples
     ///
     /// ```
-    /// use geo_types::{Coordinate, LineString, Polygon};
+    /// use geo_types::{coord, LineString, Polygon};
     ///
     /// let mut polygon = Polygon::new(
     ///     LineString::from(vec![(0., 0.), (1., 1.), (1., 0.), (0., 0.)]),
@@ -291,7 +291,7 @@ impl<T: CoordNum> Polygon<T> {
     /// );
     ///
     /// polygon.interiors_mut(|interiors| {
-    ///     interiors[0].0[1] = Coordinate { x: 0.8, y: 0.8 };
+    ///     interiors[0].0[1] = coord! { x: 0.8, y: 0.8 };
     /// });
     ///
     /// assert_eq!(
@@ -309,7 +309,7 @@ impl<T: CoordNum> Polygon<T> {
     /// longer match, those `LineString`s [will be closed]:
     ///
     /// ```
-    /// use geo_types::{Coordinate, LineString, Polygon};
+    /// use geo_types::{coord, LineString, Polygon};
     ///
     /// let mut polygon = Polygon::new(
     ///     LineString::from(vec![(0., 0.), (1., 1.), (1., 0.), (0., 0.)]),
@@ -322,7 +322,7 @@ impl<T: CoordNum> Polygon<T> {
     /// );
     ///
     /// polygon.interiors_mut(|interiors| {
-    ///     interiors[0].0[0] = Coordinate { x: 0.1, y: 0.2 };
+    ///     interiors[0].0[0] = coord! { x: 0.1, y: 0.2 };
     /// });
     ///
     /// assert_eq!(
@@ -355,7 +355,7 @@ impl<T: CoordNum> Polygon<T> {
     /// # Examples
     ///
     /// ```
-    /// use geo_types::{Coordinate, LineString, Polygon};
+    /// use geo_types::{coord, LineString, Polygon};
     ///
     /// let mut polygon = Polygon::new(
     ///     LineString::from(vec![(0., 0.), (1., 1.), (1., 0.), (0., 0.)]),

--- a/geo-types/src/private_utils.rs
+++ b/geo-types/src/private_utils.rs
@@ -35,11 +35,11 @@ where
         }
 
         return Some(Rect::new(
-            Coordinate {
+            coord! {
                 x: xrange.0,
                 y: yrange.0,
             },
-            Coordinate {
+            coord! {
                 x: xrange.1,
                 y: yrange.1,
             },

--- a/geo-types/src/rect.rs
+++ b/geo-types/src/rect.rs
@@ -1,4 +1,4 @@
-use crate::{polygon, CoordFloat, CoordNum, Coordinate, Line, Polygon};
+use crate::{coord, polygon, CoordFloat, CoordNum, Coordinate, Line, Polygon};
 
 #[cfg(any(feature = "approx", test))]
 use approx::{AbsDiffEq, RelativeEq};
@@ -23,17 +23,17 @@ use approx::{AbsDiffEq, RelativeEq};
 /// # Examples
 ///
 /// ```
-/// use geo_types::{Coordinate, Rect};
+/// use geo_types::{coord, Rect};
 ///
 /// let rect = Rect::new(
-///     Coordinate { x: 0., y: 4.},
-///     Coordinate { x: 3., y: 10.},
+///     coord! { x: 0., y: 4.},
+///     coord! { x: 3., y: 10.},
 /// );
 ///
 /// assert_eq!(3., rect.width());
 /// assert_eq!(6., rect.height());
 /// assert_eq!(
-///     Coordinate { x: 1.5, y: 7. },
+///     coord! { x: 1.5, y: 7. },
 ///     rect.center()
 /// );
 /// ```
@@ -50,14 +50,14 @@ impl<T: CoordNum> Rect<T> {
     /// # Examples
     ///
     /// ```
-    /// use geo_types::{Coordinate, Rect};
+    /// use geo_types::{coord, Rect};
     ///
     /// let rect = Rect::new(
-    ///     Coordinate { x: 10., y: 20. },
-    ///     Coordinate { x: 30., y: 10. }
+    ///     coord! { x: 10., y: 20. },
+    ///     coord! { x: 30., y: 10. }
     /// );
-    /// assert_eq!(rect.min(), Coordinate { x: 10., y: 10. });
-    /// assert_eq!(rect.max(), Coordinate { x: 30., y: 20. });
+    /// assert_eq!(rect.min(), coord! { x: 10., y: 10. });
+    /// assert_eq!(rect.max(), coord! { x: 30., y: 20. });
     /// ```
     pub fn new<C>(c1: C, c2: C) -> Rect<T>
     where
@@ -76,8 +76,8 @@ impl<T: CoordNum> Rect<T> {
             (c2.y, c1.y)
         };
         Rect {
-            min: Coordinate { x: min_x, y: min_y },
-            max: Coordinate { x: max_x, y: max_y },
+            min: coord! { x: min_x, y: min_y },
+            max: coord! { x: max_x, y: max_y },
         }
     }
 
@@ -98,14 +98,14 @@ impl<T: CoordNum> Rect<T> {
     /// # Examples
     ///
     /// ```rust
-    /// use geo_types::{Coordinate, Rect};
+    /// use geo_types::{coord, Rect};
     ///
     /// let rect = Rect::new(
-    ///     Coordinate { x: 5., y: 5. },
-    ///     Coordinate { x: 15., y: 15. },
+    ///     coord! { x: 5., y: 5. },
+    ///     coord! { x: 15., y: 15. },
     /// );
     ///
-    /// assert_eq!(rect.min(), Coordinate { x: 5., y: 5. });
+    /// assert_eq!(rect.min(), coord! { x: 5., y: 5. });
     /// ```
     pub fn min(self) -> Coordinate<T> {
         self.min
@@ -129,14 +129,14 @@ impl<T: CoordNum> Rect<T> {
     /// # Examples
     ///
     /// ```rust
-    /// use geo_types::{Coordinate, Rect};
+    /// use geo_types::{coord, Rect};
     ///
     /// let rect = Rect::new(
-    ///     Coordinate { x: 5., y: 5. },
-    ///     Coordinate { x: 15., y: 15. },
+    ///     coord! { x: 5., y: 5. },
+    ///     coord! { x: 15., y: 15. },
     /// );
     ///
-    /// assert_eq!(rect.max(), Coordinate { x: 15., y: 15. });
+    /// assert_eq!(rect.max(), coord! { x: 15., y: 15. });
     /// ```
     pub fn max(self) -> Coordinate<T> {
         self.max
@@ -160,11 +160,11 @@ impl<T: CoordNum> Rect<T> {
     /// # Examples
     ///
     /// ```rust
-    /// use geo_types::{Coordinate, Rect};
+    /// use geo_types::{coord, Rect};
     ///
     /// let rect = Rect::new(
-    ///     Coordinate { x: 5., y: 5. },
-    ///     Coordinate { x: 15., y: 15. },
+    ///     coord! { x: 5., y: 5. },
+    ///     coord! { x: 15., y: 15. },
     /// );
     ///
     /// assert_eq!(rect.width(), 10.);
@@ -178,11 +178,11 @@ impl<T: CoordNum> Rect<T> {
     /// # Examples
     ///
     /// ```rust
-    /// use geo_types::{Coordinate, Rect};
+    /// use geo_types::{coord, Rect};
     ///
     /// let rect = Rect::new(
-    ///     Coordinate { x: 5., y: 5. },
-    ///     Coordinate { x: 15., y: 15. },
+    ///     coord! { x: 5., y: 5. },
+    ///     coord! { x: 15., y: 15. },
     /// );
     ///
     /// assert_eq!(rect.height(), 10.);
@@ -196,11 +196,11 @@ impl<T: CoordNum> Rect<T> {
     /// # Examples
     ///
     /// ```rust
-    /// use geo_types::{Coordinate, Rect, polygon};
+    /// use geo_types::{coord, Rect, polygon};
     ///
     /// let rect = Rect::new(
-    ///     Coordinate { x: 0., y: 0. },
-    ///     Coordinate { x: 10., y: 20. },
+    ///     coord! { x: 0., y: 0. },
+    ///     coord! { x: 10., y: 20. },
     /// );
     ///
     /// assert_eq!(
@@ -227,41 +227,41 @@ impl<T: CoordNum> Rect<T> {
     pub fn to_lines(&self) -> [Line<T>; 4] {
         [
             Line::new(
-                Coordinate {
+                coord! {
                     x: self.min.x,
                     y: self.min.y,
                 },
-                Coordinate {
+                coord! {
                     x: self.min.x,
                     y: self.max.y,
                 },
             ),
             Line::new(
-                Coordinate {
+                coord! {
                     x: self.min.x,
                     y: self.max.y,
                 },
-                Coordinate {
+                coord! {
                     x: self.max.x,
                     y: self.max.y,
                 },
             ),
             Line::new(
-                Coordinate {
+                coord! {
                     x: self.min.x,
                     y: self.min.y,
                 },
-                Coordinate {
+                coord! {
                     x: self.max.x,
                     y: self.min.y,
                 },
             ),
             Line::new(
-                Coordinate {
+                coord! {
                     x: self.max.x,
                     y: self.min.y,
                 },
-                Coordinate {
+                coord! {
                     x: self.max.x,
                     y: self.max.y,
                 },
@@ -286,16 +286,16 @@ impl<T: CoordFloat> Rect<T> {
     /// # Examples
     ///
     /// ```rust
-    /// use geo_types::{Coordinate, Rect};
+    /// use geo_types::{coord, Rect};
     ///
     /// let rect = Rect::new(
-    ///     Coordinate { x: 5., y: 5. },
-    ///     Coordinate { x: 15., y: 15. },
+    ///     coord! { x: 5., y: 5. },
+    ///     coord! { x: 15., y: 15. },
     /// );
     ///
     /// assert_eq!(
     ///     rect.center(),
-    ///     Coordinate { x: 10., y: 10. }
+    ///     coord! { x: 10., y: 10. }
     /// );
     /// ```
     pub fn center(self) -> Coordinate<T> {
@@ -412,21 +412,21 @@ impl std::fmt::Display for InvalidRectCoordinatesError {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::Coordinate;
+    use crate::coord;
 
     #[test]
     fn rect() {
         let rect = Rect::new((10, 10), (20, 20));
-        assert_eq!(rect.min, Coordinate { x: 10, y: 10 });
-        assert_eq!(rect.max, Coordinate { x: 20, y: 20 });
+        assert_eq!(rect.min, coord! { x: 10, y: 10 });
+        assert_eq!(rect.max, coord! { x: 20, y: 20 });
 
         let rect = Rect::new((20, 20), (10, 10));
-        assert_eq!(rect.min, Coordinate { x: 10, y: 10 });
-        assert_eq!(rect.max, Coordinate { x: 20, y: 20 });
+        assert_eq!(rect.min, coord! { x: 10, y: 10 });
+        assert_eq!(rect.max, coord! { x: 20, y: 20 });
 
         let rect = Rect::new((10, 20), (20, 10));
-        assert_eq!(rect.min, Coordinate { x: 10, y: 10 });
-        assert_eq!(rect.max, Coordinate { x: 20, y: 20 });
+        assert_eq!(rect.min, coord! { x: 10, y: 10 });
+        assert_eq!(rect.max, coord! { x: 20, y: 20 });
     }
 
     #[test]

--- a/geo-types/src/triangle.rs
+++ b/geo-types/src/triangle.rs
@@ -29,12 +29,12 @@ impl<T: CoordNum> Triangle<T> {
     /// # Examples
     ///
     /// ```rust
-    /// use geo_types::{Coordinate, Triangle, polygon};
+    /// use geo_types::{coord, Triangle, polygon};
     ///
     /// let triangle = Triangle(
-    ///     Coordinate { x: 0., y: 0. },
-    ///     Coordinate { x: 10., y: 20. },
-    ///     Coordinate { x: 20., y: -10. },
+    ///     coord! { x: 0., y: 0. },
+    ///     coord! { x: 10., y: 20. },
+    ///     coord! { x: 20., y: -10. },
     /// );
     ///
     /// assert_eq!(


### PR DESCRIPTION
This PR updates the `geo-types` crate. See also #761.

The `coord!` macro is much more flexible way to create a coordinate, and should be used in the same way as all other ones like `line_string` and `polygon`.

This change is a noop for now, but in the future it will make it easier to introduce Z coordinate without substantial code change.

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

