### PR TITLE
Use `MultiPoint::new()` instead of `MultiPoint()`

### DIFF
--- a/geo-postgis/src/from_postgis.rs
+++ b/geo-postgis/src/from_postgis.rs
@@ -56,7 +56,7 @@ where
 {
     fn from_postgis(mp: &'a T) -> Self {
         let ret = mp.points().map(Point::from_postgis).collect();
-        MultiPoint(ret)
+        MultiPoint::new(ret)
     }
 }
 impl<'a, T> FromPostgis<&'a T> for MultiLineString<f64>

--- a/geo-types/src/multi_point.rs
+++ b/geo-types/src/multi_point.rs
@@ -84,6 +84,10 @@ impl<'a, T: CoordNum> IntoIterator for &'a mut MultiPoint<T> {
 }
 
 impl<T: CoordNum> MultiPoint<T> {
+    pub fn new(value: Vec<Point<T>>) -> Self {
+        Self(value)
+    }
+
     pub fn iter(&self) -> impl Iterator<Item = &Point<T>> {
         self.0.iter()
     }
@@ -111,8 +115,8 @@ where
     /// use geo_types::MultiPoint;
     /// use geo_types::point;
     ///
-    /// let a = MultiPoint(vec![point![x: 0., y: 0.], point![x: 10., y: 10.]]);
-    /// let b = MultiPoint(vec![point![x: 0., y: 0.], point![x: 10.001, y: 10.]]);
+    /// let a = MultiPoint::new(vec![point![x: 0., y: 0.], point![x: 10., y: 10.]]);
+    /// let b = MultiPoint::new(vec![point![x: 0., y: 0.], point![x: 10.001, y: 10.]]);
     ///
     /// approx::assert_relative_eq!(a, b, max_relative=0.1)
     /// ```
@@ -153,8 +157,8 @@ where
     /// use geo_types::MultiPoint;
     /// use geo_types::point;
     ///
-    /// let a = MultiPoint(vec![point![x: 0., y: 0.], point![x: 10., y: 10.]]);
-    /// let b = MultiPoint(vec![point![x: 0., y: 0.], point![x: 10.001, y: 10.]]);
+    /// let a = MultiPoint::new(vec![point![x: 0., y: 0.], point![x: 10., y: 10.]]);
+    /// let b = MultiPoint::new(vec![point![x: 0., y: 0.], point![x: 10.001, y: 10.]]);
     ///
     /// approx::abs_diff_eq!(a, b, epsilon=0.1);
     /// ```
@@ -176,7 +180,7 @@ mod test {
 
     #[test]
     fn test_iter() {
-        let multi = MultiPoint(vec![point![x: 0, y: 0], point![x: 10, y: 10]]);
+        let multi = MultiPoint::new(vec![point![x: 0, y: 0], point![x: 10, y: 10]]);
 
         let mut first = true;
         for p in &multi {
@@ -202,7 +206,7 @@ mod test {
 
     #[test]
     fn test_iter_mut() {
-        let mut multi = MultiPoint(vec![point![x: 0, y: 0], point![x: 10, y: 10]]);
+        let mut multi = MultiPoint::new(vec![point![x: 0, y: 0], point![x: 10, y: 10]]);
 
         for point in &mut multi {
             point.0.x += 1;
@@ -229,22 +233,22 @@ mod test {
     fn test_relative_eq() {
         let delta = 1e-6;
 
-        let multi = MultiPoint(vec![point![x: 0., y: 0.], point![x: 10., y: 10.]]);
+        let multi = MultiPoint::new(vec![point![x: 0., y: 0.], point![x: 10., y: 10.]]);
 
-        let multi_x = MultiPoint(vec![point![x: 0., y: 0.], point![x: 10.+delta, y: 10.]]);
+        let multi_x = MultiPoint::new(vec![point![x: 0., y: 0.], point![x: 10.+delta, y: 10.]]);
         assert!(multi.relative_eq(&multi_x, 1e-2, 1e-2));
         assert!(multi.relative_ne(&multi_x, 1e-12, 1e-12));
 
-        let multi_y = MultiPoint(vec![point![x: 0., y: 0.], point![x: 10., y: 10.+delta]]);
+        let multi_y = MultiPoint::new(vec![point![x: 0., y: 0.], point![x: 10., y: 10.+delta]]);
         assert!(multi.relative_eq(&multi_y, 1e-2, 1e-2));
         assert!(multi.relative_ne(&multi_y, 1e-12, 1e-12));
 
         // Under-sized but otherwise equal.
-        let multi_undersized = MultiPoint(vec![point![x: 0., y: 0.]]);
+        let multi_undersized = MultiPoint::new(vec![point![x: 0., y: 0.]]);
         assert!(multi.relative_ne(&multi_undersized, 1., 1.));
 
         // Over-sized but otherwise equal.
-        let multi_oversized = MultiPoint(vec![
+        let multi_oversized = MultiPoint::new(vec![
             point![x: 0., y: 0.],
             point![x: 10., y: 10.],
             point![x: 10., y:100.],
@@ -256,22 +260,22 @@ mod test {
     fn test_abs_diff_eq() {
         let delta = 1e-6;
 
-        let multi = MultiPoint(vec![point![x: 0., y: 0.], point![x: 10., y: 10.]]);
+        let multi = MultiPoint::new(vec![point![x: 0., y: 0.], point![x: 10., y: 10.]]);
 
-        let multi_x = MultiPoint(vec![point![x: 0., y: 0.], point![x: 10.+delta, y: 10.]]);
+        let multi_x = MultiPoint::new(vec![point![x: 0., y: 0.], point![x: 10.+delta, y: 10.]]);
         assert!(multi.abs_diff_eq(&multi_x, 1e-2));
         assert!(multi.abs_diff_ne(&multi_x, 1e-12));
 
-        let multi_y = MultiPoint(vec![point![x: 0., y: 0.], point![x: 10., y: 10.+delta]]);
+        let multi_y = MultiPoint::new(vec![point![x: 0., y: 0.], point![x: 10., y: 10.+delta]]);
         assert!(multi.abs_diff_eq(&multi_y, 1e-2));
         assert!(multi.abs_diff_ne(&multi_y, 1e-12));
 
         // Under-sized but otherwise equal.
-        let multi_undersized = MultiPoint(vec![point![x: 0., y: 0.]]);
+        let multi_undersized = MultiPoint::new(vec![point![x: 0., y: 0.]]);
         assert!(multi.abs_diff_ne(&multi_undersized, 1.));
 
         // Over-sized but otherwise equal.
-        let multi_oversized = MultiPoint(vec![
+        let multi_oversized = MultiPoint::new(vec![
             point![x: 0., y: 0.],
             point![x: 10., y: 10.],
             point![x: 10., y:100.],

--- a/geo/src/algorithm/centroid.rs
+++ b/geo/src/algorithm/centroid.rs
@@ -802,10 +802,11 @@ mod test {
         let p2 = point!(x: 2.0, y: 2.0);
         let p3 = point!(x: 0.0, y: 2.0);
 
-        let multi_point = MultiPoint(vec![p0, p1, p2, p3]);
+        let multi_point = MultiPoint::new(vec![p0, p1, p2, p3]);
         assert_eq!(multi_point.centroid().unwrap(), point!(x: 1.0, y: 1.0));
 
-        let collection = GeometryCollection(vec![MultiPoint(vec![p1, p2, p3]).into(), p0.into()]);
+        let collection =
+            GeometryCollection(vec![MultiPoint::new(vec![p1, p2, p3]).into(), p0.into()]);
 
         assert_eq!(collection.centroid().unwrap(), point!(x: 1.0, y: 1.0));
     }

--- a/geo/src/algorithm/convex_hull/test.rs
+++ b/geo/src/algorithm/convex_hull/test.rs
@@ -14,7 +14,7 @@ fn convex_hull_multipoint_test() {
         Point::new(-1, 1),
         Point::new(0, 10),
     ];
-    let mp = MultiPoint(v);
+    let mp = MultiPoint::new(v);
     let correct = vec![
         Coordinate::from((0, -10)),
         Coordinate::from((10, 0)),

--- a/geo/src/algorithm/coords_iter.rs
+++ b/geo/src/algorithm/coords_iter.rs
@@ -22,7 +22,7 @@ pub trait CoordsIter<'a> {
     /// ```
     /// use geo::coords_iter::CoordsIter;
     ///
-    /// let multi_point = geo::MultiPoint(vec![
+    /// let multi_point = geo::MultiPoint::new(vec![
     ///     geo::point!(x: -10., y: 0.),
     ///     geo::point!(x: 20., y: 20.),
     ///     geo::point!(x: 30., y: 40.),
@@ -684,7 +684,7 @@ mod test {
         expected_coords.append(&mut coords.clone());
         expected_coords.append(&mut coords);
 
-        let actual_coords = MultiPoint(vec![point, point])
+        let actual_coords = MultiPoint::new(vec![point, point])
             .coords_iter()
             .collect::<Vec<_>>();
 

--- a/geo/src/algorithm/euclidean_distance.rs
+++ b/geo/src/algorithm/euclidean_distance.rs
@@ -863,7 +863,7 @@ mod test {
             Point::new(-1.0, 1.0),
             Point::new(0.0, 10.0),
         ];
-        let mp = MultiPoint(v);
+        let mp = MultiPoint::new(v);
         let p = Point::new(50.0, 50.0);
         assert_relative_eq!(p.euclidean_distance(&mp), 64.03124237432849)
     }

--- a/geo/src/algorithm/extremes.rs
+++ b/geo/src/algorithm/extremes.rs
@@ -122,7 +122,7 @@ mod test {
 
     #[test]
     fn empty() {
-        let multi_point: MultiPoint<f32> = MultiPoint(vec![]);
+        let multi_point: MultiPoint<f32> = MultiPoint::new(vec![]);
 
         let actual = multi_point.extremes();
 

--- a/geo/src/algorithm/intersects/mod.rs
+++ b/geo/src/algorithm/intersects/mod.rs
@@ -543,7 +543,7 @@ mod test {
         );
         let geom = Geometry::Point(pt);
         let gc = GeometryCollection(vec![geom.clone()]);
-        let multi_point = MultiPoint(vec![pt]);
+        let multi_point = MultiPoint::new(vec![pt]);
         let multi_ls = MultiLineString(vec![ls.clone()]);
         let multi_poly = MultiPolygon(vec![poly.clone()]);
 

--- a/geo/src/algorithm/map_coords.rs
+++ b/geo/src/algorithm/map_coords.rs
@@ -317,7 +317,7 @@ impl<T: CoordNum, NT: CoordNum> MapCoords<T, NT> for MultiPoint<T> {
     type Output = MultiPoint<NT>;
 
     fn map_coords(&self, func: impl Fn(&(T, T)) -> (NT, NT) + Copy) -> Self::Output {
-        MultiPoint(self.iter().map(|p| p.map_coords(func)).collect())
+        MultiPoint::new(self.iter().map(|p| p.map_coords(func)).collect())
     }
 }
 
@@ -328,7 +328,7 @@ impl<T: CoordNum, NT: CoordNum, E> TryMapCoords<T, NT, E> for MultiPoint<T> {
         &self,
         func: impl Fn(&(T, T)) -> Result<(NT, NT), E> + Copy,
     ) -> Result<Self::Output, E> {
-        Ok(MultiPoint(
+        Ok(MultiPoint::new(
             self.0
                 .iter()
                 .map(|p| p.try_map_coords(func))
@@ -718,11 +718,11 @@ mod test {
     fn multipoint() {
         let p1 = Point::new(10., 10.);
         let p2 = Point::new(0., -100.);
-        let mp = MultiPoint(vec![p1, p2]);
+        let mp = MultiPoint::new(vec![p1, p2]);
 
         assert_eq!(
             mp.map_coords(|&(x, y)| (x + 10., y + 100.)),
-            MultiPoint(vec![Point::new(20., 110.), Point::new(10., 0.)])
+            MultiPoint::new(vec![Point::new(20., 110.), Point::new(10., 0.)])
         );
     }
 

--- a/geo/src/algorithm/rotate.rs
+++ b/geo/src/algorithm/rotate.rs
@@ -358,14 +358,14 @@ mod test {
 
     #[test]
     fn test_rotate_multipoints() {
-        let multi_points = MultiPoint(vec![
+        let multi_points = MultiPoint::new(vec![
             point!(x: 0., y: 0.),
             point!(x: 1., y: 1.),
             point!(x: 2., y: 1.),
         ]);
 
         // Results match shapely for `centroid`
-        let expected_for_centroid = MultiPoint(vec![
+        let expected_for_centroid = MultiPoint::new(vec![
             point!(x: 0.7642977396044841, y: -0.5118446353109125),
             point!(x: 0.7642977396044842, y:  0.9023689270621824),
             point!(x: 1.471404520791032, y:  1.60947570824873),
@@ -376,7 +376,7 @@ mod test {
         );
 
         // Results match shapely for `center`
-        let expected_for_center = MultiPoint(vec![
+        let expected_for_center = MultiPoint::new(vec![
             point!(x: 0.6464466094067262, y: -0.5606601717798212),
             point!(x: 0.6464466094067263, y: 0.8535533905932737),
             point!(x: 1.353553390593274, y: 1.560660171779821),


### PR DESCRIPTION
Make migration simpler by using static function that will still be available if `MultiPoint` becomes a type alias.

Similar to #777

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- ~[ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.~
---

