### PR TITLE
Use `GeometryCollection::new_from()` instead of `GeometryCollection()`

### DIFF
--- a/geo-postgis/src/from_postgis.rs
+++ b/geo-postgis/src/from_postgis.rs
@@ -91,7 +91,7 @@ where
             .iter()
             .filter_map(Option::from_postgis)
             .collect();
-        GeometryCollection(geoms)
+        GeometryCollection::new_from(geoms)
     }
 }
 impl<'a, T> FromPostgis<&'a GeometryT<T>> for Option<Geometry<f64>>

--- a/geo-types/src/geometry_collection.rs
+++ b/geo-types/src/geometry_collection.rs
@@ -25,7 +25,7 @@ use std::ops::{Index, IndexMut};
 /// use geo_types::{Point, point, Geometry, GeometryCollection};
 /// let p = point!(x: 1.0, y: 1.0);
 /// let pe = Geometry::Point(p);
-/// let gc = GeometryCollection(vec![pe]);
+/// let gc = GeometryCollection::new_from(vec![pe]);
 /// for geom in gc {
 ///     println!("{:?}", Point::try_from(geom).unwrap().x());
 /// }
@@ -37,7 +37,7 @@ use std::ops::{Index, IndexMut};
 /// use geo_types::{Point, point, Geometry, GeometryCollection};
 /// let p = point!(x: 1.0, y: 1.0);
 /// let pe = Geometry::Point(p);
-/// let gc = GeometryCollection(vec![pe]);
+/// let gc = GeometryCollection::new_from(vec![pe]);
 /// gc.iter().for_each(|geom| println!("{:?}", geom));
 /// ```
 ///
@@ -48,7 +48,7 @@ use std::ops::{Index, IndexMut};
 /// use geo_types::{Point, point, Geometry, GeometryCollection};
 /// let p = point!(x: 1.0, y: 1.0);
 /// let pe = Geometry::Point(p);
-/// let mut gc = GeometryCollection(vec![pe]);
+/// let mut gc = GeometryCollection::new_from(vec![pe]);
 /// gc.iter_mut().for_each(|geom| {
 ///    if let Geometry::Point(p) = geom {
 ///        p.set_x(0.2);
@@ -65,7 +65,7 @@ use std::ops::{Index, IndexMut};
 /// use geo_types::{Point, point, Geometry, GeometryCollection};
 /// let p = point!(x: 1.0, y: 1.0);
 /// let pe = Geometry::Point(p);
-/// let gc = GeometryCollection(vec![pe]);
+/// let gc = GeometryCollection::new_from(vec![pe]);
 /// println!("{:?}", gc[0]);
 /// ```
 ///
@@ -83,8 +83,18 @@ impl<T: CoordNum> Default for GeometryCollection<T> {
 
 impl<T: CoordNum> GeometryCollection<T> {
     /// Return an empty GeometryCollection
+    #[deprecated(
+        note = "Will be replaced with a parametrized version in upcoming version. Use GeometryCollection::default() instead"
+    )]
     pub fn new() -> Self {
         GeometryCollection::default()
+    }
+
+    /// DO NOT USE!
+    /// This fn will be renamed to `new` in the upcoming version.
+    /// This fn is not marked as deprecated because it would require extensive refactoring of the geo code.
+    pub fn new_from(value: Vec<Geometry<T>>) -> Self {
+        Self(value)
     }
 
     /// Number of geometries in this GeometryCollection
@@ -244,8 +254,8 @@ where
     /// ```
     /// use geo_types::{GeometryCollection, point};
     ///
-    /// let a = GeometryCollection(vec![point![x: 1.0, y: 2.0].into()]);
-    /// let b = GeometryCollection(vec![point![x: 1.0, y: 2.01].into()]);
+    /// let a = GeometryCollection::new_from(vec![point![x: 1.0, y: 2.0].into()]);
+    /// let b = GeometryCollection::new_from(vec![point![x: 1.0, y: 2.01].into()]);
     ///
     /// approx::assert_relative_eq!(a, b, max_relative=0.1);
     /// approx::assert_relative_ne!(a, b, max_relative=0.0001);
@@ -286,8 +296,8 @@ where
     /// ```
     /// use geo_types::{GeometryCollection, point};
     ///
-    /// let a = GeometryCollection(vec![point![x: 0.0, y: 0.0].into()]);
-    /// let b = GeometryCollection(vec![point![x: 0.0, y: 0.1].into()]);
+    /// let a = GeometryCollection::new_from(vec![point![x: 0.0, y: 0.0].into()]);
+    /// let b = GeometryCollection::new_from(vec![point![x: 0.0, y: 0.1].into()]);
     ///
     /// approx::abs_diff_eq!(a, b, epsilon=0.1);
     /// approx::abs_diff_ne!(a, b, epsilon=0.001);

