### PR TITLE
Add point!(x, y) macro

### DIFF
--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -12,6 +12,8 @@
   * <https://github.com/georust/geo/issues/762>
 * Add ExactsizeIterator impl for Points iterator on LineString
   * <https://github.com/georust/geo/pull/767>
+* Support positional `point!(x, y)` macro, preferred over `Point::new(x, y)`
+  * <https://github.com/georust/geo/pull/774>
 
 ## 0.7.3
 

--- a/geo-types/src/macros.rs
+++ b/geo-types/src/macros.rs
@@ -1,7 +1,8 @@
 /// Creates a [`Point`] from the given coordinates.
 ///
 /// ```txt
-/// point!(x: <number>, y: <number>)
+/// point!(<x_number>, <y_number>)
+/// point! { x: <number>, y: <number> }
 /// ```
 ///
 /// # Examples
@@ -11,7 +12,7 @@
 /// ```
 /// use geo_types::point;
 ///
-/// let p = point! { x: 181.2, y: 51.79 };
+/// let p = point!(181.2, 51.79);
 ///
 /// assert_eq!(p, geo_types::Point(geo_types::coord! {
 ///     x: 181.2,
@@ -24,6 +25,9 @@
 macro_rules! point {
     ( $($tag:tt : $val:expr),* $(,)? ) => {
         $crate::Point ( $crate::coord! { $( $tag: $val , )* } )
+    };
+    ( $x:expr, $y:expr $(,)? ) => {
+        $crate::point! { x: $x, y: $y }
     };
 }
 

--- a/geo/benches/contains.rs
+++ b/geo/benches/contains.rs
@@ -15,7 +15,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             (x: 1.0, y: 1.0),
             (x: 0.0, y: 0.0),
         ];
