### PR TITLE
Use `Triangle::new()` instead of `Triangle()`

### DIFF
--- a/geo-types/src/line_string.rs
+++ b/geo-types/src/line_string.rs
@@ -262,7 +262,7 @@ impl<T: CoordNum> LineString<T> {
         self.0.windows(3).map(|w| {
             // slice::windows(N) is guaranteed to yield a slice with exactly N elements
             unsafe {
-                Triangle(
+                Triangle::new(
                     *w.get_unchecked(0),
                     *w.get_unchecked(1),
                     *w.get_unchecked(2),

--- a/geo-types/src/triangle.rs
+++ b/geo-types/src/triangle.rs
@@ -12,6 +12,11 @@ use approx::{AbsDiffEq, RelativeEq};
 pub struct Triangle<T: CoordNum>(pub Coordinate<T>, pub Coordinate<T>, pub Coordinate<T>);
 
 impl<T: CoordNum> Triangle<T> {
+    /// Instantiate Self from the raw content value
+    pub fn new(v1: Coordinate<T>, v2: Coordinate<T>, v3: Coordinate<T>) -> Self {
+        Self(v1, v2, v3)
+    }
+
     pub fn to_array(&self) -> [Coordinate<T>; 3] {
         [self.0, self.1, self.2]
     }
@@ -31,7 +36,7 @@ impl<T: CoordNum> Triangle<T> {
     /// ```rust
     /// use geo_types::{coord, Triangle, polygon};
     ///
-    /// let triangle = Triangle(
+    /// let triangle = Triangle::new(
     ///     coord! { x: 0., y: 0. },
     ///     coord! { x: 10., y: 20. },
     ///     coord! { x: 20., y: -10. },
@@ -75,8 +80,8 @@ where
     /// ```
     /// use geo_types::{point, Triangle};
     ///
-    /// let a = Triangle((0.0, 0.0).into(), (10.0, 10.0).into(), (0.0, 5.0).into());
-    /// let b = Triangle((0.0, 0.0).into(), (10.01, 10.0).into(), (0.0, 5.0).into());
+    /// let a = Triangle::new((0.0, 0.0).into(), (10.0, 10.0).into(), (0.0, 5.0).into());
+    /// let b = Triangle::new((0.0, 0.0).into(), (10.01, 10.0).into(), (0.0, 5.0).into());
     ///
     /// approx::assert_relative_eq!(a, b, max_relative=0.1);
     /// approx::assert_relative_ne!(a, b, max_relative=0.0001);
@@ -122,8 +127,8 @@ where
     /// ```
     /// use geo_types::{point, Triangle};
     ///
-    /// let a = Triangle((0.0, 0.0).into(), (10.0, 10.0).into(), (0.0, 5.0).into());
-    /// let b = Triangle((0.0, 0.0).into(), (10.01, 10.0).into(), (0.0, 5.0).into());
+    /// let a = Triangle::new((0.0, 0.0).into(), (10.0, 10.0).into(), (0.0, 5.0).into());
+    /// let b = Triangle::new((0.0, 0.0).into(), (10.01, 10.0).into(), (0.0, 5.0).into());
     ///
     /// approx::abs_diff_eq!(a, b, epsilon=0.1);
     /// approx::abs_diff_ne!(a, b, epsilon=0.001);

--- a/geo/src/algorithm/area.rs
+++ b/geo/src/algorithm/area.rs
@@ -396,14 +396,14 @@ mod test {
 
     #[test]
     fn area_triangle_test() {
-        let triangle = Triangle(
+        let triangle = Triangle::new(
             coord! { x: 0.0, y: 0.0 },
             coord! { x: 1.0, y: 0.0 },
             coord! { x: 0.0, y: 1.0 },
         );
         assert_relative_eq!(triangle.signed_area(), 0.5);
 
-        let triangle = Triangle(
+        let triangle = Triangle::new(
             coord! { x: 0.0, y: 0.0 },
             coord! { x: 0.0, y: 1.0 },
             coord! { x: 1.0, y: 0.0 },

--- a/geo/src/algorithm/centroid.rs
+++ b/geo/src/algorithm/centroid.rs
@@ -813,38 +813,38 @@ mod test {
     fn triangles() {
         // boring triangle
         assert_eq!(
-            Triangle(c(0., 0.), c(3., 0.), c(1.5, 3.)).centroid(),
+            Triangle::new(c(0., 0.), c(3., 0.), c(1.5, 3.)).centroid(),
             point!(x: 1.5, y: 1.0)
         );
 
         // flat triangle
         assert_eq!(
-            Triangle(c(0., 0.), c(3., 0.), c(1., 0.)).centroid(),
+            Triangle::new(c(0., 0.), c(3., 0.), c(1., 0.)).centroid(),
             point!(x: 1.5, y: 0.0)
         );
 
         // flat triangle that's not axis-aligned
         assert_eq!(
-            Triangle(c(0., 0.), c(3., 3.), c(1., 1.)).centroid(),
+            Triangle::new(c(0., 0.), c(3., 3.), c(1., 1.)).centroid(),
             point!(x: 1.5, y: 1.5)
         );
 
         // triangle with some repeated points
         assert_eq!(
-            Triangle(c(0., 0.), c(0., 0.), c(1., 0.)).centroid(),
+            Triangle::new(c(0., 0.), c(0., 0.), c(1., 0.)).centroid(),
             point!(x: 0.5, y: 0.0)
         );
 
         // triangle with all repeated points
         assert_eq!(
-            Triangle(c(0., 0.5), c(0., 0.5), c(0., 0.5)).centroid(),
+            Triangle::new(c(0., 0.5), c(0., 0.5), c(0., 0.5)).centroid(),
             point!(x: 0., y: 0.5)
         )
     }
 
     #[test]
     fn degenerate_triangle_like_ring() {
-        let triangle = Triangle(c(0., 0.), c(1., 1.), c(2., 2.));
+        let triangle = Triangle::new(c(0., 0.), c(1., 1.), c(2., 2.));
         let poly: Polygon<_> = triangle.into();
 
         let line = Line::new(c(0., 1.), c(1., 3.));

--- a/geo/src/algorithm/contains/mod.rs
+++ b/geo/src/algorithm/contains/mod.rs
@@ -502,13 +502,13 @@ mod test {
     // https://github.com/georust/geo/issues/473
     fn triangle_contains_collinear_points() {
         let origin: Coordinate<f64> = (0., 0.).into();
-        let tri = Triangle(origin, origin, origin);
+        let tri = Triangle::new(origin, origin, origin);
         let pt: Point<f64> = (0., 1.23456).into();
         assert!(!tri.contains(&pt));
         let pt: Point<f64> = (0., 0.).into();
         assert!(!tri.contains(&pt));
         let origin: Coordinate<f64> = (0., 0.).into();
-        let tri = Triangle((1., 1.).into(), origin, origin);
+        let tri = Triangle::new((1., 1.).into(), origin, origin);
         let pt: Point<f64> = (1., 1.).into();
         assert!(!tri.contains(&pt));
         let pt: Point<f64> = (0.5, 0.5).into();

--- a/geo/src/algorithm/coordinate_position.rs
+++ b/geo/src/algorithm/coordinate_position.rs
@@ -691,7 +691,7 @@ mod test {
 
     #[test]
     fn test_triangle() {
-        let triangle = Triangle((0.0, 0.0).into(), (5.0, 10.0).into(), (10.0, 0.0).into());
+        let triangle = Triangle::new((0.0, 0.0).into(), (5.0, 10.0).into(), (10.0, 0.0).into());
         assert_eq!(
             triangle.coordinate_position(&coord! { x: 5.0, y: 5.0 }),
             CoordPos::Inside
@@ -708,7 +708,7 @@ mod test {
 
     #[test]
     fn test_collection() {
-        let triangle = Triangle((0.0, 0.0).into(), (5.0, 10.0).into(), (10.0, 0.0).into());
+        let triangle = Triangle::new((0.0, 0.0).into(), (5.0, 10.0).into(), (10.0, 0.0).into());
         let rect = Rect::new((0.0, 0.0), (10.0, 10.0));
         let collection = GeometryCollection(vec![triangle.into(), rect.into()]);
 

--- a/geo/src/algorithm/coords_iter.rs
+++ b/geo/src/algorithm/coords_iter.rs
@@ -772,7 +772,7 @@ mod test {
 
     fn create_triangle() -> (Triangle<f64>, Vec<Coordinate<f64>>) {
         (
-            Triangle(
+            Triangle::new(
                 coord! { x: 1., y: 2. },
                 coord! { x: 3., y: 4. },
                 coord! { x: 5., y: 6. },

--- a/geo/src/algorithm/intersects/mod.rs
+++ b/geo/src/algorithm/intersects/mod.rs
@@ -536,7 +536,7 @@ mod test {
         let ls = line_string![(0., 0.).into(), (1., 1.).into()];
         let poly = Polygon::new(LineString::from(vec![(0., 0.), (1., 1.), (1., 0.)]), vec![]);
         let rect = Rect::new(coord! { x: 10., y: 20. }, coord! { x: 30., y: 10. });
-        let tri = Triangle(
+        let tri = Triangle::new(
             coord! { x: 0., y: 0. },
             coord! { x: 10., y: 20. },
             coord! { x: 20., y: -10. },

--- a/geo/src/algorithm/lines_iter.rs
+++ b/geo/src/algorithm/lines_iter.rs
@@ -289,7 +289,7 @@ mod test {
 
     #[test]
     fn test_triangle() {
-        let triangle = Triangle(
+        let triangle = Triangle::new(
             coord! { x: 0., y: 0. },
             coord! { x: 1., y: 2. },
             coord! { x: 2., y: 3. },

--- a/geo/src/algorithm/map_coords.rs
+++ b/geo/src/algorithm/map_coords.rs
@@ -540,7 +540,7 @@ impl<T: CoordNum, NT: CoordNum> MapCoords<T, NT> for Triangle<T> {
         let p2 = func(&self.1.x_y());
         let p3 = func(&self.2.x_y());
 
-        Triangle(
+        Triangle::new(
             coord! { x: p1.0, y: p1.1 },
             coord! { x: p2.0, y: p2.1 },
             coord! { x: p3.0, y: p3.1 },
@@ -559,7 +559,7 @@ impl<T: CoordNum, NT: CoordNum, E> TryMapCoords<T, NT, E> for Triangle<T> {
         let p2 = func(&self.1.x_y())?;
         let p3 = func(&self.2.x_y())?;
 
-        Ok(Triangle(
+        Ok(Triangle::new(
             coord! { x: p1.0, y: p1.1 },
             coord! { x: p2.0, y: p2.1 },
             coord! { x: p3.0, y: p3.1 },
@@ -573,7 +573,7 @@ impl<T: CoordNum> MapCoordsInplace<T> for Triangle<T> {
         let p2 = func(&self.1.x_y());
         let p3 = func(&self.2.x_y());
 
-        let mut new_triangle = Triangle(
+        let mut new_triangle = Triangle::new(
             coord! { x: p1.0, y: p1.1 },
             coord! { x: p2.0, y: p2.1 },
             coord! { x: p3.0, y: p3.1 },

--- a/geo/src/algorithm/simplifyvw.rs
+++ b/geo/src/algorithm/simplifyvw.rs
@@ -154,7 +154,7 @@ where
                 // Out of bounds, i.e. we're on one edge
                 continue;
             }
-            let area = Triangle(
+            let area = Triangle::new(
                 orig.0[ai as usize],
                 orig.0[current_point as usize],
                 orig.0[bi as usize],
@@ -335,7 +335,7 @@ where
                 // Out of bounds, i.e. we're on one edge
                 continue;
             }
-            let new = Triangle(
+            let new = Triangle::new(
                 orig.0[ai as usize],
                 orig.0[current_point as usize],
                 orig.0[bi as usize],
@@ -394,7 +394,7 @@ where
 {
     let point_a = orig[triangle.left];
     let point_c = orig[triangle.right];
-    let bounding_rect = Triangle(
+    let bounding_rect = Triangle::new(
         orig[triangle.left],
         orig[triangle.current],
         orig[triangle.right],


### PR DESCRIPTION
Make migration simpler by using static function that will still be available if `Triangle` becomes a type alias.

Similar to https://github.com/georust/geo/pull/777

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- ~[ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.~
---

