### PR TITLE
 Migrate jts-test-runner code

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+        with:
+          submodules: 'true'
       - run: rustup component add rustfmt clippy
       - run: cargo fmt --all -- --check
       - run: cargo clippy --all-features --all-targets -- -Dwarnings
@@ -102,6 +104,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+        with:
+          submodules: 'true'
       - run: cargo check --all-targets --no-default-features
       # we don't want to test `proj-network` because it only enables the `proj` feature
       - run: cargo test --features "use-proj use-serde"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "geo/tests/data"]
+	path = geo/tests/data
+	url = https://github.com/georust/jts-test-runner.git

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -30,11 +30,13 @@ serde = { version = "1.0", optional = true, features = ["derive"] }
 approx = "0.4.0"
 criterion = { version = "0.3" }
 geo-test-fixtures = { path = "../geo-test-fixtures" }
-# jts-test-runner is an internal crate which exists only to be part of the geo test suite.
-# As such it's kept unpublished. It's in a separate repo primarily because it's kind of large.
-jts-test-runner = { git = "https://github.com/georust/jts-test-runner", rev = "1cf7a2f848a10869720383e931271d0dd54f7bf8" }
+include_dir = { version = "0.6", features = ["search"] }
+log = "0.4.14"
 pretty_env_logger = "0.4"
 rand = "0.8.0"
+serde =  { version = "1.0.136", features = ["derive"] }
+serde-xml-rs = "0.5.1"
+wkt = { version = "0.9", features = ["geo-types", "serde"] }
 
 [[bench]]
 name = "area"

