### PR TITLE
Unlink geo-types from the rest of the crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,5 @@ members = ["geo", "geo-types", "geo-postgis", "geo-test-fixtures", "jts-test-run
 
 # Ensure any transitive dependencies also use the local geo/geo-types
 geo = { path = "geo" }
-geo-types = { path = "geo-types" }
+# Uncomment this after geo-types 0.8+ is published with TZM support
+# geo-types = { path = "geo-types" }

--- a/geo-postgis/Cargo.toml
+++ b/geo-postgis/Cargo.toml
@@ -12,4 +12,6 @@ edition = "2021"
 
 [dependencies]
 postgis = { version = ">=0.7.0, <0.9.0" }
-geo-types = { version = "0.7", path = "../geo-types" }
+geo-types = "0.7.4"
+# Use this after geo-types 0.8+ is published with TZM support
+#geo-types = { version = "0.8", path = "../geo-types" }

--- a/geo-test-fixtures/Cargo.toml
+++ b/geo-test-fixtures/Cargo.toml
@@ -6,4 +6,6 @@ publish = false
 
 [dependencies]
 wkt = { version = "0.10.0", default-features = false }
-geo-types = { path = "../geo-types" }
+geo-types = "0.7.4"
+# Use this after geo-types 0.8+ is published with TZM support
+#geo-types = { version = "0.8", path = "../geo-types" }

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -17,7 +17,7 @@ proj-network = ["use-proj", "proj/network"]
 use-serde = ["serde", "geo-types/serde"]
 
 [dependencies]
-geo-types = { version = "0.7.3", features = ["approx", "use-rstar"] }
+geo-types = { version = "0.7.4", features = ["approx", "use-rstar"] }
 geographiclib-rs = "0.2"
 log = "0.4.11"
 num-traits = "0.2"

--- a/geo/fuzz/Cargo.toml
+++ b/geo/fuzz/Cargo.toml
@@ -16,7 +16,8 @@ path = ".."
 
 [dependencies.geo-types]
 features = ["arbitrary"]
-path = "../../geo-types"
+# Uncomment after geo-types 0.8+ is published with TZM support
+# path = "../../geo-types"
 
 # Prevent this from interfering with workspaces
 [workspace]
@@ -30,4 +31,5 @@ doc = false
 
 [patch.crates-io]
 geo = { path = ".." }
-geo-types = { path = "../../geo-types" }
+# Uncomment after geo-types 0.8+ is published with TZM support
+# geo-types = { path = "../../geo-types" }


### PR DESCRIPTION
Remove `geo-types` patches in `Cargo.toml` files, so that `geo-types` is now completelly separated from the rest of the code.

This should be reverted once geo-types 0.8+ is released.

This PR makes it easier to review unlinking part, in preparation for #797 and #772 

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
~- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.~
---
