### PR TITLE
fix typo in deprecation message

### DIFF
--- a/geo/src/algorithm/map_coords.rs
+++ b/geo/src/algorithm/map_coords.rs
@@ -849,7 +849,7 @@ pub(crate) mod deprecated {
     /// Map a function over all the coordinates in an object in place
     #[deprecated(
         since = "0.21.0",
-        note = "use `MapCoordsInPlace::try_map_coords_in_place` instead"
+        note = "use `MapCoordsInPlace::map_coords_in_place` instead"
     )]
     pub trait MapCoordsInplace<T>: MapCoordsInPlace<T> {
         /// Apply a function to all the coordinates in a geometric object, in place


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
