### PR TITLE
Use `MultiPolygon::new()` instead of `MultiPolygon()`

### DIFF
--- a/geo-postgis/src/from_postgis.rs
+++ b/geo-postgis/src/from_postgis.rs
@@ -76,7 +76,7 @@ where
     /// (return `None` when `from_postgis()` is called on them).
     fn from_postgis(mp: &'a T) -> Self {
         let ret = mp.polygons().filter_map(Option::from_postgis).collect();
-        MultiPolygon(ret)
+        MultiPolygon::new(ret)
     }
 }
 impl<'a, T> FromPostgis<&'a GeometryCollectionT<T>> for GeometryCollection<f64>

--- a/geo-types/src/multi_polygon.rs
+++ b/geo-types/src/multi_polygon.rs
@@ -75,6 +75,11 @@ impl<'a, T: CoordNum> IntoIterator for &'a mut MultiPolygon<T> {
 }
 
 impl<T: CoordNum> MultiPolygon<T> {
+    /// Instantiate Self from the raw content value
+    pub fn new(value: Vec<Polygon<T>>) -> Self {
+        Self(value)
+    }
+
     pub fn iter(&self) -> impl Iterator<Item = &Polygon<T>> {
         self.0.iter()
     }
@@ -102,9 +107,9 @@ where
     /// use geo_types::{polygon, Polygon, MultiPolygon};
     ///
     /// let a_el: Polygon<f32> = polygon![(x: 0., y: 0.), (x: 5., y: 0.), (x: 7., y: 9.), (x: 0., y: 0.)];
-    /// let a = MultiPolygon(vec![a_el]);
+    /// let a = MultiPolygon::new(vec![a_el]);
     /// let b_el: Polygon<f32> = polygon![(x: 0., y: 0.), (x: 5., y: 0.), (x: 7.01, y: 9.), (x: 0., y: 0.)];
-    /// let b = MultiPolygon(vec![b_el]);
+    /// let b = MultiPolygon::new(vec![b_el]);
     ///
     /// approx::assert_relative_eq!(a, b, max_relative=0.1);
     /// approx::assert_relative_ne!(a, b, max_relative=0.001);
@@ -146,9 +151,9 @@ where
     /// use geo_types::{polygon, Polygon, MultiPolygon};
     ///
     /// let a_el: Polygon<f32> = polygon![(x: 0., y: 0.), (x: 5., y: 0.), (x: 7., y: 9.), (x: 0., y: 0.)];
-    /// let a = MultiPolygon(vec![a_el]);
+    /// let a = MultiPolygon::new(vec![a_el]);
     /// let b_el: Polygon<f32> = polygon![(x: 0., y: 0.), (x: 5., y: 0.), (x: 7.01, y: 9.), (x: 0., y: 0.)];
-    /// let b = MultiPolygon(vec![b_el]);
+    /// let b = MultiPolygon::new(vec![b_el]);
     ///
     /// approx::abs_diff_eq!(a, b, epsilon=0.1);
     /// approx::abs_diff_ne!(a, b, epsilon=0.001);
@@ -171,7 +176,7 @@ mod test {
 
     #[test]
     fn test_iter() {
-        let multi = MultiPolygon(vec![
+        let multi = MultiPolygon::new(vec![
             polygon![(x: 0, y: 0), (x: 2, y: 0), (x: 1, y: 2), (x:0, y:0)],
             polygon![(x: 10, y: 10), (x: 12, y: 10), (x: 11, y: 12), (x:10, y:10)],
         ]);
@@ -212,7 +217,7 @@ mod test {
 
     #[test]
     fn test_iter_mut() {
-        let mut multi = MultiPolygon(vec![
+        let mut multi = MultiPolygon::new(vec![
             polygon![(x: 0, y: 0), (x: 2, y: 0), (x: 1, y: 2), (x:0, y:0)],
             polygon![(x: 10, y: 10), (x: 12, y: 10), (x: 11, y: 12), (x:10, y:10)],
         ]);

--- a/geo/src/algorithm/area.rs
+++ b/geo/src/algorithm/area.rs
@@ -384,7 +384,7 @@ mod test {
             (x: 5., y: 6.),
             (x: 5., y: 5.)
         ];
-        let mpoly = MultiPolygon(vec![poly0, poly1, poly2]);
+        let mpoly = MultiPolygon::new(vec![poly0, poly1, poly2]);
         assert_relative_eq!(mpoly.signed_area(), 102.);
         assert_relative_eq!(mpoly.signed_area(), 102.);
     }
@@ -429,7 +429,7 @@ mod test {
         ];
         let polygon_area = polygon_cw.unsigned_area();
 
-        let multi_polygon = MultiPolygon(vec![polygon_cw, polygon_ccw]);
+        let multi_polygon = MultiPolygon::new(vec![polygon_cw, polygon_ccw]);
 
         assert_eq!(polygon_area * 2., multi_polygon.unsigned_area());
     }

--- a/geo/src/algorithm/bounding_rect.rs
+++ b/geo/src/algorithm/bounding_rect.rs
@@ -277,7 +277,7 @@ mod test {
     }
     #[test]
     fn multipolygon_test() {
-        let mpoly = MultiPolygon(vec![
+        let mpoly = MultiPolygon::new(vec![
             polygon![(x: 0., y: 0.), (x: 50., y: 0.), (x: 0., y: -70.), (x: 0., y: 0.)],
             polygon![(x: 0., y: 0.), (x: 5., y: 0.), (x: 0., y: 80.), (x: 0., y: 0.)],
             polygon![(x: 0., y: 0.), (x: -60., y: 0.), (x: 0., y: 6.), (x: 0., y: 0.)],

--- a/geo/src/algorithm/centroid.rs
+++ b/geo/src/algorithm/centroid.rs
@@ -669,7 +669,7 @@ mod test {
             LineString::from(vec![p(0., 0.), p(1., 0.), p(0., 0.)]),
             vec![],
         );
-        let multipoly = MultiPolygon(vec![poly]);
+        let multipoly = MultiPolygon::new(vec![poly]);
         assert_eq!(multipoly.centroid(), Some(p(0.5, 0.)));
     }
     #[test]
@@ -682,7 +682,7 @@ mod test {
             LineString::from(vec![p(2., 2.), p(6., 2.), p(2., 2.)]),
             vec![],
         );
-        let multipoly = MultiPolygon(vec![p1, p2]);
+        let multipoly = MultiPolygon::new(vec![p1, p2]);
         assert_eq!(multipoly.centroid(), Some(p(3., 2.)));
     }
     #[test]
@@ -696,7 +696,7 @@ mod test {
             LineString::from(vec![p(2., 2.), p(2., 2.), p(2., 2.)]),
             vec![],
         );
-        let multipoly = MultiPolygon(vec![p1, p2]);
+        let multipoly = MultiPolygon::new(vec![p1, p2]);
         assert_eq!(multipoly.centroid(), Some(p(1.5, 1.5)));
     }
     #[test]
@@ -712,7 +712,7 @@ mod test {
             LineString::from(vec![p(2., 2.), p(6., 2.), p(2., 2.)]),
             vec![],
         );
-        let multipoly = MultiPolygon(vec![normal.clone(), flat]);
+        let multipoly = MultiPolygon::new(vec![normal.clone(), flat]);
         assert_eq!(multipoly.centroid(), normal.centroid());
     }
     #[test]
@@ -750,14 +750,14 @@ mod test {
     // Tests: Centroid of MultiPolygon
     #[test]
     fn empty_multipolygon_polygon_test() {
-        assert!(MultiPolygon::<f64>(Vec::new()).centroid().is_none());
+        assert!(MultiPolygon::<f64>::new(Vec::new()).centroid().is_none());
     }
     #[test]
     fn multipolygon_one_polygon_test() {
         let linestring =
             LineString::from(vec![p(0., 0.), p(2., 0.), p(2., 2.), p(0., 2.), p(0., 0.)]);
         let poly = Polygon::new(linestring, Vec::new());
-        assert_eq!(MultiPolygon(vec![poly]).centroid(), Some(p(1., 1.)));
+        assert_eq!(MultiPolygon::new(vec![poly]).centroid(), Some(p(1., 1.)));
     }
     #[test]
     fn multipolygon_two_polygons_test() {
@@ -767,7 +767,7 @@ mod test {
         let linestring =
             LineString::from(vec![p(7., 1.), p(8., 1.), p(8., 2.), p(7., 2.), p(7., 1.)]);
         let poly2 = Polygon::new(linestring, Vec::new());
-        let centroid = MultiPolygon(vec![poly1, poly2]).centroid().unwrap();
+        let centroid = MultiPolygon::new(vec![poly1, poly2]).centroid().unwrap();
         assert_relative_eq!(
             centroid,
             point![x: 4.071428571428571, y: 1.9285714285714286]
@@ -780,7 +780,7 @@ mod test {
         let linestring = LineString::from(vec![(0., 0.), (-2., 0.), (-2., 2.), (0., 2.), (0., 0.)]);
         let poly2 = Polygon::new(linestring, Vec::new());
         assert_relative_eq!(
-            MultiPolygon(vec![poly1, poly2]).centroid().unwrap(),
+            MultiPolygon::new(vec![poly1, poly2]).centroid().unwrap(),
             point![x: 0., y: 1.]
         );
     }

--- a/geo/src/algorithm/chaikin_smoothing.rs
+++ b/geo/src/algorithm/chaikin_smoothing.rs
@@ -74,7 +74,7 @@ where
     T: CoordFloat + FromPrimitive,
 {
     fn chaikin_smoothing(&self, n_iterations: usize) -> Self {
-        MultiPolygon(
+        MultiPolygon::new(
             self.0
                 .iter()
                 .map(|poly| poly.chaikin_smoothing(n_iterations))

--- a/geo/src/algorithm/closest_point.rs
+++ b/geo/src/algorithm/closest_point.rs
@@ -337,7 +337,7 @@ mod tests {
         let square_10 = square_1.translate(10.0, 10.0);
         let square_50 = square_1.translate(50.0, 50.0);
 
-        let multi_polygon = MultiPolygon(vec![square_1, square_10, square_50]);
+        let multi_polygon = MultiPolygon::new(vec![square_1, square_10, square_50]);
         let result = multi_polygon.closest_point(&point!(x: 8.0, y: 8.0));
         assert_eq!(result, Closest::SinglePoint(point!(x: 10.0, y: 10.0)));
 

--- a/geo/src/algorithm/concave_hull.rs
+++ b/geo/src/algorithm/concave_hull.rs
@@ -438,7 +438,7 @@ mod test {
              (x: 3.0, y: 1.0),
              (x: 3.0, y: 2.0)
         ];
-        let multipolygon = MultiPolygon(vec![v1, v2]);
+        let multipolygon = MultiPolygon::new(vec![v1, v2]);
         let res = multipolygon.concave_hull(2.0);
         let correct = vec![
             Coordinate::from((4.0, 0.0)),

--- a/geo/src/algorithm/contains/mod.rs
+++ b/geo/src/algorithm/contains/mod.rs
@@ -233,7 +233,7 @@ mod test {
     /// Tests: Point in MultiPolygon
     #[test]
     fn empty_multipolygon_test() {
-        let multipoly = MultiPolygon(Vec::new());
+        let multipoly = MultiPolygon::new(Vec::new());
         assert!(!multipoly.contains(&Point::new(2., 1.)));
     }
     #[test]
@@ -246,7 +246,7 @@ mod test {
             LineString::from(vec![(2., 0.), (3., 0.), (3., 1.), (2., 1.), (2., 0.)]),
             Vec::new(),
         );
-        let multipoly = MultiPolygon(vec![poly1, poly2]);
+        let multipoly = MultiPolygon::new(vec![poly1, poly2]);
         assert!(multipoly.contains(&Point::new(0.5, 0.5)));
         assert!(multipoly.contains(&Point::new(2.5, 0.5)));
         assert!(!multipoly.contains(&Point::new(1.5, 0.5)));
@@ -267,7 +267,7 @@ mod test {
             Vec::new(),
         );
 
-        let multipoly = MultiPolygon(vec![poly1, poly2]);
+        let multipoly = MultiPolygon::new(vec![poly1, poly2]);
         assert!(multipoly.contains(&Point::new(3., 5.)));
         assert!(multipoly.contains(&Point::new(12., 2.)));
         assert!(!multipoly.contains(&Point::new(3., 2.)));

--- a/geo/src/algorithm/convex_hull/test.rs
+++ b/geo/src/algorithm/convex_hull/test.rs
@@ -67,7 +67,7 @@ fn convex_hull_multilinestring_test() {
 fn convex_hull_multipolygon_test() {
     let p1 = polygon![(x: 0.0, y: 0.0), (x: 1.0, y: 10.0), (x: 2.0, y: 0.0), (x: 0.0, y: 0.0)];
     let p2 = polygon![(x: 3.0, y: 0.0), (x: 4.0, y: 10.0), (x: 5.0, y: 0.0), (x: 3.0, y: 0.0)];
-    let mp = MultiPolygon(vec![p1, p2]);
+    let mp = MultiPolygon::new(vec![p1, p2]);
     let correct = vec![
         Coordinate::from((5.0, 0.0)),
         Coordinate::from((4.0, 10.0)),

--- a/geo/src/algorithm/coords_iter.rs
+++ b/geo/src/algorithm/coords_iter.rs
@@ -712,7 +712,7 @@ mod test {
         expected_coords.append(&mut coords.clone());
         expected_coords.append(&mut coords);
 
-        let actual_coords = MultiPolygon(vec![polygon.clone(), polygon])
+        let actual_coords = MultiPolygon::new(vec![polygon.clone(), polygon])
             .coords_iter()
             .collect::<Vec<_>>();
 

--- a/geo/src/algorithm/euclidean_distance.rs
+++ b/geo/src/algorithm/euclidean_distance.rs
@@ -753,7 +753,7 @@ mod test {
         let pol1 = Polygon::new(ls1, vec![]);
         let pol2 = Polygon::new(ls2, vec![]);
         let pol3 = Polygon::new(ls3, vec![]);
-        let mp = MultiPolygon(vec![pol1.clone(), pol2, pol3]);
+        let mp = MultiPolygon::new(vec![pol1.clone(), pol2, pol3]);
         let pnt1 = Point::new(0.0, 15.0);
         let pnt2 = Point::new(10.0, 20.0);
         let ln = Line::new(pnt1.0, pnt2.0);
@@ -768,7 +768,7 @@ mod test {
         let ls2 = LineString::from(vec![(3.0, 0.0), (4.0, 10.0), (5.0, 0.0), (3.0, 0.0)]);
         let p1 = Polygon::new(ls1, vec![]);
         let p2 = Polygon::new(ls2, vec![]);
-        let mp = MultiPolygon(vec![p1, p2]);
+        let mp = MultiPolygon::new(vec![p1, p2]);
         let p = Point::new(50.0, 50.0);
         assert_relative_eq!(p.euclidean_distance(&mp), 60.959002616512684);
     }

--- a/geo/src/algorithm/intersects/mod.rs
+++ b/geo/src/algorithm/intersects/mod.rs
@@ -545,7 +545,7 @@ mod test {
         let gc = GeometryCollection(vec![geom.clone()]);
         let multi_point = MultiPoint(vec![pt]);
         let multi_ls = MultiLineString(vec![ls.clone()]);
-        let multi_poly = MultiPolygon(vec![poly.clone()]);
+        let multi_poly = MultiPolygon::new(vec![poly.clone()]);
 
         let _ = pt.intersects(&pt);
         let _ = pt.intersects(&ln);

--- a/geo/src/algorithm/lines_iter.rs
+++ b/geo/src/algorithm/lines_iter.rs
@@ -250,7 +250,7 @@ mod test {
 
     #[test]
     fn test_multi_polygon() {
-        let mp = MultiPolygon(vec![
+        let mp = MultiPolygon::new(vec![
             polygon!(
                 exterior: [(x: 0., y: 0.), (x: 0., y: 10.), (x: 10., y: 10.), (x: 10., y: 0.)],
                 interiors: [[(x: 1., y: 1.), (x: 1., y: 2.), (x: 2., y: 2.), (x: 2., y: 1.)]],

--- a/geo/src/algorithm/map_coords.rs
+++ b/geo/src/algorithm/map_coords.rs
@@ -381,7 +381,7 @@ impl<T: CoordNum, NT: CoordNum> MapCoords<T, NT> for MultiPolygon<T> {
     type Output = MultiPolygon<NT>;
 
     fn map_coords(&self, func: impl Fn(&(T, T)) -> (NT, NT) + Copy) -> Self::Output {
-        MultiPolygon(self.iter().map(|p| p.map_coords(func)).collect())
+        MultiPolygon::new(self.iter().map(|p| p.map_coords(func)).collect())
     }
 }
 
@@ -392,7 +392,7 @@ impl<T: CoordNum, NT: CoordNum, E> TryMapCoords<T, NT, E> for MultiPolygon<T> {
         &self,
         func: impl Fn(&(T, T)) -> Result<(NT, NT), E> + Copy,
     ) -> Result<Self::Output, E> {
-        Ok(MultiPolygon(
+        Ok(MultiPolygon::new(
             self.0
                 .iter()
                 .map(|p| p.try_map_coords(func))
@@ -770,7 +770,7 @@ mod test {
             ],
         ];
 
-        let mp = MultiPolygon(vec![poly1, poly2]);
+        let mp = MultiPolygon::new(vec![poly1, poly2]);
         let mp2 = mp.map_coords(|&(x, y)| (x * 2., y + 100.));
         assert_eq!(mp2.0.len(), 2);
         assert_relative_eq!(

--- a/geo/src/algorithm/orient.rs
+++ b/geo/src/algorithm/orient.rs
@@ -79,7 +79,7 @@ where
     T: GeoNum,
 {
     fn orient(&self, direction: Direction) -> MultiPolygon<T> {
-        MultiPolygon(self.iter().map(|poly| poly.orient(direction)).collect())
+        MultiPolygon::new(self.iter().map(|poly| poly.orient(direction)).collect())
     }
 }
 

--- a/geo/src/algorithm/simplify.rs
+++ b/geo/src/algorithm/simplify.rs
@@ -239,7 +239,7 @@ where
     T: GeoFloat,
 {
     fn simplify(&self, epsilon: &T) -> Self {
-        MultiPolygon(self.iter().map(|p| p.simplify(epsilon)).collect())
+        MultiPolygon::new(self.iter().map(|p| p.simplify(epsilon)).collect())
     }
 }
 
@@ -332,7 +332,7 @@ mod test {
 
     #[test]
     fn multipolygon() {
-        let mpoly = MultiPolygon(vec![polygon![
+        let mpoly = MultiPolygon::new(vec![polygon![
             (x: 0., y: 0.),
             (x: 0., y: 10.),
             (x: 5., y: 11.),
@@ -345,7 +345,7 @@ mod test {
 
         assert_eq!(
             mpoly2,
-            MultiPolygon(vec![polygon![
+            MultiPolygon::new(vec![polygon![
                 (x: 0., y: 0.),
                 (x: 0., y: 10.),
                 (x: 10., y: 10.),

--- a/geo/src/algorithm/simplifyvw.rs
+++ b/geo/src/algorithm/simplifyvw.rs
@@ -606,7 +606,7 @@ where
     T: CoordFloat + RTreeNum,
 {
     fn simplifyvw_preserve(&self, epsilon: &T) -> MultiPolygon<T> {
-        MultiPolygon(
+        MultiPolygon::new(
             self.0
                 .iter()
                 .map(|p| p.simplifyvw_preserve(epsilon))
@@ -662,7 +662,7 @@ where
     T: CoordFloat,
 {
     fn simplifyvw(&self, epsilon: &T) -> MultiPolygon<T> {
-        MultiPolygon(self.iter().map(|p| p.simplifyvw(epsilon)).collect())
+        MultiPolygon::new(self.iter().map(|p| p.simplifyvw(epsilon)).collect())
     }
 }
 
@@ -900,7 +900,7 @@ mod test {
 
     #[test]
     fn multipolygon() {
-        let mpoly = MultiPolygon(vec![Polygon::new(
+        let mpoly = MultiPolygon::new(vec![Polygon::new(
             LineString::from(vec![
                 (0., 0.),
                 (0., 10.),
@@ -916,7 +916,7 @@ mod test {
 
         assert_relative_eq!(
             mpoly2,
-            MultiPolygon(vec![Polygon::new(
+            MultiPolygon::new(vec![Polygon::new(
                 LineString::from(vec![(0., 0.), (0., 10.), (10., 10.), (10., 0.), (0., 0.)]),
                 vec![],
             )]),


### PR DESCRIPTION
Make migration simpler by using static function that will still be available if `MultiPolygon` becomes a type alias.

Similar to https://github.com/georust/geo/pull/777

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

