### PR TITLE
Simplify Point(coord!()) into point!

### DIFF
--- a/geo-types/src/line.rs
+++ b/geo-types/src/line.rs
@@ -49,10 +49,10 @@ impl<T: CoordNum> Line<T> {
     /// Equivalent to:
     ///
     /// ```rust
-    /// # use geo_types::{Line, coord, Point};
+    /// # use geo_types::{Line, point};
     /// # let line = Line::new(
-    /// #     Point(coord! { x: 4., y: -12. }),
-    /// #     Point(coord! { x: 0., y: 9. }),
+    /// #     point! { x: 4., y: -12. },
+    /// #     point! { x: 0., y: 9. },
     /// # );
     /// # assert_eq!(
     /// #     line.dx(),
@@ -68,10 +68,10 @@ impl<T: CoordNum> Line<T> {
     /// Equivalent to:
     ///
     /// ```rust
-    /// # use geo_types::{Line, coord, Point};
+    /// # use geo_types::{Line, point};
     /// # let line = Line::new(
-    /// #     Point(coord! { x: 4., y: -12. }),
-    /// #     Point(coord! { x: 0., y: 9. }),
+    /// #     point! { x: 4., y: -12. },
+    /// #     point! { x: 0., y: 9. },
     /// # );
     /// # assert_eq!(
     /// #     line.dy(),
@@ -87,10 +87,10 @@ impl<T: CoordNum> Line<T> {
     /// Equivalent to:
     ///
     /// ```rust
-    /// # use geo_types::{Line, coord, Point};
+    /// # use geo_types::{Line, point};
     /// # let line = Line::new(
-    /// #     Point(coord! { x: 4., y: -12. }),
-    /// #     Point(coord! { x: 0., y: 9. }),
+    /// #     point! { x: 4., y: -12. },
+    /// #     point! { x: 0., y: 9. },
     /// # );
     /// # assert_eq!(
     /// #     line.slope(),
@@ -101,9 +101,9 @@ impl<T: CoordNum> Line<T> {
     /// Note that:
     ///
     /// ```rust
-    /// # use geo_types::{Line, coord, Point};
-    /// # let a = Point(coord! { x: 4., y: -12. });
-    /// # let b = Point(coord! { x: 0., y: 9. });
+    /// # use geo_types::{Line, point};
+    /// # let a = point! { x: 4., y: -12. };
+    /// # let b = point! { x: 0., y: 9. };
     /// # assert!(
     /// Line::new(a, b).slope() == Line::new(b, a).slope()
     /// # );
@@ -117,10 +117,10 @@ impl<T: CoordNum> Line<T> {
     /// Equivalent to:
     ///
     /// ```rust
-    /// # use geo_types::{Line, coord, Point};
+    /// # use geo_types::{Line, point};
     /// # let line = Line::new(
-    /// #     Point(coord! { x: 4., y: -12. }),
-    /// #     Point(coord! { x: 0., y: 9. }),
+    /// #     point! { x: 4., y: -12. },
+    /// #     point! { x: 0., y: 9. },
     /// # );
     /// # assert_eq!(
     /// #     line.determinant(),
@@ -131,9 +131,9 @@ impl<T: CoordNum> Line<T> {
     /// Note that:
     ///
     /// ```rust
-    /// # use geo_types::{Line, coord, Point};
-    /// # let a = Point(coord! { x: 4., y: -12. });
-    /// # let b = Point(coord! { x: 0., y: 9. });
+    /// # use geo_types::{Line, point};
+    /// # let a = point! { x: 4., y: -12. };
+    /// # let b = point! { x: 0., y: 9. };
     /// # assert!(
     /// Line::new(a, b).determinant() == -Line::new(b, a).determinant()
     /// # );
@@ -256,18 +256,18 @@ impl_rstar_line!(rstar_0_9);
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::coord;
+    use crate::{coord, point};
 
     #[test]
     fn test_abs_diff_eq() {
         let delta = 1e-6;
         let line = Line::new(coord! { x: 0., y: 0. }, coord! { x: 1., y: 1. });
         let line_start_x = Line::new(
-            Point(coord! {
+            point! {
                 x: 0. + delta,
                 y: 0.,
-            }),
-            Point(coord! { x: 1., y: 1. }),
+            },
+            point! { x: 1., y: 1. },
         );
         assert!(line.abs_diff_eq(&line_start_x, 1e-2));
         assert!(line.abs_diff_ne(&line_start_x, 1e-12));
@@ -311,11 +311,11 @@ mod test {
 
         let line = Line::new(coord! { x: 0., y: 0. }, coord! { x: 1., y: 1. });
         let line_start_x = Line::new(
-            Point(coord! {
+            point! {
                 x: 0. + delta,
                 y: 0.,
-            }),
-            Point(coord! { x: 1., y: 1. }),
+            },
+            point! { x: 1., y: 1. },
         );
         let line_start_y = Line::new(
             coord! {

--- a/geo-types/src/macros.rs
+++ b/geo-types/src/macros.rs
@@ -11,7 +11,7 @@
 /// ```
 /// use geo_types::point;
 ///
-/// let p = point!(x: 181.2, y: 51.79);
+/// let p = point! { x: 181.2, y: 51.79 };
 ///
 /// assert_eq!(p, geo_types::Point(geo_types::coord! {
 ///     x: 181.2,
@@ -22,8 +22,8 @@
 /// [`Point`]: ./struct.Point.html
 #[macro_export]
 macro_rules! point {
-    (x: $x:expr, y: $y:expr $(,)?) => {
-        $crate::Point::new($x, $y)
+    ( $($tag:tt : $val:expr),* $(,)? ) => {
+        $crate::Point ( $crate::coord! { $( $tag: $val , )* } )
     };
 }
 

--- a/geo-types/src/point.rs
+++ b/geo-types/src/point.rs
@@ -1,4 +1,4 @@
-use crate::{coord, CoordFloat, CoordNum, Coordinate};
+use crate::{point, CoordFloat, CoordNum, Coordinate};
 
 #[cfg(any(feature = "approx", test))]
 use approx::{AbsDiffEq, RelativeEq};
@@ -74,7 +74,7 @@ impl<T: CoordNum> Point<T> {
     /// assert_eq!(p.y(), 2.345);
     /// ```
     pub fn new(x: T, y: T) -> Point<T> {
-        Point(coord! { x: x, y: y })
+        point! { x: x, y: y }
     }
 
     /// Returns the x/horizontal component of the point.
@@ -232,10 +232,10 @@ impl<T: CoordNum> Point<T> {
     /// # Examples
     ///
     /// ```
-    /// use geo_types::{coord, Point};
+    /// use geo_types::{point, Point};
     ///
-    /// let point = Point(coord! { x: 1.5, y: 0.5 });
-    /// let dot = point.dot(Point(coord! { x: 2.0, y: 4.5 }));
+    /// let point = point! { x: 1.5, y: 0.5 };
+    /// let dot = point.dot(point! { x: 2.0, y: 4.5 });
     ///
     /// assert_eq!(dot, 5.25);
     /// ```
@@ -250,11 +250,11 @@ impl<T: CoordNum> Point<T> {
     /// # Examples
     ///
     /// ```
-    /// use geo_types::{coord, Point};
+    /// use geo_types::point;
     ///
-    /// let point_a = Point(coord! { x: 1., y: 2. });
-    /// let point_b = Point(coord! { x: 3., y: 5. });
-    /// let point_c = Point(coord! { x: 7., y: 12. });
+    /// let point_a = point! { x: 1., y: 2. };
+    /// let point_b = point! { x: 3., y: 5. };
+    /// let point_c = point! { x: 7., y: 12. };
     ///
     /// let cross = point_a.cross_prod(point_b, point_c);
     ///

--- a/geo/examples/types.rs
+++ b/geo/examples/types.rs
@@ -1,14 +1,13 @@
 extern crate geo;
 
-use geo::{coord, Point};
+use geo::Point;
+use geo_types::point;
 
 fn main() {
-    let c = coord! {
+    let p = point! {
         x: 40.02f64,
         y: 116.34,
     };
-
-    let p = Point(c);
 
     let Point(coord) = p;
     println!("Point at ({}, {})", coord.x, coord.y);

--- a/geo/src/algorithm/bounding_rect.rs
+++ b/geo/src/algorithm/bounding_rect.rs
@@ -209,8 +209,8 @@ mod test {
     use crate::algorithm::bounding_rect::BoundingRect;
     use crate::line_string;
     use crate::{
-        coord, polygon, Geometry, GeometryCollection, Line, LineString, MultiLineString,
-        MultiPoint, MultiPolygon, Point, Polygon, Rect,
+        coord, point, polygon, Geometry, GeometryCollection, Line, LineString, MultiLineString,
+        MultiPoint, MultiPolygon, Polygon, Rect,
     };
 
     #[test]
@@ -314,7 +314,7 @@ mod test {
     fn point_bounding_rect_test() {
         assert_eq!(
             Rect::new(coord! { x: 1., y: 2. }, coord! { x: 1., y: 2. }),
-            Point(coord! { x: 1., y: 2. }).bounding_rect(),
+            point! { x: 1., y: 2. }.bounding_rect(),
         );
     }
 
@@ -323,8 +323,8 @@ mod test {
         assert_eq!(
             Some(Rect::new(coord! { x: 0., y: 0. }, coord! { x: 1., y: 2. })),
             GeometryCollection(vec![
-                Geometry::Point(Point(coord! { x: 0., y: 0. })),
-                Geometry::Point(Point(coord! { x: 1., y: 2. })),
+                Geometry::Point(point! { x: 0., y: 0. }),
+                Geometry::Point(point! { x: 1., y: 2. }),
             ])
             .bounding_rect(),
         );

--- a/geo/src/algorithm/centroid.rs
+++ b/geo/src/algorithm/centroid.rs
@@ -475,7 +475,7 @@ mod test {
 
     /// small helper to create a point
     fn p<T: GeoFloat>(x: T, y: T) -> Point<T> {
-        Point(c(x, y))
+        point! { x: x, y: y }
     }
 
     // Tests: Centroid of LineString
@@ -553,7 +553,7 @@ mod test {
             (x: 11., y: 1.)
         ];
         let mls: MultiLineString<f64> = MultiLineString(vec![linestring]);
-        assert_relative_eq!(mls.centroid().unwrap(), Point(coord! { x: 6., y: 1. }));
+        assert_relative_eq!(mls.centroid().unwrap(), point! { x: 6., y: 1. });
     }
     #[test]
     fn multilinestring_test() {


### PR DESCRIPTION
Minor simplification of many `Point( coord! { ... })` into a more straightforward `point! { ... }` as initially proposed in prior PR https://github.com/georust/geo/pull/760#pullrequestreview-903652541

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- ~[ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.~
---