-        let in_candidate = geo::Point::new(0.5, 0.1);
+        let in_candidate = point!(0.5, 0.1);
         bencher.iter(|| {
             criterion::black_box(
                 criterion::black_box(&polygon).contains(criterion::black_box(&in_candidate)),
@@ -30,7 +30,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             (x: 1.0, y: 1.0),
             (x: 0.0, y: 0.0),
         ];
-        let out_candidate = geo::Point::new(2.0, 2.0);
+        let out_candidate = point!(2.0, 2.0);
         bencher.iter(|| {
             criterion::black_box(
                 criterion::black_box(&polygon).contains(criterion::black_box(&out_candidate)),

--- a/geo/examples/concavehull-usage.rs
+++ b/geo/examples/concavehull-usage.rs
@@ -1,7 +1,7 @@
 use geo::algorithm::concave_hull::ConcaveHull;
 use geo::algorithm::convex_hull::ConvexHull;
 use geo::{Coordinate, Point};
-use geo_types::MultiPoint;
+use geo_types::{point, MultiPoint};
 use std::fs::File;
 use std::io::Write;
 
@@ -37,10 +37,7 @@ fn produce_file_content(start_str: &str, mid_str: &str) -> String {
 fn move_points_in_viewbox(width: f64, height: f64, points: Vec<Point<f64>>) -> Vec<Point<f64>> {
     let mut new_points = vec![];
     for point in points {
-        new_points.push(Point::new(
-            point.0.x + width / 2.0,
-            point.0.y + height / 2.0,
-        ));
+        new_points.push(point!(point.0.x + width / 2.0, point.0.y + height / 2.0));
     }
     new_points
 }
@@ -63,7 +60,7 @@ fn main() -> std::io::Result<()> {
     let v: Vec<_> = norway
         .0
         .into_iter()
-        .map(|coord| Point::new(coord.x, coord.y))
+        .map(|coord| point!(coord.x, coord.y))
         .collect();
     let moved_v = move_points_in_viewbox(width as f64, height as f64, v);
     let multipoint = MultiPoint::from(moved_v);

--- a/geo/src/algorithm/bounding_rect.rs
+++ b/geo/src/algorithm/bounding_rect.rs
@@ -314,7 +314,7 @@ mod test {
     fn point_bounding_rect_test() {
         assert_eq!(
             Rect::new(coord! { x: 1., y: 2. }, coord! { x: 1., y: 2. }),
-            point! { x: 1., y: 2. }.bounding_rect(),
+            point!(1., 2.).bounding_rect(),
         );
     }
 

--- a/geo/src/algorithm/centroid.rs
+++ b/geo/src/algorithm/centroid.rs
@@ -152,14 +152,14 @@ where
 ///
 /// ```
 /// use geo::algorithm::centroid::Centroid;
-/// use geo::{MultiPoint, Point};
+/// use geo::{MultiPoint, Point, point};
 ///
 /// let empty: Vec<Point<f64>> = Vec::new();
 /// let empty_multi_points: MultiPoint<_> = empty.into();
 /// assert_eq!(empty_multi_points.centroid(), None);
 ///
 /// let points: MultiPoint<_> = vec![(5., 1.), (1., 3.), (3., 2.)].into();
-/// assert_eq!(points.centroid(), Some(Point::new(3., 2.)));
+/// assert_eq!(points.centroid(), Some(point!(3., 2.)));
 /// ```
 impl<T> Centroid for MultiPoint<T>
 where

--- a/geo/src/algorithm/closest_point.rs
+++ b/geo/src/algorithm/closest_point.rs
@@ -17,12 +17,12 @@ use std::iter;
 ///
 /// ```rust
 /// # use geo::algorithm::closest_point::ClosestPoint;
-/// # use geo::{Point, Line, Closest};
-/// let p: Point<f32> = Point::new(0.0, 100.0);
-/// let horizontal_line: Line<f32> = Line::new(Point::new(-50.0, 0.0), Point::new(50.0, 0.0));
+/// # use geo::{point, Point, Line, Closest};
+/// let p: Point<f32> = point!(0.0, 100.0);
+/// let horizontal_line: Line<f32> = Line::new(point!(-50.0, 0.0), point!(50.0, 0.0));
 ///
 /// let closest = horizontal_line.closest_point(&p);
-/// assert_eq!(closest, Closest::SinglePoint(Point::new(0.0, 0.0)));
+/// assert_eq!(closest, Closest::SinglePoint(point!(0.0, 0.0)));
 /// ```
 pub trait ClosestPoint<F: GeoFloat, Rhs = Point<F>> {
     /// Find the closest point between `self` and `p`.
@@ -209,8 +209,8 @@ mod tests {
     closest!(intersects: start_point, (0.0, 0.0));
     closest!(intersects: end_point, (100.0, 100.0));
     closest!(intersects: mid_point, (50.0, 50.0));
-    closest!(in_line_far_away, (1000.0, 1000.0) => Closest::SinglePoint(Point::new(100.0, 100.0)));
-    closest!(perpendicular_from_50_50, (0.0, 100.0) => Closest::SinglePoint(Point::new(50.0, 50.0)));
+    closest!(in_line_far_away, (1000.0, 1000.0) => Closest::SinglePoint(point!(100.0, 100.0)));
+    closest!(perpendicular_from_50_50, (0.0, 100.0) => Closest::SinglePoint(point!(50.0, 50.0)));
 
     fn a_square(width: f32) -> LineString<f32> {
         LineString::from(vec![
@@ -225,7 +225,7 @@ mod tests {
     #[test]
     fn zero_length_line_is_indeterminate() {
         let line: Line<f32> = Line::from([(0.0, 0.0), (0.0, 0.0)]);
-        let p: Point<f32> = Point::new(100.0, 100.0);
+        let p: Point<f32> = point!(100.0, 100.0);
         let should_be: Closest<f32> = Closest::Indeterminate;
 
         let got = line.closest_point(&p);
@@ -260,7 +260,7 @@ mod tests {
     #[test]
     fn empty_line_string_is_indeterminate() {
         let ls: LineString<f32> = LineString(Vec::new());
-        let p = Point::new(0.0, 0.0);
+        let p = point!(0.0, 0.0);
 
         let got = ls.closest_point(&p);
         assert_eq!(got, Closest::Indeterminate);
@@ -277,7 +277,7 @@ mod tests {
     #[test]
     fn polygon_without_rings_and_point_outside_is_same_as_linestring() {
         let poly = holy_polygon();
-        let p = Point::new(1000.0, 12345.678);
+        let p = point!(1000.0, 12345.678);
         assert!(
             !poly.exterior().contains(&p),
             "`p` should be outside the polygon!"

--- a/geo/src/algorithm/contains/mod.rs
+++ b/geo/src/algorithm/contains/mod.rs
@@ -53,14 +53,14 @@ mod test {
     use crate::algorithm::contains::Contains;
     use crate::line_string;
     use crate::{
-        coord, Coordinate, Line, LineString, MultiPolygon, Point, Polygon, Rect, Triangle,
+        coord, point, Coordinate, Line, LineString, MultiPolygon, Point, Polygon, Rect, Triangle,
     };
 
     #[test]
     // see https://github.com/georust/geo/issues/452
     fn linestring_contains_point() {
         let line_string = LineString::from(vec![(0., 0.), (3., 3.)]);
-        let point_on_line = Point::new(1., 1.);
+        let point_on_line = point!(1., 1.);
         assert!(line_string.contains(&point_on_line));
     }
     #[test]
@@ -135,61 +135,61 @@ mod test {
     #[test]
     fn empty_linestring_test() {
         let linestring = LineString(Vec::new());
-        assert!(!linestring.contains(&Point::new(2., 1.)));
+        assert!(!linestring.contains(&point!(2., 1.)));
     }
     #[test]
     fn linestring_point_is_vertex_test() {
         let linestring = LineString::from(vec![(0., 0.), (2., 0.), (2., 2.)]);
         // Note: the end points of a linestring are not
         // considered to be "contained"
-        assert!(linestring.contains(&Point::new(2., 0.)));
-        assert!(!linestring.contains(&Point::new(0., 0.)));
-        assert!(!linestring.contains(&Point::new(2., 2.)));
+        assert!(linestring.contains(&point!(2., 0.)));
+        assert!(!linestring.contains(&point!(0., 0.)));
+        assert!(!linestring.contains(&point!(2., 2.)));
     }
     #[test]
     fn linestring_test() {
         let linestring = LineString::from(vec![(0., 0.), (2., 0.), (2., 2.)]);
-        assert!(linestring.contains(&Point::new(1., 0.)));
+        assert!(linestring.contains(&point!(1., 0.)));
     }
     /// Tests: Point in Polygon
     #[test]
     fn empty_polygon_test() {
         let linestring = LineString(Vec::new());
         let poly = Polygon::new(linestring, Vec::new());
-        assert!(!poly.contains(&Point::new(2., 1.)));
+        assert!(!poly.contains(&point!(2., 1.)));
     }
     #[test]
     fn polygon_with_one_point_test() {
         let linestring = LineString::from(vec![(2., 1.)]);
         let poly = Polygon::new(linestring, Vec::new());
-        assert!(!poly.contains(&Point::new(3., 1.)));
+        assert!(!poly.contains(&point!(3., 1.)));
     }
     #[test]
     fn polygon_with_one_point_is_vertex_test() {
         let linestring = LineString::from(vec![(2., 1.)]);
         let poly = Polygon::new(linestring, Vec::new());
-        assert!(!poly.contains(&Point::new(2., 1.)));
+        assert!(!poly.contains(&point!(2., 1.)));
     }
     #[test]
     fn polygon_with_point_on_boundary_test() {
         let linestring = LineString::from(vec![(0., 0.), (2., 0.), (2., 2.), (0., 2.), (0., 0.)]);
         let poly = Polygon::new(linestring, Vec::new());
-        assert!(!poly.contains(&Point::new(1., 0.)));
-        assert!(!poly.contains(&Point::new(2., 1.)));
-        assert!(!poly.contains(&Point::new(1., 2.)));
-        assert!(!poly.contains(&Point::new(0., 1.)));
+        assert!(!poly.contains(&point!(1., 0.)));
+        assert!(!poly.contains(&point!(2., 1.)));
+        assert!(!poly.contains(&point!(1., 2.)));
+        assert!(!poly.contains(&point!(0., 1.)));
     }
     #[test]
     fn point_in_polygon_test() {
         let linestring = LineString::from(vec![(0., 0.), (2., 0.), (2., 2.), (0., 2.), (0., 0.)]);
         let poly = Polygon::new(linestring, Vec::new());
-        assert!(poly.contains(&Point::new(1., 1.)));
+        assert!(poly.contains(&point!(1., 1.)));
     }
     #[test]
     fn point_in_polygon_with_ray_passing_through_a_vertex_test() {
         let linestring = LineString::from(vec![(1., 0.), (0., 1.), (-1., 0.), (0., -1.)]);
         let poly = Polygon::new(linestring, Vec::new());
-        assert!(poly.contains(&Point::new(0., 0.)));
+        assert!(poly.contains(&point!(0., 0.)));
     }
     #[test]
     fn point_in_polygon_with_ray_passing_through_a_vertex_and_not_crossing() {
@@ -203,15 +203,15 @@ mod test {
             (0., 0.),
         ]);
         let poly = Polygon::new(linestring, Vec::new());
-        assert!(poly.contains(&Point::new(1., 1.)));
+        assert!(poly.contains(&point!(1., 1.)));
     }
     #[test]
     fn point_out_polygon_test() {
         let linestring = LineString::from(vec![(0., 0.), (2., 0.), (2., 2.), (0., 2.), (0., 0.)]);
         let poly = Polygon::new(linestring, Vec::new());
-        assert!(!poly.contains(&Point::new(2.1, 1.)));
-        assert!(!poly.contains(&Point::new(1., 2.1)));
-        assert!(!poly.contains(&Point::new(2.1, 2.1)));
+        assert!(!poly.contains(&point!(2.1, 1.)));
+        assert!(!poly.contains(&point!(1., 2.1)));
+        assert!(!poly.contains(&point!(2.1, 2.1)));
     }
     #[test]
     fn point_polygon_with_inner_test() {
@@ -224,17 +224,17 @@ mod test {
             [0.0, 0.0],
         ]);
         let poly = Polygon::new(linestring, vec![inner_linestring]);
-        assert!(!poly.contains(&Point::new(0.25, 0.25)));
-        assert!(!poly.contains(&Point::new(1., 1.)));
-        assert!(!poly.contains(&Point::new(1.5, 1.5)));
-        assert!(!poly.contains(&Point::new(1.5, 1.)));
+        assert!(!poly.contains(&point!(0.25, 0.25)));
+        assert!(!poly.contains(&point!(1., 1.)));
+        assert!(!poly.contains(&point!(1.5, 1.5)));
+        assert!(!poly.contains(&point!(1.5, 1.)));
     }
 
     /// Tests: Point in MultiPolygon
     #[test]
     fn empty_multipolygon_test() {
         let multipoly = MultiPolygon(Vec::new());
-        assert!(!multipoly.contains(&Point::new(2., 1.)));
+        assert!(!multipoly.contains(&point!(2., 1.)));
     }
     #[test]
     fn empty_multipolygon_two_polygons_test() {
@@ -247,9 +247,9 @@ mod test {
             Vec::new(),
         );
         let multipoly = MultiPolygon(vec![poly1, poly2]);
-        assert!(multipoly.contains(&Point::new(0.5, 0.5)));
-        assert!(multipoly.contains(&Point::new(2.5, 0.5)));
-        assert!(!multipoly.contains(&Point::new(1.5, 0.5)));
+        assert!(multipoly.contains(&point!(0.5, 0.5)));
+        assert!(multipoly.contains(&point!(2.5, 0.5)));
+        assert!(!multipoly.contains(&point!(1.5, 0.5)));
     }
     #[test]
     fn empty_multipolygon_two_polygons_and_inner_test() {
@@ -268,10 +268,10 @@ mod test {
         );
 
         let multipoly = MultiPolygon(vec![poly1, poly2]);
-        assert!(multipoly.contains(&Point::new(3., 5.)));
-        assert!(multipoly.contains(&Point::new(12., 2.)));
-        assert!(!multipoly.contains(&Point::new(3., 2.)));
-        assert!(!multipoly.contains(&Point::new(7., 2.)));
+        assert!(multipoly.contains(&point!(3., 5.)));
+        assert!(multipoly.contains(&point!(12., 2.)));
+        assert!(!multipoly.contains(&point!(3., 2.)));
+        assert!(!multipoly.contains(&point!(7., 2.)));
     }
     /// Tests: LineString in Polygon
     #[test]
@@ -446,10 +446,10 @@ mod test {
 
     #[test]
     fn integer_bounding_rects() {
-        let p: Point<i32> = Point::new(10, 20);
+        let p: Point<i32> = point!(10, 20);
         let bounding_rect: Rect<i32> = Rect::new(coord! { x: 0, y: 0 }, coord! { x: 100, y: 100 });
         assert!(bounding_rect.contains(&p));
-        assert!(!bounding_rect.contains(&Point::new(-10, -10)));
+        assert!(!bounding_rect.contains(&point!(-10, -10)));
 
         let smaller_bounding_rect: Rect<i32> =
             Rect::new(coord! { x: 10, y: 10 }, coord! { x: 20, y: 20 });
@@ -459,42 +459,42 @@ mod test {
     #[test]
     fn triangle_not_contains_point_on_edge() {
         let t = Triangle::from([(0.0, 0.0), (2.0, 0.0), (2.0, 2.0)]);
-        let p = Point::new(1.0, 0.0);
+        let p = point!(1.0, 0.0);
         assert!(!t.contains(&p));
     }
 
     #[test]
     fn triangle_not_contains_point_on_vertex() {
         let t = Triangle::from([(0.0, 0.0), (2.0, 0.0), (2.0, 2.0)]);
-        let p = Point::new(2.0, 0.0);
+        let p = point!(2.0, 0.0);
         assert!(!t.contains(&p));
     }
 
     #[test]
     fn triangle_contains_point_inside() {
         let t = Triangle::from([(0.0, 0.0), (2.0, 0.0), (2.0, 2.0)]);
-        let p = Point::new(1.0, 0.5);
+        let p = point!(1.0, 0.5);
         assert!(t.contains(&p));
     }
 
     #[test]
     fn triangle_not_contains_point_above() {
         let t = Triangle::from([(0.0, 0.0), (2.0, 0.0), (2.0, 2.0)]);
-        let p = Point::new(1.0, 1.5);
+        let p = point!(1.0, 1.5);
         assert!(!t.contains(&p));
     }
 
     #[test]
     fn triangle_not_contains_point_below() {
         let t = Triangle::from([(0.0, 0.0), (2.0, 0.0), (2.0, 2.0)]);
-        let p = Point::new(-1.0, 0.5);
+        let p = point!(-1.0, 0.5);
         assert!(!t.contains(&p));
     }
 
     #[test]
     fn triangle_contains_neg_point() {
         let t = Triangle::from([(0.0, 0.0), (-2.0, 0.0), (-2.0, -2.0)]);
-        let p = Point::new(-1.0, -0.5);
+        let p = point!(-1.0, -0.5);
         assert!(t.contains(&p));
     }
 

--- a/geo/src/algorithm/convex_hull/test.rs
+++ b/geo/src/algorithm/convex_hull/test.rs
@@ -4,15 +4,15 @@ use crate::*;
 #[test]
 fn convex_hull_multipoint_test() {
     let v = vec![
-        Point::new(0, 10),
-        Point::new(1, 1),
-        Point::new(10, 0),
-        Point::new(1, -1),
-        Point::new(0, -10),
-        Point::new(-1, -1),
-        Point::new(-10, 0),
-        Point::new(-1, 1),
-        Point::new(0, 10),
+        point!(0, 10),
+        point!(1, 1),
+        point!(10, 0),
+        point!(1, -1),
+        point!(0, -10),
+        point!(-1, -1),
+        point!(-10, 0),
+        point!(-1, 1),
+        point!(0, 10),
     ];
     let mp = MultiPoint(v);
     let correct = vec![

--- a/geo/src/algorithm/haversine_intermediate.rs
+++ b/geo/src/algorithm/haversine_intermediate.rs
@@ -1,4 +1,5 @@
 use crate::{CoordFloat, Point, MEAN_EARTH_RADIUS};
+use geo_types::point;
 use num_traits::FromPrimitive;
 
 /// Returns a new Point along a great circle route between two existing points
@@ -12,16 +13,16 @@ pub trait HaversineIntermediate<T: CoordFloat> {
     /// # #[macro_use] extern crate approx;
     /// #
     /// use geo::algorithm::haversine_intermediate::HaversineIntermediate;
-    /// use geo::Point;
+    /// use geo::{Point, point};
     ///
     /// let p1 = Point::<f64>::new(10.0, 20.0);
     /// let p2 = Point::<f64>::new(125.0, 25.0);
     /// let i20 = p1.haversine_intermediate(&p2, 0.2);
     /// let i50 = p1.haversine_intermediate(&p2, 0.5);
     /// let i80 = p1.haversine_intermediate(&p2, 0.8);
-    /// let i20_should = Point::new(29.8, 29.9);
-    /// let i50_should = Point::new(65.8, 37.7);
-    /// let i80_should = Point::new(103.5, 33.5);
+    /// let i20_should = point!(29.8, 29.9);
+    /// let i50_should = point!(65.8, 37.7);
+    /// let i80_should = point!(103.5, 33.5);
     /// assert_relative_eq!(i20.x(), i20_should.x(), epsilon = 0.2);
     /// assert_relative_eq!(i20.y(), i20_should.y(), epsilon = 0.2);
     /// assert_relative_eq!(i50.x(), i50_should.x(), epsilon = 0.2);
@@ -122,7 +123,7 @@ fn get_point<T: CoordFloat + FromPrimitive>(params: &HaversineParams<T>, f: T) -
     let lat = z.atan2(x.hypot(y));
     let lon = y.atan2(x);
 
-    Point::new(lon.to_degrees(), lat.to_degrees())
+    point!(lon.to_degrees(), lat.to_degrees())
 }
 
 #[allow(clippy::many_single_char_names)]
@@ -186,9 +187,9 @@ mod test {
         let i20 = p1.haversine_intermediate(&p2, 0.2);
         let i50 = p1.haversine_intermediate(&p2, 0.5);
         let i80 = p1.haversine_intermediate(&p2, 0.8);
-        let i20_should = Point::new(29.83519, 29.94841);
-        let i50_should = Point::new(65.87471, 37.72201);
-        let i80_should = Point::new(103.56036, 33.50518);
+        let i20_should = point!(29.83519, 29.94841);
+        let i50_should = point!(65.87471, 37.72201);
+        let i80_should = point!(103.56036, 33.50518);
         assert_relative_eq!(i20.x(), i20_should.x(), epsilon = 0.2);
         assert_relative_eq!(i20.y(), i20_should.y(), epsilon = 0.2);
         assert_relative_eq!(i50.x(), i50_should.x(), epsilon = 0.2);
@@ -202,7 +203,7 @@ mod test {
         let p1 = Point::<f64>::new(0.0, 10.0);
         let p2 = Point::<f64>::new(180.0, 10.0);
         let i50 = p1.haversine_intermediate(&p2, 0.5);
-        let i50_should = Point::new(90.0, 90.0);
+        let i50_should = point!(90.0, 90.0);
         assert_relative_eq!(i50.x(), i50_should.x(), epsilon = 1.0e-6);
         assert_relative_eq!(i50.y(), i50_should.y(), epsilon = 1.0e-6);
     }

--- a/geo/src/algorithm/intersects/mod.rs
+++ b/geo/src/algorithm/intersects/mod.rs
@@ -111,8 +111,8 @@ where
 mod test {
     use crate::algorithm::intersects::Intersects;
     use crate::{
-        coord, line_string, polygon, Geometry, Line, LineString, MultiLineString, MultiPoint,
-        MultiPolygon, Point, Polygon, Rect,
+        coord, line_string, point, polygon, Geometry, Line, LineString, MultiLineString,
+        MultiPoint, MultiPolygon, Point, Polygon, Rect,
     };
 
     /// Tests: intersection LineString and LineString
@@ -402,7 +402,7 @@ mod test {
     }
     #[test]
     fn point_intersects_line_test() {
-        let p0 = Point::new(2., 4.);
+        let p0 = point!(2., 4.);
         // vertical line
         let line1 = Line::from([(2., 0.), (2., 5.)]);
         // point on line, but outside line segment
@@ -531,7 +531,7 @@ mod test {
     #[test]
     fn exhaustive_compile_test() {
         use geo_types::{GeometryCollection, Triangle};
-        let pt: Point<f64> = Point::new(0., 0.);
+        let pt: Point<f64> = point!(0., 0.);
         let ln: Line<f64> = Line::new((0., 0.), (1., 1.));
         let ls = line_string![(0., 0.).into(), (1., 1.).into()];
         let poly = Polygon::new(LineString::from(vec![(0., 0.), (1., 1.), (1., 0.)]), vec![]);

--- a/geo/src/algorithm/line_locate_point.rs
+++ b/geo/src/algorithm/line_locate_point.rs
@@ -117,29 +117,29 @@ mod test {
     fn test_line_locate_point_line() {
         // Some finite examples
         let line = Line::new(coord! { x: -1.0, y: 0.0 }, coord! { x: 1.0, y: 0.0 });
-        let point = Point::new(0.0, 1.0);
+        let point = point!(0.0, 1.0);
         assert_eq!(line.line_locate_point(&point), Some(0.5));
 
-        let point = Point::new(1.0, 1.0);
+        let point = point!(1.0, 1.0);
         assert_eq!(line.line_locate_point(&point), Some(1.0));
 
-        let point = Point::new(2.0, 1.0);
+        let point = point!(2.0, 1.0);
         assert_eq!(line.line_locate_point(&point), Some(1.0));
 
-        let point = Point::new(-1.0, 1.0);
+        let point = point!(-1.0, 1.0);
         assert_eq!(line.line_locate_point(&point), Some(0.0));
 
-        let point = Point::new(-2.0, 1.0);
+        let point = point!(-2.0, 1.0);
         assert_eq!(line.line_locate_point(&point), Some(0.0));
 
         // point contains inf or nan
-        let point = Point::new(Float::nan(), 1.0);
+        let point = point!(Float::nan(), 1.0);
         assert_eq!(line.line_locate_point(&point), None);
 
-        let point = Point::new(Float::infinity(), 1.0);
+        let point = point!(Float::infinity(), 1.0);
         assert_eq!(line.line_locate_point(&point), None);
 
-        let point = Point::new(Float::neg_infinity(), 1.0);
+        let point = point!(Float::neg_infinity(), 1.0);
         assert_eq!(line.line_locate_point(&point), None);
 
         // line contains inf or nan
@@ -150,7 +150,7 @@ mod test {
                 y: 0.0,
             },
         );
-        let point = Point::new(1000.0, 1000.0);
+        let point = point!(1000.0, 1000.0);
         assert_eq!(line.line_locate_point(&point), None);
 
         let line = Line::new(
@@ -160,7 +160,7 @@ mod test {
                 y: 0.0,
             },
         );
-        let point = Point::new(1000.0, 1000.0);
+        let point = point!(1000.0, 1000.0);
         assert_eq!(line.line_locate_point(&point), None);
 
         let line = Line::new(
@@ -170,7 +170,7 @@ mod test {
                 y: 0.0,
             },
         );
-        let point = Point::new(1000.0, 1000.0);
+        let point = point!(1000.0, 1000.0);
         assert_eq!(line.line_locate_point(&point), None);
 
         // zero length line
@@ -180,11 +180,11 @@ mod test {
 
         // another concrete example
         let line: Line<f64> = Line::new(coord! { x: 0.0, y: 0.0 }, coord! { x: 10.0, y: 0.0 });
-        let pt = Point::new(555.0, 555.0);
+        let pt = point!(555.0, 555.0);
         assert_eq!(line.line_locate_point(&pt), Some(1.0));
-        let pt = Point::new(10.0000001, 0.0);
+        let pt = point!(10.0000001, 0.0);
         assert_eq!(line.line_locate_point(&pt), Some(1.0));
-        let pt = Point::new(9.0, 0.001);
+        let pt = point!(9.0, 0.001);
         assert_eq!(line.line_locate_point(&pt), Some(0.9));
     }
 


### PR DESCRIPTION
This follows up from #773, including all of its changes (so better to merge that one first for shorter diff).
    
This PR adds support for the positional `point!(x,y)` macro, making it appear more like a function.

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

