### PR TITLE
Hide benchmarking criterion html report warnings

### DIFF
--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -27,7 +27,7 @@ serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 approx = "0.4.0"
-criterion = "0.3"
+criterion = { version = "0.3", features = ["html_reports"] }
 geo-test-fixtures = { path = "../geo-test-fixtures" }
 jts-test-runner = { path = "../jts-test-runner" }
 pretty_env_logger = "0.4"


### PR DESCRIPTION
Per criterion instructions, adding html to the crate requirements removes
the future compatibility warning (criterion will remove html by default in the next verion)

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
~- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.~
---
