### PR TITLE
extend point! macro to support more ways to instantiate

### DIFF
--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -14,7 +14,7 @@
   * <https://github.com/georust/geo/issues/762>
 * Add ExactsizeIterator impl for Points iterator on LineString
   * <https://github.com/georust/geo/pull/767>
-* Extend `point!` macro to support positional arguments `point!(x, y)` and single coordinate expression arguments `point!(coordinate)`.
+* Extend `point!` macro to support single coordinate expression arguments `point!(coordinate)` (coordinate can be created with the `coord!` macro)
   * <https://github.com/georust/geo/pull/775>
 
 ## 0.7.3

--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -14,6 +14,8 @@
   * <https://github.com/georust/geo/issues/762>
 * Add ExactsizeIterator impl for Points iterator on LineString
   * <https://github.com/georust/geo/pull/767>
+* Extend `point!` macro to support positional arguments `point!(x, y)` and single coordinate expression arguments `point!(coordinate)`.
+  * <https://github.com/georust/geo/pull/775>
 
 ## 0.7.3
 

--- a/geo-types/src/macros.rs
+++ b/geo-types/src/macros.rs
@@ -1,7 +1,6 @@
 /// Creates a [`Point`] from the given coordinates.
 ///
 /// ```txt
-/// point!(<x_number>, <y_number>)
 /// point! { x: <number>, y: <number> }
 /// point!(<coordinate>)
 /// ```
@@ -11,9 +10,14 @@
 /// Creating a [`Point`], supplying x/y values:
 ///
 /// ```
-/// use geo_types::point;
+/// use geo_types::{point, coord};
 ///
 /// let p = point! { x: 181.2, y: 51.79 };
+///
+/// assert_eq!(p.x(), 181.2);
+/// assert_eq!(p.y(), 51.79);
+///
+/// let p = point!(coord! { x: 181.2, y: 51.79 });
 ///
 /// assert_eq!(p.x(), 181.2);
 /// assert_eq!(p.y(), 51.79);
@@ -24,9 +28,6 @@
 macro_rules! point {
     ( $($tag:tt : $val:expr),* $(,)? ) => {
         $crate::point! ( $crate::coord! { $( $tag: $val , )* } )
-    };
-    ( $x:expr, $y:expr $(,)? ) => {
-        $crate::point! { x: $x, y: $y }
     };
     ( $coord:expr $(,)? ) => {
         $crate::Point::from($coord)
@@ -303,14 +304,6 @@ mod test {
             x: 1.2,
             y: 3.4,
         };
-        assert_eq!(p.x(), 1.2);
-        assert_eq!(p.y(), 3.4);
-
-        let p = point!(1.2, 3.4);
-        assert_eq!(p.x(), 1.2);
-        assert_eq!(p.y(), 3.4);
-
-        let p = point!(1.2, 3.4,);
         assert_eq!(p.x(), 1.2);
         assert_eq!(p.y(), 3.4);
 

--- a/geo-types/src/macros.rs
+++ b/geo-types/src/macros.rs
@@ -1,7 +1,9 @@
 /// Creates a [`Point`] from the given coordinates.
 ///
 /// ```txt
-/// point!(x: <number>, y: <number>)
+/// point!(<x_number>, <y_number>)
+/// point! { x: <number>, y: <number> }
+/// point!(<coordinate>)
 /// ```
 ///
 /// # Examples
@@ -13,17 +15,21 @@
 ///
 /// let p = point! { x: 181.2, y: 51.79 };
 ///
-/// assert_eq!(p, geo_types::Point(geo_types::coord! {
-///     x: 181.2,
-///     y: 51.79,
-/// }));
+/// assert_eq!(p.x(), 181.2);
+/// assert_eq!(p.y(), 51.79);
 /// ```
 ///
 /// [`Point`]: ./struct.Point.html
 #[macro_export]
 macro_rules! point {
     ( $($tag:tt : $val:expr),* $(,)? ) => {
-        $crate::Point::from( $crate::coord! { $( $tag: $val , )* } )
+        $crate::point! ( $crate::coord! { $( $tag: $val , )* } )
+    };
+    ( $x:expr, $y:expr $(,)? ) => {
+        $crate::point! { x: $x, y: $y }
+    };
+    ( $coord:expr $(,)? ) => {
+        $crate::Point::from($coord)
     };
 }
 
@@ -297,6 +303,22 @@ mod test {
             x: 1.2,
             y: 3.4,
         };
+        assert_eq!(p.x(), 1.2);
+        assert_eq!(p.y(), 3.4);
+
+        let p = point!(1.2, 3.4);
+        assert_eq!(p.x(), 1.2);
+        assert_eq!(p.y(), 3.4);
+
+        let p = point!(1.2, 3.4,);
+        assert_eq!(p.x(), 1.2);
+        assert_eq!(p.y(), 3.4);
+
+        let p = point!(coord! { x: 1.2, y: 3.4 });
+        assert_eq!(p.x(), 1.2);
+        assert_eq!(p.y(), 3.4);
+
+        let p = point!(coord! { x: 1.2, y: 3.4 },);
         assert_eq!(p.x(), 1.2);
         assert_eq!(p.y(), 3.4);
     }


### PR DESCRIPTION
To be consistent with other macros, `point!` can now be used as:

```
point! { x: <number>, y: <number> }
point!(<coordinate>)
```

Also replace a few `format!("{}", v)` with `v.to_string()`

See also https://github.com/georust/geo/pull/742#issuecomment-1068731936

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

