### PR TITLE
Use coord! macro instead of Coordinate ctor (part 2)

### DIFF
--- a/geo/examples/types.rs
+++ b/geo/examples/types.rs
@@ -1,9 +1,9 @@
 extern crate geo;
 
-use geo::{Coordinate, Point};
+use geo::{coord, Point};
 
 fn main() {
-    let c = Coordinate {
+    let c = coord! {
         x: 40.02f64,
         y: 116.34,
     };

--- a/geo/src/algorithm/area.rs
+++ b/geo/src/algorithm/area.rs
@@ -264,7 +264,7 @@ where
 #[cfg(test)]
 mod test {
     use crate::algorithm::area::Area;
-    use crate::{line_string, polygon, coord, Line, MultiPolygon, Polygon, Rect, Triangle};
+    use crate::{coord, line_string, polygon, Line, MultiPolygon, Polygon, Rect, Triangle};
 
     // Area of the polygon
     #[test]

--- a/geo/src/algorithm/area.rs
+++ b/geo/src/algorithm/area.rs
@@ -264,7 +264,7 @@ where
 #[cfg(test)]
 mod test {
     use crate::algorithm::area::Area;
-    use crate::{line_string, polygon, Coordinate, Line, MultiPolygon, Polygon, Rect, Triangle};
+    use crate::{line_string, polygon, coord, Line, MultiPolygon, Polygon, Rect, Triangle};
 
     // Area of the polygon
     #[test]
@@ -300,7 +300,7 @@ mod test {
                 (0..NUM_VERTICES)
                     .map(|i| {
                         let angle = i as f64 * ANGLE_INC;
-                        Coordinate {
+                        coord! {
                             x: angle.cos(),
                             y: angle.sin(),
                         }
@@ -326,11 +326,10 @@ mod test {
     }
     #[test]
     fn rectangle_test() {
-        let rect1: Rect<f32> =
-            Rect::new(Coordinate { x: 10., y: 30. }, Coordinate { x: 20., y: 40. });
+        let rect1: Rect<f32> = Rect::new(coord! { x: 10., y: 30. }, coord! { x: 20., y: 40. });
         assert_relative_eq!(rect1.signed_area(), 100.);
 
-        let rect2: Rect<i32> = Rect::new(Coordinate { x: 10, y: 30 }, Coordinate { x: 20, y: 40 });
+        let rect2: Rect<i32> = Rect::new(coord! { x: 10, y: 30 }, coord! { x: 20, y: 40 });
         assert_eq!(rect2.signed_area(), 100);
     }
     #[test]
@@ -391,23 +390,23 @@ mod test {
     }
     #[test]
     fn area_line_test() {
-        let line1 = Line::new(Coordinate { x: 0.0, y: 0.0 }, Coordinate { x: 1.0, y: 1.0 });
+        let line1 = Line::new(coord! { x: 0.0, y: 0.0 }, coord! { x: 1.0, y: 1.0 });
         assert_relative_eq!(line1.signed_area(), 0.);
     }
 
     #[test]
     fn area_triangle_test() {
         let triangle = Triangle(
-            Coordinate { x: 0.0, y: 0.0 },
-            Coordinate { x: 1.0, y: 0.0 },
-            Coordinate { x: 0.0, y: 1.0 },
+            coord! { x: 0.0, y: 0.0 },
+            coord! { x: 1.0, y: 0.0 },
+            coord! { x: 0.0, y: 1.0 },
         );
         assert_relative_eq!(triangle.signed_area(), 0.5);
 
         let triangle = Triangle(
-            Coordinate { x: 0.0, y: 0.0 },
-            Coordinate { x: 0.0, y: 1.0 },
-            Coordinate { x: 1.0, y: 0.0 },
+            coord! { x: 0.0, y: 0.0 },
+            coord! { x: 0.0, y: 1.0 },
+            coord! { x: 1.0, y: 0.0 },
         );
         assert_relative_eq!(triangle.signed_area(), -0.5);
     }
@@ -415,18 +414,18 @@ mod test {
     #[test]
     fn area_multi_polygon_area_reversed() {
         let polygon_cw: Polygon<f32> = polygon![
-            Coordinate { x: 0.0, y: 0.0 },
-            Coordinate { x: 0.0, y: 1.0 },
-            Coordinate { x: 1.0, y: 1.0 },
-            Coordinate { x: 1.0, y: 0.0 },
-            Coordinate { x: 0.0, y: 0.0 },
+            coord! { x: 0.0, y: 0.0 },
+            coord! { x: 0.0, y: 1.0 },
+            coord! { x: 1.0, y: 1.0 },
+            coord! { x: 1.0, y: 0.0 },
+            coord! { x: 0.0, y: 0.0 },
         ];
         let polygon_ccw: Polygon<f32> = polygon![
-            Coordinate { x: 0.0, y: 0.0 },
-            Coordinate { x: 1.0, y: 0.0 },
-            Coordinate { x: 1.0, y: 1.0 },
-            Coordinate { x: 0.0, y: 1.0 },
-            Coordinate { x: 0.0, y: 0.0 },
+            coord! { x: 0.0, y: 0.0 },
+            coord! { x: 1.0, y: 0.0 },
+            coord! { x: 1.0, y: 1.0 },
+            coord! { x: 0.0, y: 1.0 },
+            coord! { x: 0.0, y: 0.0 },
         ];
         let polygon_area = polygon_cw.unsigned_area();
 

--- a/geo/src/algorithm/bounding_rect.rs
+++ b/geo/src/algorithm/bounding_rect.rs
@@ -1,6 +1,6 @@
 use crate::utils::{partial_max, partial_min};
 use crate::{
-    CoordNum, coord, Geometry, GeometryCollection, GeometryCow, Line, LineString, MultiLineString,
+    coord, CoordNum, Geometry, GeometryCollection, GeometryCow, Line, LineString, MultiLineString,
     MultiPoint, MultiPolygon, Point, Polygon, Rect, Triangle,
 };
 use geo_types::private_utils::{get_bounding_rect, line_string_bounding_rect};
@@ -209,8 +209,8 @@ mod test {
     use crate::algorithm::bounding_rect::BoundingRect;
     use crate::line_string;
     use crate::{
-        polygon, coord, Geometry, GeometryCollection, Line, LineString, MultiLineString, MultiPoint,
-        MultiPolygon, Point, Polygon, Rect,
+        coord, polygon, Geometry, GeometryCollection, Line, LineString, MultiLineString,
+        MultiPoint, MultiPolygon, Point, Polygon, Rect,
     };
 
     #[test]

--- a/geo/src/algorithm/bounding_rect.rs
+++ b/geo/src/algorithm/bounding_rect.rs
@@ -1,7 +1,7 @@
 use crate::utils::{partial_max, partial_min};
 use crate::{
-    CoordNum, Coordinate, Geometry, GeometryCollection, GeometryCow, Line, LineString,
-    MultiLineString, MultiPoint, MultiPolygon, Point, Polygon, Rect, Triangle,
+    CoordNum, coord, Geometry, GeometryCollection, GeometryCow, Line, LineString, MultiLineString,
+    MultiPoint, MultiPolygon, Point, Polygon, Rect, Triangle,
 };
 use geo_types::private_utils::{get_bounding_rect, line_string_bounding_rect};
 
@@ -192,11 +192,11 @@ where
 // Return a new rectangle that encompasses the provided rectangles
 fn bounding_rect_merge<T: CoordNum>(a: Rect<T>, b: Rect<T>) -> Rect<T> {
     Rect::new(
-        Coordinate {
+        coord! {
             x: partial_min(a.min().x, b.min().x),
             y: partial_min(a.min().y, b.min().y),
         },
-        Coordinate {
+        coord! {
             x: partial_max(a.max().x, b.max().x),
             y: partial_max(a.max().y, b.max().y),
         },
@@ -209,8 +209,8 @@ mod test {
     use crate::algorithm::bounding_rect::BoundingRect;
     use crate::line_string;
     use crate::{
-        polygon, Coordinate, Geometry, GeometryCollection, Line, LineString, MultiLineString,
-        MultiPoint, MultiPolygon, Point, Polygon, Rect,
+        polygon, coord, Geometry, GeometryCollection, Line, LineString, MultiLineString, MultiPoint,
+        MultiPolygon, Point, Polygon, Rect,
     };
 
     #[test]
@@ -223,11 +223,11 @@ mod test {
     fn linestring_one_point_test() {
         let linestring = line_string![(x: 40.02f64, y: 116.34)];
         let bounding_rect = Rect::new(
-            Coordinate {
+            coord! {
                 x: 40.02f64,
                 y: 116.34,
             },
-            Coordinate {
+            coord! {
                 x: 40.02,
                 y: 116.34,
             },
@@ -242,7 +242,7 @@ mod test {
             (x: -3., y: -3.),
             (x: -4., y: 4.)
         ];
-        let bounding_rect = Rect::new(Coordinate { x: -4., y: -3. }, Coordinate { x: 2., y: 4. });
+        let bounding_rect = Rect::new(coord! { x: -4., y: -3. }, coord! { x: 2., y: 4. });
         assert_eq!(bounding_rect, linestring.bounding_rect().unwrap());
     }
     #[test]
@@ -253,16 +253,13 @@ mod test {
             line_string![(x: 1., y: 1.), (x: 1., y: -60.)],
             line_string![(x: 1., y: 1.), (x: 1., y: 70.)],
         ]);
-        let bounding_rect = Rect::new(
-            Coordinate { x: -40., y: -60. },
-            Coordinate { x: 50., y: 70. },
-        );
+        let bounding_rect = Rect::new(coord! { x: -40., y: -60. }, coord! { x: 50., y: 70. });
         assert_eq!(bounding_rect, multiline.bounding_rect().unwrap());
     }
     #[test]
     fn multipoint_test() {
         let multipoint = MultiPoint::from(vec![(1., 1.), (2., -2.), (-3., -3.), (-4., 4.)]);
-        let bounding_rect = Rect::new(Coordinate { x: -4., y: -3. }, Coordinate { x: 2., y: 4. });
+        let bounding_rect = Rect::new(coord! { x: -4., y: -3. }, coord! { x: 2., y: 4. });
         assert_eq!(bounding_rect, multipoint.bounding_rect().unwrap());
     }
     #[test]
@@ -285,23 +282,20 @@ mod test {
             polygon![(x: 0., y: 0.), (x: 5., y: 0.), (x: 0., y: 80.), (x: 0., y: 0.)],
             polygon![(x: 0., y: 0.), (x: -60., y: 0.), (x: 0., y: 6.), (x: 0., y: 0.)],
         ]);
-        let bounding_rect = Rect::new(
-            Coordinate { x: -60., y: -70. },
-            Coordinate { x: 50., y: 80. },
-        );
+        let bounding_rect = Rect::new(coord! { x: -60., y: -70. }, coord! { x: 50., y: 80. });
         assert_eq!(bounding_rect, mpoly.bounding_rect().unwrap());
     }
     #[test]
     fn line_test() {
-        let line1 = Line::new(Coordinate { x: 0., y: 1. }, Coordinate { x: 2., y: 3. });
-        let line2 = Line::new(Coordinate { x: 2., y: 3. }, Coordinate { x: 0., y: 1. });
+        let line1 = Line::new(coord! { x: 0., y: 1. }, coord! { x: 2., y: 3. });
+        let line2 = Line::new(coord! { x: 2., y: 3. }, coord! { x: 0., y: 1. });
         assert_eq!(
             line1.bounding_rect(),
-            Rect::new(Coordinate { x: 0., y: 1. }, Coordinate { x: 2., y: 3. },)
+            Rect::new(coord! { x: 0., y: 1. }, coord! { x: 2., y: 3. },)
         );
         assert_eq!(
             line2.bounding_rect(),
-            Rect::new(Coordinate { x: 0., y: 1. }, Coordinate { x: 2., y: 3. },)
+            Rect::new(coord! { x: 0., y: 1. }, coord! { x: 2., y: 3. },)
         );
     }
 
@@ -309,31 +303,28 @@ mod test {
     fn bounding_rect_merge_test() {
         assert_eq!(
             bounding_rect_merge(
-                Rect::new(Coordinate { x: 0., y: 0. }, Coordinate { x: 1., y: 1. }),
-                Rect::new(Coordinate { x: 1., y: 1. }, Coordinate { x: 2., y: 2. }),
+                Rect::new(coord! { x: 0., y: 0. }, coord! { x: 1., y: 1. }),
+                Rect::new(coord! { x: 1., y: 1. }, coord! { x: 2., y: 2. }),
             ),
-            Rect::new(Coordinate { x: 0., y: 0. }, Coordinate { x: 2., y: 2. }),
+            Rect::new(coord! { x: 0., y: 0. }, coord! { x: 2., y: 2. }),
         );
     }
 
     #[test]
     fn point_bounding_rect_test() {
         assert_eq!(
-            Rect::new(Coordinate { x: 1., y: 2. }, Coordinate { x: 1., y: 2. }),
-            Point(Coordinate { x: 1., y: 2. }).bounding_rect(),
+            Rect::new(coord! { x: 1., y: 2. }, coord! { x: 1., y: 2. }),
+            Point(coord! { x: 1., y: 2. }).bounding_rect(),
         );
     }
 
     #[test]
     fn geometry_collection_bounding_rect_test() {
         assert_eq!(
-            Some(Rect::new(
-                Coordinate { x: 0., y: 0. },
-                Coordinate { x: 1., y: 2. }
-            )),
+            Some(Rect::new(coord! { x: 0., y: 0. }, coord! { x: 1., y: 2. })),
             GeometryCollection(vec![
-                Geometry::Point(Point(Coordinate { x: 0., y: 0. })),
-                Geometry::Point(Point(Coordinate { x: 1., y: 2. })),
+                Geometry::Point(Point(coord! { x: 0., y: 0. })),
+                Geometry::Point(Point(coord! { x: 1., y: 2. })),
             ])
             .bounding_rect(),
         );

--- a/geo/src/algorithm/centroid.rs
+++ b/geo/src/algorithm/centroid.rs
@@ -466,11 +466,11 @@ impl<T: GeoFloat> WeightedCentroid<T> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{line_string, point, polygon};
+    use crate::{coord, line_string, point, polygon};
 
     /// small helper to create a coordinate
     fn c<T: GeoFloat>(x: T, y: T) -> Coordinate<T> {
-        Coordinate { x, y }
+        coord! { x: x, y: y }
     }
 
     /// small helper to create a point
@@ -487,7 +487,7 @@ mod test {
     }
     #[test]
     fn linestring_one_point_test() {
-        let coord = Coordinate {
+        let coord = coord! {
             x: 40.02f64,
             y: 116.34,
         };
@@ -531,7 +531,7 @@ mod test {
     }
     #[test]
     fn multilinestring_length_0_test() {
-        let coord = Coordinate {
+        let coord = coord! {
             x: 40.02f64,
             y: 116.34,
         };
@@ -553,7 +553,7 @@ mod test {
             (x: 11., y: 1.)
         ];
         let mls: MultiLineString<f64> = MultiLineString(vec![linestring]);
-        assert_relative_eq!(mls.centroid().unwrap(), Point(Coordinate { x: 6., y: 1. }));
+        assert_relative_eq!(mls.centroid().unwrap(), Point(coord! { x: 6., y: 1. }));
     }
     #[test]
     fn multilinestring_test() {
@@ -592,7 +592,7 @@ mod test {
                 (0..NUM_VERTICES)
                     .map(|i| {
                         let angle = i as f64 * ANGLE_INC;
-                        Coordinate {
+                        coord! {
                             x: angle.cos(),
                             y: angle.sin(),
                         }
@@ -786,7 +786,7 @@ mod test {
     }
     #[test]
     fn bounding_rect_test() {
-        let bounding_rect = Rect::new(Coordinate { x: 0., y: 50. }, Coordinate { x: 4., y: 100. });
+        let bounding_rect = Rect::new(coord! { x: 0., y: 50. }, coord! { x: 4., y: 100. });
         let point = point![x: 2., y: 75.];
         assert_eq!(point, bounding_rect.centroid());
     }

--- a/geo/src/algorithm/chaikin_smoothing.rs
+++ b/geo/src/algorithm/chaikin_smoothing.rs
@@ -2,7 +2,7 @@ use std::ops::Mul;
 
 use num_traits::FromPrimitive;
 
-use crate::{CoordFloat, Coordinate, LineString, MultiLineString, MultiPolygon, Polygon};
+use crate::{CoordFloat, coord, Coordinate, LineString, MultiLineString, MultiPolygon, Polygon};
 
 /// Smoothen `LineString`, `Polygon`, `MultiLineString` and `MultiPolygon` using Chaikins algorithm.
 ///
@@ -120,11 +120,11 @@ fn smoothen_coordinates<T>(c0: Coordinate<T>, c1: Coordinate<T>) -> (Coordinate<
 where
     T: CoordFloat + Mul<T> + FromPrimitive,
 {
-    let q = Coordinate {
+    let q = coord! {
         x: (T::from(0.75).unwrap() * c0.x) + (T::from(0.25).unwrap() * c1.x),
         y: (T::from(0.75).unwrap() * c0.y) + (T::from(0.25).unwrap() * c1.y),
     };
-    let r = Coordinate {
+    let r = coord! {
         x: (T::from(0.25).unwrap() * c0.x) + (T::from(0.75).unwrap() * c1.x),
         y: (T::from(0.25).unwrap() * c0.y) + (T::from(0.75).unwrap() * c1.y),
     };

--- a/geo/src/algorithm/chaikin_smoothing.rs
+++ b/geo/src/algorithm/chaikin_smoothing.rs
@@ -2,7 +2,7 @@ use std::ops::Mul;
 
 use num_traits::FromPrimitive;
 
-use crate::{CoordFloat, coord, Coordinate, LineString, MultiLineString, MultiPolygon, Polygon};
+use crate::{coord, CoordFloat, Coordinate, LineString, MultiLineString, MultiPolygon, Polygon};
 
 /// Smoothen `LineString`, `Polygon`, `MultiLineString` and `MultiPolygon` using Chaikins algorithm.
 ///

--- a/geo/src/algorithm/concave_hull.rs
+++ b/geo/src/algorithm/concave_hull.rs
@@ -6,7 +6,7 @@ use crate::utils::partial_min;
 use crate::{
     GeoFloat, Line, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon,
 };
-use geo_types::{CoordNum, coord, Coordinate};
+use geo_types::{coord, CoordNum, Coordinate};
 use rstar::{RTree, RTreeNum};
 use std::collections::VecDeque;
 

--- a/geo/src/algorithm/concave_hull.rs
+++ b/geo/src/algorithm/concave_hull.rs
@@ -6,7 +6,7 @@ use crate::utils::partial_min;
 use crate::{
     GeoFloat, Line, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon,
 };
-use geo_types::{CoordNum, Coordinate};
+use geo_types::{CoordNum, coord, Coordinate};
 use rstar::{RTree, RTreeNum};
 use std::collections::VecDeque;
 
@@ -124,7 +124,7 @@ where
     let two = T::add(T::one(), T::one());
     let search_dist = T::div(T::sqrt(T::powi(w, 2) + T::powi(h, 2)), two);
     let centroid = line.centroid();
-    let centroid_coord = Coordinate {
+    let centroid_coord = coord! {
         x: centroid.x(),
         y: centroid.y(),
     };
@@ -175,7 +175,7 @@ where
                 let far_enough = edge_length / decision_distance > concavity;
                 let are_edges_equal = closest_edge == line;
                 if far_enough && are_edges_equal {
-                    Some(Coordinate {
+                    Some(coord! {
                         x: closest_point.x(),
                         y: closest_point.y(),
                     })
@@ -263,9 +263,9 @@ mod test {
     #[test]
     fn triangle_test() {
         let mut triangle = vec![
-            Coordinate { x: 0.0, y: 0.0 },
-            Coordinate { x: 4.0, y: 0.0 },
-            Coordinate { x: 2.0, y: 2.0 },
+            coord! { x: 0.0, y: 0.0 },
+            coord! { x: 4.0, y: 0.0 },
+            coord! { x: 2.0, y: 2.0 },
         ];
 
         let correct = line_string![
@@ -283,10 +283,10 @@ mod test {
     #[test]
     fn square_test() {
         let mut square = vec![
-            Coordinate { x: 0.0, y: 0.0 },
-            Coordinate { x: 4.0, y: 0.0 },
-            Coordinate { x: 4.0, y: 4.0 },
-            Coordinate { x: 0.0, y: 4.0 },
+            coord! { x: 0.0, y: 0.0 },
+            coord! { x: 4.0, y: 0.0 },
+            coord! { x: 4.0, y: 4.0 },
+            coord! { x: 0.0, y: 4.0 },
         ];
 
         let correct = line_string![
@@ -305,11 +305,11 @@ mod test {
     #[test]
     fn one_flex_test() {
         let mut v = vec![
-            Coordinate { x: 0.0, y: 0.0 },
-            Coordinate { x: 2.0, y: 1.0 },
-            Coordinate { x: 4.0, y: 0.0 },
-            Coordinate { x: 4.0, y: 4.0 },
-            Coordinate { x: 0.0, y: 4.0 },
+            coord! { x: 0.0, y: 0.0 },
+            coord! { x: 2.0, y: 1.0 },
+            coord! { x: 4.0, y: 0.0 },
+            coord! { x: 4.0, y: 4.0 },
+            coord! { x: 0.0, y: 4.0 },
         ];
         let correct = line_string![
             (x: 4.0, y: 0.0),
@@ -327,14 +327,14 @@ mod test {
     #[test]
     fn four_flex_test() {
         let mut v = vec![
-            Coordinate { x: 0.0, y: 0.0 },
-            Coordinate { x: 2.0, y: 1.0 },
-            Coordinate { x: 4.0, y: 0.0 },
-            Coordinate { x: 3.0, y: 2.0 },
-            Coordinate { x: 4.0, y: 4.0 },
-            Coordinate { x: 2.0, y: 3.0 },
-            Coordinate { x: 0.0, y: 4.0 },
-            Coordinate { x: 1.0, y: 2.0 },
+            coord! { x: 0.0, y: 0.0 },
+            coord! { x: 2.0, y: 1.0 },
+            coord! { x: 4.0, y: 0.0 },
+            coord! { x: 3.0, y: 2.0 },
+            coord! { x: 4.0, y: 4.0 },
+            coord! { x: 2.0, y: 3.0 },
+            coord! { x: 0.0, y: 4.0 },
+            coord! { x: 1.0, y: 2.0 },
         ];
         let correct = line_string![
             (x: 4.0, y: 0.0),
@@ -355,11 +355,11 @@ mod test {
     #[test]
     fn consecutive_flex_test() {
         let mut v = vec![
-            Coordinate { x: 0.0, y: 0.0 },
-            Coordinate { x: 4.0, y: 0.0 },
-            Coordinate { x: 4.0, y: 4.0 },
-            Coordinate { x: 3.0, y: 1.0 },
-            Coordinate { x: 3.0, y: 2.0 },
+            coord! { x: 0.0, y: 0.0 },
+            coord! { x: 4.0, y: 0.0 },
+            coord! { x: 4.0, y: 4.0 },
+            coord! { x: 3.0, y: 1.0 },
+            coord! { x: 3.0, y: 2.0 },
         ];
         let correct = line_string![
             (x: 4.0, y: 0.0),

--- a/geo/src/algorithm/contains/mod.rs
+++ b/geo/src/algorithm/contains/mod.rs
@@ -52,7 +52,7 @@ mod triangle;
 mod test {
     use crate::algorithm::contains::Contains;
     use crate::line_string;
-    use crate::{Coordinate, Line, LineString, MultiPolygon, Point, Polygon, Rect, Triangle};
+    use crate::{coord, Coordinate, Line, LineString, MultiPolygon, Point, Polygon, Rect, Triangle};
 
     #[test]
     // see https://github.com/georust/geo/issues/452
@@ -306,20 +306,15 @@ mod test {
     }
     #[test]
     fn bounding_rect_in_inner_bounding_rect_test() {
-        let bounding_rect_xl = Rect::new(
-            Coordinate { x: -100., y: -200. },
-            Coordinate { x: 100., y: 200. },
-        );
-        let bounding_rect_sm = Rect::new(
-            Coordinate { x: -10., y: -20. },
-            Coordinate { x: 10., y: 20. },
-        );
+        let bounding_rect_xl =
+            Rect::new(coord! { x: -100., y: -200. }, coord! { x: 100., y: 200. });
+        let bounding_rect_sm = Rect::new(coord! { x: -10., y: -20. }, coord! { x: 10., y: 20. });
         assert!(bounding_rect_xl.contains(&bounding_rect_sm));
         assert!(!bounding_rect_sm.contains(&bounding_rect_xl));
     }
     #[test]
     fn point_in_line_test() {
-        let c = |x, y| Coordinate { x, y };
+        let c = |x, y| coord! { x: x, y: y };
         let p0 = c(2., 4.);
         // vertical line
         let line1 = Line::new(c(2., 0.), c(2., 5.));
@@ -333,7 +328,7 @@ mod test {
     }
     #[test]
     fn line_in_line_test() {
-        let c = |x, y| Coordinate { x, y };
+        let c = |x, y| coord! { x: x, y: y };
         let line0 = Line::new(c(0., 1.), c(3., 4.));
         // first point on line0, second not
         let line1 = Line::new(c(1., 2.), c(2., 2.));
@@ -369,7 +364,7 @@ mod test {
     }
     #[test]
     fn line_in_polygon_test() {
-        let c = |x, y| Coordinate { x, y };
+        let c = |x, y| coord! { x: x, y: y };
         let line = Line::new(c(0.0, 10.0), c(30.0, 40.0));
         let linestring0 = line_string![
             c(-10.0, 0.0),
@@ -395,7 +390,7 @@ mod test {
         // Some DE-9IM edge cases for checking line is
         // inside polygon The end points of the line can be
         // on the boundary of the polygon.
-        let c = |x, y| Coordinate { x, y };
+        let c = |x, y| coord! { x: x, y: y };
         // A non-convex polygon
         let linestring0 = line_string![
             c(0.0, 0.0),
@@ -412,7 +407,7 @@ mod test {
     }
     #[test]
     fn line_in_linestring_edgecases() {
-        let c = |x, y| Coordinate { x, y };
+        let c = |x, y| coord! { x: x, y: y };
         use crate::line_string;
         let mut ls = line_string![c(0, 0), c(1, 0), c(0, 1), c(-1, 0)];
         assert!(!ls.contains(&Line::from([(0, 0), (0, 0)])));
@@ -450,13 +445,12 @@ mod test {
     #[test]
     fn integer_bounding_rects() {
         let p: Point<i32> = Point::new(10, 20);
-        let bounding_rect: Rect<i32> =
-            Rect::new(Coordinate { x: 0, y: 0 }, Coordinate { x: 100, y: 100 });
+        let bounding_rect: Rect<i32> = Rect::new(coord! { x: 0, y: 0 }, coord! { x: 100, y: 100 });
         assert!(bounding_rect.contains(&p));
         assert!(!bounding_rect.contains(&Point::new(-10, -10)));
 
         let smaller_bounding_rect: Rect<i32> =
-            Rect::new(Coordinate { x: 10, y: 10 }, Coordinate { x: 20, y: 20 });
+            Rect::new(coord! { x: 10, y: 10 }, coord! { x: 20, y: 20 });
         assert!(bounding_rect.contains(&smaller_bounding_rect));
     }
 

--- a/geo/src/algorithm/contains/mod.rs
+++ b/geo/src/algorithm/contains/mod.rs
@@ -52,7 +52,9 @@ mod triangle;
 mod test {
     use crate::algorithm::contains::Contains;
     use crate::line_string;
-    use crate::{coord, Coordinate, Line, LineString, MultiPolygon, Point, Polygon, Rect, Triangle};
+    use crate::{
+        coord, Coordinate, Line, LineString, MultiPolygon, Point, Polygon, Rect, Triangle,
+    };
 
     #[test]
     // see https://github.com/georust/geo/issues/452

--- a/geo/src/algorithm/convex_hull/qhull.rs
+++ b/geo/src/algorithm/convex_hull/qhull.rs
@@ -1,7 +1,7 @@
 use super::{swap_remove_to_first, trivial_hull};
 use crate::kernels::{HasKernel, Kernel, Orientation};
 use crate::utils::partition_slice;
-use crate::{Coordinate, GeoNum, LineString};
+use crate::{coord, Coordinate, GeoNum, LineString};
 
 // Determines if `p_c` lies on the positive side of the
 // segment `p_a` to `p_b`. In other words, whether segment
@@ -83,15 +83,15 @@ fn hull_set<T>(
     // Construct orthogonal vector to `p_b` - `p_a` We
     // compute inner product of this with `v` - `p_a` to
     // find the farthest point from the line segment a-b.
-    let p_orth = Coordinate {
-        y: p_b.x - p_a.x,
+    let p_orth = coord! {
         x: p_a.y - p_b.y,
+        y: p_b.x - p_a.x,
     };
 
     let furthest_idx = set
         .iter()
         .map(|pt| {
-            let p_diff = Coordinate {
+            let p_diff = coord! {
                 x: pt.x - p_a.x,
                 y: pt.y - p_a.y,
             };
@@ -123,13 +123,13 @@ mod test {
     #[test]
     fn quick_hull_test1() {
         let mut v = vec![
-            Coordinate { x: 0.0, y: 0.0 },
-            Coordinate { x: 4.0, y: 0.0 },
-            Coordinate { x: 4.0, y: 1.0 },
-            Coordinate { x: 1.0, y: 1.0 },
-            Coordinate { x: 1.0, y: 4.0 },
-            Coordinate { x: 0.0, y: 4.0 },
-            Coordinate { x: 0.0, y: 0.0 },
+            coord! { x: 0.0, y: 0.0 },
+            coord! { x: 4.0, y: 0.0 },
+            coord! { x: 4.0, y: 1.0 },
+            coord! { x: 1.0, y: 1.0 },
+            coord! { x: 1.0, y: 4.0 },
+            coord! { x: 0.0, y: 4.0 },
+            coord! { x: 0.0, y: 0.0 },
         ];
         let res = quick_hull(&mut v);
         assert!(res.is_strictly_ccw_convex());
@@ -138,22 +138,22 @@ mod test {
     #[test]
     fn quick_hull_test2() {
         let mut v = vec![
-            Coordinate { x: 0, y: 10 },
-            Coordinate { x: 1, y: 1 },
-            Coordinate { x: 10, y: 0 },
-            Coordinate { x: 1, y: -1 },
-            Coordinate { x: 0, y: -10 },
-            Coordinate { x: -1, y: -1 },
-            Coordinate { x: -10, y: 0 },
-            Coordinate { x: -1, y: 1 },
-            Coordinate { x: 0, y: 10 },
+            coord! { x: 0, y: 10 },
+            coord! { x: 1, y: 1 },
+            coord! { x: 10, y: 0 },
+            coord! { x: 1, y: -1 },
+            coord! { x: 0, y: -10 },
+            coord! { x: -1, y: -1 },
+            coord! { x: -10, y: 0 },
+            coord! { x: -1, y: 1 },
+            coord! { x: 0, y: 10 },
         ];
         let correct = vec![
-            Coordinate { x: 0, y: -10 },
-            Coordinate { x: 10, y: 0 },
-            Coordinate { x: 0, y: 10 },
-            Coordinate { x: -10, y: 0 },
-            Coordinate { x: 0, y: -10 },
+            coord! { x: 0, y: -10 },
+            coord! { x: 10, y: 0 },
+            coord! { x: 0, y: 10 },
+            coord! { x: -10, y: 0 },
+            coord! { x: 0, y: -10 },
         ];
         let res = quick_hull(&mut v);
         assert_eq!(res.0, correct);
@@ -170,15 +170,9 @@ mod test {
             (0.0, 1.0),
             (1.0, 0.0),
         ];
-        let mut v: Vec<_> = initial
-            .iter()
-            .map(|e| Coordinate { x: e.0, y: e.1 })
-            .collect();
+        let mut v: Vec<_> = initial.iter().map(|e| coord! { x: e.0, y: e.1 }).collect();
         let correct = vec![(1.0, 0.0), (2.0, 1.0), (1.0, 2.0), (0.0, 1.0), (1.0, 0.0)];
-        let v_correct: Vec<_> = correct
-            .iter()
-            .map(|e| Coordinate { x: e.0, y: e.1 })
-            .collect();
+        let v_correct: Vec<_> = correct.iter().map(|e| coord! { x: e.0, y: e.1 }).collect();
         let res = quick_hull(&mut v);
         assert_eq!(res.0, v_correct);
     }
@@ -196,10 +190,7 @@ mod test {
             (0., 2.),
             (0., 0.),
         ];
-        let mut v: Vec<_> = initial
-            .iter()
-            .map(|e| Coordinate { x: e.0, y: e.1 })
-            .collect();
+        let mut v: Vec<_> = initial.iter().map(|e| coord! { x: e.0, y: e.1 }).collect();
         let res = quick_hull(&mut v);
         assert!(res.is_strictly_ccw_convex());
     }
@@ -236,10 +227,7 @@ mod test {
             (1., -1.),
             (1., 1.),
         ];
-        let mut v: Vec<_> = initial
-            .iter()
-            .map(|e| Coordinate { x: e.0, y: e.1 })
-            .collect();
+        let mut v: Vec<_> = initial.iter().map(|e| coord! { x: e.0, y: e.1 }).collect();
         let res = quick_hull(&mut v);
         assert!(res.is_strictly_ccw_convex());
     }

--- a/geo/src/algorithm/coordinate_position.rs
+++ b/geo/src/algorithm/coordinate_position.rs
@@ -2,7 +2,7 @@ use crate::algorithm::{
     bounding_rect::BoundingRect, dimensions::HasDimensions, intersects::Intersects,
 };
 use crate::{
-    Coordinate, GeoNum, Geometry, GeometryCollection, GeometryCow, Line, LineString,
+    coord, Coordinate, GeoNum, Geometry, GeometryCollection, GeometryCow, Line, LineString,
     MultiLineString, MultiPoint, MultiPolygon, Point, Polygon, Rect, Triangle,
 };
 
@@ -19,18 +19,18 @@ pub enum CoordPos {
 /// # Examples
 ///
 /// ```rust
-/// use geo::{polygon, Coordinate};
+/// use geo::{polygon, coord};
 /// use geo::coordinate_position::{CoordinatePosition, CoordPos};
 ///
 /// let square_poly = polygon![(x: 0.0, y: 0.0), (x: 2.0, y: 0.0), (x: 2.0, y: 2.0), (x: 0.0, y: 2.0), (x: 0.0, y: 0.0)];
 ///
-/// let inside_coord = Coordinate { x: 1.0, y: 1.0 };
+/// let inside_coord = coord! { x: 1.0, y: 1.0 };
 /// assert_eq!(square_poly.coordinate_position(&inside_coord), CoordPos::Inside);
 ///
-/// let boundary_coord = Coordinate { x: 0.0, y: 1.0 };
+/// let boundary_coord = coord! { x: 0.0, y: 1.0 };
 /// assert_eq!(square_poly.coordinate_position(&boundary_coord), CoordPos::OnBoundary);
 ///
-/// let outside_coord = Coordinate { x: 5.0, y: 5.0 };
+/// let outside_coord = coord! { x: 5.0, y: 5.0 };
 /// assert_eq!(square_poly.coordinate_position(&outside_coord), CoordPos::Outside);
 /// ```
 pub trait CoordinatePosition {
@@ -421,7 +421,7 @@ where
         // coordinate of the current segment.
         let ray = Line::new(
             coord,
-            Coordinate {
+            coord! {
                 x: max_x,
                 y: coord.y,
             },
@@ -455,25 +455,25 @@ mod test {
     fn test_simple_poly() {
         let square_poly = polygon![(x: 0.0, y: 0.0), (x: 2.0, y: 0.0), (x: 2.0, y: 2.0), (x: 0.0, y: 2.0), (x: 0.0, y: 0.0)];
 
-        let inside_coord = Coordinate { x: 1.0, y: 1.0 };
+        let inside_coord = coord! { x: 1.0, y: 1.0 };
         assert_eq!(
             square_poly.coordinate_position(&inside_coord),
             CoordPos::Inside
         );
 
-        let vertex_coord = Coordinate { x: 0.0, y: 0.0 };
+        let vertex_coord = coord! { x: 0.0, y: 0.0 };
         assert_eq!(
             square_poly.coordinate_position(&vertex_coord),
             CoordPos::OnBoundary
         );
 
-        let boundary_coord = Coordinate { x: 0.0, y: 1.0 };
+        let boundary_coord = coord! { x: 0.0, y: 1.0 };
         assert_eq!(
             square_poly.coordinate_position(&boundary_coord),
             CoordPos::OnBoundary
         );
 
-        let outside_coord = Coordinate { x: 5.0, y: 5.0 };
+        let outside_coord = coord! { x: 5.0, y: 5.0 };
         assert_eq!(
             square_poly.coordinate_position(&outside_coord),
             CoordPos::Outside
@@ -501,25 +501,25 @@ mod test {
             ],
         ];
 
-        let inside_hole = Coordinate { x: 14.0, y: 14.0 };
+        let inside_hole = coord! { x: 14.0, y: 14.0 };
         assert_eq!(poly.coordinate_position(&inside_hole), CoordPos::Outside);
 
-        let outside_poly = Coordinate { x: 30.0, y: 30.0 };
+        let outside_poly = coord! { x: 30.0, y: 30.0 };
         assert_eq!(poly.coordinate_position(&outside_poly), CoordPos::Outside);
 
-        let on_outside_border = Coordinate { x: 20.0, y: 15.0 };
+        let on_outside_border = coord! { x: 20.0, y: 15.0 };
         assert_eq!(
             poly.coordinate_position(&on_outside_border),
             CoordPos::OnBoundary
         );
 
-        let on_inside_border = Coordinate { x: 13.0, y: 15.0 };
+        let on_inside_border = coord! { x: 13.0, y: 15.0 };
         assert_eq!(
             poly.coordinate_position(&on_inside_border),
             CoordPos::OnBoundary
         );
 
-        let inside_coord = Coordinate { x: 12.0, y: 12.0 };
+        let inside_coord = coord! { x: 12.0, y: 12.0 };
         assert_eq!(poly.coordinate_position(&inside_coord), CoordPos::Inside);
     }
 
@@ -528,16 +528,16 @@ mod test {
         use crate::point;
         let line = Line::new(point![x: 0.0, y: 0.0], point![x: 10.0, y: 10.0]);
 
-        let start = Coordinate { x: 0.0, y: 0.0 };
+        let start = coord! { x: 0.0, y: 0.0 };
         assert_eq!(line.coordinate_position(&start), CoordPos::OnBoundary);
 
-        let end = Coordinate { x: 10.0, y: 10.0 };
+        let end = coord! { x: 10.0, y: 10.0 };
         assert_eq!(line.coordinate_position(&end), CoordPos::OnBoundary);
 
-        let interior = Coordinate { x: 5.0, y: 5.0 };
+        let interior = coord! { x: 5.0, y: 5.0 };
         assert_eq!(line.coordinate_position(&interior), CoordPos::Inside);
 
-        let outside = Coordinate { x: 6.0, y: 5.0 };
+        let outside = coord! { x: 6.0, y: 5.0 };
         assert_eq!(line.coordinate_position(&outside), CoordPos::Outside);
     }
 
@@ -545,10 +545,10 @@ mod test {
     fn test_degenerate_line() {
         let line = Line::new(point![x: 0.0, y: 0.0], point![x: 0.0, y: 0.0]);
 
-        let start = Coordinate { x: 0.0, y: 0.0 };
+        let start = coord! { x: 0.0, y: 0.0 };
         assert_eq!(line.coordinate_position(&start), CoordPos::Inside);
 
-        let outside = Coordinate { x: 10.0, y: 10.0 };
+        let outside = coord! { x: 10.0, y: 10.0 };
         assert_eq!(line.coordinate_position(&outside), CoordPos::Outside);
     }
 
@@ -556,8 +556,8 @@ mod test {
     fn test_point() {
         let p1 = point![x: 2.0, y: 0.0];
 
-        let c1 = Coordinate { x: 2.0, y: 0.0 };
-        let c2 = Coordinate { x: 3.0, y: 3.0 };
+        let c1 = coord! { x: 2.0, y: 0.0 };
+        let c2 = coord! { x: 3.0, y: 3.0 };
 
         assert_eq!(p1.coordinate_position(&c1), CoordPos::Inside);
         assert_eq!(p1.coordinate_position(&c2), CoordPos::Outside);
@@ -577,16 +577,16 @@ mod test {
             CoordPos::OnBoundary
         );
 
-        let midpoint = Coordinate { x: 0.5, y: 0.5 };
+        let midpoint = coord! { x: 0.5, y: 0.5 };
         assert_eq!(line_string.coordinate_position(&midpoint), CoordPos::Inside);
 
-        let vertex = Coordinate { x: 2.0, y: 0.0 };
+        let vertex = coord! { x: 2.0, y: 0.0 };
         assert_eq!(line_string.coordinate_position(&vertex), CoordPos::Inside);
 
-        let end = Coordinate { x: 3.0, y: 0.0 };
+        let end = coord! { x: 3.0, y: 0.0 };
         assert_eq!(line_string.coordinate_position(&end), CoordPos::OnBoundary);
 
-        let outside = Coordinate { x: 3.0, y: 1.0 };
+        let outside = coord! { x: 3.0, y: 1.0 };
         assert_eq!(line_string.coordinate_position(&outside), CoordPos::Outside);
     }
 
@@ -617,10 +617,10 @@ mod test {
         let start = Coordinate::zero();
         assert_eq!(line_string.coordinate_position(&start), CoordPos::Inside);
 
-        let midpoint = Coordinate { x: 0.5, y: 0.5 };
+        let midpoint = coord! { x: 0.5, y: 0.5 };
         assert_eq!(line_string.coordinate_position(&midpoint), CoordPos::Inside);
 
-        let outside = Coordinate { x: 3.0, y: 1.0 };
+        let outside = coord! { x: 3.0, y: 1.0 };
         assert_eq!(line_string.coordinate_position(&outside), CoordPos::Outside);
     }
 
@@ -638,13 +638,13 @@ mod test {
             line_string![(x: 0.0, y: -2.0), (x: -0.5, y: -0.5)],
         ]);
 
-        let outside_of_all = Coordinate { x: 123.0, y: 123.0 };
+        let outside_of_all = coord! { x: 123.0, y: 123.0 };
         assert_eq!(
             multi_line_string.coordinate_position(&outside_of_all),
             CoordPos::Outside
         );
 
-        let end_of_one_line = Coordinate { x: -1.0, y: -1.0 };
+        let end_of_one_line = coord! { x: -1.0, y: -1.0 };
         assert_eq!(
             multi_line_string.coordinate_position(&end_of_one_line),
             CoordPos::OnBoundary
@@ -658,14 +658,14 @@ mod test {
         );
 
         // *in* the first line, on the boundary of the third line
-        let one_end_plus_midpoint = Coordinate { x: 0.5, y: 0.5 };
+        let one_end_plus_midpoint = coord! { x: 0.5, y: 0.5 };
         assert_eq!(
             multi_line_string.coordinate_position(&one_end_plus_midpoint),
             CoordPos::OnBoundary
         );
 
         // *in* the first line, on the *boundary* of the fourth and fifth line
-        let two_ends_plus_midpoint = Coordinate { x: -0.5, y: -0.5 };
+        let two_ends_plus_midpoint = coord! { x: -0.5, y: -0.5 };
         assert_eq!(
             multi_line_string.coordinate_position(&two_ends_plus_midpoint),
             CoordPos::Inside
@@ -676,15 +676,15 @@ mod test {
     fn test_rect() {
         let rect = Rect::new((0.0, 0.0), (10.0, 10.0));
         assert_eq!(
-            rect.coordinate_position(&Coordinate { x: 5.0, y: 5.0 }),
+            rect.coordinate_position(&coord! { x: 5.0, y: 5.0 }),
             CoordPos::Inside
         );
         assert_eq!(
-            rect.coordinate_position(&Coordinate { x: 0.0, y: 5.0 }),
+            rect.coordinate_position(&coord! { x: 0.0, y: 5.0 }),
             CoordPos::OnBoundary
         );
         assert_eq!(
-            rect.coordinate_position(&Coordinate { x: 15.0, y: 15.0 }),
+            rect.coordinate_position(&coord! { x: 15.0, y: 15.0 }),
             CoordPos::Outside
         );
     }
@@ -693,11 +693,11 @@ mod test {
     fn test_triangle() {
         let triangle = Triangle((0.0, 0.0).into(), (5.0, 10.0).into(), (10.0, 0.0).into());
         assert_eq!(
-            triangle.coordinate_position(&Coordinate { x: 5.0, y: 5.0 }),
+            triangle.coordinate_position(&coord! { x: 5.0, y: 5.0 }),
             CoordPos::Inside
         );
         assert_eq!(
-            triangle.coordinate_position(&Coordinate { x: 2.5, y: 5.0 }),
+            triangle.coordinate_position(&coord! { x: 2.5, y: 5.0 }),
             CoordPos::OnBoundary
         );
         assert_eq!(
@@ -714,25 +714,25 @@ mod test {
 
         //  outside of both
         assert_eq!(
-            collection.coordinate_position(&Coordinate { x: 15.0, y: 15.0 }),
+            collection.coordinate_position(&coord! { x: 15.0, y: 15.0 }),
             CoordPos::Outside
         );
 
         // inside both
         assert_eq!(
-            collection.coordinate_position(&Coordinate { x: 5.0, y: 5.0 }),
+            collection.coordinate_position(&coord! { x: 5.0, y: 5.0 }),
             CoordPos::Inside
         );
 
         // inside one, boundary of other
         assert_eq!(
-            collection.coordinate_position(&Coordinate { x: 2.5, y: 5.0 }),
+            collection.coordinate_position(&coord! { x: 2.5, y: 5.0 }),
             CoordPos::OnBoundary
         );
 
         //  boundary of both
         assert_eq!(
-            collection.coordinate_position(&Coordinate { x: 5.0, y: 10.0 }),
+            collection.coordinate_position(&coord! { x: 5.0, y: 10.0 }),
             CoordPos::Outside
         );
     }

--- a/geo/src/algorithm/coords_iter.rs
+++ b/geo/src/algorithm/coords_iter.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 
 use crate::{
-    CoordNum, Coordinate, Geometry, GeometryCollection, Line, LineString, MultiLineString,
+    CoordNum, coord, Coordinate, Geometry, GeometryCollection, Line, LineString, MultiLineString,
     MultiPoint, MultiPolygon, Point, Polygon, Rect, Triangle,
 };
 
@@ -29,9 +29,9 @@ pub trait CoordsIter<'a> {
     /// ]);
     ///
     /// let mut iter = multi_point.coords_iter();
-    /// assert_eq!(Some(geo::Coordinate { x: -10., y: 0. }), iter.next());
-    /// assert_eq!(Some(geo::Coordinate { x: 20., y: 20. }), iter.next());
-    /// assert_eq!(Some(geo::Coordinate { x: 30., y: 40. }), iter.next());
+    /// assert_eq!(Some(geo::coord! { x: -10., y: 0. }), iter.next());
+    /// assert_eq!(Some(geo::coord! { x: 20., y: 20. }), iter.next());
+    /// assert_eq!(Some(geo::coord! { x: 30., y: 40. }), iter.next());
     /// assert_eq!(None, iter.next());
     /// ```
     fn coords_iter(&'a self) -> Self::Iter;
@@ -83,11 +83,11 @@ pub trait CoordsIter<'a> {
     /// ];
     ///
     /// let mut iter = polygon.exterior_coords_iter();
-    /// assert_eq!(Some(geo::Coordinate { x: 1., y: 0. }), iter.next());
-    /// assert_eq!(Some(geo::Coordinate { x: 2., y: 1. }), iter.next());
-    /// assert_eq!(Some(geo::Coordinate { x: 1., y: 2. }), iter.next());
-    /// assert_eq!(Some(geo::Coordinate { x: 0., y: 1. }), iter.next());
-    /// assert_eq!(Some(geo::Coordinate { x: 1., y: 0. }), iter.next());
+    /// assert_eq!(Some(geo::coord! { x: 1., y: 0. }), iter.next());
+    /// assert_eq!(Some(geo::coord! { x: 2., y: 1. }), iter.next());
+    /// assert_eq!(Some(geo::coord! { x: 1., y: 2. }), iter.next());
+    /// assert_eq!(Some(geo::coord! { x: 0., y: 1. }), iter.next());
+    /// assert_eq!(Some(geo::coord! { x: 1., y: 0. }), iter.next());
     /// assert_eq!(None, iter.next());
     /// ```
     fn exterior_coords_iter(&'a self) -> Self::ExteriorIter;
@@ -314,19 +314,19 @@ impl<'a, T: CoordNum + 'a> CoordsIter<'a> for Rect<T> {
     type Scalar = T;
 
     fn coords_iter(&'a self) -> Self::Iter {
-        iter::once(Coordinate {
+        iter::once(coord! {
             x: self.min().x,
             y: self.min().y,
         })
-        .chain(iter::once(Coordinate {
+        .chain(iter::once(coord! {
             x: self.min().x,
             y: self.max().y,
         }))
-        .chain(iter::once(Coordinate {
+        .chain(iter::once(coord! {
             x: self.max().x,
             y: self.max().y,
         }))
-        .chain(iter::once(Coordinate {
+        .chain(iter::once(coord! {
             x: self.max().x,
             y: self.min().y,
         }))
@@ -634,7 +634,7 @@ impl<'a, T: CoordNum + Debug> fmt::Debug for GeometryExteriorCoordsIter<'a, T> {
 mod test {
     use super::CoordsIter;
     use crate::{
-        line_string, point, polygon, Coordinate, Geometry, GeometryCollection, Line, LineString,
+        line_string, point, polygon, coord, Coordinate, Geometry, GeometryCollection, Line, LineString,
         MultiLineString, MultiPoint, MultiPolygon, Point, Polygon, Rect, Triangle,
     };
 
@@ -649,12 +649,12 @@ mod test {
 
     #[test]
     fn test_line() {
-        let line = Line::new(Coordinate { x: 1., y: 2. }, Coordinate { x: 2., y: 3. });
+        let line = Line::new(coord! { x: 1., y: 2. }, coord! { x: 2., y: 3. });
 
         let coords = line.coords_iter().collect::<Vec<_>>();
 
         assert_eq!(
-            vec![Coordinate { x: 1., y: 2. }, Coordinate { x: 2., y: 3. },],
+            vec![coord! { x: 1., y: 2. }, coord! { x: 2., y: 3. },],
             coords
         );
     }
@@ -767,32 +767,32 @@ mod test {
     }
 
     fn create_point() -> (Point<f64>, Vec<Coordinate<f64>>) {
-        (point!(x: 1., y: 2.), vec![Coordinate { x: 1., y: 2. }])
+        (point!(x: 1., y: 2.), vec![coord! { x: 1., y: 2. }])
     }
 
     fn create_triangle() -> (Triangle<f64>, Vec<Coordinate<f64>>) {
         (
             Triangle(
-                Coordinate { x: 1., y: 2. },
-                Coordinate { x: 3., y: 4. },
-                Coordinate { x: 5., y: 6. },
+                coord! { x: 1., y: 2. },
+                coord! { x: 3., y: 4. },
+                coord! { x: 5., y: 6. },
             ),
             vec![
-                Coordinate { x: 1., y: 2. },
-                Coordinate { x: 3., y: 4. },
-                Coordinate { x: 5., y: 6. },
+                coord! { x: 1., y: 2. },
+                coord! { x: 3., y: 4. },
+                coord! { x: 5., y: 6. },
             ],
         )
     }
 
     fn create_rect() -> (Rect<f64>, Vec<Coordinate<f64>>) {
         (
-            Rect::new(Coordinate { x: 1., y: 2. }, Coordinate { x: 3., y: 4. }),
+            Rect::new(coord! { x: 1., y: 2. }, coord! { x: 3., y: 4. }),
             vec![
-                Coordinate { x: 1., y: 2. },
-                Coordinate { x: 1., y: 4. },
-                Coordinate { x: 3., y: 4. },
-                Coordinate { x: 3., y: 2. },
+                coord! { x: 1., y: 2. },
+                coord! { x: 1., y: 4. },
+                coord! { x: 3., y: 4. },
+                coord! { x: 3., y: 2. },
             ],
         )
     }
@@ -803,7 +803,7 @@ mod test {
                 (x: 1., y: 2.),
                 (x: 2., y: 3.),
             ],
-            vec![Coordinate { x: 1., y: 2. }, Coordinate { x: 2., y: 3. }],
+            vec![coord! { x: 1., y: 2. }, coord! { x: 2., y: 3. }],
         )
     }
 
@@ -814,14 +814,14 @@ mod test {
                 interiors: [[(x: 1., y: 1.), (x: 9., y: 1.), (x: 5., y: 9.), (x: 1., y: 1.)]],
             ),
             vec![
-                Coordinate { x: 0.0, y: 0.0 },
-                Coordinate { x: 5.0, y: 10.0 },
-                Coordinate { x: 10.0, y: 0.0 },
-                Coordinate { x: 0.0, y: 0.0 },
-                Coordinate { x: 1.0, y: 1.0 },
-                Coordinate { x: 9.0, y: 1.0 },
-                Coordinate { x: 5.0, y: 9.0 },
-                Coordinate { x: 1.0, y: 1.0 }
+                coord! { x: 0.0, y: 0.0 },
+                coord! { x: 5.0, y: 10.0 },
+                coord! { x: 10.0, y: 0.0 },
+                coord! { x: 0.0, y: 0.0 },
+                coord! { x: 1.0, y: 1.0 },
+                coord! { x: 9.0, y: 1.0 },
+                coord! { x: 5.0, y: 9.0 },
+                coord! { x: 1.0, y: 1.0 },
             ],
         )
     }

--- a/geo/src/algorithm/coords_iter.rs
+++ b/geo/src/algorithm/coords_iter.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 
 use crate::{
-    CoordNum, coord, Coordinate, Geometry, GeometryCollection, Line, LineString, MultiLineString,
+    coord, CoordNum, Coordinate, Geometry, GeometryCollection, Line, LineString, MultiLineString,
     MultiPoint, MultiPolygon, Point, Polygon, Rect, Triangle,
 };
 
@@ -634,8 +634,8 @@ impl<'a, T: CoordNum + Debug> fmt::Debug for GeometryExteriorCoordsIter<'a, T> {
 mod test {
     use super::CoordsIter;
     use crate::{
-        line_string, point, polygon, coord, Coordinate, Geometry, GeometryCollection, Line, LineString,
-        MultiLineString, MultiPoint, MultiPolygon, Point, Polygon, Rect, Triangle,
+        coord, line_string, point, polygon, Coordinate, Geometry, GeometryCollection, Line,
+        LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon, Rect, Triangle,
     };
 
     #[test]

--- a/geo/src/algorithm/dimensions.rs
+++ b/geo/src/algorithm/dimensions.rs
@@ -43,12 +43,12 @@ pub trait HasDimensions {
     /// Types like `Point` and `Rect`, which have at least one coordinate by construction, can
     /// never be considered empty.
     /// ```
-    /// use geo_types::{Point, Coordinate, LineString};
+    /// use geo_types::{Point, coord, LineString};
     /// use geo::algorithm::dimensions::HasDimensions;
     ///
     /// let line_string = LineString(vec![
-    ///     Coordinate { x: 0., y: 0. },
-    ///     Coordinate { x: 10., y: 0. },
+    ///     coord! { x: 0., y: 0. },
+    ///     coord! { x: 10., y: 0. },
     /// ]);
     /// assert!(!line_string.is_empty());
     ///

--- a/geo/src/algorithm/euclidean_distance.rs
+++ b/geo/src/algorithm/euclidean_distance.rs
@@ -577,7 +577,7 @@ mod test {
     use crate::algorithm::euclidean_distance::EuclideanDistance;
     use crate::{Line, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon};
     use geo_types::Rect;
-    use geo_types::{polygon, private_utils::line_segment_distance, Coordinate};
+    use geo_types::{polygon, private_utils::line_segment_distance, coord};
 
     #[test]
     fn line_segment_distance_test() {
@@ -893,29 +893,29 @@ mod test {
     // See https://github.com/georust/geo/issues/476
     fn distance_line_polygon_test() {
         let line = Line::new(
-            Coordinate {
+            coord! {
                 x: -0.17084137691985102,
                 y: 0.8748085493016657,
             },
-            Coordinate {
+            coord! {
                 x: -0.17084137691985102,
                 y: 0.09858870312437906,
             },
         );
         let poly: Polygon<f64> = polygon![
-            Coordinate {
+            coord! {
                 x: -0.10781391405721802,
                 y: -0.15433610862574643,
             },
-            Coordinate {
+            coord! {
                 x: -0.7855276236615211,
                 y: 0.23694208404779793,
             },
-            Coordinate {
+            coord! {
                 x: -0.7855276236615214,
                 y: -0.5456143012992907,
             },
-            Coordinate {
+            coord! {
                 x: -0.10781391405721802,
                 y: -0.15433610862574643,
             },

--- a/geo/src/algorithm/euclidean_distance.rs
+++ b/geo/src/algorithm/euclidean_distance.rs
@@ -577,7 +577,7 @@ mod test {
     use crate::algorithm::euclidean_distance::EuclideanDistance;
     use crate::{Line, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon};
     use geo_types::Rect;
-    use geo_types::{polygon, private_utils::line_segment_distance, coord};
+    use geo_types::{coord, polygon, private_utils::line_segment_distance};
 
     #[test]
     fn line_segment_distance_test() {

--- a/geo/src/algorithm/euclidean_length.rs
+++ b/geo/src/algorithm/euclidean_length.rs
@@ -59,7 +59,7 @@ where
 mod test {
     use crate::algorithm::euclidean_length::EuclideanLength;
     use crate::line_string;
-    use crate::{Coordinate, Line, MultiLineString};
+    use crate::{coord, Line, MultiLineString};
 
     #[test]
     fn empty_linestring_test() {
@@ -103,8 +103,8 @@ mod test {
     }
     #[test]
     fn line_test() {
-        let line0 = Line::new(Coordinate { x: 0., y: 0. }, Coordinate { x: 0., y: 1. });
-        let line1 = Line::new(Coordinate { x: 0., y: 0. }, Coordinate { x: 3., y: 4. });
+        let line0 = Line::new(coord! { x: 0., y: 0. }, coord! { x: 0., y: 1. });
+        let line1 = Line::new(coord! { x: 0., y: 0. }, coord! { x: 3., y: 4. });
         assert_relative_eq!(line0.euclidean_length(), 1.);
         assert_relative_eq!(line1.euclidean_length(), 5.);
     }

--- a/geo/src/algorithm/extremes.rs
+++ b/geo/src/algorithm/extremes.rs
@@ -82,7 +82,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{polygon, MultiPoint};
+    use crate::{polygon, MultiPoint, coord};
 
     #[test]
     fn polygon() {
@@ -101,19 +101,19 @@ mod test {
             Some(Outcome {
                 x_min: Extreme {
                     index: 3,
-                    coord: Coordinate { x: 0.0, y: 1.0 }
+                    coord: coord! { x: 0.0, y: 1.0 }
                 },
                 y_min: Extreme {
                     index: 0,
-                    coord: Coordinate { x: 1.0, y: 0.0 }
+                    coord: coord! { x: 1.0, y: 0.0 }
                 },
                 x_max: Extreme {
                     index: 1,
-                    coord: Coordinate { x: 2.0, y: 1.0 }
+                    coord: coord! { x: 2.0, y: 1.0 }
                 },
                 y_max: Extreme {
                     index: 2,
-                    coord: Coordinate { x: 1.0, y: 2.0 }
+                    coord: coord! { x: 1.0, y: 2.0 }
                 }
             }),
             actual

--- a/geo/src/algorithm/extremes.rs
+++ b/geo/src/algorithm/extremes.rs
@@ -82,7 +82,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{polygon, MultiPoint, coord};
+    use crate::{coord, polygon, MultiPoint};
 
     #[test]
     fn polygon() {

--- a/geo/src/algorithm/intersects/mod.rs
+++ b/geo/src/algorithm/intersects/mod.rs
@@ -111,7 +111,7 @@ where
 mod test {
     use crate::algorithm::intersects::Intersects;
     use crate::{
-        line_string, polygon, coord, Geometry, Line, LineString, MultiLineString, MultiPoint,
+        coord, line_string, polygon, Geometry, Line, LineString, MultiLineString, MultiPoint,
         MultiPolygon, Point, Polygon, Rect,
     };
 

--- a/geo/src/algorithm/intersects/mod.rs
+++ b/geo/src/algorithm/intersects/mod.rs
@@ -111,7 +111,7 @@ where
 mod test {
     use crate::algorithm::intersects::Intersects;
     use crate::{
-        line_string, polygon, Coordinate, Geometry, Line, LineString, MultiLineString, MultiPoint,
+        line_string, polygon, coord, Geometry, Line, LineString, MultiLineString, MultiPoint,
         MultiPolygon, Point, Polygon, Rect,
     };
 
@@ -339,10 +339,10 @@ mod test {
                 (7., 4.),
             ])],
         );
-        let b1 = Rect::new(Coordinate { x: 11., y: 1. }, Coordinate { x: 13., y: 2. });
-        let b2 = Rect::new(Coordinate { x: 2., y: 2. }, Coordinate { x: 8., y: 5. });
-        let b3 = Rect::new(Coordinate { x: 8., y: 5. }, Coordinate { x: 10., y: 6. });
-        let b4 = Rect::new(Coordinate { x: 1., y: 1. }, Coordinate { x: 3., y: 3. });
+        let b1 = Rect::new(coord! { x: 11., y: 1. }, coord! { x: 13., y: 2. });
+        let b2 = Rect::new(coord! { x: 2., y: 2. }, coord! { x: 8., y: 5. });
+        let b3 = Rect::new(coord! { x: 8., y: 5. }, coord! { x: 10., y: 6. });
+        let b4 = Rect::new(coord! { x: 1., y: 1. }, coord! { x: 3., y: 3. });
         // overlaps
         assert!(poly.intersects(&b1));
         // contained in exterior, overlaps with hole
@@ -359,16 +359,10 @@ mod test {
     }
     #[test]
     fn bounding_rect_test() {
-        let bounding_rect_xl = Rect::new(
-            Coordinate { x: -100., y: -200. },
-            Coordinate { x: 100., y: 200. },
-        );
-        let bounding_rect_sm = Rect::new(
-            Coordinate { x: -10., y: -20. },
-            Coordinate { x: 10., y: 20. },
-        );
-        let bounding_rect_s2 =
-            Rect::new(Coordinate { x: 0., y: 0. }, Coordinate { x: 20., y: 30. });
+        let bounding_rect_xl =
+            Rect::new(coord! { x: -100., y: -200. }, coord! { x: 100., y: 200. });
+        let bounding_rect_sm = Rect::new(coord! { x: -10., y: -20. }, coord! { x: 10., y: 20. });
+        let bounding_rect_s2 = Rect::new(coord! { x: 0., y: 0. }, coord! { x: 20., y: 30. });
         // confirmed using GEOS
         assert!(bounding_rect_xl.intersects(&bounding_rect_sm));
         assert!(bounding_rect_sm.intersects(&bounding_rect_xl));
@@ -377,16 +371,10 @@ mod test {
     }
     #[test]
     fn rect_intersection_consistent_with_poly_intersection_test() {
-        let bounding_rect_xl = Rect::new(
-            Coordinate { x: -100., y: -200. },
-            Coordinate { x: 100., y: 200. },
-        );
-        let bounding_rect_sm = Rect::new(
-            Coordinate { x: -10., y: -20. },
-            Coordinate { x: 10., y: 20. },
-        );
-        let bounding_rect_s2 =
-            Rect::new(Coordinate { x: 0., y: 0. }, Coordinate { x: 20., y: 30. });
+        let bounding_rect_xl =
+            Rect::new(coord! { x: -100., y: -200. }, coord! { x: 100., y: 200. });
+        let bounding_rect_sm = Rect::new(coord! { x: -10., y: -20. }, coord! { x: 10., y: 20. });
+        let bounding_rect_s2 = Rect::new(coord! { x: 0., y: 0. }, coord! { x: 20., y: 30. });
 
         assert!(bounding_rect_xl.to_polygon().intersects(&bounding_rect_sm));
         assert!(bounding_rect_xl.intersects(&bounding_rect_sm.to_polygon()));
@@ -509,21 +497,21 @@ mod test {
     // See https://github.com/georust/geo/issues/419
     fn rect_test_419() {
         let a = Rect::new(
-            Coordinate {
+            coord! {
                 x: 9.228515625,
                 y: 46.83013364044739,
             },
-            Coordinate {
+            coord! {
                 x: 9.2724609375,
                 y: 46.86019101567026,
             },
         );
         let b = Rect::new(
-            Coordinate {
+            coord! {
                 x: 9.17953,
                 y: 46.82018,
             },
-            Coordinate {
+            coord! {
                 x: 9.26309,
                 y: 46.88099,
             },
@@ -547,11 +535,11 @@ mod test {
         let ln: Line<f64> = Line::new((0., 0.), (1., 1.));
         let ls = line_string![(0., 0.).into(), (1., 1.).into()];
         let poly = Polygon::new(LineString::from(vec![(0., 0.), (1., 1.), (1., 0.)]), vec![]);
-        let rect = Rect::new(Coordinate { x: 10., y: 20. }, Coordinate { x: 30., y: 10. });
+        let rect = Rect::new(coord! { x: 10., y: 20. }, coord! { x: 30., y: 10. });
         let tri = Triangle(
-            Coordinate { x: 0., y: 0. },
-            Coordinate { x: 10., y: 20. },
-            Coordinate { x: 20., y: -10. },
+            coord! { x: 0., y: 0. },
+            coord! { x: 10., y: 20. },
+            coord! { x: 20., y: -10. },
         );
         let geom = Geometry::Point(pt);
         let gc = GeometryCollection(vec![geom.clone()]);

--- a/geo/src/algorithm/k_nearest_concave_hull.rs
+++ b/geo/src/algorithm/k_nearest_concave_hull.rs
@@ -327,7 +327,7 @@ where
 mod tests {
     use super::*;
     use crate::coords_iter::CoordsIter;
-    use geo_types::coord;
+    use crate::geo_types::coord;
 
     #[test]
     fn coord_ordering() {

--- a/geo/src/algorithm/kernels/mod.rs
+++ b/geo/src/algorithm/kernels/mod.rs
@@ -1,4 +1,4 @@
-use crate::{CoordNum, coord, Coordinate};
+use crate::{coord, CoordNum, Coordinate};
 use num_traits::Zero;
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]

--- a/geo/src/algorithm/kernels/mod.rs
+++ b/geo/src/algorithm/kernels/mod.rs
@@ -1,4 +1,4 @@
-use crate::{CoordNum, Coordinate};
+use crate::{CoordNum, coord, Coordinate};
 use num_traits::Zero;
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
@@ -34,7 +34,7 @@ pub trait Kernel<T: CoordNum> {
     /// `Collinear` if zero.
     fn dot_product_sign(u: Coordinate<T>, v: Coordinate<T>) -> Orientation {
         let zero = Coordinate::zero();
-        let vdash = Coordinate {
+        let vdash = coord! {
             x: T::zero() - v.y,
             y: v.x,
         };

--- a/geo/src/algorithm/line_interpolate_point.rs
+++ b/geo/src/algorithm/line_interpolate_point.rs
@@ -110,18 +110,16 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::geo_types::coord;
     use crate::{
         algorithm::{closest_point::ClosestPoint, line_locate_point::LineLocatePoint},
-        point, Coordinate,
+        point,
     };
     use num_traits::Float;
 
     #[test]
     fn test_line_interpolate_point_line() {
-        let line = Line::new(
-            Coordinate { x: -1.0, y: 0.0 },
-            Coordinate { x: 1.0, y: 0.0 },
-        );
+        let line = Line::new(coord! { x: -1.0, y: 0.0 }, coord! { x: 1.0, y: 0.0 });
         // some finite examples
         assert_eq!(
             line.line_interpolate_point(-1.0),
@@ -159,7 +157,7 @@ mod test {
             Some(line.start_point())
         );
 
-        let line = Line::new(Coordinate { x: 0.0, y: 0.0 }, Coordinate { x: 1.0, y: 1.0 });
+        let line = Line::new(coord! { x: 0.0, y: 0.0 }, coord! { x: 1.0, y: 1.0 });
         assert_eq!(
             line.line_interpolate_point(0.5),
             Some(point!(x: 0.5, y: 0.5))
@@ -167,26 +165,26 @@ mod test {
 
         // line contains nans or infs
         let line = Line::new(
-            Coordinate {
+            coord! {
                 x: Float::nan(),
                 y: 0.0,
             },
-            Coordinate { x: 1.0, y: 1.0 },
+            coord! { x: 1.0, y: 1.0 },
         );
         assert_eq!(line.line_interpolate_point(0.5), None);
 
         let line = Line::new(
-            Coordinate {
+            coord! {
                 x: Float::infinity(),
                 y: 0.0,
             },
-            Coordinate { x: 1.0, y: 1.0 },
+            coord! { x: 1.0, y: 1.0 },
         );
         assert_eq!(line.line_interpolate_point(0.5), None);
 
         let line = Line::new(
-            Coordinate { x: 0.0, y: 0.0 },
-            Coordinate {
+            coord! { x: 0.0, y: 0.0 },
+            coord! {
                 x: 1.0,
                 y: Float::infinity(),
             },
@@ -194,17 +192,17 @@ mod test {
         assert_eq!(line.line_interpolate_point(0.5), None);
 
         let line = Line::new(
-            Coordinate {
+            coord! {
                 x: Float::neg_infinity(),
                 y: 0.0,
             },
-            Coordinate { x: 1.0, y: 1.0 },
+            coord! { x: 1.0, y: 1.0 },
         );
         assert_eq!(line.line_interpolate_point(0.5), None);
 
         let line = Line::new(
-            Coordinate { x: 0.0, y: 0.0 },
-            Coordinate {
+            coord! { x: 0.0, y: 0.0 },
+            coord! {
                 x: 1.0,
                 y: Float::neg_infinity(),
             },

--- a/geo/src/algorithm/line_intersection.rs
+++ b/geo/src/algorithm/line_intersection.rs
@@ -1,4 +1,5 @@
 use crate::{Coordinate, GeoFloat, Line};
+use geo_types::coord;
 
 use crate::algorithm::bounding_rect::BoundingRect;
 use crate::algorithm::intersects::Intersects;
@@ -35,26 +36,27 @@ impl<F: GeoFloat> LineIntersection<F> {
 /// # Examples
 ///
 /// ```
+/// use geo_types::coord;
 /// use geo::{Line, Coordinate};
 /// use geo::algorithm::line_intersection::{line_intersection, LineIntersection};
 ///
-/// let line_1 = Line::new(Coordinate {x: 0.0, y: 0.0}, Coordinate { x: 5.0, y: 5.0 } );
-/// let line_2 = Line::new(Coordinate {x: 0.0, y: 5.0}, Coordinate { x: 5.0, y: 0.0 } );
-/// let expected = LineIntersection::SinglePoint { intersection: Coordinate { x: 2.5, y: 2.5 }, is_proper: true };
+/// let line_1 = Line::new(coord! {x: 0.0, y: 0.0}, coord! { x: 5.0, y: 5.0 } );
+/// let line_2 = Line::new(coord! {x: 0.0, y: 5.0}, coord! { x: 5.0, y: 0.0 } );
+/// let expected = LineIntersection::SinglePoint { intersection: coord! { x: 2.5, y: 2.5 }, is_proper: true };
 /// assert_eq!(line_intersection(line_1, line_2), Some(expected));
 ///
-/// let line_1 = Line::new(Coordinate {x: 0.0, y: 0.0}, Coordinate { x: 5.0, y: 5.0 } );
-/// let line_2 = Line::new(Coordinate {x: 0.0, y: 1.0}, Coordinate { x: 5.0, y: 6.0 } );
+/// let line_1 = Line::new(coord! {x: 0.0, y: 0.0}, coord! { x: 5.0, y: 5.0 } );
+/// let line_2 = Line::new(coord! {x: 0.0, y: 1.0}, coord! { x: 5.0, y: 6.0 } );
 /// assert_eq!(line_intersection(line_1, line_2), None);
 ///
-/// let line_1 = Line::new(Coordinate {x: 0.0, y: 0.0}, Coordinate { x: 5.0, y: 5.0 } );
-/// let line_2 = Line::new(Coordinate {x: 5.0, y: 5.0}, Coordinate { x: 5.0, y: 0.0 } );
-/// let expected = LineIntersection::SinglePoint { intersection: Coordinate { x: 5.0, y: 5.0 }, is_proper: false };
+/// let line_1 = Line::new(coord! {x: 0.0, y: 0.0}, coord! { x: 5.0, y: 5.0 } );
+/// let line_2 = Line::new(coord! {x: 5.0, y: 5.0}, coord! { x: 5.0, y: 0.0 } );
+/// let expected = LineIntersection::SinglePoint { intersection: coord! { x: 5.0, y: 5.0 }, is_proper: false };
 /// assert_eq!(line_intersection(line_1, line_2), Some(expected));
 ///
-/// let line_1 = Line::new(Coordinate {x: 0.0, y: 0.0}, Coordinate { x: 5.0, y: 5.0 } );
-/// let line_2 = Line::new(Coordinate {x: 3.0, y: 3.0}, Coordinate { x: 6.0, y: 6.0 } );
-/// let expected = LineIntersection::Collinear { intersection: Line::new(Coordinate { x: 3.0, y: 3.0 }, Coordinate { x: 5.0, y: 5.0 })};
+/// let line_1 = Line::new(coord! {x: 0.0, y: 0.0}, coord! { x: 5.0, y: 5.0 } );
+/// let line_2 = Line::new(coord! {x: 3.0, y: 3.0}, coord! { x: 6.0, y: 6.0 } );
+/// let expected = LineIntersection::Collinear { intersection: Line::new(coord! { x: 3.0, y: 3.0 }, coord! { x: 5.0, y: 5.0 })};
 /// assert_eq!(line_intersection(line_1, line_2), Some(expected));
 /// ```
 /// Strongly inspired by, and meant to produce the same results as, [JTS's RobustLineIntersector](https://github.com/locationtech/jts/blob/master/modules/core/src/main/java/org/locationtech/jts/algorithm/RobustLineIntersector.java#L26).
@@ -266,7 +268,7 @@ fn raw_line_intersection<F: GeoFloat>(p: Line<F>, q: Line<F>) -> Option<Coordina
         None
     } else {
         // de-condition intersection point
-        Some(Coordinate {
+        Some(coord! {
             x: x_int + mid_x,
             y: y_int + mid_y,
         })
@@ -300,6 +302,7 @@ fn proper_intersection<F: GeoFloat>(p: Line<F>, q: Line<F>) -> Coordinate<F> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::geo_types::coord;
 
     /// Based on JTS test `testCentralEndpointHeuristicFailure`
     /// > Following cases were failures when using the CentralEndpointIntersector heuristic.
@@ -312,28 +315,28 @@ mod test {
     #[test]
     fn test_central_endpoint_heuristic_failure_1() {
         let line_1 = Line::new(
-            Coordinate {
+            coord! {
                 x: 163.81867067,
                 y: -211.31840378,
             },
-            Coordinate {
+            coord! {
                 x: 165.9174252,
                 y: -214.1665075,
             },
         );
         let line_2 = Line::new(
-            Coordinate {
+            coord! {
                 x: 2.84139601,
                 y: -57.95412726,
             },
-            Coordinate {
+            coord! {
                 x: 469.59990601,
                 y: -502.63851732,
             },
         );
         let actual = line_intersection(line_1, line_2);
         let expected = LineIntersection::SinglePoint {
-            intersection: Coordinate {
+            intersection: coord! {
                 x: 163.81867067,
                 y: -211.31840378,
             },
@@ -350,28 +353,28 @@ mod test {
     #[test]
     fn test_central_endpoint_heuristic_failure_2() {
         let line_1 = Line::new(
-            Coordinate {
+            coord! {
                 x: -58.00593335955,
                 y: -1.43739086465,
             },
-            Coordinate {
+            coord! {
                 x: -513.86101637525,
                 y: -457.29247388035,
             },
         );
         let line_2 = Line::new(
-            Coordinate {
+            coord! {
                 x: -215.22279674875,
                 y: -158.65425425385,
             },
-            Coordinate {
+            coord! {
                 x: -218.1208801283,
                 y: -160.68343590235,
             },
         );
         let actual = line_intersection(line_1, line_2);
         let expected = LineIntersection::SinglePoint {
-            intersection: Coordinate {
+            intersection: coord! {
                 x: -215.22279674875,
                 y: -158.65425425385,
             },
@@ -387,14 +390,8 @@ mod test {
     /// > Succeeds using DD and Shewchuk orientation
     #[test]
     fn test_tomas_fa_1() {
-        let line_1 = Line::<f64>::new(
-            Coordinate { x: -42.0, y: 163.2 },
-            Coordinate { x: 21.2, y: 265.2 },
-        );
-        let line_2 = Line::<f64>::new(
-            Coordinate { x: -26.2, y: 188.7 },
-            Coordinate { x: 37.0, y: 290.7 },
-        );
+        let line_1 = Line::<f64>::new(coord! { x: -42.0, y: 163.2 }, coord! { x: 21.2, y: 265.2 });
+        let line_2 = Line::<f64>::new(coord! { x: -26.2, y: 188.7 }, coord! { x: 37.0, y: 290.7 });
         let actual = line_intersection(line_1, line_2);
         let expected = None;
         assert_eq!(actual, expected);
@@ -407,14 +404,8 @@ mod test {
     /// > Fails using original JTS DeVillers determine orientation test.
     #[test]
     fn test_tomas_fa_2() {
-        let line_1 = Line::<f64>::new(
-            Coordinate { x: -5.9, y: 163.1 },
-            Coordinate { x: 76.1, y: 250.7 },
-        );
-        let line_2 = Line::<f64>::new(
-            Coordinate { x: 14.6, y: 185.0 },
-            Coordinate { x: 96.6, y: 272.6 },
-        );
+        let line_1 = Line::<f64>::new(coord! { x: -5.9, y: 163.1 }, coord! { x: 76.1, y: 250.7 });
+        let line_2 = Line::<f64>::new(coord! { x: 14.6, y: 185.0 }, coord! { x: 96.6, y: 272.6 });
         let actual = line_intersection(line_1, line_2);
         let expected = None;
         assert_eq!(actual, expected);
@@ -427,28 +418,28 @@ mod test {
     #[test]
     fn test_leduc_1() {
         let line_1 = Line::new(
-            Coordinate {
+            coord! {
                 x: 305690.0434123494,
                 y: 254176.46578338774,
             },
-            Coordinate {
+            coord! {
                 x: 305601.9999843455,
                 y: 254243.19999846347,
             },
         );
         let line_2 = Line::new(
-            Coordinate {
+            coord! {
                 x: 305689.6153764265,
                 y: 254177.33102743194,
             },
-            Coordinate {
+            coord! {
                 x: 305692.4999844298,
                 y: 254171.4999983967,
             },
         );
         let actual = line_intersection(line_1, line_2);
         let expected = LineIntersection::SinglePoint {
-            intersection: Coordinate {
+            intersection: coord! {
                 x: 305690.0434123494,
                 y: 254176.46578338774,
             },
@@ -463,28 +454,28 @@ mod test {
     #[test]
     fn test_geos_1() {
         let line_1 = Line::new(
-            Coordinate {
+            coord! {
                 x: 588750.7429703881,
                 y: 4518950.493668233,
             },
-            Coordinate {
+            coord! {
                 x: 588748.2060409798,
                 y: 4518933.9452804085,
             },
         );
         let line_2 = Line::new(
-            Coordinate {
+            coord! {
                 x: 588745.824857241,
                 y: 4518940.742239175,
             },
-            Coordinate {
+            coord! {
                 x: 588748.2060437313,
                 y: 4518933.9452791475,
             },
         );
         let actual = line_intersection(line_1, line_2);
         let expected = LineIntersection::SinglePoint {
-            intersection: Coordinate {
+            intersection: coord! {
                 x: 588748.2060416829,
                 y: 4518933.945284994,
             },
@@ -499,28 +490,28 @@ mod test {
     #[test]
     fn test_geos_2() {
         let line_1 = Line::new(
-            Coordinate {
+            coord! {
                 x: 588743.626135934,
                 y: 4518924.610969561,
             },
-            Coordinate {
+            coord! {
                 x: 588732.2822865889,
                 y: 4518925.4314047815,
             },
         );
         let line_2 = Line::new(
-            Coordinate {
+            coord! {
                 x: 588739.1191384895,
                 y: 4518927.235700594,
             },
-            Coordinate {
+            coord! {
                 x: 588731.7854614238,
                 y: 4518924.578370095,
             },
         );
         let actual = line_intersection(line_1, line_2);
         let expected = LineIntersection::SinglePoint {
-            intersection: Coordinate {
+            intersection: coord! {
                 x: 588733.8306132929,
                 y: 4518925.319423238,
             },
@@ -536,28 +527,28 @@ mod test {
     #[test]
     fn test_dave_skea_case() {
         let line_1 = Line::new(
-            Coordinate {
+            coord! {
                 x: 2089426.5233462777,
                 y: 1180182.387733969,
             },
-            Coordinate {
+            coord! {
                 x: 2085646.6891757075,
                 y: 1195618.7333999649,
             },
         );
         let line_2 = Line::new(
-            Coordinate {
+            coord! {
                 x: 1889281.8148903656,
                 y: 1997547.0560044837,
             },
-            Coordinate {
+            coord! {
                 x: 2259977.3672236,
                 y: 483675.17050843034,
             },
         );
         let actual = line_intersection(line_1, line_2);
         let expected = LineIntersection::SinglePoint {
-            intersection: Coordinate {
+            intersection: coord! {
                 x: 2087536.6062609926,
                 y: 1187900.560566967,
             },
@@ -572,28 +563,28 @@ mod test {
     #[test]
     fn test_cmp_5_cask_wkt() {
         let line_1 = Line::new(
-            Coordinate {
+            coord! {
                 x: 4348433.262114629,
                 y: 5552595.478385733,
             },
-            Coordinate {
+            coord! {
                 x: 4348440.849387404,
                 y: 5552599.272022122,
             },
         );
         let line_2 = Line::new(
-            Coordinate {
+            coord! {
                 x: 4348433.26211463,
                 y: 5552595.47838573,
             },
-            Coordinate {
+            coord! {
                 x: 4348440.8493874,
                 y: 5552599.27202212,
             },
         );
         let actual = line_intersection(line_1, line_2);
         let expected = LineIntersection::SinglePoint {
-            intersection: Coordinate {
+            intersection: coord! {
                 x: 4348440.8493874,
                 y: 5552599.27202212,
             },

--- a/geo/src/algorithm/line_locate_point.rs
+++ b/geo/src/algorithm/line_locate_point.rs
@@ -109,16 +109,14 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{point, Coordinate};
+    use crate::geo_types::coord;
+    use crate::point;
     use num_traits::Float;
 
     #[test]
     fn test_line_locate_point_line() {
         // Some finite examples
-        let line = Line::new(
-            Coordinate { x: -1.0, y: 0.0 },
-            Coordinate { x: 1.0, y: 0.0 },
-        );
+        let line = Line::new(coord! { x: -1.0, y: 0.0 }, coord! { x: 1.0, y: 0.0 });
         let point = Point::new(0.0, 1.0);
         assert_eq!(line.line_locate_point(&point), Some(0.5));
 
@@ -146,8 +144,8 @@ mod test {
 
         // line contains inf or nan
         let line = Line::new(
-            Coordinate { x: 0.0, y: 0.0 },
-            Coordinate {
+            coord! { x: 0.0, y: 0.0 },
+            coord! {
                 x: Float::infinity(),
                 y: 0.0,
             },
@@ -156,8 +154,8 @@ mod test {
         assert_eq!(line.line_locate_point(&point), None);
 
         let line = Line::new(
-            Coordinate { x: 0.0, y: 0.0 },
-            Coordinate {
+            coord! { x: 0.0, y: 0.0 },
+            coord! {
                 x: Float::neg_infinity(),
                 y: 0.0,
             },
@@ -166,8 +164,8 @@ mod test {
         assert_eq!(line.line_locate_point(&point), None);
 
         let line = Line::new(
-            Coordinate { x: 0.0, y: 0.0 },
-            Coordinate {
+            coord! { x: 0.0, y: 0.0 },
+            coord! {
                 x: Float::nan(),
                 y: 0.0,
             },
@@ -176,16 +174,12 @@ mod test {
         assert_eq!(line.line_locate_point(&point), None);
 
         // zero length line
-        let line: Line<f64> =
-            Line::new(Coordinate { x: 1.0, y: 1.0 }, Coordinate { x: 1.0, y: 1.0 });
+        let line: Line<f64> = Line::new(coord! { x: 1.0, y: 1.0 }, coord! { x: 1.0, y: 1.0 });
         let pt = point!(x: 2.0, y: 2.0);
         assert_eq!(line.line_locate_point(&pt), Some(0.0));
 
         // another concrete example
-        let line: Line<f64> = Line::new(
-            Coordinate { x: 0.0, y: 0.0 },
-            Coordinate { x: 10.0, y: 0.0 },
-        );
+        let line: Line<f64> = Line::new(coord! { x: 0.0, y: 0.0 }, coord! { x: 10.0, y: 0.0 });
         let pt = Point::new(555.0, 555.0);
         assert_eq!(line.line_locate_point(&pt), Some(1.0));
         let pt = Point::new(10.0000001, 0.0);
@@ -237,33 +231,33 @@ mod test {
 
         // line contains inf or nan
         let line: LineString<f64> = LineString(vec![
-            Coordinate { x: 1.0, y: 1.0 },
-            Coordinate {
+            coord! { x: 1.0, y: 1.0 },
+            coord! {
                 x: Float::nan(),
                 y: 1.0,
             },
-            Coordinate { x: 0.0, y: 0.0 },
+            coord! { x: 0.0, y: 0.0 },
         ]);
         let pt = point!(x: 2.0, y: 2.0);
         assert_eq!(line.line_locate_point(&pt), None);
 
         let line: LineString<f64> = LineString(vec![
-            Coordinate { x: 1.0, y: 1.0 },
-            Coordinate {
+            coord! { x: 1.0, y: 1.0 },
+            coord! {
                 x: Float::infinity(),
                 y: 1.0,
             },
-            Coordinate { x: 0.0, y: 0.0 },
+            coord! { x: 0.0, y: 0.0 },
         ]);
         let pt = point!(x: 2.0, y: 2.0);
         assert_eq!(line.line_locate_point(&pt), None);
         let line: LineString<f64> = LineString(vec![
-            Coordinate { x: 1.0, y: 1.0 },
-            Coordinate {
+            coord! { x: 1.0, y: 1.0 },
+            coord! {
                 x: Float::neg_infinity(),
                 y: 1.0,
             },
-            Coordinate { x: 0.0, y: 0.0 },
+            coord! { x: 0.0, y: 0.0 },
         ]);
         let pt = point!(x: 2.0, y: 2.0);
         assert_eq!(line.line_locate_point(&pt), None);

--- a/geo/src/algorithm/map_coords.rs
+++ b/geo/src/algorithm/map_coords.rs
@@ -36,7 +36,7 @@
 //! ```
 
 use crate::{
-    CoordNum, coord, Geometry, GeometryCollection, Line, LineString, MultiLineString, MultiPoint,
+    coord, CoordNum, Geometry, GeometryCollection, Line, LineString, MultiLineString, MultiPoint,
     MultiPolygon, Point, Polygon, Rect, Triangle,
 };
 

--- a/geo/src/algorithm/map_coords.rs
+++ b/geo/src/algorithm/map_coords.rs
@@ -36,8 +36,8 @@
 //! ```
 
 use crate::{
-    CoordNum, Coordinate, Geometry, GeometryCollection, Line, LineString, MultiLineString,
-    MultiPoint, MultiPolygon, Point, Polygon, Rect, Triangle,
+    CoordNum, coord, Geometry, GeometryCollection, Line, LineString, MultiLineString, MultiPoint,
+    MultiPolygon, Point, Polygon, Rect, Triangle,
 };
 
 /// Map a function over all the coordinates in an object, returning a new one
@@ -541,9 +541,9 @@ impl<T: CoordNum, NT: CoordNum> MapCoords<T, NT> for Triangle<T> {
         let p3 = func(&self.2.x_y());
 
         Triangle(
-            Coordinate { x: p1.0, y: p1.1 },
-            Coordinate { x: p2.0, y: p2.1 },
-            Coordinate { x: p3.0, y: p3.1 },
+            coord! { x: p1.0, y: p1.1 },
+            coord! { x: p2.0, y: p2.1 },
+            coord! { x: p3.0, y: p3.1 },
         )
     }
 }
@@ -560,9 +560,9 @@ impl<T: CoordNum, NT: CoordNum, E> TryMapCoords<T, NT, E> for Triangle<T> {
         let p3 = func(&self.2.x_y())?;
 
         Ok(Triangle(
-            Coordinate { x: p1.0, y: p1.1 },
-            Coordinate { x: p2.0, y: p2.1 },
-            Coordinate { x: p3.0, y: p3.1 },
+            coord! { x: p1.0, y: p1.1 },
+            coord! { x: p2.0, y: p2.1 },
+            coord! { x: p3.0, y: p3.1 },
         ))
     }
 }
@@ -574,9 +574,9 @@ impl<T: CoordNum> MapCoordsInplace<T> for Triangle<T> {
         let p3 = func(&self.2.x_y());
 
         let mut new_triangle = Triangle(
-            Coordinate { x: p1.0, y: p1.1 },
-            Coordinate { x: p2.0, y: p2.1 },
-            Coordinate { x: p3.0, y: p3.1 },
+            coord! { x: p1.0, y: p1.1 },
+            coord! { x: p2.0, y: p2.1 },
+            coord! { x: p3.0, y: p3.1 },
         );
 
         ::std::mem::swap(self, &mut new_triangle);
@@ -608,8 +608,8 @@ mod test {
     fn rect_inplace() {
         let mut rect = Rect::new((10, 10), (20, 20));
         rect.map_coords_inplace(|&(x, y)| (x + 10, y + 20));
-        assert_eq!(rect.min(), Coordinate { x: 20, y: 30 });
-        assert_eq!(rect.max(), Coordinate { x: 30, y: 40 });
+        assert_eq!(rect.min(), coord! { x: 20, y: 30 });
+        assert_eq!(rect.max(), coord! { x: 30, y: 40 });
     }
 
     #[test]
@@ -627,16 +627,16 @@ mod test {
             }
         });
 
-        assert_eq!(rect.min(), Coordinate { x: 1, y: 1 });
-        assert_eq!(rect.max(), Coordinate { x: 4, y: 4 });
+        assert_eq!(rect.min(), coord! { x: 1, y: 1 });
+        assert_eq!(rect.max(), coord! { x: 4, y: 4 });
     }
 
     #[test]
     fn rect_map_coords() {
         let rect = Rect::new((10, 10), (20, 20));
         let another_rect = rect.map_coords(|&(x, y)| (x + 10, y + 20));
-        assert_eq!(another_rect.min(), Coordinate { x: 20, y: 30 });
-        assert_eq!(another_rect.max(), Coordinate { x: 30, y: 40 });
+        assert_eq!(another_rect.min(), coord! { x: 20, y: 30 });
+        assert_eq!(another_rect.max(), coord! { x: 30, y: 40 });
     }
 
     #[test]
@@ -889,7 +889,7 @@ mod test {
 
     #[test]
     fn rect_map_invert_coords() {
-        let rect = Rect::new(Coordinate { x: 0., y: 0. }, Coordinate { x: 1., y: 1. });
+        let rect = Rect::new(coord! { x: 0., y: 0. }, coord! { x: 1., y: 1. });
 
         // This call should not panic even though Rect::new
         // constructor panics if min coords > max coords

--- a/geo/src/algorithm/relate/geomgraph/edge_end.rs
+++ b/geo/src/algorithm/relate/geomgraph/edge_end.rs
@@ -1,5 +1,5 @@
 use super::{CoordNode, Edge, Label, Quadrant};
-use crate::{Coordinate, GeoFloat};
+use crate::{coord, Coordinate, GeoFloat};
 
 use std::cell::RefCell;
 use std::fmt;
@@ -145,12 +145,12 @@ mod test {
         let fake_label = Label::empty_line_or_point();
         let edge_end_1 = EdgeEnd::new(
             Coordinate::zero(),
-            Coordinate { x: 1.0, y: 1.0 },
+            coord! { x: 1.0, y: 1.0 },
             fake_label.clone(),
         );
         let edge_end_2 = EdgeEnd::new(
             Coordinate::zero(),
-            Coordinate { x: 1.0, y: 1.0 },
+            coord! { x: 1.0, y: 1.0 },
             fake_label.clone(),
         );
         assert_eq!(
@@ -159,11 +159,7 @@ mod test {
         );
 
         // edge_end_3 is clockwise from edge_end_1
-        let edge_end_3 = EdgeEnd::new(
-            Coordinate::zero(),
-            Coordinate { x: 1.0, y: -1.0 },
-            fake_label,
-        );
+        let edge_end_3 = EdgeEnd::new(Coordinate::zero(), coord! { x: 1.0, y: -1.0 }, fake_label);
         assert_eq!(
             edge_end_1.key().cmp(edge_end_3.key()),
             std::cmp::Ordering::Less

--- a/geo/src/algorithm/relate/mod.rs
+++ b/geo/src/algorithm/relate/mod.rs
@@ -17,11 +17,11 @@ mod relate_operation;
 /// # Examples
 ///
 /// ```
-/// use geo::{Coordinate, Line, Rect, line_string};
+/// use geo::{coord, Line, Rect, line_string};
 /// use crate::geo::relate::Relate;
 ///
-/// let line = Line::new(Coordinate { x: 2.0, y: 2.0}, Coordinate { x: 4.0, y: 4.0 });
-/// let rect = Rect::new(Coordinate { x: 2.0, y: 2.0}, Coordinate { x: 4.0, y: 4.0 });
+/// let line = Line::new(coord! { x: 2.0, y: 2.0}, coord! { x: 4.0, y: 4.0 });
+/// let rect = Rect::new(coord! { x: 2.0, y: 2.0}, coord! { x: 4.0, y: 4.0 });
 /// let intersection_matrix = rect.relate(&line);
 ///
 /// assert!(intersection_matrix.is_intersects());
@@ -29,8 +29,8 @@ mod relate_operation;
 /// assert!(intersection_matrix.is_contains());
 /// assert!(!intersection_matrix.is_within());
 ///
-/// let line = Line::new(Coordinate { x: 1.0, y: 1.0}, Coordinate { x: 5.0, y: 5.0 });
-/// let rect = Rect::new(Coordinate { x: 2.0, y: 2.0}, Coordinate { x: 4.0, y: 4.0 });
+/// let line = Line::new(coord! { x: 1.0, y: 1.0}, coord! { x: 5.0, y: 5.0 });
+/// let rect = Rect::new(coord! { x: 2.0, y: 2.0}, coord! { x: 4.0, y: 4.0 });
 /// let intersection_matrix = rect.relate(&line);
 /// assert!(intersection_matrix.is_intersects());
 /// assert!(!intersection_matrix.is_disjoint());

--- a/geo/src/algorithm/simplify.rs
+++ b/geo/src/algorithm/simplify.rs
@@ -246,22 +246,23 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::geo_types::coord;
     use crate::{line_string, polygon};
 
     #[test]
     fn rdp_test() {
         let vec = vec![
-            Coordinate { x: 0.0, y: 0.0 },
-            Coordinate { x: 5.0, y: 4.0 },
-            Coordinate { x: 11.0, y: 5.5 },
-            Coordinate { x: 17.3, y: 3.2 },
-            Coordinate { x: 27.8, y: 0.1 },
+            coord! { x: 0.0, y: 0.0 },
+            coord! { x: 5.0, y: 4.0 },
+            coord! { x: 11.0, y: 5.5 },
+            coord! { x: 17.3, y: 3.2 },
+            coord! { x: 27.8, y: 0.1 },
         ];
         let compare = vec![
-            Coordinate { x: 0.0, y: 0.0 },
-            Coordinate { x: 5.0, y: 4.0 },
-            Coordinate { x: 11.0, y: 5.5 },
-            Coordinate { x: 27.8, y: 0.1 },
+            coord! { x: 0.0, y: 0.0 },
+            coord! { x: 5.0, y: 4.0 },
+            coord! { x: 11.0, y: 5.5 },
+            coord! { x: 27.8, y: 0.1 },
         ];
         let simplified = rdp(vec.into_iter(), &1.0);
         assert_eq!(simplified, compare);
@@ -275,14 +276,8 @@ mod test {
     }
     #[test]
     fn rdp_test_two_point_linestring() {
-        let vec = vec![
-            Coordinate { x: 0.0, y: 0.0 },
-            Coordinate { x: 27.8, y: 0.1 },
-        ];
-        let compare = vec![
-            Coordinate { x: 0.0, y: 0.0 },
-            Coordinate { x: 27.8, y: 0.1 },
-        ];
+        let vec = vec![coord! { x: 0.0, y: 0.0 }, coord! { x: 27.8, y: 0.1 }];
+        let compare = vec![coord! { x: 0.0, y: 0.0 }, coord! { x: 27.8, y: 0.1 }];
         let simplified = rdp(vec.into_iter(), &1.0);
         assert_eq!(simplified, compare);
     }

--- a/geo/src/lib.rs
+++ b/geo/src/lib.rs
@@ -181,8 +181,9 @@ pub use crate::traits::ToGeo;
 pub use crate::types::Closest;
 
 pub use geo_types::{
-    line_string, point, polygon, CoordFloat, CoordNum, coord, Coordinate, Geometry, GeometryCollection,
-    Line, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon, Rect, Triangle,
+    coord, line_string, point, polygon, CoordFloat, CoordNum, Coordinate, Geometry,
+    GeometryCollection, Line, LineString, MultiLineString, MultiPoint, MultiPolygon, Point,
+    Polygon, Rect, Triangle,
 };
 
 /// This module includes all the functions of geometric calculations

--- a/geo/src/lib.rs
+++ b/geo/src/lib.rs
@@ -181,7 +181,7 @@ pub use crate::traits::ToGeo;
 pub use crate::types::Closest;
 
 pub use geo_types::{
-    line_string, point, polygon, CoordFloat, CoordNum, Coordinate, Geometry, GeometryCollection,
+    line_string, point, polygon, CoordFloat, CoordNum, coord, Coordinate, Geometry, GeometryCollection,
     Line, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon, Rect, Triangle,
 };
 


### PR DESCRIPTION
This PR updates `geo` crate.  See also #760.

The `coord!` macro is much more flexible way to create a coordinate, and should be used in the same way as all other ones like `line_string` and `polygon`.

This change is a noop for now, but in the future it will make it easier to introduce Z coordinate without substantial code change.

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

