### PR TITLE
geo 0.20.1 release: FIXES: update to proper minimum geo-types version

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -1,6 +1,6 @@
 # Changes
 
-## UNRELEASED
+## 0.20.1
 
 * FIX: update to proper minimum geo-types version
 

--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## UNRELEASED
+
+* FIX: update to proper minimum geo-types version
+
 ## 0.20.0
 
 * Add `LinesIter` algorithm to iterate over the lines in geometries.

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -16,7 +16,7 @@ proj-network = ["use-proj", "proj/network"]
 use-serde = ["serde", "geo-types/serde"]
 
 [dependencies]
-geo-types = { version = "0.7.3", features = ["approx", "use-rstar"] }
+geo-types = { version = "0.7.4", features = ["approx", "use-rstar"] }
 geographiclib-rs = "0.2"
 log = "0.4.11"
 num-traits = "0.2"

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "geo"
 description = "Geospatial primitives and algorithms"
-version = "0.20.0"
+version = "0.20.1"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/georust/geo"
 documentation = "https://docs.rs/geo/"


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

geo-types before 0.7.4 won't compile

Note that this is based on the 0.20.0 tag, not main, so that we can release a non-breaking 0.20.1 release.

