### PR TITLE
Consolidate traits and rename for consistency with std lib spelling of "in_place"

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -7,6 +7,10 @@
   * <https://github.com/georust/geo/pull/810>
 * BREAKING: Bump proj dependency to 0.26 which uses proj lib 9.0
   * <https://github.com/georust/geo/pull/813>
+* MapCoords restrucuring
+  - rename MapCoordsInplace::map_coords_inplace -> MapCoordsInPlace::map_coords_in_place
+  - rename TryMapCoordsInplace::try_map_coords_inplace -> TryMapCoordsInPlace::try_map_coords_in_place
+  - Consolidate traits `TryMapCoords` into `MapCoords` and `TryMapCoordsInplace` into `MapCoordsInPlace`
 
 ## 0.20.1
 

--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -3,15 +3,16 @@
 
 ## Unreleased
 
-* Remove unneded reference for `*MapCoords*` closure parameter.
+* Remove unneeded reference for `*MapCoords*` closure parameter.
   * <https://github.com/georust/geo/pull/810>
 * BREAKING: Bump proj dependency to 0.26 which uses proj lib 9.0
   * <https://github.com/georust/geo/pull/813>
-* MapCoords restrucuring
+* rename Translate::translate_inplace -> Translate::translate_in_place
+  * <https://github.com/georust/geo/pull/811>
+* MapCoords restructuring: <https://github.com/georust/geo/pull/811>
   - rename MapCoordsInplace::map_coords_inplace -> MapCoordsInPlace::map_coords_in_place
   - rename TryMapCoordsInplace::try_map_coords_inplace -> TryMapCoordsInPlace::try_map_coords_in_place
   - Consolidate traits `TryMapCoords` into `MapCoords` and `TryMapCoordsInplace` into `MapCoordsInPlace`
-
 ## 0.20.1
 
 * FIX: update to proper minimum geo-types version

--- a/geo/src/algorithm/map_coords.rs
+++ b/geo/src/algorithm/map_coords.rs
@@ -1,840 +1,950 @@
 //! # Advanced Example: Fallible Geometry coordinate conversion using `PROJ`
 //!
-//! ```
+#![cfg_attr(feature = "use-proj", doc = "```")]
+#![cfg_attr(not(feature = "use-proj"), doc = "```ignore")]
 //! // activate the [use-proj] feature in cargo.toml in order to access proj functions
 //! use approx::assert_relative_eq;
-//! # #[cfg(feature = "use-proj")]
 //! use geo::{Coordinate, Point};
-//! # #[cfg(feature = "use-proj")]
-//! use geo::algorithm::map_coords::TryMapCoords;
-//! # #[cfg(feature = "use-proj")]
+//! use geo::algorithm::map_coords::MapCoords;
 //! use proj::{Coord, Proj, ProjError};
 //! // GeoJSON uses the WGS 84 coordinate system
-//! # #[cfg(feature = "use-proj")]
 //! let from = "EPSG:4326";
 //! // The NAD83 / California zone 6 (ftUS) coordinate system
-//! # #[cfg(feature = "use-proj")]
 //! let to = "EPSG:2230";
-//! # #[cfg(feature = "use-proj")]
 //! let to_feet = Proj::new_known_crs(&from, &to, None).unwrap();
-//! # #[cfg(feature = "use-proj")]
 //! let f = |x: f64, y: f64| -> Result<_, ProjError> {
 //!     // proj can accept Point, Coordinate, Tuple, and array values, returning a Result
 //!     let shifted = to_feet.convert((x, y))?;
 //!     Ok((shifted.x(), shifted.y()))
 //! };
-//! # #[cfg(feature = "use-proj")]
 //! // 👽
-//! # #[cfg(feature = "use-proj")]
 //! let usa_m = Point::new(-115.797615, 37.2647978);
-//! # #[cfg(feature = "use-proj")]
 //! let usa_ft = usa_m.try_map_coords(|(x, y)| f(x, y)).unwrap();
-//! # #[cfg(feature = "use-proj")]
 //! assert_relative_eq!(6693625.67217475, usa_ft.x(), epsilon = 1e-6);
-//! # #[cfg(feature = "use-proj")]
 //! assert_relative_eq!(3497301.5918027186, usa_ft.y(), epsilon = 1e-6);
 //! ```
 