--- a/geo/src/algorithm/bounding_rect.rs
+++ b/geo/src/algorithm/bounding_rect.rs
@@ -322,7 +322,7 @@ mod test {
     fn geometry_collection_bounding_rect_test() {
         assert_eq!(
             Some(Rect::new(coord! { x: 0., y: 0. }, coord! { x: 1., y: 2. })),
-            GeometryCollection(vec![
+            GeometryCollection::new_from(vec![
                 Geometry::Point(point! { x: 0., y: 0. }),
                 Geometry::Point(point! { x: 1., y: 2. }),
             ])

--- a/geo/src/algorithm/centroid.rs
+++ b/geo/src/algorithm/centroid.rs
@@ -806,7 +806,7 @@ mod test {
         assert_eq!(multi_point.centroid().unwrap(), point!(x: 1.0, y: 1.0));
 
         let collection =
-            GeometryCollection(vec![MultiPoint::new(vec![p1, p2, p3]).into(), p0.into()]);
+            GeometryCollection::new_from(vec![MultiPoint::new(vec![p1, p2, p3]).into(), p0.into()]);
 
         assert_eq!(collection.centroid().unwrap(), point!(x: 1.0, y: 1.0));
     }
@@ -850,8 +850,8 @@ mod test {
 
         let line = Line::new(c(0., 1.), c(1., 3.));
 
-        let g1 = GeometryCollection(vec![triangle.into(), line.into()]);
-        let g2 = GeometryCollection(vec![poly.into(), line.into()]);
+        let g1 = GeometryCollection::new_from(vec![triangle.into(), line.into()]);
+        let g2 = GeometryCollection::new_from(vec![poly.into(), line.into()]);
         assert_eq!(g1.centroid(), g2.centroid());
     }
 
@@ -862,8 +862,8 @@ mod test {
 
         let line = Line::new(c(0., 1.), c(1., 3.));
 
-        let g1 = GeometryCollection(vec![rect.into(), line.into()]);
-        let g2 = GeometryCollection(vec![poly.into(), line.into()]);
+        let g1 = GeometryCollection::new_from(vec![rect.into(), line.into()]);
+        let g2 = GeometryCollection::new_from(vec![poly.into(), line.into()]);
         assert_eq!(g1.centroid(), g2.centroid());
     }
 
@@ -888,8 +888,11 @@ mod test {
         );
 
         // collection with rect
-        let mut collection =
-            GeometryCollection(vec![p(0., 0.).into(), p(6., 0.).into(), p(6., 6.).into()]);
+        let mut collection = GeometryCollection::new_from(vec![
+            p(0., 0.).into(),
+            p(6., 0.).into(),
+            p(6., 6.).into(),
+        ]);
         // sanity check
         assert_eq!(collection.centroid().unwrap(), point!(x: 4., y: 2.));
 

--- a/geo/src/algorithm/coordinate_position.rs
+++ b/geo/src/algorithm/coordinate_position.rs
@@ -710,7 +710,7 @@ mod test {
     fn test_collection() {
         let triangle = Triangle::new((0.0, 0.0).into(), (5.0, 10.0).into(), (10.0, 0.0).into());
         let rect = Rect::new((0.0, 0.0), (10.0, 10.0));
-        let collection = GeometryCollection(vec![triangle.into(), rect.into()]);
+        let collection = GeometryCollection::new_from(vec![triangle.into(), rect.into()]);
 
         //  outside of both
         assert_eq!(

--- a/geo/src/algorithm/coords_iter.rs
+++ b/geo/src/algorithm/coords_iter.rs
@@ -756,7 +756,7 @@ mod test {
         let (polygon, mut coords) = create_polygon();
         expected_coords.append(&mut coords);
 
-        let actual_coords = GeometryCollection(vec![
+        let actual_coords = GeometryCollection::new_from(vec![
             Geometry::LineString(line_string),
             Geometry::Polygon(polygon),
         ])

--- a/geo/src/algorithm/dimensions.rs
+++ b/geo/src/algorithm/dimensions.rs
@@ -84,14 +84,14 @@ pub trait HasDimensions {
     /// assert_eq!(Dimensions::ZeroDimensional, degenerate_point_rect.dimensions());
     ///
     /// // collections inherit the greatest dimensionality of their elements
-    /// let geometry_collection = GeometryCollection(vec![degenerate_line_rect.into(), degenerate_point_rect.into()]);
+    /// let geometry_collection = GeometryCollection::new_from(vec![degenerate_line_rect.into(), degenerate_point_rect.into()]);
     /// assert_eq!(Dimensions::OneDimensional, geometry_collection.dimensions());
     ///
     /// let point = Point::new(10.0, 10.0);
     /// assert_eq!(Dimensions::ZeroDimensional, point.dimensions());
     ///
     /// // An `Empty` dimensionality is distinct from, and less than, being 0-dimensional
-    /// let empty_collection = GeometryCollection::<f32>(vec![]);
+    /// let empty_collection = GeometryCollection::<f32>::new_from(vec![]);
     /// assert_eq!(Dimensions::Empty, empty_collection.dimensions());
     /// assert!(empty_collection.dimensions() < point.dimensions());
     /// ```
@@ -123,10 +123,10 @@ pub trait HasDimensions {
     /// assert_eq!(Dimensions::Empty, degenerate_point_rect.boundary_dimensions());
     ///
     /// // collections inherit the greatest dimensionality of their elements
-    /// let geometry_collection = GeometryCollection(vec![degenerate_line_rect.into(), degenerate_point_rect.into()]);
+    /// let geometry_collection = GeometryCollection::new_from(vec![degenerate_line_rect.into(), degenerate_point_rect.into()]);
     /// assert_eq!(Dimensions::ZeroDimensional, geometry_collection.boundary_dimensions());
     ///
-    /// let geometry_collection = GeometryCollection::<f32>(vec![]);
+    /// let geometry_collection = GeometryCollection::<f32>::new_from(vec![]);
     /// assert_eq!(Dimensions::Empty, geometry_collection.boundary_dimensions());
     /// ```
     fn boundary_dimensions(&self) -> Dimensions;

--- a/geo/src/algorithm/intersects/mod.rs
+++ b/geo/src/algorithm/intersects/mod.rs
@@ -542,7 +542,7 @@ mod test {
             coord! { x: 20., y: -10. },
         );
         let geom = Geometry::Point(pt);
-        let gc = GeometryCollection(vec![geom.clone()]);
+        let gc = GeometryCollection::new_from(vec![geom.clone()]);
         let multi_point = MultiPoint::new(vec![pt]);
         let multi_ls = MultiLineString(vec![ls.clone()]);
         let multi_poly = MultiPolygon::new(vec![poly.clone()]);

--- a/geo/src/algorithm/map_coords.rs
+++ b/geo/src/algorithm/map_coords.rs
@@ -475,7 +475,7 @@ impl<T: CoordNum, NT: CoordNum> MapCoords<T, NT> for GeometryCollection<T> {
     type Output = GeometryCollection<NT>;
 
     fn map_coords(&self, func: impl Fn(&(T, T)) -> (NT, NT) + Copy) -> Self::Output {
-        GeometryCollection(self.iter().map(|g| g.map_coords(func)).collect())
+        GeometryCollection::new_from(self.iter().map(|g| g.map_coords(func)).collect())
     }
 }
 
@@ -486,7 +486,7 @@ impl<T: CoordNum, NT: CoordNum, E> TryMapCoords<T, NT, E> for GeometryCollection
         &self,
         func: impl Fn(&(T, T)) -> Result<(NT, NT), E> + Copy,
     ) -> Result<Self::Output, E> {
-        Ok(GeometryCollection(
+        Ok(GeometryCollection::new_from(
             self.0
                 .iter()
                 .map(|g| g.try_map_coords(func))
@@ -811,11 +811,11 @@ mod test {
         let p1 = Geometry::Point(Point::new(10., 10.));
         let line1 = Geometry::LineString(LineString::from(vec![(0., 0.), (1., 2.)]));
 
-        let gc = GeometryCollection(vec![p1, line1]);
+        let gc = GeometryCollection::new_from(vec![p1, line1]);
 
         assert_eq!(
             gc.map_coords(|&(x, y)| (x + 10., y + 100.)),
-            GeometryCollection(vec![
+            GeometryCollection::new_from(vec![
                 Geometry::Point(Point::new(20., 110.)),
                 Geometry::LineString(LineString::from(vec![(10., 100.), (11., 102.)])),
             ])


### PR DESCRIPTION
Make migration simpler by using static function that will still be available if `GeometryCollection` becomes a type alias.

Note that `GeometryCollection::new()` already exists, and is the same as ::default(). I couldn't find any usages of it.

I made `new()` deprecated, but the new method had to be something else - `new_from(val)`. Ideally, `new_from` should become `new(val)`

Similar to https://github.com/georust/geo/pull/777

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- ~[ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.~
---