--- a/geo/tests/README.md
+++ b/geo/tests/README.md
@@ -1,0 +1,40 @@
+# JTS Test Runner
+
+A tool used to compare the behavior of [GeoRust/geo] to the venerable
+[JTS](https://www.osgeo.org/projects/jts/).
+
+In particular, the contents of [./resources/testxml](./resources/testxml) were copied from 
+[JTS's test files](https://github.com/locationtech/jts/blob/master/modules/tests/src/test/resources/testxml).
+
+```
+# Run only the centroid tests
+let mut runner = TestRunner::new().matching_filename_glob("*Centroid.xml");
+runner.run().expect("test cases failed");
+
+# Run all tests
+let mut runner = TestRunner::new();
+runner.run().expect("test cases failed");
+```
+
+## GeoRust is Incomplete
+
+Not all tests are handled, in part because JTS supports a lot of things
+[GeoRust/geo] doen't support (yet!). 
+
+For some of the things which _are_ supported, [GeoRust/geo] might diverge. This
+is probably a bug, and should be investigated - precisely what this test runner
+is built to find!
+
+### Parsing New Test Case Input
+
+Parsing test case input happens in [OperationInput](./src/input.rs#L77). 
+
+Each type of test (Centroid, ConcaveHull, etc.) has different inputs, so will
+need to be handled slightly differently.
+
+### Running New Test Cases
+
+Evaluating [GeoRust/geo] behavior against the expectations in the test case
+input happens in [TestRunner#run](./src/runner.rs#65)
+
+[GeoRust/geo]: https://github.com/georust/geo

--- a/geo/tests/jts_test_runner/input.rs
+++ b/geo/tests/jts_test_runner/input.rs
@@ -1,0 +1,231 @@
+use geo::algorithm::relate::IntersectionMatrix;
+use geo::{Geometry, Point};
+use serde::{Deserialize, Deserializer};
+
+use super::Result;
+
+/// Example of the XML that these structures represent
+///
+/// ```xml
+/// <run>
+/// <precisionModel scale="1.0" offsetx="0.0" offsety="0.0"/>
+///
+/// <case>
+/// <desc>AA disjoint</desc>
+/// <a>
+/// POLYGON(
+/// (0 0, 80 0, 80 80, 0 80, 0 0))
+/// </a>
+/// <b>
+/// POLYGON(
+/// (100 200, 100 140, 180 140, 180 200, 100 200))
+/// </b>
+/// <test><op name="relate" arg3="FF2FF1212" arg1="A" arg2="B"> true </op>
+/// </test>
+/// <test>  <op name="intersects" arg1="A" arg2="B">   false   </op></test>
+/// <test>  <op name="contains" arg1="A" arg2="B">   false   </op></test>
+/// </case>
+/// </run>
+/// ```
+#[derive(Debug, Deserialize)]
+pub(crate) struct Run {
+    #[serde(rename = "case")]
+    pub cases: Vec<Case>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct Case {
+    #[serde(default)]
+    pub(crate) desc: String,
+
+    #[serde(deserialize_with = "wkt::deserialize_geometry")]
+    pub(crate) a: Geometry<f64>,
+
+    #[serde(deserialize_with = "deserialize_opt_geometry", default)]
+    pub(crate) b: Option<Geometry<f64>>,
+
+    #[serde(rename = "test", default)]
+    pub(crate) tests: Vec<Test>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct Test {
+    #[serde(rename = "op")]
+    pub(crate) operation_input: OperationInput,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CentroidInput {
+    pub(crate) arg1: String,
+
+    #[serde(rename = "$value", deserialize_with = "wkt::deserialize_point")]
+    pub(crate) expected: Option<geo::Point<f64>>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ConvexHullInput {
+    pub(crate) arg1: String,
+
+    #[serde(rename = "$value", deserialize_with = "wkt::deserialize_geometry")]
+    pub(crate) expected: geo::Geometry<f64>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct IntersectsInput {
+    pub(crate) arg1: String,
+    pub(crate) arg2: String,
+
+    #[serde(rename = "$value", deserialize_with = "deserialize_from_str")]
+    pub(crate) expected: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RelateInput {
+    pub(crate) arg1: String,
+    pub(crate) arg2: String,
+
+    #[serde(rename = "arg3", deserialize_with = "deserialize_from_str")]
+    pub(crate) expected: IntersectionMatrix,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ContainsInput {
+    pub(crate) arg1: String,
+    pub(crate) arg2: String,
+
+    #[serde(rename = "$value", deserialize_with = "deserialize_from_str")]
+    pub(crate) expected: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "name")]
+pub(crate) enum OperationInput {
+    #[serde(rename = "getCentroid")]
+    CentroidInput(CentroidInput),
+
+    #[serde(rename = "convexhull")]
+    ConvexHullInput(ConvexHullInput),
+
+    #[serde(rename = "intersects")]
+    IntersectsInput(IntersectsInput),
+
+    #[serde(rename = "relate")]
+    RelateInput(RelateInput),
+
+    #[serde(rename = "contains")]
+    ContainsInput(ContainsInput),
+
+    #[serde(other)]
+    Unsupported,
+}
+
+#[derive(Debug)]
+pub(crate) enum Operation {
+    Centroid {
+        subject: Geometry<f64>,
+        expected: Option<Point<f64>>,
+    },
+    Contains {
+        subject: Geometry<f64>,
+        target: Geometry<f64>,
+        expected: bool,
+    },
+    ConvexHull {
+        subject: Geometry<f64>,
+        expected: Geometry<f64>,
+    },
+    Intersects {
+        subject: Geometry<f64>,
+        clip: Geometry<f64>,
+        expected: bool,
+    },
+    Relate {
+        a: Geometry<f64>,
+        b: Geometry<f64>,
+        expected: IntersectionMatrix,
+    },
+}
+
+impl OperationInput {
+    pub(crate) fn into_operation(self, case: &Case) -> Result<Operation> {
+        let geometry = &case.a;
+        match self {
+            Self::CentroidInput(centroid_input) => {
+                assert_eq!("A", centroid_input.arg1);
+                Ok(Operation::Centroid {
+                    subject: geometry.clone(),
+                    expected: centroid_input.expected,
+                })
+            }
+            Self::ConvexHullInput(convex_hull_input) => {
+                assert_eq!("A", convex_hull_input.arg1);
+                Ok(Operation::ConvexHull {
+                    subject: geometry.clone(),
+                    expected: convex_hull_input.expected,
+                })
+            }
+            Self::IntersectsInput(input) => {
+                assert_eq!("A", input.arg1);
+                assert_eq!("B", input.arg2);
+                assert!(
+                    case.b.is_some(),
+                    "intersects test case must contain geometry b"
+                );
+                Ok(Operation::Intersects {
+                    subject: geometry.clone(),
+                    clip: case.b.clone().expect("no geometry b in case"),
+                    expected: input.expected,
+                })
+            }
+            Self::RelateInput(input) => {
+                assert_eq!("A", input.arg1);
+                assert_eq!("B", input.arg2);
+                assert!(
+                    case.b.is_some(),
+                    "intersects test case must contain geometry b"
+                );
+                Ok(Operation::Relate {
+                    a: geometry.clone(),
+                    b: case.b.clone().expect("no geometry b in case"),
+                    expected: input.expected,
+                })
+            }
+            Self::ContainsInput(input) => {
+                assert_eq!("A", input.arg1);
+                assert_eq!("B", input.arg2);
+                assert!(
+                    case.b.is_some(),
+                    "intersects test case must contain geometry b"
+                );
+                Ok(Operation::Contains {
+                    subject: geometry.clone(),
+                    target: case.b.clone().expect("no geometry b in case"),
+                    expected: input.expected,
+                })
+            }
+            Self::Unsupported => Err("This OperationInput not supported".into()),
+        }
+    }
+}
+
+pub fn deserialize_opt_geometry<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<Geometry<f64>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Debug, Deserialize)]
+    struct Wrapper(#[serde(deserialize_with = "wkt::deserialize_geometry")] Geometry<f64>);
+
+    Option::<Wrapper>::deserialize(deserializer).map(|opt_wrapped| opt_wrapped.map(|w| w.0))
+}
+
+pub fn deserialize_from_str<'de, T, D>(deserializer: D) -> std::result::Result<T, D::Error>
+where
+    T: std::str::FromStr,
+    D: Deserializer<'de>,
+    <T as std::str::FromStr>::Err: std::fmt::Display,
+{
+    String::deserialize(deserializer)
+        .and_then(|str| T::from_str(&str).map_err(serde::de::Error::custom))
+}

--- a/geo/tests/jts_test_runner/mod.rs
+++ b/geo/tests/jts_test_runner/mod.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate log;
-
 mod input;
 use input::Operation;
 

--- a/geo/tests/jts_test_runner/mod.rs
+++ b/geo/tests/jts_test_runner/mod.rs
@@ -1,0 +1,81 @@
+#[macro_use]
+extern crate log;
+
+mod input;
+use input::Operation;
+
+mod runner;
+pub use runner::TestRunner;
+
+type Error = Box<dyn std::error::Error>;
+type Result<T> = std::result::Result<T, Error>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn init_logging() {
+        use std::sync::Once;
+        static LOG_SETUP: Once = Once::new();
+        LOG_SETUP.call_once(|| {
+            pretty_env_logger::init();
+        });
+    }
+
+    #[test]
+    fn test_relate() {
+        init_logging();
+        let mut runner = TestRunner::new().matching_filename_glob("*Relate*.xml");
+        runner.run().expect("test cases failed");
+
+        // sanity check that *something* was run
+        assert!(
+            runner.failures().len() + runner.successes().len() > 0,
+            "No tests were run."
+        );
+
+        if !runner.failures().is_empty() {
+            let failure_text = runner
+                .failures()
+                .iter()
+                .map(|failure| format!("{}", failure))
+                .collect::<Vec<String>>()
+                .join("\n");
+            panic!(
+                "{} failures / {} successes in JTS test suite:\n{}",
+                runner.failures().len(),
+                runner.successes().len(),
+                failure_text
+            );
+        }
+    }
+
+    #[test]
+    // several of the ConvexHull tests are currently failing
+    fn test_all_general() {
+        init_logging();
+        let mut runner = TestRunner::new();
+        runner.run().expect("test cases failed");
+
+        // sanity check that *something* was run
+        assert!(
+            runner.failures().len() + runner.successes().len() > 0,
+            "No tests were run."
+        );
+
+        if !runner.failures().is_empty() {
+            let failure_text = runner
+                .failures()
+                .iter()
+                .map(|failure| format!("{}", failure))
+                .collect::<Vec<String>>()
+                .join("\n");
+            panic!(
+                "{} failures / {} successes in JTS test suite:\n{}",
+                runner.failures().len(),
+                runner.successes().len(),
+                failure_text
+            );
+        }
+    }
+}

--- a/geo/tests/jts_test_runner/runner.rs
+++ b/geo/tests/jts_test_runner/runner.rs
@@ -425,9 +425,9 @@ impl TestRunner {
         let mut cases = vec![];
 
         let filename_filter = if let Some(filter) = &self.filename_filter {
-            format!("{}", filter)
+            filter.to_string()
         } else {
-            format!("**/*.xml")
+            "**/*.xml".to_string()
         };
 
         for entry in GENERAL_TEST_XML.find(&filename_filter)? {
@@ -462,7 +462,7 @@ impl TestRunner {
                 } else {
                     debug!("parsing case {}:", &case.desc);
                 }
-                let tests = std::mem::replace(&mut case.tests, vec![]);
+                let tests = std::mem::take(&mut case.tests);
                 for test in tests {
                     let description = case.desc.clone();
 
@@ -510,7 +510,7 @@ where
     let mut matched_in_p2: BTreeSet<usize> = BTreeSet::new();
     for r1 in p1.interiors().iter() {
         let did_match = p2.interiors().iter().enumerate().find(|(j, r2)| {
-            !matched_in_p2.contains(&j) && is_ring_rotated_eq(r1, r2, &coord_matcher)
+            !matched_in_p2.contains(j) && is_ring_rotated_eq(r1, r2, &coord_matcher)
         });
         if let Some((j, _)) = did_match {
             matched_in_p2.insert(j);
@@ -518,7 +518,7 @@ where
             return false;
         }
     }
-    return true;
+    true
 }
 
 /// Test if two rings are equal upto rotation / reversal

--- a/geo/tests/jts_test_runner/runner.rs
+++ b/geo/tests/jts_test_runner/runner.rs
@@ -1,0 +1,488 @@
+use std::collections::BTreeSet;
+
+use approx::relative_eq;
+use include_dir::{include_dir, Dir, DirEntry};
+
+use super::{input, Operation, Result};
+use geo::{Coordinate, Geometry, LineString, Polygon, intersects::Intersects, prelude::Contains};
+
+const GENERAL_TEST_XML: Dir = include_dir!("resources/testxml/general");
+
+#[derive(Debug, Default)]
+pub struct TestRunner {
+    filename_filter: Option<String>,
+    desc_filter: Option<String>,
+    failures: Vec<TestFailure>,
+    unsupported: Vec<TestCase>,
+    successes: Vec<TestCase>,
+}
+
+#[derive(Debug)]
+pub struct TestCase {
+    test_file_name: String,
+    description: String,
+    operation: Operation,
+}
+
+#[derive(Debug)]
+pub struct TestFailure {
+    error_description: String,
+    test_case: TestCase,
+}
+
+impl std::fmt::Display for TestFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        write!(
+            f,
+            "failed {} case \"{}\" with error: {}",
+            &self.test_case.test_file_name, &self.test_case.description, &self.error_description
+        )
+    }
+}
+
+impl TestRunner {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn successes(&self) -> &Vec<TestCase> {
+        &self.successes
+    }
+
+    pub fn failures(&self) -> &Vec<TestFailure> {
+        &self.failures
+    }
+
+    /// `desc`: when specified runs just the test described by `desc`, otherwise all tests are run
+    pub fn matching_desc(mut self, desc: &str) -> Self {
+        self.desc_filter = Some(desc.to_string());
+        self
+    }
+
+    pub fn matching_filename_glob(mut self, filename: &str) -> Self {
+        self.filename_filter = Some(filename.to_string());
+        self
+    }
+
+    pub fn run(&mut self) -> Result<()> {
+        let cases = self.parse_cases()?;
+        debug!("cases.len(): {}", cases.len());
+
+        for test_case in cases {
+            match &test_case.operation {
+                Operation::Centroid { subject, expected } => {
+                    use geo::prelude::Centroid;
+                    match (subject.centroid(), expected) {
+                        (None, None) => {
+                            debug!("Centroid success: None == None");
+                            self.successes.push(test_case);
+                        }
+                        (Some(actual), Some(expected)) if relative_eq!(actual, expected) => {
+                            debug!("Centroid success: actual == expected");
+                            self.successes.push(test_case);
+                        }
+                        (actual, expected) => {
+                            debug!("Centroid failure: actual != expected");
+                            let error_description =
+                                format!("expected {:?}, actual: {:?}", expected, actual);
+                            self.failures.push(TestFailure {
+                                test_case,
+                                error_description,
+                            });
+                        }
+                    }
+                }
+                Operation::Contains {
+                    subject,
+                    target,
+                    expected,
+                } => {
+                    use geo::algorithm::relate::Relate;
+                    let relate_actual = subject.relate(target).is_contains();
+
+                    // TODO: impl `Contains` for `Geometry` in geo and check that result here too
+                    // let direct_actual = subject.contains(target);
+                    let verify_contains_trait = match (subject, target) {
+                        (Geometry::Point(subject), Geometry::Point(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Point(subject), Geometry::Line(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Point(subject), Geometry::LineString(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Point(subject), Geometry::Polygon(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Point(subject), Geometry::MultiPoint(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Point(subject), Geometry::MultiLineString(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Point(subject), Geometry::MultiPolygon(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Point(subject), Geometry::GeometryCollection(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Point(subject), Geometry::Rect(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Point(subject), Geometry::Triangle(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::Line(subject), Geometry::Point(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::Line(subject), Geometry::Line(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::Line(subject), Geometry::LineString(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Line(subject), Geometry::Polygon(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Line(subject), Geometry::MultiPoint(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Line(subject), Geometry::MultiLineString(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Line(subject), Geometry::MultiPolygon(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Line(subject), Geometry::GeometryCollection(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Line(subject), Geometry::Rect(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Line(subject), Geometry::Triangle(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::LineString(subject), Geometry::Point(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::LineString(subject), Geometry::Line(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::LineString(subject), Geometry::LineString(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::LineString(subject), Geometry::Polygon(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::LineString(subject), Geometry::MultiPoint(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::LineString(subject), Geometry::MultiLineString(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::LineString(subject), Geometry::MultiPolygon(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::LineString(subject), Geometry::GeometryCollection(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::LineString(subject), Geometry::Rect(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::LineString(subject), Geometry::Triangle(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::Polygon(subject), Geometry::Point(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::Polygon(subject), Geometry::Line(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::Polygon(subject), Geometry::LineString(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::Polygon(subject), Geometry::Polygon(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Polygon(subject), Geometry::MultiPoint(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Polygon(subject), Geometry::MultiLineString(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Polygon(subject), Geometry::MultiPolygon(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Polygon(subject), Geometry::GeometryCollection(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Polygon(subject), Geometry::Rect(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Polygon(subject), Geometry::Triangle(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::MultiPoint(subject), Geometry::Point(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::MultiPoint(subject), Geometry::Line(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::MultiPoint(subject), Geometry::LineString(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::MultiPoint(subject), Geometry::Polygon(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::MultiPoint(subject), Geometry::MultiPoint(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::MultiPoint(subject), Geometry::MultiLineString(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::MultiPoint(subject), Geometry::MultiPolygon(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::MultiPoint(subject), Geometry::GeometryCollection(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::MultiPoint(subject), Geometry::Rect(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::MultiPoint(subject), Geometry::Triangle(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::MultiLineString(subject), Geometry::Point(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::MultiLineString(subject), Geometry::Line(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::MultiLineString(subject), Geometry::LineString(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::MultiLineString(subject), Geometry::Polygon(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::MultiLineString(subject), Geometry::MultiPoint(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::MultiLineString(subject), Geometry::MultiLineString(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::MultiLineString(subject), Geometry::MultiPolygon(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::MultiLineString(subject), Geometry::GeometryCollection(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::MultiLineString(subject), Geometry::Rect(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::MultiLineString(subject), Geometry::Triangle(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::MultiPolygon(subject), Geometry::Point(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::MultiPolygon(subject), Geometry::Line(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::MultiPolygon(subject), Geometry::LineString(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::MultiPolygon(subject), Geometry::Polygon(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::MultiPolygon(subject), Geometry::MultiPoint(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::MultiPolygon(subject), Geometry::MultiLineString(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::MultiPolygon(subject), Geometry::MultiPolygon(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::MultiPolygon(subject), Geometry::GeometryCollection(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::MultiPolygon(subject), Geometry::Rect(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::MultiPolygon(subject), Geometry::Triangle(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::GeometryCollection(subject), Geometry::Point(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::GeometryCollection(subject), Geometry::Line(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::GeometryCollection(subject), Geometry::LineString(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::GeometryCollection(subject), Geometry::Polygon(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::GeometryCollection(subject), Geometry::MultiPoint(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::GeometryCollection(subject), Geometry::MultiLineString(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::GeometryCollection(subject), Geometry::MultiPolygon(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::GeometryCollection(subject), Geometry::GeometryCollection(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::GeometryCollection(subject), Geometry::Rect(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::GeometryCollection(subject), Geometry::Triangle(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::Rect(subject), Geometry::Point(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Rect(subject), Geometry::Line(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Rect(subject), Geometry::LineString(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Rect(subject), Geometry::Polygon(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Rect(subject), Geometry::MultiPoint(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Rect(subject), Geometry::MultiLineString(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Rect(subject), Geometry::MultiPolygon(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Rect(subject), Geometry::GeometryCollection(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::Rect(subject), Geometry::Rect(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Rect(subject), Geometry::Triangle(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::Triangle(subject), Geometry::Point(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Triangle(subject), Geometry::Line(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Triangle(subject), Geometry::LineString(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Triangle(subject), Geometry::Polygon(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Triangle(subject), Geometry::MultiPoint(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Triangle(subject), Geometry::MultiLineString(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Triangle(subject), Geometry::MultiPolygon(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Triangle(subject), Geometry::GeometryCollection(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Triangle(subject), Geometry::Rect(target)) => { subject.contains(target) == relate_actual }
+                        // (Geometry::Triangle(subject), Geometry::Triangle(target)) => { subject.contains(target) == relate_actual }
+                        _ => { true }
+                    };
+
+                    if relate_actual != *expected {
+                        debug!("Contains failure: relate_actual != expected");
+                        let error_description = format!(
+                            "expected {:?}, relate_actual: {:?}",
+                            expected, relate_actual
+                        );
+                        self.failures.push(TestFailure {
+                            test_case,
+                            error_description,
+                        });
+                    } else if !verify_contains_trait {
+                        debug!("Contains failure: relate_actual != contains_trait_impl");
+                        let error_description = format!(
+                            "expected {:?}, contains_trait_impl: {:?}",
+                            expected, !relate_actual
+                        );
+                        self.failures.push(TestFailure {
+                            test_case,
+                            error_description,
+                        });
+
+                    } else {
+                        debug!("Contains success: actual == expected");
+                        self.successes.push(test_case);
+                    }
+                }
+                Operation::ConvexHull { subject, expected } => {
+                    use geo::prelude::ConvexHull;
+
+                    let actual_polygon = match subject {
+                        Geometry::MultiPoint(g) => g.convex_hull(),
+                        Geometry::Point(_g) => {
+                            debug!("ConvexHull not implemented for this geometry (yet?)");
+                            self.unsupported.push(test_case);
+                            continue;
+                        }
+                        Geometry::Line(_g) => {
+                            debug!("ConvexHull not implemented for this geometry (yet?)");
+                            self.unsupported.push(test_case);
+                            continue;
+                        }
+                        Geometry::LineString(_g) => {
+                            debug!("ConvexHull not implemented for this geometry (yet?)");
+                            self.unsupported.push(test_case);
+                            continue;
+                        }
+                        Geometry::Polygon(g) => g.convex_hull(),
+                        Geometry::MultiLineString(_g) => {
+                            debug!("ConvexHull not implemented for this geometry (yet?)");
+                            self.unsupported.push(test_case);
+                            continue;
+                        }
+                        Geometry::MultiPolygon(_g) => {
+                            debug!("ConvexHull not implemented for this geometry (yet?)");
+                            self.unsupported.push(test_case);
+                            continue;
+                        }
+                        Geometry::GeometryCollection(_g) => {
+                            debug!("ConvexHull not implemented for this geometry (yet?)");
+                            self.unsupported.push(test_case);
+                            continue;
+                        }
+                        Geometry::Rect(_g) => {
+                            debug!("ConvexHull not implemented for this geometry (yet?)");
+                            self.unsupported.push(test_case);
+                            continue;
+                        }
+                        Geometry::Triangle(_g) => {
+                            debug!("ConvexHull doesn't support this geometry (yet?)");
+                            self.unsupported.push(test_case);
+                            continue;
+                        }
+                    };
+
+                    // JTS returns a variety of Geometry types depending on the convex hull
+                    // whereas geo *always* returns a polygon.
+                    let expected = match expected {
+                        Geometry::LineString(ext) => Polygon::new(ext.clone(), vec![]),
+                        Geometry::Polygon(p) => p.clone(),
+                        _ => {
+                            let error_description = format!("expected result for convex hull is not a polygon or a linestring: {:?}", expected);
+                            self.failures.push(TestFailure {
+                                test_case,
+                                error_description,
+                            });
+                            continue;
+                        }
+                    };
+                    if is_polygon_rotated_eq(&actual_polygon, &expected, |c1, c2| {
+                        relative_eq!(c1, c2)
+                    }) {
+                        debug!("ConvexHull success: actual == expected");
+                        self.successes.push(test_case);
+                    } else {
+                        debug!("ConvexHull failure: actual != expected");
+                        let error_description =
+                            format!("expected {:?}, actual: {:?}", expected, actual_polygon);
+                        self.failures.push(TestFailure {
+                            test_case,
+                            error_description,
+                        });
+                    }
+                }
+                Operation::Intersects {
+                    subject,
+                    clip,
+                    expected,
+                } => {
+                    use geo::algorithm::relate::Relate;
+                    let direct_actual = subject.intersects(clip);
+                    let relate_actual = subject.relate(clip).is_intersects();
+
+                    if direct_actual != *expected {
+                        debug!("Intersects failure: direct_actual != expected");
+                        let error_description = format!(
+                            "expected {:?}, direct_actual: {:?}",
+                            expected, direct_actual
+                        );
+                        self.failures.push(TestFailure {
+                            test_case,
+                            error_description,
+                        });
+                    } else if relate_actual != *expected {
+                        debug!("Intersects failure: relate_actual != expected");
+                        let error_description = format!(
+                            "expected {:?}, relate_actual: {:?}",
+                            expected, relate_actual
+                        );
+                        self.failures.push(TestFailure {
+                            test_case,
+                            error_description,
+                        });
+                    } else {
+                        debug!("Intersects success: actual == expected");
+                        self.successes.push(test_case);
+                    }
+                }
+                Operation::Relate { a, b, expected } => {
+                    use geo::algorithm::relate::Relate;
+                    let actual = a.relate(b);
+                    if actual == *expected {
+                        debug!("Relate success: actual == expected");
+                        self.successes.push(test_case);
+                    } else {
+                        debug!("Relate failure: actual != expected");
+                        let error_description =
+                            format!("expected {:?}, actual: {:?}", expected, actual);
+                        self.failures.push(TestFailure {
+                            test_case,
+                            error_description,
+                        });
+                    }
+                }
+            }
+        }
+        info!(
+            "successes: {}, failures: {}",
+            self.successes.len(),
+            self.failures.len()
+        );
+        Ok(())
+    }
+
+    fn parse_cases(&self) -> Result<Vec<TestCase>> {
+        let mut cases = vec![];
+
+        let filename_filter = if let Some(filter) = &self.filename_filter {
+            format!("{}", filter)
+        } else {
+            format!("**/*.xml")
+        };
+
+        for entry in GENERAL_TEST_XML.find(&filename_filter)? {
+            let file = match entry {
+                DirEntry::Dir(_) => {
+                    debug_assert!(false, "unexpectedly found dir.xml");
+                    continue;
+                }
+                DirEntry::File(file) => file,
+            };
+            debug!("deserializing from {:?}", file.path());
+            let file_reader = std::io::BufReader::new(file.contents());
+            let run: input::Run = match serde_xml_rs::from_reader(file_reader) {
+                Ok(r) => r,
+                Err(err) => {
+                    debug!(
+                        "skipping invalid test input: {:?}. error: {:?}",
+                        file.path(),
+                        err
+                    );
+                    continue;
+                }
+            };
+            for mut case in run.cases {
+                if let Some(desc_filter) = &self.desc_filter {
+                    if case.desc.as_str().contains(desc_filter) {
+                        debug!("filter matched case: {}", &case.desc);
+                    } else {
+                        debug!("filter skipped case: {}", &case.desc);
+                        continue;
+                    }
+                } else {
+                    debug!("parsing case {}:", &case.desc);
+                }
+                let tests = std::mem::replace(&mut case.tests, vec![]);
+                for test in tests {
+                    let description = case.desc.clone();
+
+                    let test_file_name = file
+                        .path()
+                        .file_name()
+                        .expect("file from include_dir unexpectedly missing name")
+                        .to_string_lossy()
+                        .to_string();
+
+                    match test.operation_input.into_operation(&case) {
+                        Ok(operation) => {
+                            cases.push(TestCase {
+                                description,
+                                test_file_name,
+                                operation,
+                            });
+                        }
+                        Err(e) => {
+                            debug!("skipping unsupported operation: {}", e);
+                            continue;
+                        }
+                    }
+                }
+            }
+        }
+        Ok(cases)
+    }
+}
+
+/// Test if two polygons are equal upto rotation, and
+/// permutation of interiors.
+pub fn is_polygon_rotated_eq<T, F>(p1: &Polygon<T>, p2: &Polygon<T>, coord_matcher: F) -> bool
+where
+    T: geo::GeoNum,
+    F: Fn(&Coordinate<T>, &Coordinate<T>) -> bool,
+{
+    if p1.interiors().len() != p2.interiors().len() {
+        return false;
+    }
+    if !is_ring_rotated_eq(p1.exterior(), p2.exterior(), &coord_matcher) {
+        return false;
+    }
+
+    let mut matched_in_p2: BTreeSet<usize> = BTreeSet::new();
+    for r1 in p1.interiors().iter() {
+        let did_match = p2.interiors().iter().enumerate().find(|(j, r2)| {
+            !matched_in_p2.contains(&j) && is_ring_rotated_eq(r1, r2, &coord_matcher)
+        });
+        if let Some((j, _)) = did_match {
+            matched_in_p2.insert(j);
+        } else {
+            return false;
+        }
+    }
+    return true;
+}
+
+/// Test if two rings are equal upto rotation / reversal
+pub fn is_ring_rotated_eq<T, F>(r1: &LineString<T>, r2: &LineString<T>, coord_matcher: F) -> bool
+where
+    T: geo::GeoNum,
+    F: Fn(&Coordinate<T>, &Coordinate<T>) -> bool,
+{
+    assert!(r1.is_closed(), "r1 is not closed");
+    assert!(r2.is_closed(), "r2 is not closed");
+    if r1.0.len() != r2.0.len() {
+        return false;
+    }
+    let len = r1.0.len() - 1;
+    (0..len).any(|shift| {
+        (0..len).all(|i| coord_matcher(&r1.0[i], &r2.0[(i + shift) % len]))
+            || (0..len).all(|i| coord_matcher(&r1.0[len - i], &r2.0[(i + shift) % len]))
+    })
+}

--- a/geo/tests/jts_test_runner/runner.rs
+++ b/geo/tests/jts_test_runner/runner.rs
@@ -2,11 +2,12 @@ use std::collections::BTreeSet;
 
 use approx::relative_eq;
 use include_dir::{include_dir, Dir, DirEntry};
+use log::{debug, info};
 
 use super::{input, Operation, Result};
-use geo::{Coordinate, Geometry, LineString, Polygon, intersects::Intersects, prelude::Contains};
+use geo::{intersects::Intersects, prelude::Contains, Coordinate, Geometry, LineString, Polygon};
 
-const GENERAL_TEST_XML: Dir = include_dir!("resources/testxml/general");
+const GENERAL_TEST_XML: Dir = include_dir!("tests/data/resources/testxml/general");
 
 #[derive(Debug, Default)]
 pub struct TestRunner {
@@ -53,12 +54,6 @@ impl TestRunner {
         &self.failures
     }
 
-    /// `desc`: when specified runs just the test described by `desc`, otherwise all tests are run
-    pub fn matching_desc(mut self, desc: &str) -> Self {
-        self.desc_filter = Some(desc.to_string());
-        self
-    }
-
     pub fn matching_filename_glob(mut self, filename: &str) -> Self {
         self.filename_filter = Some(filename.to_string());
         self
@@ -103,7 +98,9 @@ impl TestRunner {
                     // TODO: impl `Contains` for `Geometry` in geo and check that result here too
                     // let direct_actual = subject.contains(target);
                     let verify_contains_trait = match (subject, target) {
-                        (Geometry::Point(subject), Geometry::Point(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::Point(subject), Geometry::Point(target)) => {
+                            subject.contains(target) == relate_actual
+                        }
                         // (Geometry::Point(subject), Geometry::Line(target)) => { subject.contains(target) == relate_actual }
                         // (Geometry::Point(subject), Geometry::LineString(target)) => { subject.contains(target) == relate_actual }
                         // (Geometry::Point(subject), Geometry::Polygon(target)) => { subject.contains(target) == relate_actual }
@@ -113,9 +110,15 @@ impl TestRunner {
                         // (Geometry::Point(subject), Geometry::GeometryCollection(target)) => { subject.contains(target) == relate_actual }
                         // (Geometry::Point(subject), Geometry::Rect(target)) => { subject.contains(target) == relate_actual }
                         // (Geometry::Point(subject), Geometry::Triangle(target)) => { subject.contains(target) == relate_actual }
-                        (Geometry::Line(subject), Geometry::Point(target)) => { subject.contains(target) == relate_actual }
-                        (Geometry::Line(subject), Geometry::Line(target)) => { subject.contains(target) == relate_actual }
-                        (Geometry::Line(subject), Geometry::LineString(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::Line(subject), Geometry::Point(target)) => {
+                            subject.contains(target) == relate_actual
+                        }
+                        (Geometry::Line(subject), Geometry::Line(target)) => {
+                            subject.contains(target) == relate_actual
+                        }
+                        (Geometry::Line(subject), Geometry::LineString(target)) => {
+                            subject.contains(target) == relate_actual
+                        }
                         // (Geometry::Line(subject), Geometry::Polygon(target)) => { subject.contains(target) == relate_actual }
                         // (Geometry::Line(subject), Geometry::MultiPoint(target)) => { subject.contains(target) == relate_actual }
                         // (Geometry::Line(subject), Geometry::MultiLineString(target)) => { subject.contains(target) == relate_actual }
@@ -123,9 +126,15 @@ impl TestRunner {
                         // (Geometry::Line(subject), Geometry::GeometryCollection(target)) => { subject.contains(target) == relate_actual }
                         // (Geometry::Line(subject), Geometry::Rect(target)) => { subject.contains(target) == relate_actual }
                         // (Geometry::Line(subject), Geometry::Triangle(target)) => { subject.contains(target) == relate_actual }
-                        (Geometry::LineString(subject), Geometry::Point(target)) => { subject.contains(target) == relate_actual }
-                        (Geometry::LineString(subject), Geometry::Line(target)) => { subject.contains(target) == relate_actual }
-                        (Geometry::LineString(subject), Geometry::LineString(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::LineString(subject), Geometry::Point(target)) => {
+                            subject.contains(target) == relate_actual
+                        }
+                        (Geometry::LineString(subject), Geometry::Line(target)) => {
+                            subject.contains(target) == relate_actual
+                        }
+                        (Geometry::LineString(subject), Geometry::LineString(target)) => {
+                            subject.contains(target) == relate_actual
+                        }
                         // (Geometry::LineString(subject), Geometry::Polygon(target)) => { subject.contains(target) == relate_actual }
                         // (Geometry::LineString(subject), Geometry::MultiPoint(target)) => { subject.contains(target) == relate_actual }
                         // (Geometry::LineString(subject), Geometry::MultiLineString(target)) => { subject.contains(target) == relate_actual }
@@ -133,17 +142,27 @@ impl TestRunner {
                         // (Geometry::LineString(subject), Geometry::GeometryCollection(target)) => { subject.contains(target) == relate_actual }
                         // (Geometry::LineString(subject), Geometry::Rect(target)) => { subject.contains(target) == relate_actual }
                         // (Geometry::LineString(subject), Geometry::Triangle(target)) => { subject.contains(target) == relate_actual }
-                        (Geometry::Polygon(subject), Geometry::Point(target)) => { subject.contains(target) == relate_actual }
-                        (Geometry::Polygon(subject), Geometry::Line(target)) => { subject.contains(target) == relate_actual }
-                        (Geometry::Polygon(subject), Geometry::LineString(target)) => { subject.contains(target) == relate_actual }
-                        (Geometry::Polygon(subject), Geometry::Polygon(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::Polygon(subject), Geometry::Point(target)) => {
+                            subject.contains(target) == relate_actual
+                        }
+                        (Geometry::Polygon(subject), Geometry::Line(target)) => {
+                            subject.contains(target) == relate_actual
+                        }
+                        (Geometry::Polygon(subject), Geometry::LineString(target)) => {
+                            subject.contains(target) == relate_actual
+                        }
+                        (Geometry::Polygon(subject), Geometry::Polygon(target)) => {
+                            subject.contains(target) == relate_actual
+                        }
                         // (Geometry::Polygon(subject), Geometry::MultiPoint(target)) => { subject.contains(target) == relate_actual }
                         // (Geometry::Polygon(subject), Geometry::MultiLineString(target)) => { subject.contains(target) == relate_actual }
                         // (Geometry::Polygon(subject), Geometry::MultiPolygon(target)) => { subject.contains(target) == relate_actual }
                         // (Geometry::Polygon(subject), Geometry::GeometryCollection(target)) => { subject.contains(target) == relate_actual }
                         // (Geometry::Polygon(subject), Geometry::Rect(target)) => { subject.contains(target) == relate_actual }
                         // (Geometry::Polygon(subject), Geometry::Triangle(target)) => { subject.contains(target) == relate_actual }
-                        (Geometry::MultiPoint(subject), Geometry::Point(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::MultiPoint(subject), Geometry::Point(target)) => {
+                            subject.contains(target) == relate_actual
+                        }
                         // (Geometry::MultiPoint(subject), Geometry::Line(target)) => { subject.contains(target) == relate_actual }
                         // (Geometry::MultiPoint(subject), Geometry::LineString(target)) => { subject.contains(target) == relate_actual }
                         // (Geometry::MultiPoint(subject), Geometry::Polygon(target)) => { subject.contains(target) == relate_actual }
@@ -153,9 +172,15 @@ impl TestRunner {
                         // (Geometry::MultiPoint(subject), Geometry::GeometryCollection(target)) => { subject.contains(target) == relate_actual }
                         // (Geometry::MultiPoint(subject), Geometry::Rect(target)) => { subject.contains(target) == relate_actual }
                         // (Geometry::MultiPoint(subject), Geometry::Triangle(target)) => { subject.contains(target) == relate_actual }
-                        (Geometry::MultiLineString(subject), Geometry::Point(target)) => { subject.contains(target) == relate_actual }
-                        (Geometry::MultiLineString(subject), Geometry::Line(target)) => { subject.contains(target) == relate_actual }
-                        (Geometry::MultiLineString(subject), Geometry::LineString(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::MultiLineString(subject), Geometry::Point(target)) => {
+                            subject.contains(target) == relate_actual
+                        }
+                        (Geometry::MultiLineString(subject), Geometry::Line(target)) => {
+                            subject.contains(target) == relate_actual
+                        }
+                        (Geometry::MultiLineString(subject), Geometry::LineString(target)) => {
+                            subject.contains(target) == relate_actual
+                        }
                         // (Geometry::MultiLineString(subject), Geometry::Polygon(target)) => { subject.contains(target) == relate_actual }
                         // (Geometry::MultiLineString(subject), Geometry::MultiPoint(target)) => { subject.contains(target) == relate_actual }
                         // (Geometry::MultiLineString(subject), Geometry::MultiLineString(target)) => { subject.contains(target) == relate_actual }
@@ -163,17 +188,39 @@ impl TestRunner {
                         // (Geometry::MultiLineString(subject), Geometry::GeometryCollection(target)) => { subject.contains(target) == relate_actual }
                         // (Geometry::MultiLineString(subject), Geometry::Rect(target)) => { subject.contains(target) == relate_actual }
                         // (Geometry::MultiLineString(subject), Geometry::Triangle(target)) => { subject.contains(target) == relate_actual }
-                        (Geometry::MultiPolygon(subject), Geometry::Point(target)) => { subject.contains(target) == relate_actual }
-                        (Geometry::MultiPolygon(subject), Geometry::Line(target)) => { subject.contains(target) == relate_actual }
-                        (Geometry::MultiPolygon(subject), Geometry::LineString(target)) => { subject.contains(target) == relate_actual }
-                        (Geometry::MultiPolygon(subject), Geometry::Polygon(target)) => { subject.contains(target) == relate_actual }
-                        (Geometry::MultiPolygon(subject), Geometry::MultiPoint(target)) => { subject.contains(target) == relate_actual }
-                        (Geometry::MultiPolygon(subject), Geometry::MultiLineString(target)) => { subject.contains(target) == relate_actual }
-                        (Geometry::MultiPolygon(subject), Geometry::MultiPolygon(target)) => { subject.contains(target) == relate_actual }
-                        (Geometry::MultiPolygon(subject), Geometry::GeometryCollection(target)) => { subject.contains(target) == relate_actual }
-                        (Geometry::MultiPolygon(subject), Geometry::Rect(target)) => { subject.contains(target) == relate_actual }
-                        (Geometry::MultiPolygon(subject), Geometry::Triangle(target)) => { subject.contains(target) == relate_actual }
-                        (Geometry::GeometryCollection(subject), Geometry::Point(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::MultiPolygon(subject), Geometry::Point(target)) => {
+                            subject.contains(target) == relate_actual
+                        }
+                        (Geometry::MultiPolygon(subject), Geometry::Line(target)) => {
+                            subject.contains(target) == relate_actual
+                        }
+                        (Geometry::MultiPolygon(subject), Geometry::LineString(target)) => {
+                            subject.contains(target) == relate_actual
+                        }
+                        (Geometry::MultiPolygon(subject), Geometry::Polygon(target)) => {
+                            subject.contains(target) == relate_actual
+                        }
+                        (Geometry::MultiPolygon(subject), Geometry::MultiPoint(target)) => {
+                            subject.contains(target) == relate_actual
+                        }
+                        (Geometry::MultiPolygon(subject), Geometry::MultiLineString(target)) => {
+                            subject.contains(target) == relate_actual
+                        }
+                        (Geometry::MultiPolygon(subject), Geometry::MultiPolygon(target)) => {
+                            subject.contains(target) == relate_actual
+                        }
+                        (Geometry::MultiPolygon(subject), Geometry::GeometryCollection(target)) => {
+                            subject.contains(target) == relate_actual
+                        }
+                        (Geometry::MultiPolygon(subject), Geometry::Rect(target)) => {
+                            subject.contains(target) == relate_actual
+                        }
+                        (Geometry::MultiPolygon(subject), Geometry::Triangle(target)) => {
+                            subject.contains(target) == relate_actual
+                        }
+                        (Geometry::GeometryCollection(subject), Geometry::Point(target)) => {
+                            subject.contains(target) == relate_actual
+                        }
                         // (Geometry::GeometryCollection(subject), Geometry::Line(target)) => { subject.contains(target) == relate_actual }
                         // (Geometry::GeometryCollection(subject), Geometry::LineString(target)) => { subject.contains(target) == relate_actual }
                         // (Geometry::GeometryCollection(subject), Geometry::Polygon(target)) => { subject.contains(target) == relate_actual }
@@ -183,7 +230,9 @@ impl TestRunner {
                         // (Geometry::GeometryCollection(subject), Geometry::GeometryCollection(target)) => { subject.contains(target) == relate_actual }
                         // (Geometry::GeometryCollection(subject), Geometry::Rect(target)) => { subject.contains(target) == relate_actual }
                         // (Geometry::GeometryCollection(subject), Geometry::Triangle(target)) => { subject.contains(target) == relate_actual }
-                        (Geometry::Rect(subject), Geometry::Point(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::Rect(subject), Geometry::Point(target)) => {
+                            subject.contains(target) == relate_actual
+                        }
                         // (Geometry::Rect(subject), Geometry::Line(target)) => { subject.contains(target) == relate_actual }
                         // (Geometry::Rect(subject), Geometry::LineString(target)) => { subject.contains(target) == relate_actual }
                         // (Geometry::Rect(subject), Geometry::Polygon(target)) => { subject.contains(target) == relate_actual }
@@ -191,9 +240,13 @@ impl TestRunner {
                         // (Geometry::Rect(subject), Geometry::MultiLineString(target)) => { subject.contains(target) == relate_actual }
                         // (Geometry::Rect(subject), Geometry::MultiPolygon(target)) => { subject.contains(target) == relate_actual }
                         // (Geometry::Rect(subject), Geometry::GeometryCollection(target)) => { subject.contains(target) == relate_actual }
-                        (Geometry::Rect(subject), Geometry::Rect(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::Rect(subject), Geometry::Rect(target)) => {
+                            subject.contains(target) == relate_actual
+                        }
                         // (Geometry::Rect(subject), Geometry::Triangle(target)) => { subject.contains(target) == relate_actual }
-                        (Geometry::Triangle(subject), Geometry::Point(target)) => { subject.contains(target) == relate_actual }
+                        (Geometry::Triangle(subject), Geometry::Point(target)) => {
+                            subject.contains(target) == relate_actual
+                        }
                         // (Geometry::Triangle(subject), Geometry::Line(target)) => { subject.contains(target) == relate_actual }
                         // (Geometry::Triangle(subject), Geometry::LineString(target)) => { subject.contains(target) == relate_actual }
                         // (Geometry::Triangle(subject), Geometry::Polygon(target)) => { subject.contains(target) == relate_actual }
@@ -203,7 +256,7 @@ impl TestRunner {
                         // (Geometry::Triangle(subject), Geometry::GeometryCollection(target)) => { subject.contains(target) == relate_actual }
                         // (Geometry::Triangle(subject), Geometry::Rect(target)) => { subject.contains(target) == relate_actual }
                         // (Geometry::Triangle(subject), Geometry::Triangle(target)) => { subject.contains(target) == relate_actual }
-                        _ => { true }
+                        _ => true,
                     };
 
                     if relate_actual != *expected {
@@ -226,7 +279,6 @@ impl TestRunner {
                             test_case,
                             error_description,
                         });
-
                     } else {
                         debug!("Contains success: actual == expected");
                         self.successes.push(test_case);

--- a/geo/tests/jts_tests.rs
+++ b/geo/tests/jts_tests.rs
@@ -1,4 +1,6 @@
-use jts_test_runner::TestRunner;
+mod jts_test_runner;
+
+use crate::jts_test_runner::TestRunner;
 
 fn init_logging() {
     use std::sync::Once;


### PR DESCRIPTION
This is a work-in-progress to see if this approach is possible and workable.

Migrate [jts-test-runner](https://github.com/georust/jts-test-runner) code into this repo, while leaving the XML files in the original place. The xml files are used as a submodule. Eventually we may want to automate XML file download with the `build.rs` script.

The entire history was migrated (without the initial XML check-in). Additional changes were introduced at the end, see https://github.com/georust/geo/pull/764/commits/17b234a09996b402e69ba740130617522cbe5b6d

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

