### PR TITLE
Use `Point::from(c)` instead of `Point(c)`

### DIFF
--- a/geo-types/src/lib.rs
+++ b/geo-types/src/lib.rs
@@ -145,7 +145,7 @@ mod tests {
             y: 116.34,
         };
 
-        let p = Point(c);
+        let p = Point::from(c);
 
         let Point(c2) = p;
         assert_eq!(c, c2);

--- a/geo-types/src/line.rs
+++ b/geo-types/src/line.rs
@@ -143,11 +143,11 @@ impl<T: CoordNum> Line<T> {
     }
 
     pub fn start_point(&self) -> Point<T> {
-        Point(self.start)
+        Point::from(self.start)
     }
 
     pub fn end_point(&self) -> Point<T> {
-        Point(self.end)
+        Point::from(self.end)
     }
 
     pub fn points(&self) -> (Point<T>, Point<T>) {

--- a/geo-types/src/line_string.rs
+++ b/geo-types/src/line_string.rs
@@ -142,7 +142,7 @@ impl<'a, T: CoordNum> Iterator for PointsIter<'a, T> {
     type Item = Point<T>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().map(|c| Point(*c))
+        self.0.next().map(|c| Point::from(*c))
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -158,7 +158,7 @@ impl<'a, T: CoordNum> ExactSizeIterator for PointsIter<'a, T> {
 
 impl<'a, T: CoordNum> DoubleEndedIterator for PointsIter<'a, T> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.0.next_back().map(|c| Point(*c))
+        self.0.next_back().map(|c| Point::from(*c))
     }
 }
 
@@ -214,7 +214,7 @@ impl<T: CoordNum> LineString<T> {
 
     /// Return the coordinates of a [`LineString`] as a [`Vec`] of [`Point`]s
     pub fn into_points(self) -> Vec<Point<T>> {
-        self.0.into_iter().map(Point).collect()
+        self.0.into_iter().map(Point::from).collect()
     }
 
     /// Return the coordinates of a [`LineString`] as a [`Vec`] of [`Coordinate`]s

--- a/geo-types/src/macros.rs
+++ b/geo-types/src/macros.rs
@@ -23,7 +23,7 @@
 #[macro_export]
 macro_rules! point {
     ( $($tag:tt : $val:expr),* $(,)? ) => {
-        $crate::Point ( $crate::coord! { $( $tag: $val , )* } )
+        $crate::Point::from( $crate::coord! { $( $tag: $val , )* } )
     };
 }
 

--- a/geo-types/src/point.rs
+++ b/geo-types/src/point.rs
@@ -323,7 +323,7 @@ where
     /// assert_eq!(p.y(), -2.5);
     /// ```
     fn neg(self) -> Self::Output {
-        Point(-self.0)
+        Point::from(-self.0)
     }
 }
 
@@ -343,7 +343,7 @@ impl<T: CoordNum> Add for Point<T> {
     /// assert_eq!(p.y(), 5.0);
     /// ```
     fn add(self, rhs: Self) -> Self::Output {
-        Point(self.0 + rhs.0)
+        Point::from(self.0 + rhs.0)
     }
 }
 
@@ -382,7 +382,7 @@ impl<T: CoordNum> Sub for Point<T> {
     /// assert_eq!(p.y(), 0.5);
     /// ```
     fn sub(self, rhs: Self) -> Self::Output {
-        Point(self.0 - rhs.0)
+        Point::from(self.0 - rhs.0)
     }
 }
 
@@ -421,7 +421,7 @@ impl<T: CoordNum> Mul<T> for Point<T> {
     /// assert_eq!(p.y(), 6.0);
     /// ```
     fn mul(self, rhs: T) -> Self::Output {
-        Point(self.0 * rhs)
+        Point::from(self.0 * rhs)
     }
 }
 
@@ -460,7 +460,7 @@ impl<T: CoordNum> Div<T> for Point<T> {
     /// assert_eq!(p.y(), 1.5);
     /// ```
     fn div(self, rhs: T) -> Self::Output {
-        Point(self.0 / rhs)
+        Point::from(self.0 / rhs)
     }
 }
 

--- a/geo-types/src/polygon.rs
+++ b/geo-types/src/polygon.rs
@@ -424,8 +424,10 @@ impl<T: CoordFloat + Signed> Polygon<T> {
             .map(|(idx, _)| {
                 let prev_1 = self.previous_vertex(idx);
                 let prev_2 = self.previous_vertex(prev_1);
-                Point(self.exterior[prev_2])
-                    .cross_prod(Point(self.exterior[prev_1]), Point(self.exterior[idx]))
+                Point::from(self.exterior[prev_2]).cross_prod(
+                    Point::from(self.exterior[prev_1]),
+                    Point::from(self.exterior[idx]),
+                )
             })
             // accumulate and check cross-product result signs in a single pass
             // positive implies ccw convexity, negative implies cw convexity

--- a/geo-types/src/private_utils.rs
+++ b/geo-types/src/private_utils.rs
@@ -132,7 +132,7 @@ where
     }
     // LineString with one point equal p
     if line_string.0.len() == 1 {
-        return point_contains_point(Point(line_string[0]), point);
+        return point_contains_point(Point::from(line_string[0]), point);
     }
     // check if point is a vertex
     if line_string.0.contains(&point.0) {

--- a/geo/src/algorithm/centroid.rs
+++ b/geo/src/algorithm/centroid.rs
@@ -221,7 +221,7 @@ impl<T: GeoFloat> CentroidOperation<T> {
 
     fn centroid(&self) -> Option<Point<T>> {
         self.0.as_ref().map(|weighted_centroid| {
-            Point(weighted_centroid.accumulated / weighted_centroid.weight)
+            Point::from(weighted_centroid.accumulated / weighted_centroid.weight)
         })
     }
 
@@ -493,7 +493,7 @@ mod test {
         };
         let linestring = line_string![coord];
         let centroid = linestring.centroid();
-        assert_eq!(centroid, Some(Point(coord)));
+        assert_eq!(centroid, Some(Point::from(coord)));
     }
     #[test]
     fn linestring_test() {
@@ -540,7 +540,7 @@ mod test {
             line_string![coord],
             line_string![coord],
         ]);
-        assert_relative_eq!(mls.centroid().unwrap(), Point(coord));
+        assert_relative_eq!(mls.centroid().unwrap(), Point::from(coord));
     }
     #[test]
     fn multilinestring_one_line_test() {

--- a/geo/src/algorithm/closest_point.rs
+++ b/geo/src/algorithm/closest_point.rs
@@ -64,8 +64,8 @@ impl<F: GeoFloat> ClosestPoint<F> for Line<F> {
         //
         // Line equation: P = start + t * (end - start)
 
-        let direction_vector = Point(self.end - self.start);
-        let to_p = Point(p.0 - self.start);
+        let direction_vector = Point::from(self.end - self.start);
+        let to_p = Point::from(p.0 - self.start);
 
         let t = to_p.dot(direction_vector) / direction_vector.dot(direction_vector);
 
@@ -78,7 +78,7 @@ impl<F: GeoFloat> ClosestPoint<F> for Line<F> {
 
         let x = direction_vector.x();
         let y = direction_vector.y();
-        let c = Point(self.start + (t * x, t * y).into());
+        let c = Point::from(self.start + (t * x, t * y).into());
 
         if self.intersects(p) {
             Closest::Intersection(c)
@@ -131,7 +131,7 @@ impl<F: GeoFloat> ClosestPoint<F> for Polygon<F> {
 
 impl<F: GeoFloat> ClosestPoint<F> for Coordinate<F> {
     fn closest_point(&self, p: &Point<F>) -> Closest<F> {
-        Point(*self).closest_point(p)
+        Point::from(*self).closest_point(p)
     }
 }
 

--- a/geo/src/algorithm/contains/mod.rs
+++ b/geo/src/algorithm/contains/mod.rs
@@ -324,9 +324,9 @@ mod test {
         let line2 = Line::new(c(0., 6.), c(1.5, 4.5));
         // point on line
         let line3 = Line::new(c(0., 6.), c(3., 3.));
-        assert!(line1.contains(&Point(p0)));
-        assert!(!line2.contains(&Point(p0)));
-        assert!(line3.contains(&Point(p0)));
+        assert!(line1.contains(&Point::from(p0)));
+        assert!(!line2.contains(&Point::from(p0)));
+        assert!(line3.contains(&Point::from(p0)));
     }
     #[test]
     fn line_in_line_test() {

--- a/geo/src/algorithm/euclidean_distance.rs
+++ b/geo/src/algorithm/euclidean_distance.rs
@@ -249,7 +249,7 @@ where
 {
     /// Minimum distance from a `Line` to a `Coordinate`
     fn euclidean_distance(&self, coord: &Coordinate<T>) -> T {
-        ::geo_types::private_utils::point_line_euclidean_distance(Point(*coord), *self)
+        ::geo_types::private_utils::point_line_euclidean_distance(Point::from(*coord), *self)
     }
 }
 
@@ -387,7 +387,9 @@ where
     fn euclidean_distance(&self, other: &Polygon<T>) -> T {
         if self.intersects(other) || other.contains(self) {
             T::zero()
-        } else if !other.interiors().is_empty() && ring_contains_point(other, Point(self.0[0])) {
+        } else if !other.interiors().is_empty()
+            && ring_contains_point(other, Point::from(self.0[0]))
+        {
             // check each ring distance, returning the minimum
             let mut mindist: T = Float::max_value();
             for ring in other.interiors() {
@@ -461,7 +463,9 @@ where
             return T::zero();
         }
         // Containment check
-        if !self.interiors().is_empty() && ring_contains_point(self, Point(poly2.exterior().0[0])) {
+        if !self.interiors().is_empty()
+            && ring_contains_point(self, Point::from(poly2.exterior().0[0]))
+        {
             // check each ring distance, returning the minimum
             let mut mindist: T = Float::max_value();
             for ring in self.interiors() {
@@ -469,7 +473,7 @@ where
             }
             return mindist;
         } else if !poly2.interiors().is_empty()
-            && ring_contains_point(poly2, Point(self.exterior().0[0]))
+            && ring_contains_point(poly2, Point::from(self.exterior().0[0]))
         {
             let mut mindist: T = Float::max_value();
             for ring in poly2.interiors() {

--- a/geo/src/algorithm/polygon_distance_fast_path.rs
+++ b/geo/src/algorithm/polygon_distance_fast_path.rs
@@ -16,8 +16,8 @@ where
 {
     let poly1_extremes = poly1.extremes().unwrap();
     let poly2_extremes = poly2.extremes().unwrap();
-    let ymin1 = Point(poly1.exterior().0[poly1_extremes.y_min.index]);
-    let ymax2 = Point(poly2.exterior().0[poly2_extremes.y_max.index]);
+    let ymin1 = Point::from(poly1.exterior().0[poly1_extremes.y_min.index]);
+    let ymax2 = Point::from(poly2.exterior().0[poly2_extremes.y_max.index]);
 
     let mut state = Polydist {
         poly1,
@@ -129,7 +129,7 @@ where
     let mut sin;
     let pnext = poly.exterior().0[next_vertex(poly, idx)];
     let pprev = poly.exterior().0[prev_vertex(poly, idx)];
-    let clockwise = Point(pprev).cross_prod(Point(p.0), Point(pnext)) < T::zero();
+    let clockwise = Point::from(pprev).cross_prod(Point::from(p.0), Point::from(pnext)) < T::zero();
     let slope_prev;
     let slope_next;
     // Slope isn't 0, things are complicated
@@ -323,7 +323,7 @@ where
     let hundred = T::from(100).unwrap();
     let pnext = poly.exterior().0[next_vertex(poly, idx)];
     let pprev = poly.exterior().0[prev_vertex(poly, idx)];
-    let clockwise = Point(pprev).cross_prod(Point(p.0), Point(pnext)) < T::zero();
+    let clockwise = Point::from(pprev).cross_prod(Point::from(p.0), Point::from(pnext)) < T::zero();
     let punit;
     if !vertical {
         punit = unitvector(m, poly, p, idx);
@@ -360,8 +360,8 @@ where
         // implies p.x() < pprev.x()
         punit = Point::new(p.x(), p.y() - hundred);
     }
-    let triarea = Triangle::from([p, punit, Point(pnext)]).signed_area();
-    let edgelen = p.euclidean_distance(&Point(pnext));
+    let triarea = Triangle::from([p, punit, Point::from(pnext)]).signed_area();
+    let edgelen = p.euclidean_distance(&Point::from(pnext));
     let mut sine = triarea / (T::from(0.5).unwrap() * T::from(100).unwrap() * edgelen);
     if sine < -T::one() || sine > T::one() {
         sine = T::one();
@@ -369,7 +369,7 @@ where
     let angle;
     let perpunit = unitpvector(p, punit);
     let mut obtuse = false;
-    let left = leftturn(p, perpunit, Point(pnext));
+    let left = leftturn(p, perpunit, Point::from(pnext));
     if left == 0 {
         obtuse = true;
     }
@@ -453,14 +453,14 @@ where
     if (state.ap1 - minangle).abs() < T::from(0.002).unwrap() {
         state.ip1 = true;
         let p1next = next_vertex(state.poly1, state.p1_idx);
-        state.p1next = Point(state.poly1.exterior().0[p1next]);
+        state.p1next = Point::from(state.poly1.exterior().0[p1next]);
         state.p1_idx = p1next;
         state.alignment = Some(AlignedEdge::VertexP);
     }
     if (state.aq2 - minangle).abs() < T::from(0.002).unwrap() {
         state.iq2 = true;
         let q2next = next_vertex(state.poly2, state.q2_idx);
-        state.q2next = Point(state.poly2.exterior().0[q2next]);
+        state.q2next = Point::from(state.poly2.exterior().0[q2next]);
         state.q2_idx = q2next;
         state.alignment = match state.alignment {
             None => Some(AlignedEdge::VertexQ),

--- a/geo/src/algorithm/simplifyvw.rs
+++ b/geo/src/algorithm/simplifyvw.rs
@@ -312,9 +312,9 @@ where
         adjacent[smallest.current as usize] = (0, 0);
         counter -= 1;
         // Remove stale segments from R* tree
-        let left_point = Point(orig.0[left as usize]);
-        let middle_point = Point(orig.0[smallest.current]);
-        let right_point = Point(orig.0[right as usize]);
+        let left_point = Point::from(orig.0[left as usize]);
+        let middle_point = Point::from(orig.0[smallest.current]);
+        let right_point = Point::from(orig.0[right as usize]);
 
         let line_1 = Line::new(left_point, middle_point);
         let line_2 = Line::new(middle_point, right_point);
@@ -410,7 +410,7 @@ where
                 && ca.0 != point_c
                 && cb.0 != point_a
                 && cb.0 != point_c
-                && cartesian_intersect(ca, cb, Point(point_a), Point(point_c))
+                && cartesian_intersect(ca, cb, Point::from(point_a), Point::from(point_c))
         })
 }
 


### PR DESCRIPTION
Per discussion in #775, use the static from() instead of tuple ctor.

This will simplify migration to a different base type because type aliases do not support tuple instantiation.

Note that unlike the other similar PRs with `::new(v)`, this one uses the existing `Point::from(v)` fn because it directly assigns consumed values instead of converting them, and because it already has a `Point::new(x, y)`

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- ~[ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.~
---