-use crate::{
-    coord, CoordNum, Geometry, GeometryCollection, Line, LineString, MultiLineString, MultiPoint,
-    MultiPolygon, Point, Polygon, Rect, Triangle,
-};
+pub use modern::*;
+mod modern {
+    pub(crate) use crate::{
+        coord, CoordNum, Geometry, GeometryCollection, Line, LineString, MultiLineString,
+        MultiPoint, MultiPolygon, Point, Polygon, Rect, Triangle,
+    };
 
-/// Map a function over all the coordinates in an object, returning a new one
-pub trait MapCoords<T, NT> {
-    type Output;
+    /// Map a function over all the coordinates in an object, returning a new one
+    pub trait MapCoords<T, NT> {
+        type Output;
 
-    /// Apply a function to all the coordinates in a geometric object, returning a new object.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use geo::algorithm::map_coords::MapCoords;
-    /// use geo::Point;
-    /// use approx::assert_relative_eq;
-    ///
-    /// let p1 = Point::new(10., 20.);
-    /// let p2 = p1.map_coords(|(x, y)| (x + 1000., y * 2.));
-    ///
-    /// assert_relative_eq!(p2, Point::new(1010., 40.), epsilon = 1e-6);
-    /// ```
-    ///
-    /// You can convert the coordinate type this way as well
-    ///
-    /// ```
-    /// # use geo::Point;
-    /// # use geo::algorithm::map_coords::MapCoords;
-    /// # use approx::assert_relative_eq;
-    ///
-    /// let p1: Point<f32> = Point::new(10.0f32, 20.0f32);
-    /// let p2: Point<f64> = p1.map_coords(|(x, y)| (x as f64, y as f64));
-    ///
-    /// assert_relative_eq!(p2, Point::new(10.0f64, 20.0f64), epsilon = 1e-6);
-    /// ```
-    fn map_coords(&self, func: impl Fn((T, T)) -> (NT, NT) + Copy) -> Self::Output
-    where
-        T: CoordNum,
-        NT: CoordNum;
-}
+        /// Apply a function to all the coordinates in a geometric object, returning a new object.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use geo::algorithm::map_coords::MapCoords;
+        /// use geo::Point;
+        /// use approx::assert_relative_eq;
+        ///
+        /// let p1 = Point::new(10., 20.);
+        /// let p2 = p1.map_coords(|(x, y)| (x + 1000., y * 2.));
+        ///
+        /// assert_relative_eq!(p2, Point::new(1010., 40.), epsilon = 1e-6);
+        /// ```
+        ///
+        /// You can convert the coordinate type this way as well
+        ///
+        /// ```
+        /// # use geo::Point;
+        /// # use geo::algorithm::map_coords::MapCoords;
+        /// # use approx::assert_relative_eq;
+        ///
+        /// let p1: Point<f32> = Point::new(10.0f32, 20.0f32);
+        /// let p2: Point<f64> = p1.map_coords(|(x, y)| (x as f64, y as f64));
+        ///
+        /// assert_relative_eq!(p2, Point::new(10.0f64, 20.0f64), epsilon = 1e-6);
+        /// ```
+        fn map_coords(&self, func: impl Fn((T, T)) -> (NT, NT) + Copy) -> Self::Output
+        where
+            T: CoordNum,
+            NT: CoordNum;
 
-/// Map a fallible function over all the coordinates in a geometry, returning a Result
-pub trait TryMapCoords<T, NT, E> {
-    type Output;
-
-    /// Map a fallible function over all the coordinates in a geometry, returning a Result
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use approx::assert_relative_eq;
-    /// use geo::algorithm::map_coords::TryMapCoords;
-    /// use geo::Point;
-    ///
-    /// let p1 = Point::new(10., 20.);
-    /// let p2 = p1
-    ///     .try_map_coords(|(x, y)| -> Result<_, std::convert::Infallible> {
-    ///         Ok((x + 1000., y * 2.))
-    ///     }).unwrap();
-    ///
-    /// assert_relative_eq!(p2, Point::new(1010., 40.), epsilon = 1e-6);
-    /// ```
-    ///
-    /// ## Advanced Example: Geometry coordinate conversion using `PROJ`
-    ///
-    /// ```
-    /// use approx::assert_relative_eq;
-    /// // activate the [use-proj] feature in cargo.toml in order to access proj functions
-    /// # #[cfg(feature = "use-proj")]
-    /// use geo::{Coordinate, Point};
-    /// # #[cfg(feature = "use-proj")]
-    /// use geo::algorithm::map_coords::TryMapCoords;
-    /// # #[cfg(feature = "use-proj")]
-    /// use proj::{Coord, Proj, ProjError};
-    /// // GeoJSON uses the WGS 84 coordinate system
-    /// # #[cfg(feature = "use-proj")]
-    /// let from = "EPSG:4326";
-    /// // The NAD83 / California zone 6 (ftUS) coordinate system
-    /// # #[cfg(feature = "use-proj")]
-    /// let to = "EPSG:2230";
-    /// # #[cfg(feature = "use-proj")]
-    /// let to_feet = Proj::new_known_crs(&from, &to, None).unwrap();
-    /// # #[cfg(feature = "use-proj")]
-    /// let f = |x: f64, y: f64| -> Result<_, ProjError> {
-    ///     // proj can accept Point, Coordinate, Tuple, and array values, returning a Result
-    ///     let shifted = to_feet.convert((x, y))?;
-    ///     Ok((shifted.x(), shifted.y()))
-    /// };
-    /// # #[cfg(feature = "use-proj")]
-    /// // 👽
-    /// # #[cfg(feature = "use-proj")]
-    /// let usa_m = Point::new(-115.797615, 37.2647978);
-    /// # #[cfg(feature = "use-proj")]
-    /// let usa_ft = usa_m.try_map_coords(|(x, y)| f(x, y)).unwrap();
-    /// # #[cfg(feature = "use-proj")]
-    /// assert_relative_eq!(6693625.67217475, usa_ft.x(), epsilon = 1e-6);
-    /// # #[cfg(feature = "use-proj")]
-    /// assert_relative_eq!(3497301.5918027186, usa_ft.y(), epsilon = 1e-6);
-    /// ```
-    fn try_map_coords(
-        &self,
-        func: impl Fn((T, T)) -> Result<(NT, NT), E> + Copy,
-    ) -> Result<Self::Output, E>
-    where
-        T: CoordNum,
-        NT: CoordNum;
-}
-
-/// Map a function over all the coordinates in an object in place
-pub trait MapCoordsInplace<T> {
-    /// Apply a function to all the coordinates in a geometric object, in place
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use geo::algorithm::map_coords::MapCoordsInplace;
-    /// use geo::Point;
-    /// use approx::assert_relative_eq;
-    ///
-    /// let mut p = Point::new(10., 20.);
-    /// p.map_coords_inplace(|(x, y)| (x + 1000., y * 2.));
-    ///
-    /// assert_relative_eq!(p, Point::new(1010., 40.), epsilon = 1e-6);
-    /// ```
-    fn map_coords_inplace(&mut self, func: impl Fn((T, T)) -> (T, T) + Copy)
-    where
-        T: CoordNum;
-}
-
-/// Map a fallible function over all the coordinates in a geometry, returning a Result
-pub trait TryMapCoordsInplace<T, E> {
-    /// Map a fallible function over all the coordinates in a geometry, in place, returning a `Result`.
-    ///
-    /// Upon encountering an `Err` from the function, `try_map_coords_inplace` immediately returns
-    /// and the geometry is potentially left in a partially mapped state.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use geo::algorithm::map_coords::TryMapCoordsInplace;
-    ///
-    /// let mut p1 = geo::point!{x: 10u32, y: 20u32};
-    ///
-    /// p1.try_map_coords_inplace(|(x, y)| -> Result<_, &str> {
-    ///     Ok((
-    ///         x.checked_add(1000).ok_or("Overflow")?,
-    ///         y.checked_mul(2).ok_or("Overflow")?,
-    ///     ))
-    /// })?;
-    ///
-    /// assert_eq!(
-    ///     p1,
-    ///     geo::point!{x: 1010u32, y: 40u32},
-    /// );
-    /// # Ok::<(), &str>(())
-    /// ```
-    fn try_map_coords_inplace(
-        &mut self,
-        func: impl Fn((T, T)) -> Result<(T, T), E>,
-    ) -> Result<(), E>
-    where
-        T: CoordNum;
-}
-
-//-----------------------//
-// Point implementations //
-//-----------------------//
-
-impl<T: CoordNum, NT: CoordNum> MapCoords<T, NT> for Point<T> {
-    type Output = Point<NT>;
-
-    fn map_coords(&self, func: impl Fn((T, T)) -> (NT, NT) + Copy) -> Self::Output {
-        let new_point = func((self.0.x, self.0.y));
-        Point::new(new_point.0, new_point.1)
+        /// Map a fallible function over all the coordinates in a geometry, returning a Result
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use approx::assert_relative_eq;
+        /// use geo::algorithm::map_coords::MapCoords;
+        /// use geo::Point;
+        ///
+        /// let p1 = Point::new(10., 20.);
+        /// let p2 = p1
+        ///     .try_map_coords(|(x, y)| -> Result<_, std::convert::Infallible> {
+        ///         Ok((x + 1000., y * 2.))
+        ///     }).unwrap();
+        ///
+        /// assert_relative_eq!(p2, Point::new(1010., 40.), epsilon = 1e-6);
+        /// ```
+        ///
+        /// ## Advanced Example: Geometry coordinate conversion using `PROJ`
+        ///
+        #[cfg_attr(feature = "use-proj", doc = "```")]
+        #[cfg_attr(not(feature = "use-proj"), doc = "```ignore")]
+        /// use approx::assert_relative_eq;
+        /// // activate the [use-proj] feature in cargo.toml in order to access proj functions
+        /// use geo::{Coordinate, Point};
+        /// use geo::map_coords::MapCoords;
+        /// use proj::{Coord, Proj, ProjError};
+        /// // GeoJSON uses the WGS 84 coordinate system
+        /// let from = "EPSG:4326";
+        /// // The NAD83 / California zone 6 (ftUS) coordinate system
+        /// let to = "EPSG:2230";
+        /// let to_feet = Proj::new_known_crs(&from, &to, None).unwrap();
+        /// let f = |x: f64, y: f64| -> Result<_, ProjError> {
+        ///     // proj can accept Point, Coordinate, Tuple, and array values, returning a Result
+        ///     let shifted = to_feet.convert((x, y))?;
+        ///     Ok((shifted.x(), shifted.y()))
+        /// };
+        /// // 👽
+        /// let usa_m = Point::new(-115.797615, 37.2647978);
+        /// let usa_ft = usa_m.try_map_coords(|(x, y)| f(x, y)).unwrap();
+        /// assert_relative_eq!(6693625.67217475, usa_ft.x(), epsilon = 1e-6);
+        /// assert_relative_eq!(3497301.5918027186, usa_ft.y(), epsilon = 1e-6);
+        /// ```
+        fn try_map_coords<E>(
+            &self,
+            func: impl Fn((T, T)) -> Result<(NT, NT), E> + Copy,
+        ) -> Result<Self::Output, E>
+        where
+            T: CoordNum,
+            NT: CoordNum;
     }
-}
 
-impl<T: CoordNum, NT: CoordNum, E> TryMapCoords<T, NT, E> for Point<T> {
-    type Output = Point<NT>;
+    pub trait MapCoordsInPlace<T> {
+        /// Apply a function to all the coordinates in a geometric object, in place
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use geo::algorithm::map_coords::MapCoordsInPlace;
+        /// use geo::Point;
+        /// use approx::assert_relative_eq;
+        ///
+        /// let mut p = Point::new(10., 20.);
+        /// p.map_coords_in_place(|(x, y)| (x + 1000., y * 2.));
+        ///
+        /// assert_relative_eq!(p, Point::new(1010., 40.), epsilon = 1e-6);
+        /// ```
+        fn map_coords_in_place(&mut self, func: impl Fn((T, T)) -> (T, T) + Copy)
+        where
+            T: CoordNum;
 
-    fn try_map_coords(
-        &self,
-        func: impl Fn((T, T)) -> Result<(NT, NT), E>,
-    ) -> Result<Self::Output, E> {
-        let new_point = func((self.0.x, self.0.y))?;
-        Ok(Point::new(new_point.0, new_point.1))
+        /// Map a fallible function over all the coordinates in a geometry, in place, returning a `Result`.
+        ///
+        /// Upon encountering an `Err` from the function, `try_map_coords_in_place` immediately returns
+        /// and the geometry is potentially left in a partially mapped state.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use geo::algorithm::map_coords::MapCoordsInPlace;
+        ///
+        /// let mut p1 = geo::point!{x: 10u32, y: 20u32};
+        ///
+        /// p1.try_map_coords_in_place(|(x, y)| -> Result<_, &str> {
+        ///     Ok((
+        ///         x.checked_add(1000).ok_or("Overflow")?,
+        ///         y.checked_mul(2).ok_or("Overflow")?,
+        ///     ))
+        /// })?;
+        ///
+        /// assert_eq!(
+        ///     p1,
+        ///     geo::point!{x: 1010u32, y: 40u32},
+        /// );
+        /// # Ok::<(), &str>(())
+        /// ```
+        fn try_map_coords_in_place<E>(
+            &mut self,
+            func: impl Fn((T, T)) -> Result<(T, T), E>,
+        ) -> Result<(), E>
+        where
+            T: CoordNum;
     }
-}
 
-impl<T: CoordNum> MapCoordsInplace<T> for Point<T> {
-    fn map_coords_inplace(&mut self, func: impl Fn((T, T)) -> (T, T)) {
-        let new_point = func((self.0.x, self.0.y));
-        self.0.x = new_point.0;
-        self.0.y = new_point.1;
-    }
-}
+    //-----------------------//
+    // Point implementations //
+    //-----------------------//
 
-impl<T: CoordNum, E> TryMapCoordsInplace<T, E> for Point<T> {
-    fn try_map_coords_inplace(
-        &mut self,
-        func: impl Fn((T, T)) -> Result<(T, T), E>,
-    ) -> Result<(), E> {
-        let new_point = func((self.0.x, self.0.y))?;
-        self.0.x = new_point.0;
-        self.0.y = new_point.1;
+    impl<T: CoordNum, NT: CoordNum> MapCoords<T, NT> for Point<T> {
+        type Output = Point<NT>;
 
-        Ok(())
-    }
-}
+        fn map_coords(&self, func: impl Fn((T, T)) -> (NT, NT) + Copy) -> Self::Output {
+            let new_point = func((self.0.x, self.0.y));
+            Point::new(new_point.0, new_point.1)
+        }
 
-//----------------------//
-// Line implementations //
-//----------------------//
-
-impl<T: CoordNum, NT: CoordNum> MapCoords<T, NT> for Line<T> {
-    type Output = Line<NT>;
-
-    fn map_coords(&self, func: impl Fn((T, T)) -> (NT, NT) + Copy) -> Self::Output {
-        Line::new(
-            self.start_point().map_coords(func).0,
-            self.end_point().map_coords(func).0,
-        )
-    }
-}
-
-impl<T: CoordNum, NT: CoordNum, E> TryMapCoords<T, NT, E> for Line<T> {
-    type Output = Line<NT>;
-
-    fn try_map_coords(
-        &self,
-        func: impl Fn((T, T)) -> Result<(NT, NT), E> + Copy,
-    ) -> Result<Self::Output, E> {
-        Ok(Line::new(
-            self.start_point().try_map_coords(func)?.0,
-            self.end_point().try_map_coords(func)?.0,
-        ))
-    }
-}
-
-impl<T: CoordNum> MapCoordsInplace<T> for Line<T> {
-    fn map_coords_inplace(&mut self, func: impl Fn((T, T)) -> (T, T)) {
-        let new_start = func((self.start.x, self.start.y));
-        self.start.x = new_start.0;
-        self.start.y = new_start.1;
-
-        let new_end = func((self.end.x, self.end.y));
-        self.end.x = new_end.0;
-        self.end.y = new_end.1;
-    }
-}
-
-impl<T: CoordNum, E> TryMapCoordsInplace<T, E> for Line<T> {
-    fn try_map_coords_inplace(
-        &mut self,
-        func: impl Fn((T, T)) -> Result<(T, T), E>,
-    ) -> Result<(), E> {
-        let new_start = func((self.start.x, self.start.y))?;
-        self.start.x = new_start.0;
-        self.start.y = new_start.1;
-
-        let new_end = func((self.end.x, self.end.y))?;
-        self.end.x = new_end.0;
-        self.end.y = new_end.1;
-
-        Ok(())
-    }
-}
-
-//----------------------------//
-// LineString implementations //
-//----------------------------//
-
-impl<T: CoordNum, NT: CoordNum> MapCoords<T, NT> for LineString<T> {
-    type Output = LineString<NT>;
-
-    fn map_coords(&self, func: impl Fn((T, T)) -> (NT, NT) + Copy) -> Self::Output {
-        LineString::from(
-            self.points()
-                .map(|p| p.map_coords(func))
-                .collect::<Vec<_>>(),
-        )
-    }
-}
-
-impl<T: CoordNum, NT: CoordNum, E> TryMapCoords<T, NT, E> for LineString<T> {
-    type Output = LineString<NT>;
-
-    fn try_map_coords(
-        &self,
-        func: impl Fn((T, T)) -> Result<(NT, NT), E> + Copy,
-    ) -> Result<Self::Output, E> {
-        Ok(LineString::from(
-            self.points()
-                .map(|p| p.try_map_coords(func))
-                .collect::<Result<Vec<_>, E>>()?,
-        ))
-    }
-}
-
-impl<T: CoordNum> MapCoordsInplace<T> for LineString<T> {
-    fn map_coords_inplace(&mut self, func: impl Fn((T, T)) -> (T, T)) {
-        for p in &mut self.0 {
-            let new_coords = func((p.x, p.y));
-            p.x = new_coords.0;
-            p.y = new_coords.1;
+        fn try_map_coords<E>(
+            &self,
+            func: impl Fn((T, T)) -> Result<(NT, NT), E>,
+        ) -> Result<Self::Output, E> {
+            let new_point = func((self.0.x, self.0.y))?;
+            Ok(Point::new(new_point.0, new_point.1))
         }
     }
-}
 
-impl<T: CoordNum, E> TryMapCoordsInplace<T, E> for LineString<T> {
-    fn try_map_coords_inplace(
-        &mut self,
-        func: impl Fn((T, T)) -> Result<(T, T), E>,
-    ) -> Result<(), E> {
-        for p in &mut self.0 {
-            let new_coords = func((p.x, p.y))?;
-            p.x = new_coords.0;
-            p.y = new_coords.1;
+    impl<T: CoordNum> MapCoordsInPlace<T> for Point<T> {
+        fn map_coords_in_place(&mut self, func: impl Fn((T, T)) -> (T, T)) {
+            let new_point = func((self.0.x, self.0.y));
+            self.0.x = new_point.0;
+            self.0.y = new_point.1;
         }
-        Ok(())
+
+        fn try_map_coords_in_place<E>(
+            &mut self,
+            func: impl Fn((T, T)) -> Result<(T, T), E>,
+        ) -> Result<(), E> {
+            let new_point = func((self.0.x, self.0.y))?;
+            self.0.x = new_point.0;
+            self.0.y = new_point.1;
+
+            Ok(())
+        }
     }
-}
 
-//-------------------------//
-// Polygon implementations //
-//-------------------------//
+    //----------------------//
+    // Line implementations //
+    //----------------------//
 
-impl<T: CoordNum, NT: CoordNum> MapCoords<T, NT> for Polygon<T> {
-    type Output = Polygon<NT>;
+    impl<T: CoordNum, NT: CoordNum> MapCoords<T, NT> for Line<T> {
+        type Output = Line<NT>;
 
-    fn map_coords(&self, func: impl Fn((T, T)) -> (NT, NT) + Copy) -> Self::Output {
-        Polygon::new(
-            self.exterior().map_coords(func),
-            self.interiors()
-                .iter()
-                .map(|l| l.map_coords(func))
-                .collect(),
-        )
+        fn map_coords(&self, func: impl Fn((T, T)) -> (NT, NT) + Copy) -> Self::Output {
+            Line::new(
+                self.start_point().map_coords(func).0,
+                self.end_point().map_coords(func).0,
+            )
+        }
+
+        fn try_map_coords<E>(
+            &self,
+            func: impl Fn((T, T)) -> Result<(NT, NT), E> + Copy,
+        ) -> Result<Self::Output, E> {
+            Ok(Line::new(
+                self.start_point().try_map_coords(func)?.0,
+                self.end_point().try_map_coords(func)?.0,
+            ))
+        }
     }
-}
 
-impl<T: CoordNum, NT: CoordNum, E> TryMapCoords<T, NT, E> for Polygon<T> {
-    type Output = Polygon<NT>;
+    impl<T: CoordNum> MapCoordsInPlace<T> for Line<T> {
+        fn map_coords_in_place(&mut self, func: impl Fn((T, T)) -> (T, T)) {
+            let new_start = func((self.start.x, self.start.y));
+            self.start.x = new_start.0;
+            self.start.y = new_start.1;
 
-    fn try_map_coords(
-        &self,
-        func: impl Fn((T, T)) -> Result<(NT, NT), E> + Copy,
-    ) -> Result<Self::Output, E> {
-        Ok(Polygon::new(
-            self.exterior().try_map_coords(func)?,
-            self.interiors()
-                .iter()
-                .map(|l| l.try_map_coords(func))
-                .collect::<Result<Vec<_>, E>>()?,
-        ))
+            let new_end = func((self.end.x, self.end.y));
+            self.end.x = new_end.0;
+            self.end.y = new_end.1;
+        }
+
+        fn try_map_coords_in_place<E>(
+            &mut self,
+            func: impl Fn((T, T)) -> Result<(T, T), E>,
+        ) -> Result<(), E> {
+            let new_start = func((self.start.x, self.start.y))?;
+            self.start.x = new_start.0;
+            self.start.y = new_start.1;
+
+            let new_end = func((self.end.x, self.end.y))?;
+            self.end.x = new_end.0;
+            self.end.y = new_end.1;
+
+            Ok(())
+        }
     }
-}
 
-impl<T: CoordNum> MapCoordsInplace<T> for Polygon<T> {
-    fn map_coords_inplace(&mut self, func: impl Fn((T, T)) -> (T, T) + Copy) {
-        self.exterior_mut(|line_string| {
-            line_string.map_coords_inplace(func);
-        });
+    //----------------------------//
+    // LineString implementations //
+    //----------------------------//
 
-        self.interiors_mut(|line_strings| {
-            for line_string in line_strings {
-                line_string.map_coords_inplace(func);
+    impl<T: CoordNum, NT: CoordNum> MapCoords<T, NT> for LineString<T> {
+        type Output = LineString<NT>;
+
+        fn map_coords(&self, func: impl Fn((T, T)) -> (NT, NT) + Copy) -> Self::Output {
+            LineString::from(
+                self.points()
+                    .map(|p| p.map_coords(func))
+                    .collect::<Vec<_>>(),
+            )
+        }
+
+        fn try_map_coords<E>(
+            &self,
+            func: impl Fn((T, T)) -> Result<(NT, NT), E> + Copy,
+        ) -> Result<Self::Output, E> {
+            Ok(LineString::from(
+                self.points()
+                    .map(|p| p.try_map_coords(func))
+                    .collect::<Result<Vec<_>, E>>()?,
+            ))
+        }
+    }
+
+    impl<T: CoordNum> MapCoordsInPlace<T> for LineString<T> {
+        fn map_coords_in_place(&mut self, func: impl Fn((T, T)) -> (T, T)) {
+            for p in &mut self.0 {
+                let new_coords = func((p.x, p.y));
+                p.x = new_coords.0;
+                p.y = new_coords.1;
             }
-        });
-    }
-}
+        }
 
-impl<T: CoordNum, E> TryMapCoordsInplace<T, E> for Polygon<T> {
-    fn try_map_coords_inplace(
-        &mut self,
-        func: impl Fn((T, T)) -> Result<(T, T), E>,
-    ) -> Result<(), E> {
-        let mut result = Ok(());
-
-        self.exterior_mut(|line_string| {
-            if let Err(e) = line_string.try_map_coords_inplace(&func) {
-                result = Err(e);
+        fn try_map_coords_in_place<E>(
+            &mut self,
+            func: impl Fn((T, T)) -> Result<(T, T), E>,
+        ) -> Result<(), E> {
+            for p in &mut self.0 {
+                let new_coords = func((p.x, p.y))?;
+                p.x = new_coords.0;
+                p.y = new_coords.1;
             }
-        });
+            Ok(())
+        }
+    }
 
-        if result.is_ok() {
+    //-------------------------//
+    // Polygon implementations //
+    //-------------------------//
+
+    impl<T: CoordNum, NT: CoordNum> MapCoords<T, NT> for Polygon<T> {
+        type Output = Polygon<NT>;
+
+        fn map_coords(&self, func: impl Fn((T, T)) -> (NT, NT) + Copy) -> Self::Output {
+            Polygon::new(
+                self.exterior().map_coords(func),
+                self.interiors()
+                    .iter()
+                    .map(|l| l.map_coords(func))
+                    .collect(),
+            )
+        }
+
+        fn try_map_coords<E>(
+            &self,
+            func: impl Fn((T, T)) -> Result<(NT, NT), E> + Copy,
+        ) -> Result<Self::Output, E> {
+            Ok(Polygon::new(
+                self.exterior().try_map_coords(func)?,
+                self.interiors()
+                    .iter()
+                    .map(|l| l.try_map_coords(func))
+                    .collect::<Result<Vec<_>, E>>()?,
+            ))
+        }
+    }
+
+    impl<T: CoordNum> MapCoordsInPlace<T> for Polygon<T> {
+        fn map_coords_in_place(&mut self, func: impl Fn((T, T)) -> (T, T) + Copy) {
+            self.exterior_mut(|line_string| {
+                line_string.map_coords_in_place(func);
+            });
+
             self.interiors_mut(|line_strings| {
                 for line_string in line_strings {
-                    if let Err(e) = line_string.try_map_coords_inplace(&func) {
-                        result = Err(e);
-                        break;
-                    }
+                    line_string.map_coords_in_place(func);
                 }
             });
         }
 
-        result
-    }
-}
+        fn try_map_coords_in_place<E>(
+            &mut self,
+            func: impl Fn((T, T)) -> Result<(T, T), E>,
+        ) -> Result<(), E> {
+            let mut result = Ok(());
 
-//----------------------------//
-// MultiPoint implementations //
-//----------------------------//
+            self.exterior_mut(|line_string| {
+                if let Err(e) = line_string.try_map_coords_in_place(&func) {
+                    result = Err(e);
+                }
+            });
 
-impl<T: CoordNum, NT: CoordNum> MapCoords<T, NT> for MultiPoint<T> {
-    type Output = MultiPoint<NT>;
-
-    fn map_coords(&self, func: impl Fn((T, T)) -> (NT, NT) + Copy) -> Self::Output {
-        MultiPoint::new(self.iter().map(|p| p.map_coords(func)).collect())
-    }
-}
-
-impl<T: CoordNum, NT: CoordNum, E> TryMapCoords<T, NT, E> for MultiPoint<T> {
-    type Output = MultiPoint<NT>;
-
-    fn try_map_coords(
-        &self,
-        func: impl Fn((T, T)) -> Result<(NT, NT), E> + Copy,
-    ) -> Result<Self::Output, E> {
-        Ok(MultiPoint::new(
-            self.0
-                .iter()
-                .map(|p| p.try_map_coords(func))
-                .collect::<Result<Vec<_>, E>>()?,
-        ))
-    }
-}
-
-impl<T: CoordNum> MapCoordsInplace<T> for MultiPoint<T> {
-    fn map_coords_inplace(&mut self, func: impl Fn((T, T)) -> (T, T) + Copy) {
-        for p in &mut self.0 {
-            p.map_coords_inplace(func);
-        }
-    }
-}
-
-impl<T: CoordNum, E> TryMapCoordsInplace<T, E> for MultiPoint<T> {
-    fn try_map_coords_inplace(
-        &mut self,
-        func: impl Fn((T, T)) -> Result<(T, T), E>,
-    ) -> Result<(), E> {
-        for p in &mut self.0 {
-            p.try_map_coords_inplace(&func)?;
-        }
-        Ok(())
-    }
-}
-
-//---------------------------------//
-// MultiLineString implementations //
-//---------------------------------//
-
-impl<T: CoordNum, NT: CoordNum> MapCoords<T, NT> for MultiLineString<T> {
-    type Output = MultiLineString<NT>;
-
-    fn map_coords(&self, func: impl Fn((T, T)) -> (NT, NT) + Copy) -> Self::Output {
-        MultiLineString::new(self.iter().map(|l| l.map_coords(func)).collect())
-    }
-}
-
-impl<T: CoordNum, NT: CoordNum, E> TryMapCoords<T, NT, E> for MultiLineString<T> {
-    type Output = MultiLineString<NT>;
-
-    fn try_map_coords(
-        &self,
-        func: impl Fn((T, T)) -> Result<(NT, NT), E> + Copy,
-    ) -> Result<Self::Output, E> {
-        Ok(MultiLineString::new(
-            self.0
-                .iter()
-                .map(|l| l.try_map_coords(func))
-                .collect::<Result<Vec<_>, E>>()?,
-        ))
-    }
-}
-
-impl<T: CoordNum> MapCoordsInplace<T> for MultiLineString<T> {
-    fn map_coords_inplace(&mut self, func: impl Fn((T, T)) -> (T, T) + Copy) {
-        for p in &mut self.0 {
-            p.map_coords_inplace(func);
-        }
-    }
-}
-
-impl<T: CoordNum, E> TryMapCoordsInplace<T, E> for MultiLineString<T> {
-    fn try_map_coords_inplace(
-        &mut self,
-        func: impl Fn((T, T)) -> Result<(T, T), E>,
-    ) -> Result<(), E> {
-        for p in &mut self.0 {
-            p.try_map_coords_inplace(&func)?;
-        }
-        Ok(())
-    }
-}
-
-//------------------------------//
-// MultiPolygon implementations //
-//------------------------------//
-
-impl<T: CoordNum, NT: CoordNum> MapCoords<T, NT> for MultiPolygon<T> {
-    type Output = MultiPolygon<NT>;
-
-    fn map_coords(&self, func: impl Fn((T, T)) -> (NT, NT) + Copy) -> Self::Output {
-        MultiPolygon::new(self.iter().map(|p| p.map_coords(func)).collect())
-    }
-}
-
-impl<T: CoordNum, NT: CoordNum, E> TryMapCoords<T, NT, E> for MultiPolygon<T> {
-    type Output = MultiPolygon<NT>;
-
-    fn try_map_coords(
-        &self,
-        func: impl Fn((T, T)) -> Result<(NT, NT), E> + Copy,
-    ) -> Result<Self::Output, E> {
-        Ok(MultiPolygon::new(
-            self.0
-                .iter()
-                .map(|p| p.try_map_coords(func))
-                .collect::<Result<Vec<_>, E>>()?,
-        ))
-    }
-}
-
-impl<T: CoordNum> MapCoordsInplace<T> for MultiPolygon<T> {
-    fn map_coords_inplace(&mut self, func: impl Fn((T, T)) -> (T, T) + Copy) {
-        for p in &mut self.0 {
-            p.map_coords_inplace(func);
-        }
-    }
-}
-
-impl<T: CoordNum, E> TryMapCoordsInplace<T, E> for MultiPolygon<T> {
-    fn try_map_coords_inplace(
-        &mut self,
-        func: impl Fn((T, T)) -> Result<(T, T), E>,
-    ) -> Result<(), E> {
-        for p in &mut self.0 {
-            p.try_map_coords_inplace(&func)?;
-        }
-        Ok(())
-    }
-}
-
-//--------------------------//
-// Geometry implementations //
-//--------------------------//
-
-impl<T: CoordNum, NT: CoordNum> MapCoords<T, NT> for Geometry<T> {
-    type Output = Geometry<NT>;
-
-    fn map_coords(&self, func: impl Fn((T, T)) -> (NT, NT) + Copy) -> Self::Output {
-        match *self {
-            Geometry::Point(ref x) => Geometry::Point(x.map_coords(func)),
-            Geometry::Line(ref x) => Geometry::Line(x.map_coords(func)),
-            Geometry::LineString(ref x) => Geometry::LineString(x.map_coords(func)),
-            Geometry::Polygon(ref x) => Geometry::Polygon(x.map_coords(func)),
-            Geometry::MultiPoint(ref x) => Geometry::MultiPoint(x.map_coords(func)),
-            Geometry::MultiLineString(ref x) => Geometry::MultiLineString(x.map_coords(func)),
-            Geometry::MultiPolygon(ref x) => Geometry::MultiPolygon(x.map_coords(func)),
-            Geometry::GeometryCollection(ref x) => Geometry::GeometryCollection(x.map_coords(func)),
-            Geometry::Rect(ref x) => Geometry::Rect(x.map_coords(func)),
-            Geometry::Triangle(ref x) => Geometry::Triangle(x.map_coords(func)),
-        }
-    }
-}
-
-impl<T: CoordNum, NT: CoordNum, E> TryMapCoords<T, NT, E> for Geometry<T> {
-    type Output = Geometry<NT>;
-
-    fn try_map_coords(
-        &self,
-        func: impl Fn((T, T)) -> Result<(NT, NT), E> + Copy,
-    ) -> Result<Self::Output, E> {
-        match *self {
-            Geometry::Point(ref x) => Ok(Geometry::Point(x.try_map_coords(func)?)),
-            Geometry::Line(ref x) => Ok(Geometry::Line(x.try_map_coords(func)?)),
-            Geometry::LineString(ref x) => Ok(Geometry::LineString(x.try_map_coords(func)?)),
-            Geometry::Polygon(ref x) => Ok(Geometry::Polygon(x.try_map_coords(func)?)),
-            Geometry::MultiPoint(ref x) => Ok(Geometry::MultiPoint(x.try_map_coords(func)?)),
-            Geometry::MultiLineString(ref x) => {
-                Ok(Geometry::MultiLineString(x.try_map_coords(func)?))
+            if result.is_ok() {
+                self.interiors_mut(|line_strings| {
+                    for line_string in line_strings {
+                        if let Err(e) = line_string.try_map_coords_in_place(&func) {
+                            result = Err(e);
+                            break;
+                        }
+                    }
+                });
             }
-            Geometry::MultiPolygon(ref x) => Ok(Geometry::MultiPolygon(x.try_map_coords(func)?)),
-            Geometry::GeometryCollection(ref x) => {
-                Ok(Geometry::GeometryCollection(x.try_map_coords(func)?))
+
+            result
+        }
+    }
+
+    //----------------------------//
+    // MultiPoint implementations //
+    //----------------------------//
+
+    impl<T: CoordNum, NT: CoordNum> MapCoords<T, NT> for MultiPoint<T> {
+        type Output = MultiPoint<NT>;
+
+        fn map_coords(&self, func: impl Fn((T, T)) -> (NT, NT) + Copy) -> Self::Output {
+            MultiPoint::new(self.iter().map(|p| p.map_coords(func)).collect())
+        }
+
+        fn try_map_coords<E>(
+            &self,
+            func: impl Fn((T, T)) -> Result<(NT, NT), E> + Copy,
+        ) -> Result<Self::Output, E> {
+            Ok(MultiPoint::new(
+                self.0
+                    .iter()
+                    .map(|p| p.try_map_coords(func))
+                    .collect::<Result<Vec<_>, E>>()?,
+            ))
+        }
+    }
+
+    impl<T: CoordNum> MapCoordsInPlace<T> for MultiPoint<T> {
+        fn map_coords_in_place(&mut self, func: impl Fn((T, T)) -> (T, T) + Copy) {
+            for p in &mut self.0 {
+                p.map_coords_in_place(func);
             }
-            Geometry::Rect(ref x) => Ok(Geometry::Rect(x.try_map_coords(func)?)),
-            Geometry::Triangle(ref x) => Ok(Geometry::Triangle(x.try_map_coords(func)?)),
+        }
+
+        fn try_map_coords_in_place<E>(
+            &mut self,
+            func: impl Fn((T, T)) -> Result<(T, T), E>,
+        ) -> Result<(), E> {
+            for p in &mut self.0 {
+                p.try_map_coords_in_place(&func)?;
+            }
+            Ok(())
+        }
+    }
+
+    //---------------------------------//
+    // MultiLineString implementations //
+    //---------------------------------//
+
+    impl<T: CoordNum, NT: CoordNum> MapCoords<T, NT> for MultiLineString<T> {
+        type Output = MultiLineString<NT>;
+
+        fn map_coords(&self, func: impl Fn((T, T)) -> (NT, NT) + Copy) -> Self::Output {
+            MultiLineString::new(self.iter().map(|l| l.map_coords(func)).collect())
+        }
+
+        fn try_map_coords<E>(
+            &self,
+            func: impl Fn((T, T)) -> Result<(NT, NT), E> + Copy,
+        ) -> Result<Self::Output, E> {
+            Ok(MultiLineString::new(
+                self.0
+                    .iter()
+                    .map(|l| l.try_map_coords(func))
+                    .collect::<Result<Vec<_>, E>>()?,
+            ))
+        }
+    }
+
+    impl<T: CoordNum> MapCoordsInPlace<T> for MultiLineString<T> {
+        fn map_coords_in_place(&mut self, func: impl Fn((T, T)) -> (T, T) + Copy) {
+            for p in &mut self.0 {
+                p.map_coords_in_place(func);
+            }
+        }
+
+        fn try_map_coords_in_place<E>(
+            &mut self,
+            func: impl Fn((T, T)) -> Result<(T, T), E>,
+        ) -> Result<(), E> {
+            for p in &mut self.0 {
+                p.try_map_coords_in_place(&func)?;
+            }
+            Ok(())
+        }
+    }
+
+    //------------------------------//
+    // MultiPolygon implementations //
+    //------------------------------//
+
+    impl<T: CoordNum, NT: CoordNum> MapCoords<T, NT> for MultiPolygon<T> {
+        type Output = MultiPolygon<NT>;
+
+        fn map_coords(&self, func: impl Fn((T, T)) -> (NT, NT) + Copy) -> Self::Output {
+            MultiPolygon::new(self.iter().map(|p| p.map_coords(func)).collect())
+        }
+
+        fn try_map_coords<E>(
+            &self,
+            func: impl Fn((T, T)) -> Result<(NT, NT), E> + Copy,
+        ) -> Result<Self::Output, E> {
+            Ok(MultiPolygon::new(
+                self.0
+                    .iter()
+                    .map(|p| p.try_map_coords(func))
+                    .collect::<Result<Vec<_>, E>>()?,
+            ))
+        }
+    }
+
+    impl<T: CoordNum> MapCoordsInPlace<T> for MultiPolygon<T> {
+        fn map_coords_in_place(&mut self, func: impl Fn((T, T)) -> (T, T) + Copy) {
+            for p in &mut self.0 {
+                p.map_coords_in_place(func);
+            }
+        }
+
+        fn try_map_coords_in_place<E>(
+            &mut self,
+            func: impl Fn((T, T)) -> Result<(T, T), E>,
+        ) -> Result<(), E> {
+            for p in &mut self.0 {
+                p.try_map_coords_in_place(&func)?;
+            }
+            Ok(())
+        }
+    }
+
+    //--------------------------//
+    // Geometry implementations //
+    //--------------------------//
+
+    impl<T: CoordNum, NT: CoordNum> MapCoords<T, NT> for Geometry<T> {
+        type Output = Geometry<NT>;
+
+        fn map_coords(&self, func: impl Fn((T, T)) -> (NT, NT) + Copy) -> Self::Output {
+            match *self {
+                Geometry::Point(ref x) => Geometry::Point(x.map_coords(func)),
+                Geometry::Line(ref x) => Geometry::Line(x.map_coords(func)),
+                Geometry::LineString(ref x) => Geometry::LineString(x.map_coords(func)),
+                Geometry::Polygon(ref x) => Geometry::Polygon(x.map_coords(func)),
+                Geometry::MultiPoint(ref x) => Geometry::MultiPoint(x.map_coords(func)),
+                Geometry::MultiLineString(ref x) => Geometry::MultiLineString(x.map_coords(func)),
+                Geometry::MultiPolygon(ref x) => Geometry::MultiPolygon(x.map_coords(func)),
+                Geometry::GeometryCollection(ref x) => {
+                    Geometry::GeometryCollection(x.map_coords(func))
+                }
+                Geometry::Rect(ref x) => Geometry::Rect(x.map_coords(func)),
+                Geometry::Triangle(ref x) => Geometry::Triangle(x.map_coords(func)),
+            }
+        }
+
+        fn try_map_coords<E>(
+            &self,
+            func: impl Fn((T, T)) -> Result<(NT, NT), E> + Copy,
+        ) -> Result<Self::Output, E> {
+            match *self {
+                Geometry::Point(ref x) => Ok(Geometry::Point(x.try_map_coords(func)?)),
+                Geometry::Line(ref x) => Ok(Geometry::Line(x.try_map_coords(func)?)),
+                Geometry::LineString(ref x) => Ok(Geometry::LineString(x.try_map_coords(func)?)),
+                Geometry::Polygon(ref x) => Ok(Geometry::Polygon(x.try_map_coords(func)?)),
+                Geometry::MultiPoint(ref x) => Ok(Geometry::MultiPoint(x.try_map_coords(func)?)),
+                Geometry::MultiLineString(ref x) => {
+                    Ok(Geometry::MultiLineString(x.try_map_coords(func)?))
+                }
+                Geometry::MultiPolygon(ref x) => {
+                    Ok(Geometry::MultiPolygon(x.try_map_coords(func)?))
+                }
+                Geometry::GeometryCollection(ref x) => {
+                    Ok(Geometry::GeometryCollection(x.try_map_coords(func)?))
+                }
+                Geometry::Rect(ref x) => Ok(Geometry::Rect(x.try_map_coords(func)?)),
+                Geometry::Triangle(ref x) => Ok(Geometry::Triangle(x.try_map_coords(func)?)),
+            }
+        }
+    }
+
+    impl<T: CoordNum> MapCoordsInPlace<T> for Geometry<T> {
+        fn map_coords_in_place(&mut self, func: impl Fn((T, T)) -> (T, T) + Copy) {
+            match *self {
+                Geometry::Point(ref mut x) => x.map_coords_in_place(func),
+                Geometry::Line(ref mut x) => x.map_coords_in_place(func),
+                Geometry::LineString(ref mut x) => x.map_coords_in_place(func),
+                Geometry::Polygon(ref mut x) => x.map_coords_in_place(func),
+                Geometry::MultiPoint(ref mut x) => x.map_coords_in_place(func),
+                Geometry::MultiLineString(ref mut x) => x.map_coords_in_place(func),
+                Geometry::MultiPolygon(ref mut x) => x.map_coords_in_place(func),
+                Geometry::GeometryCollection(ref mut x) => x.map_coords_in_place(func),
+                Geometry::Rect(ref mut x) => x.map_coords_in_place(func),
+                Geometry::Triangle(ref mut x) => x.map_coords_in_place(func),
+            }
+        }
+
+        fn try_map_coords_in_place<E>(
+            &mut self,
+            func: impl Fn((T, T)) -> Result<(T, T), E>,
+        ) -> Result<(), E> {
+            match *self {
+                Geometry::Point(ref mut x) => x.try_map_coords_in_place(func),
+                Geometry::Line(ref mut x) => x.try_map_coords_in_place(func),
+                Geometry::LineString(ref mut x) => x.try_map_coords_in_place(func),
+                Geometry::Polygon(ref mut x) => x.try_map_coords_in_place(func),
+                Geometry::MultiPoint(ref mut x) => x.try_map_coords_in_place(func),
+                Geometry::MultiLineString(ref mut x) => x.try_map_coords_in_place(func),
+                Geometry::MultiPolygon(ref mut x) => x.try_map_coords_in_place(func),
+                Geometry::GeometryCollection(ref mut x) => x.try_map_coords_in_place(func),
+                Geometry::Rect(ref mut x) => x.try_map_coords_in_place(func),
+                Geometry::Triangle(ref mut x) => x.try_map_coords_in_place(func),
+            }
+        }
+    }
+
+    //------------------------------------//
+    // GeometryCollection implementations //
+    //------------------------------------//
+
+    impl<T: CoordNum, NT: CoordNum> MapCoords<T, NT> for GeometryCollection<T> {
+        type Output = GeometryCollection<NT>;
+
+        fn map_coords(&self, func: impl Fn((T, T)) -> (NT, NT) + Copy) -> Self::Output {
+            GeometryCollection::new_from(self.iter().map(|g| g.map_coords(func)).collect())
+        }
+
+        fn try_map_coords<E>(
+            &self,
+            func: impl Fn((T, T)) -> Result<(NT, NT), E> + Copy,
+        ) -> Result<Self::Output, E> {
+            Ok(GeometryCollection::new_from(
+                self.0
+                    .iter()
+                    .map(|g| g.try_map_coords(func))
+                    .collect::<Result<Vec<_>, E>>()?,
+            ))
+        }
+    }
+
+    impl<T: CoordNum> MapCoordsInPlace<T> for GeometryCollection<T> {
+        fn map_coords_in_place(&mut self, func: impl Fn((T, T)) -> (T, T) + Copy) {
+            for p in &mut self.0 {
+                p.map_coords_in_place(func);
+            }
+        }
+
+        fn try_map_coords_in_place<E>(
+            &mut self,
+            func: impl Fn((T, T)) -> Result<(T, T), E>,
+        ) -> Result<(), E> {
+            for p in &mut self.0 {
+                p.try_map_coords_in_place(&func)?;
+            }
+            Ok(())
+        }
+    }
+
+    //----------------------//
+    // Rect implementations //
+    //----------------------//
+
+    impl<T: CoordNum, NT: CoordNum> MapCoords<T, NT> for Rect<T> {
+        type Output = Rect<NT>;
+
+        fn map_coords(&self, func: impl Fn((T, T)) -> (NT, NT) + Copy) -> Self::Output {
+            Rect::new(func(self.min().x_y()), func(self.max().x_y()))
+        }
+
+        fn try_map_coords<E>(
+            &self,
+            func: impl Fn((T, T)) -> Result<(NT, NT), E>,
+        ) -> Result<Self::Output, E> {
+            Ok(Rect::new(func(self.min().x_y())?, func(self.max().x_y())?))
+        }
+    }
+
+    impl<T: CoordNum> MapCoordsInPlace<T> for Rect<T> {
+        fn map_coords_in_place(&mut self, func: impl Fn((T, T)) -> (T, T)) {
+            let mut new_rect = Rect::new(func(self.min().x_y()), func(self.max().x_y()));
+            ::std::mem::swap(self, &mut new_rect);
+        }
+
+        fn try_map_coords_in_place<E>(
+            &mut self,
+            func: impl Fn((T, T)) -> Result<(T, T), E>,
+        ) -> Result<(), E> {
+            let mut new_rect = Rect::new(func(self.min().x_y())?, func(self.max().x_y())?);
+            ::std::mem::swap(self, &mut new_rect);
+            Ok(())
+        }
+    }
+
+    //--------------------------//
+    // Triangle implementations //
+    //--------------------------//
+
+    impl<T: CoordNum, NT: CoordNum> MapCoords<T, NT> for Triangle<T> {
+        type Output = Triangle<NT>;
+
+        fn map_coords(&self, func: impl Fn((T, T)) -> (NT, NT) + Copy) -> Self::Output {
+            let p1 = func(self.0.x_y());
+            let p2 = func(self.1.x_y());
+            let p3 = func(self.2.x_y());
+
+            Triangle::new(
+                coord! { x: p1.0, y: p1.1 },
+                coord! { x: p2.0, y: p2.1 },
+                coord! { x: p3.0, y: p3.1 },
+            )
+        }
+
+        fn try_map_coords<E>(
+            &self,
+            func: impl Fn((T, T)) -> Result<(NT, NT), E>,
+        ) -> Result<Self::Output, E> {
+            let p1 = func(self.0.x_y())?;
+            let p2 = func(self.1.x_y())?;
+            let p3 = func(self.2.x_y())?;
+
+            Ok(Triangle::new(
+                coord! { x: p1.0, y: p1.1 },
+                coord! { x: p2.0, y: p2.1 },
+                coord! { x: p3.0, y: p3.1 },
+            ))
+        }
+    }
+
+    impl<T: CoordNum> MapCoordsInPlace<T> for Triangle<T> {
+        fn map_coords_in_place(&mut self, func: impl Fn((T, T)) -> (T, T)) {
+            let p1 = func(self.0.x_y());
+            let p2 = func(self.1.x_y());
+            let p3 = func(self.2.x_y());
+
+            let mut new_triangle = Triangle::new(
+                coord! { x: p1.0, y: p1.1 },
+                coord! { x: p2.0, y: p2.1 },
+                coord! { x: p3.0, y: p3.1 },
+            );
+
+            ::std::mem::swap(self, &mut new_triangle);
+        }
+
+        fn try_map_coords_in_place<E>(
+            &mut self,
+            func: impl Fn((T, T)) -> Result<(T, T), E>,
+        ) -> Result<(), E> {
+            let p1 = func(self.0.x_y())?;
+            let p2 = func(self.1.x_y())?;
+            let p3 = func(self.2.x_y())?;
+
+            let mut new_triangle = Triangle::new(
+                coord! { x: p1.0, y: p1.1 },
+                coord! { x: p2.0, y: p2.1 },
+                coord! { x: p3.0, y: p3.1 },
+            );
+
+            ::std::mem::swap(self, &mut new_triangle);
+
+            Ok(())
         }
     }
 }
+pub use deprecated::*;
+pub(crate) mod deprecated {
+    use super::*;
 
-impl<T: CoordNum> MapCoordsInplace<T> for Geometry<T> {
-    fn map_coords_inplace(&mut self, func: impl Fn((T, T)) -> (T, T) + Copy) {
-        match *self {
-            Geometry::Point(ref mut x) => x.map_coords_inplace(func),
-            Geometry::Line(ref mut x) => x.map_coords_inplace(func),
-            Geometry::LineString(ref mut x) => x.map_coords_inplace(func),
-            Geometry::Polygon(ref mut x) => x.map_coords_inplace(func),
-            Geometry::MultiPoint(ref mut x) => x.map_coords_inplace(func),
-            Geometry::MultiLineString(ref mut x) => x.map_coords_inplace(func),
-            Geometry::MultiPolygon(ref mut x) => x.map_coords_inplace(func),
-            Geometry::GeometryCollection(ref mut x) => x.map_coords_inplace(func),
-            Geometry::Rect(ref mut x) => x.map_coords_inplace(func),
-            Geometry::Triangle(ref mut x) => x.map_coords_inplace(func),
-        }
+    /// Map a fallible function over all the coordinates in a geometry, returning a Result
+    #[deprecated(since = "0.21.0", note = "use `MapCoords::try_map_coords` instead")]
+    pub trait TryMapCoords<T, NT, E> {
+        type Output;
+
+        /// Map a fallible function over all the coordinates in a geometry, returning a Result
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use approx::assert_relative_eq;
+        /// #[allow(deprecated)]
+        /// use geo::algorithm::map_coords::TryMapCoords;
+        /// use geo::Point;
+        ///
+        /// let p1 = Point::new(10., 20.);
+        /// #[allow(deprecated)]
+        /// let p2 = p1
+        ///     .try_map_coords(|(x, y)| -> Result<_, std::convert::Infallible> {
+        ///         Ok((x + 1000., y * 2.))
+        ///     }).unwrap();
+        ///
+        /// assert_relative_eq!(p2, Point::new(1010., 40.), epsilon = 1e-6);
+        /// ```
+        ///
+        /// ## Advanced Example: Geometry coordinate conversion using `PROJ`
+        ///
+        #[cfg_attr(feature = "use-proj", doc = "```")]
+        #[cfg_attr(not(feature = "use-proj"), doc = "```ignore")]
+        /// use approx::assert_relative_eq;
+        /// // activate the [use-proj] feature in cargo.toml in order to access proj functions
+        /// use geo::{Coordinate, Point};
+        /// #[allow(deprecated)]
+        /// use geo::algorithm::map_coords::TryMapCoords;
+        /// use proj::{Coord, Proj, ProjError};
+        /// // GeoJSON uses the WGS 84 coordinate system
+        /// let from = "EPSG:4326";
+        /// // The NAD83 / California zone 6 (ftUS) coordinate system
+        /// let to = "EPSG:2230";
+        /// let to_feet = Proj::new_known_crs(&from, &to, None).unwrap();
+        /// let f = |x: f64, y: f64| -> Result<_, ProjError> {
+        ///     // proj can accept Point, Coordinate, Tuple, and array values, returning a Result
+        ///     let shifted = to_feet.convert((x, y))?;
+        ///     Ok((shifted.x(), shifted.y()))
+        /// };
+        ///
+        /// // 👽
+        /// let usa_m = Point::new(-115.797615, 37.2647978);
+        /// #[allow(deprecated)]
+        /// let usa_ft = usa_m.try_map_coords(|(x, y)| f(x, y)).unwrap();
+        /// assert_relative_eq!(6693625.67217475, usa_ft.x(), epsilon = 1e-6);
+        /// assert_relative_eq!(3497301.5918027186, usa_ft.y(), epsilon = 1e-6);
+        /// ```
+        fn try_map_coords(
+            &self,
+            func: impl Fn((T, T)) -> Result<(NT, NT), E> + Copy,
+        ) -> Result<Self::Output, E>
+        where
+            T: CoordNum,
+            NT: CoordNum;
     }
-}
 
-impl<T: CoordNum, E> TryMapCoordsInplace<T, E> for Geometry<T> {
-    fn try_map_coords_inplace(
-        &mut self,
-        func: impl Fn((T, T)) -> Result<(T, T), E>,
-    ) -> Result<(), E> {
-        match *self {
-            Geometry::Point(ref mut x) => x.try_map_coords_inplace(func),
-            Geometry::Line(ref mut x) => x.try_map_coords_inplace(func),
-            Geometry::LineString(ref mut x) => x.try_map_coords_inplace(func),
-            Geometry::Polygon(ref mut x) => x.try_map_coords_inplace(func),
-            Geometry::MultiPoint(ref mut x) => x.try_map_coords_inplace(func),
-            Geometry::MultiLineString(ref mut x) => x.try_map_coords_inplace(func),
-            Geometry::MultiPolygon(ref mut x) => x.try_map_coords_inplace(func),
-            Geometry::GeometryCollection(ref mut x) => x.try_map_coords_inplace(func),
-            Geometry::Rect(ref mut x) => x.try_map_coords_inplace(func),
-            Geometry::Triangle(ref mut x) => x.try_map_coords_inplace(func),
-        }
+    #[deprecated(
+        since = "0.21.0",
+        note = "use `MapCoordsInPlace::try_map_coords_in_place` instead"
+    )]
+    pub trait TryMapCoordsInplace<T, E> {
+        /// Map a fallible function over all the coordinates in a geometry, in place, returning a `Result`.
+        ///
+        /// Upon encountering an `Err` from the function, `try_map_coords_in_place` immediately returns
+        /// and the geometry is potentially left in a partially mapped state.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #[allow(deprecated)]
+        /// use geo::algorithm::map_coords::TryMapCoordsInplace;
+        ///
+        /// let mut p1 = geo::point!{x: 10u32, y: 20u32};
+        ///
+        /// #[allow(deprecated)]
+        /// p1.try_map_coords_inplace(|(x, y)| -> Result<_, &str> {
+        ///     Ok((
+        ///         x.checked_add(1000).ok_or("Overflow")?,
+        ///         y.checked_mul(2).ok_or("Overflow")?,
+        ///     ))
+        /// })?;
+        ///
+        /// assert_eq!(
+        ///     p1,
+        ///     geo::point!{x: 1010u32, y: 40u32},
+        /// );
+        /// # Ok::<(), &str>(())
+        /// ```
+        fn try_map_coords_inplace(
+            &mut self,
+            func: impl Fn((T, T)) -> Result<(T, T), E>,
+        ) -> Result<(), E>
+        where
+            T: CoordNum;
     }
-}
 
-//------------------------------------//
-// GeometryCollection implementations //
-//------------------------------------//
-
-impl<T: CoordNum, NT: CoordNum> MapCoords<T, NT> for GeometryCollection<T> {
-    type Output = GeometryCollection<NT>;
-
-    fn map_coords(&self, func: impl Fn((T, T)) -> (NT, NT) + Copy) -> Self::Output {
-        GeometryCollection::new_from(self.iter().map(|g| g.map_coords(func)).collect())
+    /// Map a function over all the coordinates in an object in place
+    #[deprecated(
+        since = "0.21.0",
+        note = "use `MapCoordsInPlace::try_map_coords_in_place` instead"
+    )]
+    pub trait MapCoordsInplace<T>: MapCoordsInPlace<T> {
+        /// Apply a function to all the coordinates in a geometric object, in place
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// #[allow(deprecated)]
+        /// use geo::algorithm::map_coords::MapCoordsInplace;
+        /// use geo::Point;
+        /// use approx::assert_relative_eq;
+        ///
+        /// let mut p = Point::new(10., 20.);
+        /// #[allow(deprecated)]
+        /// p.map_coords_inplace(|(x, y)| (x + 1000., y * 2.));
+        ///
+        /// assert_relative_eq!(p, Point::new(1010., 40.), epsilon = 1e-6);
+        /// ```
+        fn map_coords_inplace(&mut self, func: impl Fn((T, T)) -> (T, T) + Copy)
+        where
+            T: CoordNum;
     }
-}
 
-impl<T: CoordNum, NT: CoordNum, E> TryMapCoords<T, NT, E> for GeometryCollection<T> {
-    type Output = GeometryCollection<NT>;
+    macro_rules! impl_deprecated_map_coords {
+        ($geom:ident) => {
+            #[allow(deprecated)]
+            impl<T: CoordNum, NT: CoordNum, E> TryMapCoords<T, NT, E> for $geom<T> {
+                type Output = $geom<NT>;
 
-    fn try_map_coords(
-        &self,
-        func: impl Fn((T, T)) -> Result<(NT, NT), E> + Copy,
-    ) -> Result<Self::Output, E> {
-        Ok(GeometryCollection::new_from(
-            self.0
-                .iter()
-                .map(|g| g.try_map_coords(func))
-                .collect::<Result<Vec<_>, E>>()?,
-        ))
+                fn try_map_coords(
+                    &self,
+                    func: impl Fn((T, T)) -> Result<(NT, NT), E> + Copy,
+                ) -> Result<Self::Output, E> {
+                    MapCoords::try_map_coords(self, func)
+                }
+            }
+
+            #[allow(deprecated)]
+            impl<T: CoordNum, E> TryMapCoordsInplace<T, E> for $geom<T> {
+                fn try_map_coords_inplace(
+                    &mut self,
+                    func: impl Fn((T, T)) -> Result<(T, T), E>,
+                ) -> Result<(), E> {
+                    MapCoordsInPlace::try_map_coords_in_place(self, func)
+                }
+            }
+
+            #[allow(deprecated)]
+            impl<T: CoordNum> MapCoordsInplace<T> for $geom<T> {
+                /// Apply a function to all the coordinates in a geometric object, in place
+                ///
+                /// # Examples
+                ///
+                /// ```
+                /// #[allow(deprecated)]
+                /// use geo::algorithm::map_coords::MapCoordsInplace;
+                /// use geo::Point;
+                /// use approx::assert_relative_eq;
+                ///
+                /// let mut p = Point::new(10., 20.);
+                /// #[allow(deprecated)]
+                /// p.map_coords_inplace(|(x, y)| (x + 1000., y * 2.));
+                ///
+                /// assert_relative_eq!(p, Point::new(1010., 40.), epsilon = 1e-6);
+                /// ```
+                fn map_coords_inplace(&mut self, func: impl Fn((T, T)) -> (T, T) + Copy)
+                where
+                    T: CoordNum,
+                {
+                    MapCoordsInPlace::map_coords_in_place(self, func)
+                }
+            }
+        };
     }
-}
 
-impl<T: CoordNum> MapCoordsInplace<T> for GeometryCollection<T> {
-    fn map_coords_inplace(&mut self, func: impl Fn((T, T)) -> (T, T) + Copy) {
-        for p in &mut self.0 {
-            p.map_coords_inplace(func);
-        }
-    }
-}
-
-impl<T: CoordNum, E> TryMapCoordsInplace<T, E> for GeometryCollection<T> {
-    fn try_map_coords_inplace(
-        &mut self,
-        func: impl Fn((T, T)) -> Result<(T, T), E>,
-    ) -> Result<(), E> {
-        for p in &mut self.0 {
-            p.try_map_coords_inplace(&func)?;
-        }
-        Ok(())
-    }
-}
-
-//----------------------//
-// Rect implementations //
-//----------------------//
-
-impl<T: CoordNum, NT: CoordNum> MapCoords<T, NT> for Rect<T> {
-    type Output = Rect<NT>;
-
-    fn map_coords(&self, func: impl Fn((T, T)) -> (NT, NT) + Copy) -> Self::Output {
-        Rect::new(func(self.min().x_y()), func(self.max().x_y()))
-    }
-}
-
-impl<T: CoordNum, NT: CoordNum, E> TryMapCoords<T, NT, E> for Rect<T> {
-    type Output = Rect<NT>;
-
-    fn try_map_coords(
-        &self,
-        func: impl Fn((T, T)) -> Result<(NT, NT), E>,
-    ) -> Result<Self::Output, E> {
-        Ok(Rect::new(func(self.min().x_y())?, func(self.max().x_y())?))
-    }
-}
-
-impl<T: CoordNum> MapCoordsInplace<T> for Rect<T> {
-    fn map_coords_inplace(&mut self, func: impl Fn((T, T)) -> (T, T)) {
-        let mut new_rect = Rect::new(func(self.min().x_y()), func(self.max().x_y()));
-        ::std::mem::swap(self, &mut new_rect);
-    }
-}
-
-impl<T: CoordNum, E> TryMapCoordsInplace<T, E> for Rect<T> {
-    fn try_map_coords_inplace(
-        &mut self,
-        func: impl Fn((T, T)) -> Result<(T, T), E>,
-    ) -> Result<(), E> {
-        let mut new_rect = Rect::new(func(self.min().x_y())?, func(self.max().x_y())?);
-        ::std::mem::swap(self, &mut new_rect);
-        Ok(())
-    }
-}
-
-//--------------------------//
-// Triangle implementations //
-//--------------------------//
-
-impl<T: CoordNum, NT: CoordNum> MapCoords<T, NT> for Triangle<T> {
-    type Output = Triangle<NT>;
-
-    fn map_coords(&self, func: impl Fn((T, T)) -> (NT, NT) + Copy) -> Self::Output {
-        let p1 = func(self.0.x_y());
-        let p2 = func(self.1.x_y());
-        let p3 = func(self.2.x_y());
-
-        Triangle::new(
-            coord! { x: p1.0, y: p1.1 },
-            coord! { x: p2.0, y: p2.1 },
-            coord! { x: p3.0, y: p3.1 },
-        )
-    }
-}
-
-impl<T: CoordNum, NT: CoordNum, E> TryMapCoords<T, NT, E> for Triangle<T> {
-    type Output = Triangle<NT>;
-
-    fn try_map_coords(
-        &self,
-        func: impl Fn((T, T)) -> Result<(NT, NT), E>,
-    ) -> Result<Self::Output, E> {
-        let p1 = func(self.0.x_y())?;
-        let p2 = func(self.1.x_y())?;
-        let p3 = func(self.2.x_y())?;
-
-        Ok(Triangle::new(
-            coord! { x: p1.0, y: p1.1 },
-            coord! { x: p2.0, y: p2.1 },
-            coord! { x: p3.0, y: p3.1 },
-        ))
-    }
-}
-
-impl<T: CoordNum> MapCoordsInplace<T> for Triangle<T> {
-    fn map_coords_inplace(&mut self, func: impl Fn((T, T)) -> (T, T)) {
-        let p1 = func(self.0.x_y());
-        let p2 = func(self.1.x_y());
-        let p3 = func(self.2.x_y());
-
-        let mut new_triangle = Triangle::new(
-            coord! { x: p1.0, y: p1.1 },
-            coord! { x: p2.0, y: p2.1 },
-            coord! { x: p3.0, y: p3.1 },
-        );
-
-        ::std::mem::swap(self, &mut new_triangle);
-    }
-}
-
-impl<T: CoordNum, E> TryMapCoordsInplace<T, E> for Triangle<T> {
-    fn try_map_coords_inplace(
-        &mut self,
-        func: impl Fn((T, T)) -> Result<(T, T), E>,
-    ) -> Result<(), E> {
-        let p1 = func(self.0.x_y())?;
-        let p2 = func(self.1.x_y())?;
-        let p3 = func(self.2.x_y())?;
-
-        let mut new_triangle = Triangle::new(
-            coord! { x: p1.0, y: p1.1 },
-            coord! { x: p2.0, y: p2.1 },
-            coord! { x: p3.0, y: p3.1 },
-        );
-
-        ::std::mem::swap(self, &mut new_triangle);
-
-        Ok(())
-    }
+    impl_deprecated_map_coords!(Point);
+    impl_deprecated_map_coords!(Line);
+    impl_deprecated_map_coords!(LineString);
+    impl_deprecated_map_coords!(Polygon);
+    impl_deprecated_map_coords!(MultiPoint);
+    impl_deprecated_map_coords!(MultiLineString);
+    impl_deprecated_map_coords!(MultiPolygon);
+    impl_deprecated_map_coords!(Geometry);
+    impl_deprecated_map_coords!(GeometryCollection);
+    impl_deprecated_map_coords!(Triangle);
+    impl_deprecated_map_coords!(Rect);
 }
 
 #[cfg(test)]
 mod test {
-    use super::*;
-    use crate::{polygon, Coordinate};
+    use super::{MapCoords, MapCoordsInPlace};
+    use crate::{
+        coord, polygon, Coordinate, Geometry, GeometryCollection, Line, LineString,
+        MultiLineString, MultiPoint, MultiPolygon, Point, Polygon, Rect,
+    };
 
     #[test]
     fn point() {
@@ -847,7 +957,7 @@ mod test {
     #[test]
     fn point_inplace() {
         let mut p2 = Point::new(10f32, 10f32);
-        p2.map_coords_inplace(|(x, y)| (x + 10., y + 100.));
+        p2.map_coords_in_place(|(x, y)| (x + 10., y + 100.));
         assert_relative_eq!(p2.x(), 20.);
         assert_relative_eq!(p2.y(), 110.);
     }
@@ -855,7 +965,7 @@ mod test {
     #[test]
     fn rect_inplace() {
         let mut rect = Rect::new((10, 10), (20, 20));
-        rect.map_coords_inplace(|(x, y)| (x + 10, y + 20));
+        rect.map_coords_in_place(|(x, y)| (x + 10, y + 20));
         assert_eq!(rect.min(), coord! { x: 20, y: 30 });
         assert_eq!(rect.max(), coord! { x: 30, y: 40 });
     }
@@ -865,7 +975,7 @@ mod test {
         let mut rect = Rect::new((2, 2), (3, 3));
         // Rect's enforce that rect.min is up and left of p2.  Here we test that the points are
         // normalized into a valid rect, regardless of the order they are mapped.
-        rect.map_coords_inplace(|pt| {
+        rect.map_coords_in_place(|pt| {
             match pt {
                 // old min point maps to new max point
                 (2, 2) => (4, 4),

--- a/geo/src/algorithm/translate.rs
+++ b/geo/src/algorithm/translate.rs
@@ -29,6 +29,12 @@ pub trait Translate<T> {
         T: CoordNum;
 
     /// Translate a Geometry along its axes, but in place.
+    fn translate_in_place(&mut self, xoff: T, yoff: T)
+    where
+        T: CoordNum;
+
+    /// Translate a Geometry along its axes, but in place.
+    #[deprecated(since = "0.20.1", note = "renamed to `translate_in_place`")]
     fn translate_inplace(&mut self, xoff: T, yoff: T)
     where
         T: CoordNum;
@@ -43,8 +49,12 @@ where
         self.map_coords(|(x, y)| (x + xoff, y + yoff))
     }
 
-    fn translate_inplace(&mut self, xoff: T, yoff: T) {
+    fn translate_in_place(&mut self, xoff: T, yoff: T) {
         self.map_coords_in_place(|(x, y)| (x + xoff, y + yoff))
+    }
+
+    fn translate_inplace(&mut self, xoff: T, yoff: T) {
+        self.translate_in_place(xoff, yoff)
     }
 }
 
@@ -58,6 +68,12 @@ mod test {
         let p = point!(x: 1.0, y: 5.0);
         let translated = p.translate(30.0, 20.0);
         assert_eq!(translated, point!(x: 31.0, y: 25.0));
+    }
+    #[test]
+    fn test_translate_point_in_place() {
+        let mut p = point!(x: 1.0, y: 5.0);
+        p.translate_in_place(30.0, 20.0);
+        assert_eq!(p, point!(x: 31.0, y: 25.0));
     }
     #[test]
     fn test_translate_linestring() {

--- a/geo/src/algorithm/translate.rs
+++ b/geo/src/algorithm/translate.rs
@@ -1,4 +1,4 @@
-use crate::algorithm::map_coords::{MapCoords, MapCoordsInplace};
+use crate::algorithm::map_coords::{MapCoords, MapCoordsInPlace};
 use crate::CoordNum;
 
 pub trait Translate<T> {
@@ -37,14 +37,14 @@ pub trait Translate<T> {
 impl<T, G> Translate<T> for G
 where
     T: CoordNum,
-    G: MapCoords<T, T, Output = G> + MapCoordsInplace<T>,
+    G: MapCoords<T, T, Output = G> + MapCoordsInPlace<T>,
 {
     fn translate(&self, xoff: T, yoff: T) -> Self {
         self.map_coords(|(x, y)| (x + xoff, y + yoff))
     }
 
     fn translate_inplace(&mut self, xoff: T, yoff: T) {
-        self.map_coords_inplace(|(x, y)| (x + xoff, y + yoff))
+        self.map_coords_in_place(|(x, y)| (x + xoff, y + yoff))
     }
 }
 


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Fixes: https://github.com/georust/geo/issues/802 and https://github.com/georust/geo/issues/721

---

Deprecated the old traits.

Note - the diff looks huge, but it's mostly whitespace changes because I put the new implementations into a new module.
Reminder that you can omit whitespace from the diff with https://github.com/georust/geo/pull/811/files?diff=unified&w=1

Without putting the new implementations into a new module, it'd live in the same namespace as the deprecated traits, causing references to `try_map_coords` to be ambiguous, which would require changing a couple dozen lines like: `p.try_map_coords(func)` to `MapCoords::try_map_coords(&p, func)` - I could do that instead if you prefer.



