### PR TITLE
Revert "Merge #779"

### DIFF
--- a/geo-types/src/lib.rs
+++ b/geo-types/src/lib.rs
@@ -168,13 +168,13 @@ mod tests {
 
     #[test]
     fn polygon_new_test() {
-        let exterior = LineString::from(vec![
+        let exterior = LineString(vec![
             coord! { x: 0., y: 0. },
             coord! { x: 1., y: 1. },
             coord! { x: 1., y: 0. },
             coord! { x: 0., y: 0. },
         ]);
-        let interiors = vec![LineString::from(vec![
+        let interiors = vec![LineString(vec![
             coord! { x: 0.1, y: 0.1 },
             coord! { x: 0.9, y: 0.9 },
             coord! { x: 0.9, y: 0.1 },

--- a/geo-types/src/line_string.rs
+++ b/geo-types/src/line_string.rs
@@ -35,7 +35,7 @@ use std::ops::{Index, IndexMut};
 /// ```
 /// use geo_types::{coord, LineString};
 ///
-/// let line_string = LineString::from(vec![
+/// let line_string = LineString(vec![
 ///     coord! { x: 0., y: 0. },
 ///     coord! { x: 10., y: 0. },
 /// ]);
@@ -83,7 +83,7 @@ use std::ops::{Index, IndexMut};
 /// ```
 /// use geo_types::{coord, LineString};
 ///
-/// let line_string = LineString::from(vec![
+/// let line_string = LineString(vec![
 ///     coord! { x: 0., y: 0. },
 ///     coord! { x: 10., y: 0. },
 /// ]);
@@ -100,7 +100,7 @@ use std::ops::{Index, IndexMut};
 /// ```
 /// use geo_types::{coord, LineString};
 ///
-/// let line_string = LineString::from(vec![
+/// let line_string = LineString(vec![
 ///     coord! { x: 0., y: 0. },
 ///     coord! { x: 10., y: 0. },
 /// ]);
@@ -120,7 +120,7 @@ use std::ops::{Index, IndexMut};
 /// ```
 /// use geo_types::{coord, LineString, Point};
 ///
-/// let line_string = LineString::from(vec![
+/// let line_string = LineString(vec![
 ///     coord! { x: 0., y: 0. },
 ///     coord! { x: 10., y: 0. },
 /// ]);
@@ -529,7 +529,7 @@ mod test {
     #[test]
     fn test_exact_size() {
         // see https://github.com/georust/geo/issues/762
-        let ls = LineString::from(vec![coord! { x: 0., y: 0. }, coord! { x: 10., y: 0. }]);
+        let ls = LineString(vec![coord! { x: 0., y: 0. }, coord! { x: 10., y: 0. }]);
 
         // reference to force the `impl IntoIterator for &LineString` impl, giving a `CoordinatesIter`
         for c in (&ls).into_iter().rev().skip(1).rev() {
@@ -601,14 +601,14 @@ mod test {
         let start = coord! { x: 0, y: 0 };
         let end = coord! { x: 10, y: 10 };
         let line = Line::new(start, end);
-        let expected = LineString::from(vec![start, end]);
+        let expected = LineString(vec![start, end]);
 
         assert_eq!(expected, LineString::from(line));
 
         let start = coord! { x: 10., y: 0.5 };
         let end = coord! { x: 10000., y: 10.4 };
         let line = Line::new(start, end);
-        let expected = LineString::from(vec![start, end]);
+        let expected = LineString(vec![start, end]);
 
         assert_eq!(expected, LineString::from(line));
     }

--- a/geo/src/algorithm/centroid.rs
+++ b/geo/src/algorithm/centroid.rs
@@ -725,10 +725,9 @@ mod test {
     }
     #[test]
     fn empty_interior_polygon_test() {
-        let empty: Vec<Coordinate<f64>> = vec![];
         let poly = Polygon::new(
             LineString::from(vec![p(0., 0.), p(0., 1.), p(1., 1.), p(1., 0.), p(0., 0.)]),
-            vec![LineString::from(empty)],
+            vec![LineString(vec![])],
         );
         assert_eq!(poly.centroid(), Some(p(0.5, 0.5)));
     }

--- a/geo/src/algorithm/closest_point.rs
+++ b/geo/src/algorithm/closest_point.rs
@@ -259,8 +259,7 @@ mod tests {
 
     #[test]
     fn empty_line_string_is_indeterminate() {
-        let empty: Vec<Coordinate<f32>> = Vec::new();
-        let ls = LineString::from(empty);
+        let ls: LineString<f32> = LineString(Vec::new());
         let p = Point::new(0.0, 0.0);
 
         let got = ls.closest_point(&p);

--- a/geo/src/algorithm/contains/mod.rs
+++ b/geo/src/algorithm/contains/mod.rs
@@ -134,8 +134,7 @@ mod test {
     /// Tests: Point in LineString
     #[test]
     fn empty_linestring_test() {
-        let empty: Vec<Coordinate<f64>> = Vec::new();
-        let linestring = LineString::from(empty);
+        let linestring = LineString(Vec::new());
         assert!(!linestring.contains(&Point::new(2., 1.)));
     }
     #[test]
@@ -155,8 +154,7 @@ mod test {
     /// Tests: Point in Polygon
     #[test]
     fn empty_polygon_test() {
-        let empty: Vec<Coordinate<f64>> = Vec::new();
-        let linestring = LineString::from(empty);
+        let linestring = LineString(Vec::new());
         let poly = Polygon::new(linestring, Vec::new());
         assert!(!poly.contains(&Point::new(2., 1.)));
     }

--- a/geo/src/algorithm/contains/triangle.rs
+++ b/geo/src/algorithm/contains/triangle.rs
@@ -10,7 +10,7 @@ where
     T: GeoNum,
 {
     fn contains(&self, coord: &Coordinate<T>) -> bool {
-        let ls = LineString::from(vec![self.0, self.1, self.2, self.0]);
+        let ls = LineString(vec![self.0, self.1, self.2, self.0]);
         use crate::utils::{coord_pos_relative_to_ring, CoordPos};
         coord_pos_relative_to_ring(*coord, &ls) == CoordPos::Inside
     }

--- a/geo/src/algorithm/convex_hull/graham.rs
+++ b/geo/src/algorithm/convex_hull/graham.rs
@@ -80,7 +80,7 @@ where
     }
 
     // Close and output the line string
-    let mut output = LineString::from(output);
+    let mut output = LineString(output);
     output.close();
     output
 }

--- a/geo/src/algorithm/convex_hull/mod.rs
+++ b/geo/src/algorithm/convex_hull/mod.rs
@@ -126,7 +126,7 @@ where
         ls.push(ls[0]);
     }
 
-    let mut ls = LineString::from(ls);
+    let mut ls = LineString(ls);
     ls.close();
 
     // Maintain the CCW invariance

--- a/geo/src/algorithm/coordinate_position.rs
+++ b/geo/src/algorithm/coordinate_position.rs
@@ -444,8 +444,7 @@ mod test {
 
     #[test]
     fn test_empty_poly() {
-        let empty: Vec<Coordinate<f64>> = vec![];
-        let square_poly = Polygon::new(LineString::from(empty), vec![]);
+        let square_poly: Polygon<f64> = Polygon::new(LineString(vec![]), vec![]);
         assert_eq!(
             square_poly.coordinate_position(&Coordinate::zero()),
             CoordPos::Outside

--- a/geo/src/algorithm/dimensions.rs
+++ b/geo/src/algorithm/dimensions.rs
@@ -43,17 +43,16 @@ pub trait HasDimensions {
     /// Types like `Point` and `Rect`, which have at least one coordinate by construction, can
     /// never be considered empty.
     /// ```
-    /// use geo_types::{Point, coord, Coordinate, LineString};
+    /// use geo_types::{Point, coord, LineString};
     /// use geo::algorithm::dimensions::HasDimensions;
     ///
-    /// let line_string = LineString::from(vec![
+    /// let line_string = LineString(vec![
     ///     coord! { x: 0., y: 0. },
     ///     coord! { x: 10., y: 0. },
     /// ]);
     /// assert!(!line_string.is_empty());
     ///
-    /// let empty: Vec<Coordinate<f64>> = vec![];
-    /// let empty_line_string = LineString::from(empty);
+    /// let empty_line_string: LineString<f64> = LineString(vec![]);
     /// assert!(empty_line_string.is_empty());
     ///
     /// let point = Point::new(0.0, 0.0);

--- a/geo/src/algorithm/euclidean_distance.rs
+++ b/geo/src/algorithm/euclidean_distance.rs
@@ -687,8 +687,8 @@ mod test {
     // Point to Polygon, empty Polygon
     fn point_polygon_empty_test() {
         // an empty Polygon
-        let points: Vec<Coordinate<f64>> = vec![];
-        let ls = LineString::from(points);
+        let points = vec![];
+        let ls = LineString(points);
         let poly = Polygon::new(ls, vec![]);
         // A point on the octagon
         let p = Point::new(2.5, 0.5);
@@ -824,8 +824,8 @@ mod test {
     #[test]
     // Point to LineString, empty LineString
     fn point_linestring_empty_test() {
-        let points: Vec<Coordinate<f64>> = vec![];
-        let ls = LineString::from(points);
+        let points = vec![];
+        let ls = LineString(points);
         let p = Point::new(5.0, 4.0);
         let dist = p.euclidean_distance(&ls);
         assert_relative_eq!(dist, 0.0);

--- a/geo/src/algorithm/intersects/mod.rs
+++ b/geo/src/algorithm/intersects/mod.rs
@@ -114,7 +114,6 @@ mod test {
         coord, line_string, polygon, Geometry, Line, LineString, MultiLineString, MultiPoint,
         MultiPolygon, Point, Polygon, Rect,
     };
-    use geo_types::Coordinate;
 
     /// Tests: intersection LineString and LineString
     #[test]
@@ -125,8 +124,7 @@ mod test {
     #[test]
     fn empty_linestring2_test() {
         let linestring = line_string![(x: 3., y: 2.), (x: 7., y: 6.)];
-        let empty: Vec<Coordinate<f64>> = Vec::new();
-        assert!(!linestring.intersects(&LineString::from(empty)));
+        assert!(!linestring.intersects(&LineString(Vec::new())));
     }
     #[test]
     fn empty_all_linestring_test() {

--- a/geo/src/algorithm/k_nearest_concave_hull.rs
+++ b/geo/src/algorithm/k_nearest_concave_hull.rs
@@ -310,8 +310,8 @@ where
         return false;
     }
 
-    let coords: Vec<Coordinate<T>> = hull.iter().take(hull.len() - 1).cloned().collect();
-    let linestring = LineString::from(coords);
+    let coords = hull.iter().take(hull.len() - 1).cloned().collect();
+    let linestring = LineString(coords);
     let line = crate::Line::new(*line[0], *line[1]);
     linestring.intersects(&line)
 }
@@ -402,8 +402,7 @@ mod tests {
     #[test]
     fn empty_hull() {
         let actual: Polygon<f64> = concave_hull(vec![].iter(), 3);
-        let empty: Vec<Coordinate<f64>> = vec![];
-        let expected = Polygon::new(LineString::from(empty), vec![]);
+        let expected = Polygon::new(LineString(vec![]), vec![]);
         assert_eq!(actual, expected);
     }
 }

--- a/geo/src/algorithm/line_locate_point.rs
+++ b/geo/src/algorithm/line_locate_point.rs
@@ -111,7 +111,6 @@ mod test {
     use super::*;
     use crate::geo_types::coord;
     use crate::point;
-    use geo_types::Coordinate;
     use num_traits::Float;
 
     #[test]
@@ -213,24 +212,25 @@ mod test {
         assert_eq!(ring.line_locate_point(&pt), None);
 
         // point is equidistant to two line segments - return the fraction from the first closest
-        let line: Vec<Coordinate<f64>> = vec![
+        let line: LineString<f64> = LineString(vec![
             (0.0, 0.0).into(),
             (1.0, 0.0).into(),
             (1.0, 1.0).into(),
             (0.0, 1.0).into(),
-        ];
-        let line = LineString::from(line);
+        ]);
         let pt = point!(x: 0.0, y: 0.5);
         assert_eq!(line.line_locate_point(&pt), Some(0.0));
 
-        let line: Vec<Coordinate<f64>> =
-            vec![(1.0, 1.0).into(), (1.0, 1.0).into(), (1.0, 1.0).into()];
-        let line = LineString::from(line);
+        let line: LineString<f64> = LineString(vec![
+            (1.0, 1.0).into(),
+            (1.0, 1.0).into(),
+            (1.0, 1.0).into(),
+        ]);
         let pt = point!(x: 2.0, y: 2.0);
         assert_eq!(line.line_locate_point(&pt), Some(0.0));
 
         // line contains inf or nan
-        let line = LineString::from(vec![
+        let line: LineString<f64> = LineString(vec![
             coord! { x: 1.0, y: 1.0 },
             coord! {
                 x: Float::nan(),
@@ -241,7 +241,7 @@ mod test {
         let pt = point!(x: 2.0, y: 2.0);
         assert_eq!(line.line_locate_point(&pt), None);
 
-        let line = LineString::from(vec![
+        let line: LineString<f64> = LineString(vec![
             coord! { x: 1.0, y: 1.0 },
             coord! {
                 x: Float::infinity(),
@@ -251,7 +251,7 @@ mod test {
         ]);
         let pt = point!(x: 2.0, y: 2.0);
         assert_eq!(line.line_locate_point(&pt), None);
-        let line = LineString::from(vec![
+        let line: LineString<f64> = LineString(vec![
             coord! { x: 1.0, y: 1.0 },
             coord! {
                 x: Float::neg_infinity(),


### PR DESCRIPTION
This reverts commit b7e7529818bab57ed1f438b4bbe6a1d672ac45b7, reversing
changes made to 93b0a39dec0039025a74fb621d633b62e9b26b3d.

The #779 makes every instantiation perform an extra allocation and copying, need a different approach.

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
---

