### PR TITLE
Use `MultiLineString::new()` instead of `MultiLineString()`

### DIFF
--- a/geo-postgis/src/from_postgis.rs
+++ b/geo-postgis/src/from_postgis.rs
@@ -65,7 +65,7 @@ where
 {
     fn from_postgis(mp: &'a T) -> Self {
         let ret = mp.lines().map(LineString::from_postgis).collect();
-        MultiLineString(ret)
+        MultiLineString::new(ret)
     }
 }
 impl<'a, T> FromPostgis<&'a T> for MultiPolygon<f64>

--- a/geo-types/src/multi_line_string.rs
+++ b/geo-types/src/multi_line_string.rs
@@ -36,6 +36,11 @@ use std::iter::FromIterator;
 pub struct MultiLineString<T: CoordNum>(pub Vec<LineString<T>>);
 
 impl<T: CoordNum> MultiLineString<T> {
+    /// Instantiate Self from the raw content value
+    pub fn new(value: Vec<LineString<T>>) -> Self {
+        Self(value)
+    }
+
     /// True if the MultiLineString is empty or if all of its LineStrings are closed - see
     /// [`LineString::is_closed`].
     ///
@@ -45,16 +50,16 @@ impl<T: CoordNum> MultiLineString<T> {
     /// use geo_types::{MultiLineString, LineString, line_string};
     ///
     /// let open_line_string: LineString<f32> = line_string![(x: 0., y: 0.), (x: 5., y: 0.)];
-    /// assert!(!MultiLineString(vec![open_line_string.clone()]).is_closed());
+    /// assert!(!MultiLineString::new(vec![open_line_string.clone()]).is_closed());
     ///
     /// let closed_line_string: LineString<f32> = line_string![(x: 0., y: 0.), (x: 5., y: 0.), (x: 0., y: 0.)];
-    /// assert!(MultiLineString(vec![closed_line_string.clone()]).is_closed());
+    /// assert!(MultiLineString::new(vec![closed_line_string.clone()]).is_closed());
     ///
     /// // MultiLineString is not closed if *any* of it's LineStrings are not closed
-    /// assert!(!MultiLineString(vec![open_line_string, closed_line_string]).is_closed());
+    /// assert!(!MultiLineString::new(vec![open_line_string, closed_line_string]).is_closed());
     ///
     /// // An empty MultiLineString is closed
-    /// assert!(MultiLineString::<f32>(vec![]).is_closed());
+    /// assert!(MultiLineString::<f32>::new(vec![]).is_closed());
     /// ```
     pub fn is_closed(&self) -> bool {
         // Note: Unlike JTS et al, we consider an empty MultiLineString as closed.
@@ -128,8 +133,8 @@ where
     /// ```
     /// use geo_types::{MultiLineString, line_string};
     ///
-    /// let a = MultiLineString(vec![line_string![(x: 0., y: 0.), (x: 10., y: 10.)]]);
-    /// let b = MultiLineString(vec![line_string![(x: 0., y: 0.), (x: 10.01, y: 10.)]]);
+    /// let a = MultiLineString::new(vec![line_string![(x: 0., y: 0.), (x: 10., y: 10.)]]);
+    /// let b = MultiLineString::new(vec![line_string![(x: 0., y: 0.), (x: 10.01, y: 10.)]]);
     ///
     /// approx::assert_relative_eq!(a, b, max_relative=0.1);
     /// approx::assert_relative_ne!(a, b, max_relative=0.0001);
@@ -170,8 +175,8 @@ where
     /// ```
     /// use geo_types::{MultiLineString, line_string};
     ///
-    /// let a = MultiLineString(vec![line_string![(x: 0., y: 0.), (x: 10., y: 10.)]]);
-    /// let b = MultiLineString(vec![line_string![(x: 0., y: 0.), (x: 10.01, y: 10.)]]);
+    /// let a = MultiLineString::new(vec![line_string![(x: 0., y: 0.), (x: 10., y: 10.)]]);
+    /// let b = MultiLineString::new(vec![line_string![(x: 0., y: 0.), (x: 10.01, y: 10.)]]);
     ///
     /// approx::abs_diff_eq!(a, b, epsilon=0.1);
     /// approx::abs_diff_ne!(a, b, epsilon=0.001);
@@ -194,10 +199,11 @@ mod test {
 
     #[test]
     fn test_iter() {
-        let multi = MultiLineString(vec![
+        let multi: Vec<LineString<i32>> = vec![
             line_string![(x: 0, y: 0), (x: 2, y: 0), (x: 1, y: 2), (x:0, y:0)],
             line_string![(x: 10, y: 10), (x: 12, y: 10), (x: 11, y: 12), (x:10, y:10)],
-        ]);
+        ];
+        let multi: MultiLineString<i32> = MultiLineString::new(multi);
 
         let mut first = true;
         for p in &multi {
@@ -235,7 +241,7 @@ mod test {
 
     #[test]
     fn test_iter_mut() {
-        let mut multi = MultiLineString(vec![
+        let mut multi = MultiLineString::new(vec![
             line_string![(x: 0, y: 0), (x: 2, y: 0), (x: 1, y: 2), (x:0, y:0)],
             line_string![(x: 10, y: 10), (x: 12, y: 10), (x: 11, y: 12), (x:10, y:10)],
         ]);

--- a/geo/src/algorithm/bounding_rect.rs
+++ b/geo/src/algorithm/bounding_rect.rs
@@ -247,7 +247,7 @@ mod test {
     }
     #[test]
     fn multilinestring_test() {
-        let multiline = MultiLineString(vec![
+        let multiline = MultiLineString::new(vec![
             line_string![(x: 1., y: 1.), (x: -40., y: 1.)],
             line_string![(x: 1., y: 1.), (x: 50., y: 1.)],
             line_string![(x: 1., y: 1.), (x: 1., y: -60.)],

--- a/geo/src/algorithm/centroid.rs
+++ b/geo/src/algorithm/centroid.rs
@@ -513,19 +513,19 @@ mod test {
         assert_eq!(l1.centroid(), Some(p(1., 1.)));
 
         let l2 = LineString::from(vec![p(2., 2.), p(2., 2.), p(2., 2.)]);
-        let mls = MultiLineString(vec![l1, l2]);
+        let mls = MultiLineString::new(vec![l1, l2]);
         assert_eq!(mls.centroid(), Some(p(1.5, 1.5)));
     }
     // Tests: Centroid of MultiLineString
     #[test]
     fn empty_multilinestring_test() {
-        let mls: MultiLineString<f64> = MultiLineString(vec![]);
+        let mls: MultiLineString<f64> = MultiLineString::new(vec![]);
         let centroid = mls.centroid();
         assert!(centroid.is_none());
     }
     #[test]
     fn multilinestring_with_empty_line_test() {
-        let mls: MultiLineString<f64> = MultiLineString(vec![line_string![]]);
+        let mls: MultiLineString<f64> = MultiLineString::new(vec![line_string![]]);
         let centroid = mls.centroid();
         assert!(centroid.is_none());
     }
@@ -535,7 +535,7 @@ mod test {
             x: 40.02f64,
             y: 116.34,
         };
-        let mls: MultiLineString<f64> = MultiLineString(vec![
+        let mls: MultiLineString<f64> = MultiLineString::new(vec![
             line_string![coord],
             line_string![coord],
             line_string![coord],
@@ -552,7 +552,7 @@ mod test {
             (x: 10., y: 1.),
             (x: 11., y: 1.)
         ];
-        let mls: MultiLineString<f64> = MultiLineString(vec![linestring]);
+        let mls: MultiLineString<f64> = MultiLineString::new(vec![linestring]);
         assert_relative_eq!(mls.centroid().unwrap(), point! { x: 6., y: 1. });
     }
     #[test]
@@ -560,7 +560,7 @@ mod test {
         let v1 = line_string![(x: 0.0, y: 0.0), (x: 1.0, y: 10.0)];
         let v2 = line_string![(x: 1.0, y: 10.0), (x: 2.0, y: 0.0), (x: 3.0, y: 1.0)];
         let v3 = line_string![(x: -12.0, y: -100.0), (x: 7.0, y: 8.0)];
-        let mls = MultiLineString(vec![v1, v2, v3]);
+        let mls = MultiLineString::new(vec![v1, v2, v3]);
         assert_relative_eq!(
             mls.centroid().unwrap(),
             point![x: -1.9097834383655845, y: -37.683866439745714]

--- a/geo/src/algorithm/chaikin_smoothing.rs
+++ b/geo/src/algorithm/chaikin_smoothing.rs
@@ -45,7 +45,7 @@ where
     T: CoordFloat + FromPrimitive,
 {
     fn chaikin_smoothing(&self, n_iterations: usize) -> Self {
-        MultiLineString(
+        MultiLineString::new(
             self.0
                 .iter()
                 .map(|ls| ls.chaikin_smoothing(n_iterations))

--- a/geo/src/algorithm/concave_hull.rs
+++ b/geo/src/algorithm/concave_hull.rs
@@ -414,7 +414,7 @@ mod test {
              (x: 3.0, y: 1.0),
              (x: 3.0, y: 2.0)
         ];
-        let mls = MultiLineString(vec![v1, v2]);
+        let mls = MultiLineString::new(vec![v1, v2]);
         let correct = vec![
             Coordinate::from((4.0, 0.0)),
             Coordinate::from((4.0, 4.0)),

--- a/geo/src/algorithm/convex_hull/test.rs
+++ b/geo/src/algorithm/convex_hull/test.rs
@@ -52,7 +52,7 @@ fn convex_hull_linestring_test() {
 fn convex_hull_multilinestring_test() {
     let v1 = line_string![(x: 0.0, y: 0.0), (x: 1.0, y: 10.0)];
     let v2 = line_string![(x: 1.0, y: 10.0), (x: 2.0, y: 0.0), (x: 3.0, y: 1.0)];
-    let mls = MultiLineString(vec![v1, v2]);
+    let mls = MultiLineString::new(vec![v1, v2]);
     let correct = vec![
         Coordinate::from((2.0, 0.0)),
         Coordinate::from((3.0, 1.0)),

--- a/geo/src/algorithm/coordinate_position.rs
+++ b/geo/src/algorithm/coordinate_position.rs
@@ -626,7 +626,7 @@ mod test {
 
     #[test]
     fn test_boundary_rule() {
-        let multi_line_string = MultiLineString(vec![
+        let multi_line_string = MultiLineString::new(vec![
             // first two lines have same start point but different end point
             line_string![(x: 0.0, y: 0.0), (x: 1.0, y: 1.0)],
             line_string![(x: 0.0, y: 0.0), (x: -1.0, y: -1.0)],

--- a/geo/src/algorithm/coords_iter.rs
+++ b/geo/src/algorithm/coords_iter.rs
@@ -698,7 +698,7 @@ mod test {
         expected_coords.append(&mut coords.clone());
         expected_coords.append(&mut coords);
 
-        let actual_coords = MultiLineString(vec![line_string.clone(), line_string])
+        let actual_coords = MultiLineString::new(vec![line_string.clone(), line_string])
             .coords_iter()
             .collect::<Vec<_>>();
 

--- a/geo/src/algorithm/euclidean_distance.rs
+++ b/geo/src/algorithm/euclidean_distance.rs
@@ -838,7 +838,7 @@ mod test {
     fn distance_multilinestring_test() {
         let v1 = LineString::from(vec![(0.0, 0.0), (1.0, 10.0)]);
         let v2 = LineString::from(vec![(1.0, 10.0), (2.0, 0.0), (3.0, 1.0)]);
-        let mls = MultiLineString(vec![v1, v2]);
+        let mls = MultiLineString::new(vec![v1, v2]);
         let p = Point::new(50.0, 50.0);
         assert_relative_eq!(p.euclidean_distance(&mls), 63.25345840347388);
     }

--- a/geo/src/algorithm/euclidean_length.rs
+++ b/geo/src/algorithm/euclidean_length.rs
@@ -85,7 +85,7 @@ mod test {
     }
     #[test]
     fn multilinestring_test() {
-        let mline = MultiLineString(vec![
+        let mline = MultiLineString::new(vec![
             line_string![
                 (x: 1., y: 0.),
                 (x: 7., y: 0.),

--- a/geo/src/algorithm/intersects/mod.rs
+++ b/geo/src/algorithm/intersects/mod.rs
@@ -544,7 +544,7 @@ mod test {
         let geom = Geometry::Point(pt);
         let gc = GeometryCollection(vec![geom.clone()]);
         let multi_point = MultiPoint::new(vec![pt]);
-        let multi_ls = MultiLineString(vec![ls.clone()]);
+        let multi_ls = MultiLineString::new(vec![ls.clone()]);
         let multi_poly = MultiPolygon::new(vec![poly.clone()]);
 
         let _ = pt.intersects(&pt);

--- a/geo/src/algorithm/lines_iter.rs
+++ b/geo/src/algorithm/lines_iter.rs
@@ -206,7 +206,7 @@ mod test {
 
     #[test]
     fn test_multi_line_string() {
-        let mls = MultiLineString(vec![
+        let mls = MultiLineString::new(vec![
             line_string![],
             line_string![(x: 0., y: 0.), (x: 1., y: 1.)],
             line_string![(x: 0., y: 0.), (x: 1., y: 1.), (x:2., y: 2.)],

--- a/geo/src/algorithm/map_coords.rs
+++ b/geo/src/algorithm/map_coords.rs
@@ -349,7 +349,7 @@ impl<T: CoordNum, NT: CoordNum> MapCoords<T, NT> for MultiLineString<T> {
     type Output = MultiLineString<NT>;
 
     fn map_coords(&self, func: impl Fn(&(T, T)) -> (NT, NT) + Copy) -> Self::Output {
-        MultiLineString(self.iter().map(|l| l.map_coords(func)).collect())
+        MultiLineString::new(self.iter().map(|l| l.map_coords(func)).collect())
     }
 }
 
@@ -360,7 +360,7 @@ impl<T: CoordNum, NT: CoordNum, E> TryMapCoords<T, NT, E> for MultiLineString<T>
         &self,
         func: impl Fn(&(T, T)) -> Result<(NT, NT), E> + Copy,
     ) -> Result<Self::Output, E> {
-        Ok(MultiLineString(
+        Ok(MultiLineString::new(
             self.0
                 .iter()
                 .map(|l| l.try_map_coords(func))
@@ -730,11 +730,11 @@ mod test {
     fn multilinestring() {
         let line1: LineString<f32> = LineString::from(vec![(0., 0.), (1., 2.)]);
         let line2: LineString<f32> = LineString::from(vec![(-1., 0.), (0., 0.), (1., 2.)]);
-        let mline = MultiLineString(vec![line1, line2]);
+        let mline = MultiLineString::new(vec![line1, line2]);
         let mline2 = mline.map_coords(|&(x, y)| (x + 10., y - 100.));
         assert_relative_eq!(
             mline2,
-            MultiLineString(vec![
+            MultiLineString::new(vec![
                 LineString::from(vec![(10., -100.), (11., -98.)]),
                 LineString::from(vec![(9., -100.), (10., -100.), (11., -98.)]),
             ]),

--- a/geo/src/algorithm/rotate.rs
+++ b/geo/src/algorithm/rotate.rs
@@ -584,10 +584,10 @@ mod test {
             (x: 20., y: 20.),
             (x: 40., y: 20.)
         ];
-        let multi_line_string: MultiLineString<f64> = MultiLineString(vec![ls1, ls2]);
+        let multi_line_string: MultiLineString<f64> = MultiLineString::new(vec![ls1, ls2]);
 
         // Results match with Shapely for `centroid`
-        let expected_around_centroid = MultiLineString(vec![
+        let expected_around_centroid = MultiLineString::new(vec![
             line_string![
                 (x: -5.062519283392216, y: 19.72288595632566),
                 (x: -3.648305721019121, y: 19.72288595632566),
@@ -606,7 +606,7 @@ mod test {
         );
 
         // Results match with Shapely for `center`
-        let expected_around_center: MultiLineString<f64> = MultiLineString(vec![
+        let expected_around_center: MultiLineString<f64> = MultiLineString::new(vec![
             line_string![
                 (x: -1.213203435596426, y: 17.07106781186548),
                 (x: 0.2010101267766693, y: 17.07106781186548),
@@ -757,7 +757,7 @@ mod test {
         assert_eq!(empty_linestring, rotated_empty_linestring);
 
         // multi line string
-        let empty_multilinestring: MultiLineString<f64> = MultiLineString::<f64>(vec![]);
+        let empty_multilinestring: MultiLineString<f64> = MultiLineString::<f64>::new(vec![]);
         let rotated_empty_multilinestring = empty_multilinestring.rotate_around_centroid(90.);
         assert_eq!(empty_multilinestring, rotated_empty_multilinestring);
 

--- a/geo/src/algorithm/simplify.rs
+++ b/geo/src/algorithm/simplify.rs
@@ -215,7 +215,7 @@ where
     T: GeoFloat,
 {
     fn simplify(&self, epsilon: &T) -> Self {
-        MultiLineString(self.iter().map(|l| l.simplify(epsilon)).collect())
+        MultiLineString::new(self.iter().map(|l| l.simplify(epsilon)).collect())
     }
 }
 
@@ -284,7 +284,7 @@ mod test {
 
     #[test]
     fn multilinestring() {
-        let mline = MultiLineString(vec![LineString::from(vec![
+        let mline = MultiLineString::new(vec![LineString::from(vec![
             (0.0, 0.0),
             (5.0, 4.0),
             (11.0, 5.5),
@@ -296,7 +296,7 @@ mod test {
 
         assert_eq!(
             mline2,
-            MultiLineString(vec![LineString::from(vec![
+            MultiLineString::new(vec![LineString::from(vec![
                 (0.0, 0.0),
                 (5.0, 4.0),
                 (11.0, 5.5),

--- a/geo/src/algorithm/simplifyvw.rs
+++ b/geo/src/algorithm/simplifyvw.rs
@@ -576,7 +576,7 @@ where
     T: CoordFloat + RTreeNum,
 {
     fn simplifyvw_preserve(&self, epsilon: &T) -> MultiLineString<T> {
-        MultiLineString(
+        MultiLineString::new(
             self.0
                 .iter()
                 .map(|l| l.simplifyvw_preserve(epsilon))
@@ -638,7 +638,7 @@ where
     T: CoordFloat,
 {
     fn simplifyvw(&self, epsilon: &T) -> MultiLineString<T> {
-        MultiLineString(self.iter().map(|l| l.simplifyvw(epsilon)).collect())
+        MultiLineString::new(self.iter().map(|l| l.simplifyvw(epsilon)).collect())
     }
 }
 
@@ -864,10 +864,10 @@ mod test {
         let correct = vec![(5.0, 2.0), (7.0, 25.0), (10.0, 10.0)];
         let correct_ls: Vec<_> = correct.iter().map(|e| Point::new(e.0, e.1)).collect();
 
-        let mline = MultiLineString(vec![LineString::from(points_ls)]);
+        let mline = MultiLineString::new(vec![LineString::from(points_ls)]);
         assert_relative_eq!(
             mline.simplifyvw(&30.),
-            MultiLineString(vec![LineString::from(correct_ls)]),
+            MultiLineString::new(vec![LineString::from(correct_ls)]),
             epsilon = 1e-6
         );
     }


### PR DESCRIPTION
Make migration simpler by using static function that will still be available if `MultiLineString` becomes a type alias.

Similar to https://github.com/georust/geo/pull/777

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- ~[ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.~
---

