### PR TITLE
Generalize geo-type macros

### DIFF
--- a/geo-types/src/macros.rs
+++ b/geo-types/src/macros.rs
@@ -22,8 +22,8 @@
 /// [`Point`]: ./struct.Point.html
 #[macro_export]
 macro_rules! point {
-    (x: $x:expr, y: $y:expr $(,)?) => {
-        $crate::Point::new($x, $y)
+    ( $($tag:tt : $val:expr),* ) => {
+        $crate::Point ( $crate::coord! { $( $tag: $val , )* } )
     };
 }
 
@@ -118,12 +118,12 @@ macro_rules! coord {
 macro_rules! line_string {
     () => { $crate::LineString(vec![]) };
     (
-        $((x: $x:expr, y: $y:expr $(,)?)),*
+        $(( $($tag:tt : $val:expr),* )),*
         $(,)?
     ) => {
         line_string![
             $(
-                $crate::coord! { x: $x, y: $y },
+                $crate::coord! { $( $tag: $val , )* },
             )*
         ]
     };
@@ -212,12 +212,12 @@ macro_rules! polygon {
     () => { $crate::Polygon::new(line_string![], vec![]) };
     (
         exterior: [
-            $((x: $exterior_x:expr, y: $exterior_y:expr $(,)?)),*
+            $(( $($exterior_tag:tt : $exterior_val:expr),* )),*
             $(,)?
         ],
         interiors: [
             $([
-                $((x: $interior_x:expr, y: $interior_y:expr $(,)?)),*
+                $(( $($interior_tag:tt : $interior_val:expr),* )),*
                 $(,)?
             ]),*
             $(,)?
@@ -227,12 +227,12 @@ macro_rules! polygon {
         polygon!(
             exterior: [
                 $(
-                    $crate::coord! { x: $exterior_x, y: $exterior_y },
+                    $crate::coord! { $( $exterior_tag: $exterior_val , )* },
                 )*
             ],
             interiors: [
                 $([
-                    $($crate::coord! { x: $interior_x, y: $interior_y }),*
+                    $($crate::coord! { $( $interior_tag: $interior_val , )* }),*
                 ]),*
             ],
         )
@@ -267,11 +267,11 @@ macro_rules! polygon {
         )
     };
     (
-        $((x: $x:expr, y: $y:expr $(,)?)),*
+        $(( $($tag:tt : $val:expr),* )),*
         $(,)?
     ) => {
         polygon![
-            $($crate::coord! { x: $x, y: $y }),*
+            $($crate::coord! { $( $tag: $val , )* }),*
         ]
     };
     (


### PR DESCRIPTION
Make all coordinate-specific logic limited just to the `coord!` macro, and all other macros will pass their parameters as is.

This change is a noop because `coord!` macro still uses the same parameter pattern as before.

This PR removes hardcoded x,y coordinates from the `point!`, `line_string!`, and `polygon!` macros, and instead each macro expects `token: expression` pair(s) that is passed as a parameter to the `coord!` macro.

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- ~[ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.~
---

