### PR TITLE
Use Self keyword where appropriate

### DIFF
--- a/geo-types/src/arbitrary.rs
+++ b/geo-types/src/arbitrary.rs
@@ -14,7 +14,7 @@ impl<'a, T: arbitrary::Arbitrary<'a> + CoordFloat> arbitrary::Arbitrary<'a> for 
 
 impl<'a, T: arbitrary::Arbitrary<'a> + CoordFloat> arbitrary::Arbitrary<'a> for Point<T> {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        u.arbitrary::<Coordinate<T>>().map(Point)
+        u.arbitrary::<Coordinate<T>>().map(Self)
     }
 }
 
@@ -26,7 +26,7 @@ impl<'a, T: arbitrary::Arbitrary<'a> + CoordFloat> arbitrary::Arbitrary<'a> for 
             return Err(arbitrary::Error::IncorrectFormat);
         }
 
-        Ok(LineString(coords))
+        Ok(Self(coords))
     }
 
     fn size_hint(_depth: usize) -> (usize, Option<usize>) {
@@ -45,19 +45,19 @@ impl<'a, T: arbitrary::Arbitrary<'a> + CoordFloat> arbitrary::Arbitrary<'a> for 
 
 impl<'a, T: arbitrary::Arbitrary<'a> + CoordFloat> arbitrary::Arbitrary<'a> for MultiPoint<T> {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        u.arbitrary::<Vec<Point<T>>>().map(MultiPoint)
+        u.arbitrary::<Vec<Point<T>>>().map(Self)
     }
 }
 
 impl<'a, T: arbitrary::Arbitrary<'a> + CoordFloat> arbitrary::Arbitrary<'a> for MultiLineString<T> {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        u.arbitrary::<Vec<LineString<T>>>().map(MultiLineString)
+        u.arbitrary::<Vec<LineString<T>>>().map(Self)
     }
 }
 
 impl<'a, T: arbitrary::Arbitrary<'a> + CoordFloat> arbitrary::Arbitrary<'a> for MultiPolygon<T> {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        u.arbitrary::<Vec<Polygon<T>>>().map(MultiPolygon)
+        u.arbitrary::<Vec<Polygon<T>>>().map(Self)
     }
 }
 
@@ -80,7 +80,7 @@ impl<'a, T: arbitrary::Arbitrary<'a> + CoordFloat> arbitrary::Arbitrary<'a> for 
 
 impl<'a, T: arbitrary::Arbitrary<'a> + CoordFloat> arbitrary::Arbitrary<'a> for Triangle<T> {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        Ok(Triangle(
