### PR TITLE
Add missing size_hint method on LineString iterators

### DIFF
--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -8,6 +8,8 @@
   * <https://github.com/georust/geo/pull/741>
 * Macros `coord!`, `point!`, `line_string!`, and `polygon!` now support trailing commas such as `coord! { x: 181.2, y: 51.79, }`
   * <https://github.com/georust/geo/pull/752>
+* Add missing size_hint() method for point and coordinate iterators on LineString
+  * <https://github.com/georust/geo/issues/762>
 
 ## 0.7.3
 

--- a/geo-types/src/line_string.rs
+++ b/geo-types/src/line_string.rs
@@ -144,6 +144,10 @@ impl<'a, T: CoordNum> Iterator for PointsIter<'a, T> {
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next().map(|c| Point(*c))
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
 }
 
 impl<'a, T: CoordNum> DoubleEndedIterator for PointsIter<'a, T> {
@@ -161,6 +165,10 @@ impl<'a, T: CoordNum> Iterator for CoordinatesIter<'a, T> {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
     }
 }
 
@@ -510,6 +518,20 @@ mod test {
     use super::*;
     use crate::coord;
     use approx::AbsDiffEq;
+
+    #[test]
+    fn test_exact_size() {
+        // see https://github.com/georust/geo/issues/762
+        let ls = LineString(vec![
+            Coordinate { x: 0., y: 0. },
+            Coordinate { x: 10., y: 0. },
+        ]);
+
+        // reference to force the `impl IntoIterator for &LineString` impl, giving a `CoordinatesIter`
+        for c in (&ls).into_iter().rev().skip(1).rev() {
+            println!("{:?}", c);
+        }
+    }
 
     #[test]
     fn test_abs_diff_eq() {


### PR DESCRIPTION
Fixes https://github.com/georust/geo/issues/762

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

