### PR TITLE
Tiny follow up coord fix

### DIFF
--- a/geo-types/src/line_string.rs
+++ b/geo-types/src/line_string.rs
@@ -529,8 +529,8 @@ mod test {
     fn test_exact_size() {
         // see https://github.com/georust/geo/issues/762
         let ls = LineString(vec![
-            Coordinate { x: 0., y: 0. },
-            Coordinate { x: 10., y: 0. },
+            coord! { x: 0., y: 0. },
+            coord! { x: 10., y: 0. },
         ]);
 
         // reference to force the `impl IntoIterator for &LineString` impl, giving a `CoordinatesIter`


### PR DESCRIPTION
This fixes the change introduced in #766

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- ~[ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.~
---