+        Ok(Self(
             u.arbitrary::<Coordinate<T>>()?,
             u.arbitrary::<Coordinate<T>>()?,
             u.arbitrary::<Coordinate<T>>()?,

--- a/geo-types/src/coordinate.rs
+++ b/geo-types/src/coordinate.rs
@@ -110,9 +110,9 @@ impl<T> Neg for Coordinate<T>
 where
     T: CoordNum + Neg<Output = T>,
 {
-    type Output = Coordinate<T>;
+    type Output = Self;
 
-    fn neg(self) -> Coordinate<T> {
+    fn neg(self) -> Self {
         (-self.x, -self.y).into()
     }
 }
@@ -132,9 +132,9 @@ where
 /// assert_eq!(sum.y, 5.0);
 /// ```
 impl<T: CoordNum> Add for Coordinate<T> {
-    type Output = Coordinate<T>;
+    type Output = Self;
 
-    fn add(self, rhs: Coordinate<T>) -> Coordinate<T> {
+    fn add(self, rhs: Self) -> Self {
         (self.x + rhs.x, self.y + rhs.y).into()
     }
 }
@@ -154,9 +154,9 @@ impl<T: CoordNum> Add for Coordinate<T> {
 /// assert_eq!(diff.y, 0.);
 /// ```
 impl<T: CoordNum> Sub for Coordinate<T> {
-    type Output = Coordinate<T>;
+    type Output = Self;
 
-    fn sub(self, rhs: Coordinate<T>) -> Coordinate<T> {
+    fn sub(self, rhs: Self) -> Self {
         (self.x - rhs.x, self.y - rhs.y).into()
     }
 }
@@ -175,9 +175,9 @@ impl<T: CoordNum> Sub for Coordinate<T> {
 /// assert_eq!(q.y, 10.0);
 /// ```
 impl<T: CoordNum> Mul<T> for Coordinate<T> {
-    type Output = Coordinate<T>;
+    type Output = Self;
 
-    fn mul(self, rhs: T) -> Coordinate<T> {
+    fn mul(self, rhs: T) -> Self {
         (self.x * rhs, self.y * rhs).into()
     }
 }
@@ -196,9 +196,9 @@ impl<T: CoordNum> Mul<T> for Coordinate<T> {
 /// assert_eq!(q.y, 2.5);
 /// ```
 impl<T: CoordNum> Div<T> for Coordinate<T> {
-    type Output = Coordinate<T>;
+    type Output = Self;
 
-    fn div(self, rhs: T) -> Coordinate<T> {
+    fn div(self, rhs: T) -> Self {
         (self.x / rhs, self.y / rhs).into()
     }
 }

--- a/geo-types/src/geometry.rs
+++ b/geo-types/src/geometry.rs
@@ -40,49 +40,49 @@ pub enum Geometry<T: CoordNum> {
 }
 
 impl<T: CoordNum> From<Point<T>> for Geometry<T> {
-    fn from(x: Point<T>) -> Geometry<T> {
+    fn from(x: Point<T>) -> Self {
         Geometry::Point(x)
     }
 }
 impl<T: CoordNum> From<Line<T>> for Geometry<T> {
-    fn from(x: Line<T>) -> Geometry<T> {
+    fn from(x: Line<T>) -> Self {
         Geometry::Line(x)
     }
 }
 impl<T: CoordNum> From<LineString<T>> for Geometry<T> {
-    fn from(x: LineString<T>) -> Geometry<T> {
+    fn from(x: LineString<T>) -> Self {
         Geometry::LineString(x)
     }
 }
 impl<T: CoordNum> From<Polygon<T>> for Geometry<T> {
-    fn from(x: Polygon<T>) -> Geometry<T> {
+    fn from(x: Polygon<T>) -> Self {
         Geometry::Polygon(x)
     }
 }
 impl<T: CoordNum> From<MultiPoint<T>> for Geometry<T> {
-    fn from(x: MultiPoint<T>) -> Geometry<T> {
+    fn from(x: MultiPoint<T>) -> Self {
         Geometry::MultiPoint(x)
     }
 }
 impl<T: CoordNum> From<MultiLineString<T>> for Geometry<T> {
-    fn from(x: MultiLineString<T>) -> Geometry<T> {
+    fn from(x: MultiLineString<T>) -> Self {
         Geometry::MultiLineString(x)
     }
 }
 impl<T: CoordNum> From<MultiPolygon<T>> for Geometry<T> {
-    fn from(x: MultiPolygon<T>) -> Geometry<T> {
+    fn from(x: MultiPolygon<T>) -> Self {
         Geometry::MultiPolygon(x)
     }
 }
 
 impl<T: CoordNum> From<Rect<T>> for Geometry<T> {
-    fn from(x: Rect<T>) -> Geometry<T> {
+    fn from(x: Rect<T>) -> Self {
         Geometry::Rect(x)
     }
 }
 
 impl<T: CoordNum> From<Triangle<T>> for Geometry<T> {
-    fn from(x: Triangle<T>) -> Geometry<T> {
+    fn from(x: Triangle<T>) -> Self {
         Geometry::Triangle(x)
     }
 }

--- a/geo-types/src/geometry_collection.rs
+++ b/geo-types/src/geometry_collection.rs
@@ -77,13 +77,13 @@ pub struct GeometryCollection<T: CoordNum>(pub Vec<Geometry<T>>);
 // todo: consider adding Default as a CoordNum requirement
 impl<T: CoordNum> Default for GeometryCollection<T> {
     fn default() -> Self {
-        GeometryCollection(Vec::new())
+        Self(Vec::new())
     }
 }
 
 impl<T: CoordNum> GeometryCollection<T> {
     /// Return an empty GeometryCollection
-    pub fn new() -> GeometryCollection<T> {
+    pub fn new() -> Self {
         GeometryCollection::default()
     }
 
@@ -102,14 +102,14 @@ impl<T: CoordNum> GeometryCollection<T> {
 /// GeometryCollection
 impl<T: CoordNum, IG: Into<Geometry<T>>> From<IG> for GeometryCollection<T> {
     fn from(x: IG) -> Self {
-        GeometryCollection(vec![x.into()])
+        Self(vec![x.into()])
     }
 }
 
 /// Collect Geometries (or what can be converted to a Geometry) into a GeometryCollection
 impl<T: CoordNum, IG: Into<Geometry<T>>> FromIterator<IG> for GeometryCollection<T> {
     fn from_iter<I: IntoIterator<Item = IG>>(iter: I) -> Self {
-        GeometryCollection(iter.into_iter().map(|g| g.into()).collect())
+        Self(iter.into_iter().map(|g| g.into()).collect())
     }
 }
 

--- a/geo-types/src/line.rs
+++ b/geo-types/src/line.rs
@@ -29,11 +29,11 @@ impl<T: CoordNum> Line<T> {
     /// assert_eq!(line.start, coord! { x: 0., y: 0. });
     /// assert_eq!(line.end, coord! { x: 1., y: 2. });
     /// ```
-    pub fn new<C>(start: C, end: C) -> Line<T>
+    pub fn new<C>(start: C, end: C) -> Self
     where
         C: Into<Coordinate<T>>,
     {
-        Line {
+        Self {
             start: start.into(),
             end: end.into(),
         }
@@ -156,7 +156,7 @@ impl<T: CoordNum> Line<T> {
 }
 
 impl<T: CoordNum> From<[(T, T); 2]> for Line<T> {
-    fn from(coord: [(T, T); 2]) -> Line<T> {
+    fn from(coord: [(T, T); 2]) -> Self {
         Line::new(coord[0], coord[1])
     }
 }

--- a/geo-types/src/line_string.rs
+++ b/geo-types/src/line_string.rs
@@ -333,20 +333,20 @@ impl<T: CoordNum> LineString<T> {
 /// Turn a [`Vec`] of [`Point`]-like objects into a [`LineString`].
 impl<T: CoordNum, IC: Into<Coordinate<T>>> From<Vec<IC>> for LineString<T> {
     fn from(v: Vec<IC>) -> Self {
-        LineString(v.into_iter().map(|c| c.into()).collect())
+        Self(v.into_iter().map(|c| c.into()).collect())
     }
 }
 
 impl<T: CoordNum> From<Line<T>> for LineString<T> {
     fn from(line: Line<T>) -> Self {
-        LineString(vec![line.start, line.end])
+        Self(vec![line.start, line.end])
     }
 }
 
 /// Turn an iterator of [`Point`]-like objects into a [`LineString`].
 impl<T: CoordNum, IC: Into<Coordinate<T>>> FromIterator<IC> for LineString<T> {
     fn from_iter<I: IntoIterator<Item = IC>>(iter: I) -> Self {
-        LineString(iter.into_iter().map(|c| c.into()).collect())
+        Self(iter.into_iter().map(|c| c.into()).collect())
     }
 }
 

--- a/geo-types/src/multi_line_string.rs
+++ b/geo-types/src/multi_line_string.rs
@@ -64,13 +64,13 @@ impl<T: CoordNum> MultiLineString<T> {
 
 impl<T: CoordNum, ILS: Into<LineString<T>>> From<ILS> for MultiLineString<T> {
     fn from(ls: ILS) -> Self {
-        MultiLineString(vec![ls.into()])
+        Self(vec![ls.into()])
     }
 }
 
 impl<T: CoordNum, ILS: Into<LineString<T>>> FromIterator<ILS> for MultiLineString<T> {
     fn from_iter<I: IntoIterator<Item = ILS>>(iter: I) -> Self {
-        MultiLineString(iter.into_iter().map(|ls| ls.into()).collect())
+        Self(iter.into_iter().map(|ls| ls.into()).collect())
     }
 }
 

--- a/geo-types/src/multi_point.rs
+++ b/geo-types/src/multi_point.rs
@@ -35,23 +35,23 @@ pub struct MultiPoint<T: CoordNum>(pub Vec<Point<T>>);
 impl<T: CoordNum, IP: Into<Point<T>>> From<IP> for MultiPoint<T> {
     /// Convert a single `Point` (or something which can be converted to a `Point`) into a
     /// one-member `MultiPoint`
-    fn from(x: IP) -> MultiPoint<T> {
-        MultiPoint(vec![x.into()])
+    fn from(x: IP) -> Self {
+        Self(vec![x.into()])
     }
 }
 
 impl<T: CoordNum, IP: Into<Point<T>>> From<Vec<IP>> for MultiPoint<T> {
     /// Convert a `Vec` of `Points` (or `Vec` of things which can be converted to a `Point`) into a
     /// `MultiPoint`.
-    fn from(v: Vec<IP>) -> MultiPoint<T> {
-        MultiPoint(v.into_iter().map(|p| p.into()).collect())
+    fn from(v: Vec<IP>) -> Self {
+        Self(v.into_iter().map(|p| p.into()).collect())
     }
 }
 
 impl<T: CoordNum, IP: Into<Point<T>>> FromIterator<IP> for MultiPoint<T> {
     /// Collect the results of a `Point` iterator into a `MultiPoint`
     fn from_iter<I: IntoIterator<Item = IP>>(iter: I) -> Self {
-        MultiPoint(iter.into_iter().map(|p| p.into()).collect())
+        Self(iter.into_iter().map(|p| p.into()).collect())
     }
 }
 

--- a/geo-types/src/multi_polygon.rs
+++ b/geo-types/src/multi_polygon.rs
@@ -31,19 +31,19 @@ pub struct MultiPolygon<T: CoordNum>(pub Vec<Polygon<T>>);
 
 impl<T: CoordNum, IP: Into<Polygon<T>>> From<IP> for MultiPolygon<T> {
     fn from(x: IP) -> Self {
-        MultiPolygon(vec![x.into()])
+        Self(vec![x.into()])
     }
 }
 
 impl<T: CoordNum, IP: Into<Polygon<T>>> From<Vec<IP>> for MultiPolygon<T> {
     fn from(x: Vec<IP>) -> Self {
-        MultiPolygon(x.into_iter().map(|p| p.into()).collect())
+        Self(x.into_iter().map(|p| p.into()).collect())
     }
 }
 
 impl<T: CoordNum, IP: Into<Polygon<T>>> FromIterator<IP> for MultiPolygon<T> {
     fn from_iter<I: IntoIterator<Item = IP>>(iter: I) -> Self {
-        MultiPolygon(iter.into_iter().map(|p| p.into()).collect())
+        Self(iter.into_iter().map(|p| p.into()).collect())
     }
 }
 

--- a/geo-types/src/point.rs
+++ b/geo-types/src/point.rs
@@ -31,19 +31,19 @@ use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssi
 pub struct Point<T: CoordNum>(pub Coordinate<T>);
 
 impl<T: CoordNum> From<Coordinate<T>> for Point<T> {
-    fn from(x: Coordinate<T>) -> Point<T> {
+    fn from(x: Coordinate<T>) -> Self {
         Point(x)
     }
 }
 
 impl<T: CoordNum> From<(T, T)> for Point<T> {
-    fn from(coords: (T, T)) -> Point<T> {
+    fn from(coords: (T, T)) -> Self {
         Point::new(coords.0, coords.1)
     }
 }
 
 impl<T: CoordNum> From<[T; 2]> for Point<T> {
-    fn from(coords: [T; 2]) -> Point<T> {
+    fn from(coords: [T; 2]) -> Self {
         Point::new(coords[0], coords[1])
     }
 }
@@ -73,7 +73,7 @@ impl<T: CoordNum> Point<T> {
     /// assert_eq!(p.x(), 1.234);
     /// assert_eq!(p.y(), 2.345);
     /// ```
-    pub fn new(x: T, y: T) -> Point<T> {
+    pub fn new(x: T, y: T) -> Self {
         point! { x: x, y: y }
     }
 
@@ -104,7 +104,7 @@ impl<T: CoordNum> Point<T> {
     ///
     /// assert_eq!(p.x(), 9.876);
     /// ```
-    pub fn set_x(&mut self, x: T) -> &mut Point<T> {
+    pub fn set_x(&mut self, x: T) -> &mut Self {
         self.0.x = x;
         self
     }
@@ -136,7 +136,7 @@ impl<T: CoordNum> Point<T> {
     ///
     /// assert_eq!(p.y(), 9.876);
     /// ```
-    pub fn set_y(&mut self, y: T) -> &mut Point<T> {
+    pub fn set_y(&mut self, y: T) -> &mut Self {
         self.0.y = y;
         self
     }
@@ -187,7 +187,7 @@ impl<T: CoordNum> Point<T> {
     /// assert_eq!(p.x(), 9.876);
     /// ```
     #[deprecated = "use `Point::set_x` instead, it's less ambiguous"]
-    pub fn set_lng(&mut self, lng: T) -> &mut Point<T> {
+    pub fn set_lng(&mut self, lng: T) -> &mut Self {
         self.set_x(lng)
     }
 
@@ -220,7 +220,7 @@ impl<T: CoordNum> Point<T> {
     /// assert_eq!(p.y(), 9.876);
     /// ```
     #[deprecated = "use `Point::set_y` instead, it's less ambiguous"]
-    pub fn set_lat(&mut self, lat: T) -> &mut Point<T> {
+    pub fn set_lat(&mut self, lat: T) -> &mut Self {
         self.set_y(lat)
     }
 }
@@ -239,7 +239,7 @@ impl<T: CoordNum> Point<T> {
     ///
     /// assert_eq!(dot, 5.25);
     /// ```
-    pub fn dot(self, other: Point<T>) -> T {
+    pub fn dot(self, other: Self) -> T {
         self.x() * other.x() + self.y() * other.y()
     }
 
@@ -260,7 +260,7 @@ impl<T: CoordNum> Point<T> {
     ///
     /// assert_eq!(cross, 2.0)
     /// ```
-    pub fn cross_prod(self, point_b: Point<T>, point_c: Point<T>) -> T {
+    pub fn cross_prod(self, point_b: Self, point_c: Self) -> T {
         (point_b.x() - self.x()) * (point_c.y() - self.y())
             - (point_b.y() - self.y()) * (point_c.x() - self.x())
     }
@@ -278,7 +278,7 @@ impl<T: CoordFloat> Point<T> {
     /// assert_eq!(x.round(), 71.0);
     /// assert_eq!(y.round(), 134.0);
     /// ```
-    pub fn to_degrees(self) -> Point<T> {
+    pub fn to_degrees(self) -> Self {
         let (x, y) = self.x_y();
         let x = x.to_degrees();
         let y = y.to_degrees();
@@ -296,7 +296,7 @@ impl<T: CoordFloat> Point<T> {
     /// assert_eq!(x.round(), 3.0);
     /// assert_eq!(y.round(), 6.0);
     /// ```
-    pub fn to_radians(self) -> Point<T> {
+    pub fn to_radians(self) -> Self {
         let (x, y) = self.x_y();
         let x = x.to_radians();
         let y = y.to_radians();
@@ -308,7 +308,7 @@ impl<T> Neg for Point<T>
 where
     T: CoordNum + Neg<Output = T>,
 {
-    type Output = Point<T>;
+    type Output = Self;
 
     /// Returns a point with the x and y components negated.
     ///
@@ -322,13 +322,13 @@ where
     /// assert_eq!(p.x(), 1.25);
     /// assert_eq!(p.y(), -2.5);
     /// ```
-    fn neg(self) -> Point<T> {
+    fn neg(self) -> Self::Output {
         Point(-self.0)
     }
 }
 
 impl<T: CoordNum> Add for Point<T> {
-    type Output = Point<T>;
+    type Output = Self;
 
     /// Add a point to the given point.
     ///
@@ -342,7 +342,7 @@ impl<T: CoordNum> Add for Point<T> {
     /// assert_eq!(p.x(), 2.75);
     /// assert_eq!(p.y(), 5.0);
     /// ```
-    fn add(self, rhs: Point<T>) -> Point<T> {
+    fn add(self, rhs: Self) -> Self::Output {
         Point(self.0 + rhs.0)
     }
 }
@@ -361,13 +361,13 @@ impl<T: CoordNum> AddAssign for Point<T> {
     /// assert_eq!(p.x(), 2.75);
     /// assert_eq!(p.y(), 5.0);
     /// ```
-    fn add_assign(&mut self, rhs: Point<T>) {
+    fn add_assign(&mut self, rhs: Self) {
         self.0 = self.0 + rhs.0;
     }
 }
 
 impl<T: CoordNum> Sub for Point<T> {
-    type Output = Point<T>;
+    type Output = Self;
 
     /// Subtract a point from the given point.
     ///
@@ -381,7 +381,7 @@ impl<T: CoordNum> Sub for Point<T> {
     /// assert_eq!(p.x(), -0.25);
     /// assert_eq!(p.y(), 0.5);
     /// ```
-    fn sub(self, rhs: Point<T>) -> Point<T> {
+    fn sub(self, rhs: Self) -> Self::Output {
         Point(self.0 - rhs.0)
     }
 }
@@ -400,13 +400,13 @@ impl<T: CoordNum> SubAssign for Point<T> {
     /// assert_eq!(p.x(), -0.25);
     /// assert_eq!(p.y(), 0.0);
     /// ```
-    fn sub_assign(&mut self, rhs: Point<T>) {
+    fn sub_assign(&mut self, rhs: Self) {
         self.0 = self.0 - rhs.0;
     }
 }
 
 impl<T: CoordNum> Mul<T> for Point<T> {
-    type Output = Point<T>;
+    type Output = Self;
 
     /// Scaler multiplication of a point
     ///
@@ -420,7 +420,7 @@ impl<T: CoordNum> Mul<T> for Point<T> {
     /// assert_eq!(p.x(), 4.0);
     /// assert_eq!(p.y(), 6.0);
     /// ```
-    fn mul(self, rhs: T) -> Point<T> {
+    fn mul(self, rhs: T) -> Self::Output {
         Point(self.0 * rhs)
     }
 }
@@ -445,7 +445,7 @@ impl<T: CoordNum> MulAssign<T> for Point<T> {
 }
 
 impl<T: CoordNum> Div<T> for Point<T> {
-    type Output = Point<T>;
+    type Output = Self;
 
     /// Scaler division of a point
     ///
@@ -459,7 +459,7 @@ impl<T: CoordNum> Div<T> for Point<T> {
     /// assert_eq!(p.x(), 1.0);
     /// assert_eq!(p.y(), 1.5);
     /// ```
-    fn div(self, rhs: T) -> Point<T> {
+    fn div(self, rhs: T) -> Self::Output {
         Point(self.0 / rhs)
     }
 }

--- a/geo-types/src/polygon.rs
+++ b/geo-types/src/polygon.rs
@@ -122,12 +122,12 @@ impl<T: CoordNum> Polygon<T> {
     ///     &LineString::from(vec![(0., 0.), (1., 1.), (1., 0.), (0., 0.),])
     /// );
     /// ```
-    pub fn new(mut exterior: LineString<T>, mut interiors: Vec<LineString<T>>) -> Polygon<T> {
+    pub fn new(mut exterior: LineString<T>, mut interiors: Vec<LineString<T>>) -> Self {
         exterior.close();
         for interior in &mut interiors {
             interior.close();
         }
-        Polygon {
+        Self {
             exterior,
             interiors,
         }
@@ -440,7 +440,7 @@ impl<T: CoordFloat + Signed> Polygon<T> {
 }
 
 impl<T: CoordNum> From<Rect<T>> for Polygon<T> {
-    fn from(r: Rect<T>) -> Polygon<T> {
+    fn from(r: Rect<T>) -> Self {
         Polygon::new(
             vec![
                 (r.min().x, r.min().y),
@@ -456,7 +456,7 @@ impl<T: CoordNum> From<Rect<T>> for Polygon<T> {
 }
 
 impl<T: CoordNum> From<Triangle<T>> for Polygon<T> {
-    fn from(t: Triangle<T>) -> Polygon<T> {
+    fn from(t: Triangle<T>) -> Self {
         Polygon::new(vec![t.0, t.1, t.2, t.0].into(), Vec::new())
     }
 }

--- a/geo-types/src/triangle.rs
+++ b/geo-types/src/triangle.rs
@@ -53,8 +53,8 @@ impl<T: CoordNum> Triangle<T> {
 }
 
 impl<IC: Into<Coordinate<T>> + Copy, T: CoordNum> From<[IC; 3]> for Triangle<T> {
-    fn from(array: [IC; 3]) -> Triangle<T> {
-        Triangle(array[0].into(), array[1].into(), array[2].into())
+    fn from(array: [IC; 3]) -> Self {
+        Self(array[0].into(), array[1].into(), array[2].into())
     }
 }
 


### PR DESCRIPTION
The `Self` keyword should (in theory) make it easier to maintain a more generic code, especially if we migrate to 3d+m support.

* Replace return types with `-> Self`
* Replace some tuple constructors with `Self(x)`
* Replace where appropriate `type Output = Self;`

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- ~[ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.~
---
