### PR TITLE
deprecate direct field access for geo-types

### DIFF
--- a/geo-postgis/src/from_postgis.rs
+++ b/geo-postgis/src/from_postgis.rs
@@ -86,12 +86,12 @@ where
     /// This implementation discards geometries that don't convert
     /// (return `None` when `from_postgis()` is called on them).
     fn from_postgis(gc: &'a GeometryCollectionT<T>) -> Self {
-        let geoms = gc
+        let geoms: Vec<_> = gc
             .geometries
             .iter()
             .filter_map(Option::from_postgis)
             .collect();
-        GeometryCollection::new_from(geoms)
+        GeometryCollection::from(geoms)
     }
 }
 impl<'a, T> FromPostgis<&'a GeometryT<T>> for Option<Geometry<f64>>

--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -1,5 +1,57 @@
 # Changes
 
+## UNRELEASED
+
+* DEPRECATED: Direct access to geometry fields (this is a big change).
+
+  This is intended to be a non-breaking change for now, to give people an
+  upgrade window. In an upcoming *breaking* release of geo-types we'll drop pub
+  field access altogether.
+
+  This is in pursuit of adding support for 3D/4D geometries. We'll leverage
+  generics in a way that is intended to avoid runtime cost for our mostly 2D
+  user base. See https://github.com/georust/geo/issues/5 for more.
+
+  ADDED: A bunch of new methods that correspond to the deprecated field access.
+  Here's a cheatsheet of new methods, and a reminder of few existing methods
+  which you might now need:
+  * Coordinate:
+    - `Coordinate::new(x, y)`
+    - `coord.x()` / `coord.x_mut()`
+    - `coord.y()` / `coord.y_mut()`
+  * Point:
+    - `point.coord()` / `point.coord_mut()`
+    - `point.x_mut()`
+    - `point.y_mut()`
+    - `point.x()` / `point.y()` are not new, but you might need them now.
+  * GeometryCollection:
+    - `GeometryCollection::from(geometry_vec)`
+    - `gc.geometries()` / `gc.geometries_mut()`
+    - `gc.push(geometry)`: add a Geometry
+    - `gc.into_inner()`: decompose into an owned Vec<Geometry> 
+  * Line:
+    - `line.start()` / `line.start_mut()`
+    - `line.end()` / `line.end_mut()`
+  * LineString:
+    - `line_string.inner()` / `line_string.inner_mut()`
+    - `line_string.push(coord)`
+    - `line_string[2]` get a particular coord. This isn't new, but you might need it now.
+    - `line_string[0..2]` - you can now access a slice of coords too.
+  * MultiPoint:
+    - `multi_point.points()` / `multi_point.points_mut()`
+    - `multi_point.push(point)` - add a point
+    - `multi_point.into_inner()` - decompose into an owned Vec<Point>
+  * MultiLineString:
+    - `mls.line_strings()` / `mls.line_strings_mut()`
+    - `mls.push(line_string)` - add a LineString
+    - `mls.into_inner()`: decompose into an owned Vec<LineString>
+  * MultiPolygon:
+    - `multi_poly.polygons()` / `multi_poly.polygons_mut()`
+    - `multi_poly.push(polygon)`: add a Polygon
+    - `multi_poly.into_inner()`: decompose into an owned Vec<Polygon>
+
+  Something missing? Let us know! https://github.com/georust/geo/issues/new
+
 ## 0.7.4
 
 * BREAKING: Make `Rect::to_lines` return lines in winding order for `Rect::to_polygon`.

--- a/geo-types/src/coordinate.rs
+++ b/geo-types/src/coordinate.rs
@@ -26,8 +26,53 @@ use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 #[derive(Eq, PartialEq, Clone, Copy, Debug, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Coordinate<T: CoordNum> {
+    #[deprecated(
+        since = "0.7.5",
+        note = "Direct field access is deprecated - use `coord.x()` or `coord.x_mut()` for field access and  `coord!(x: 1, y: 2)` or `Coordinate::new(x, y)` for construction"
+    )]
     pub x: T,
+    #[deprecated(
+        since = "0.7.5",
+        note = "Direct field access is deprecated - use `coord.y()` or `coord.y_mut()` for field access and  `coord!(x: 1, y: 2)` or `Coordinate::new(x, y)` for construction"
+    )]
     pub y: T,
+}
+
+impl<T: CoordNum> Coordinate<T> {
+    #[inline]
+    pub fn new(x: T, y: T) -> Self {
+        // we can delete this `allow(deprecated)` once the fields are no longer pub
+        #[allow(deprecated)]
+        Self { x, y }
+    }
+
+    #[inline]
+    pub fn x(&self) -> T {
+        // we can delete this `allow(deprecated)` once the fields are no longer pub
+        #[allow(deprecated)]
+        self.x
+    }
+
+    #[inline]
+    pub fn x_mut(&mut self) -> &mut T {
+        // we can delete this `allow(deprecated)` once the fields are no longer pub
+        #[allow(deprecated)]
+        &mut self.x
+    }
+
+    #[inline]
+    pub fn y(&self) -> T {
+        // we can delete this `allow(deprecated)` once the fields are no longer pub
+        #[allow(deprecated)]
+        self.y
+    }
+
+    #[inline]
+    pub fn y_mut(&mut self) -> &mut T {
+        // we can delete this `allow(deprecated)` once the fields are no longer pub
+        #[allow(deprecated)]
+        &mut self.y
+    }
 }
 
 impl<T: CoordNum> From<(T, T)> for Coordinate<T> {
@@ -63,14 +108,14 @@ impl<T: CoordNum> From<Point<T>> for Coordinate<T> {
 impl<T: CoordNum> From<Coordinate<T>> for (T, T) {
     #[inline]
     fn from(coord: Coordinate<T>) -> Self {
-        (coord.x, coord.y)
+        (coord.x(), coord.y())
     }
 }
 
 impl<T: CoordNum> From<Coordinate<T>> for [T; 2] {
     #[inline]
     fn from(coord: Coordinate<T>) -> Self {
-        [coord.x, coord.y]
+        [coord.x(), coord.y()]
     }
 }
 
@@ -93,7 +138,7 @@ impl<T: CoordNum> Coordinate<T> {
     /// ```
     #[inline]
     pub fn x_y(&self) -> (T, T) {
-        (self.x, self.y)
+        (self.x(), self.y())
     }
 }
 
@@ -109,8 +154,8 @@ use std::ops::{Add, Div, Mul, Neg, Sub};
 /// let p = coord! { x: 1.25, y: 2.5 };
 /// let q = -p;
 ///
-/// assert_eq!(q.x, -p.x);
-/// assert_eq!(q.y, -p.y);
+/// assert_eq!(q.x(), -p.x());
+/// assert_eq!(q.y(), -p.y());
 /// ```
 impl<T> Neg for Coordinate<T>
 where
@@ -121,8 +166,8 @@ where
     #[inline]
     fn neg(self) -> Self {
         coord! {
-            x: -self.x,
-            y: -self.y,
+            x: -self.x(),
+            y: -self.y(),
         }
     }
 }
@@ -138,8 +183,8 @@ where
 /// let q = coord! { x: 1.5, y: 2.5 };
 /// let sum = p + q;
 ///
-/// assert_eq!(sum.x, 2.75);
-/// assert_eq!(sum.y, 5.0);
+/// assert_eq!(sum.x(), 2.75);
+/// assert_eq!(sum.y(), 5.0);
 /// ```
 impl<T: CoordNum> Add for Coordinate<T> {
     type Output = Self;
@@ -147,8 +192,8 @@ impl<T: CoordNum> Add for Coordinate<T> {
     #[inline]
     fn add(self, rhs: Self) -> Self {
         coord! {
-            x: self.x + rhs.x,
-            y: self.y + rhs.y,
+            x: self.x() + rhs.x(),
+            y: self.y() + rhs.y(),
         }
     }
 }
@@ -164,8 +209,8 @@ impl<T: CoordNum> Add for Coordinate<T> {
 /// let q = coord! { x: 1.25, y: 2.5 };
 /// let diff = p - q;
 ///
-/// assert_eq!(diff.x, 0.25);
-/// assert_eq!(diff.y, 0.);
+/// assert_eq!(diff.x(), 0.25);
+/// assert_eq!(diff.y(), 0.);
 /// ```
 impl<T: CoordNum> Sub for Coordinate<T> {
     type Output = Self;
@@ -173,8 +218,8 @@ impl<T: CoordNum> Sub for Coordinate<T> {
     #[inline]
     fn sub(self, rhs: Self) -> Self {
         coord! {
-            x: self.x - rhs.x,
-            y: self.y - rhs.y,
+            x: self.x() - rhs.x(),
+            y: self.y() - rhs.y(),
         }
     }
 }
@@ -189,8 +234,8 @@ impl<T: CoordNum> Sub for Coordinate<T> {
 /// let p = coord! { x: 1.25, y: 2.5 };
 /// let q = p * 4.;
 ///
-/// assert_eq!(q.x, 5.0);
-/// assert_eq!(q.y, 10.0);
+/// assert_eq!(q.x(), 5.0);
+/// assert_eq!(q.y(), 10.0);
 /// ```
 impl<T: CoordNum> Mul<T> for Coordinate<T> {
     type Output = Self;
@@ -198,8 +243,8 @@ impl<T: CoordNum> Mul<T> for Coordinate<T> {
     #[inline]
     fn mul(self, rhs: T) -> Self {
         coord! {
-            x: self.x * rhs,
-            y: self.y * rhs,
+            x: self.x() * rhs,
+            y: self.y() * rhs,
         }
     }
 }
@@ -214,8 +259,8 @@ impl<T: CoordNum> Mul<T> for Coordinate<T> {
 /// let p = coord! { x: 5., y: 10. };
 /// let q = p / 4.;
 ///
-/// assert_eq!(q.x, 1.25);
-/// assert_eq!(q.y, 2.5);
+/// assert_eq!(q.x(), 1.25);
+/// assert_eq!(q.y(), 2.5);
 /// ```
 impl<T: CoordNum> Div<T> for Coordinate<T> {
     type Output = Self;
@@ -223,8 +268,8 @@ impl<T: CoordNum> Div<T> for Coordinate<T> {
     #[inline]
     fn div(self, rhs: T) -> Self {
         coord! {
-            x: self.x / rhs,
-            y: self.y / rhs,
+            x: self.x() / rhs,
+            y: self.y() / rhs,
         }
     }
 }
@@ -240,8 +285,8 @@ use num_traits::Zero;
 ///
 /// let p: Coordinate<f64> = Zero::zero();
 ///
-/// assert_eq!(p.x, 0.);
-/// assert_eq!(p.y, 0.);
+/// assert_eq!(p.x(), 0.);
+/// assert_eq!(p.y(), 0.);
 /// ```
 impl<T: CoordNum> Coordinate<T> {
     #[inline]
@@ -260,7 +305,7 @@ impl<T: CoordNum> Zero for Coordinate<T> {
     }
     #[inline]
     fn is_zero(&self) -> bool {
-        self.x.is_zero() && self.y.is_zero()
+        self.x().is_zero() && self.y().is_zero()
     }
 }
 
@@ -278,7 +323,8 @@ where
 
     #[inline]
     fn abs_diff_eq(&self, other: &Self, epsilon: T::Epsilon) -> bool {
-        T::abs_diff_eq(&self.x, &other.x, epsilon) && T::abs_diff_eq(&self.y, &other.y, epsilon)
+        T::abs_diff_eq(&self.x(), &other.x(), epsilon)
+            && T::abs_diff_eq(&self.y(), &other.y(), epsilon)
     }
 }
 
@@ -294,8 +340,8 @@ where
 
     #[inline]
     fn relative_eq(&self, other: &Self, epsilon: T::Epsilon, max_relative: T::Epsilon) -> bool {
-        T::relative_eq(&self.x, &other.x, epsilon, max_relative)
-            && T::relative_eq(&self.y, &other.y, epsilon, max_relative)
+        T::relative_eq(&self.x(), &other.x(), epsilon, max_relative)
+            && T::relative_eq(&self.y(), &other.y(), epsilon, max_relative)
     }
 }
 
@@ -311,8 +357,8 @@ where
 
     #[inline]
     fn ulps_eq(&self, other: &Self, epsilon: T::Epsilon, max_ulps: u32) -> bool {
-        T::ulps_eq(&self.x, &other.x, epsilon, max_ulps)
-            && T::ulps_eq(&self.y, &other.y, epsilon, max_ulps)
+        T::ulps_eq(&self.x(), &other.x(), epsilon, max_ulps)
+            && T::ulps_eq(&self.y(), &other.y(), epsilon, max_ulps)
     }
 }
 
@@ -336,8 +382,8 @@ where
     #[inline]
     fn nth(&self, index: usize) -> Self::Scalar {
         match index {
-            0 => self.x,
-            1 => self.y,
+            0 => self.x(),
+            1 => self.y(),
             _ => unreachable!(),
         }
     }
@@ -345,8 +391,8 @@ where
     #[inline]
     fn nth_mut(&mut self, index: usize) -> &mut Self::Scalar {
         match index {
-            0 => &mut self.x,
-            1 => &mut self.y,
+            0 => self.x_mut(),
+            1 => self.y_mut(),
             _ => unreachable!(),
         }
     }
@@ -372,8 +418,8 @@ where
     #[inline]
     fn nth(&self, index: usize) -> Self::Scalar {
         match index {
-            0 => self.x,
-            1 => self.y,
+            0 => self.x(),
+            1 => self.y(),
             _ => unreachable!(),
         }
     }
@@ -381,8 +427,8 @@ where
     #[inline]
     fn nth_mut(&mut self, index: usize) -> &mut Self::Scalar {
         match index {
-            0 => &mut self.x,
-            1 => &mut self.y,
+            0 => self.x_mut(),
+            1 => self.y_mut(),
             _ => unreachable!(),
         }
     }

--- a/geo-types/src/geometry_collection.rs
+++ b/geo-types/src/geometry_collection.rs
@@ -25,7 +25,7 @@ use std::ops::{Index, IndexMut};
 /// use geo_types::{Point, point, Geometry, GeometryCollection};
 /// let p = point!(x: 1.0, y: 1.0);
 /// let pe = Geometry::Point(p);
-/// let gc = GeometryCollection::new_from(vec![pe]);
+/// let gc = GeometryCollection::from(vec![pe]);
 /// for geom in gc {
 ///     println!("{:?}", Point::try_from(geom).unwrap().x());
 /// }
@@ -37,7 +37,7 @@ use std::ops::{Index, IndexMut};
 /// use geo_types::{Point, point, Geometry, GeometryCollection};
 /// let p = point!(x: 1.0, y: 1.0);
 /// let pe = Geometry::Point(p);
-/// let gc = GeometryCollection::new_from(vec![pe]);
+/// let gc = GeometryCollection::from(vec![pe]);
 /// gc.iter().for_each(|geom| println!("{:?}", geom));
 /// ```
 ///
@@ -48,7 +48,7 @@ use std::ops::{Index, IndexMut};
 /// use geo_types::{Point, point, Geometry, GeometryCollection};
 /// let p = point!(x: 1.0, y: 1.0);
 /// let pe = Geometry::Point(p);
-/// let mut gc = GeometryCollection::new_from(vec![pe]);
+/// let mut gc = GeometryCollection::from(vec![pe]);
 /// gc.iter_mut().for_each(|geom| {
 ///    if let Geometry::Point(p) = geom {
 ///        p.set_x(0.2);
@@ -65,7 +65,7 @@ use std::ops::{Index, IndexMut};
 /// use geo_types::{Point, point, Geometry, GeometryCollection};
 /// let p = point!(x: 1.0, y: 1.0);
 /// let pe = Geometry::Point(p);
-/// let gc = GeometryCollection::new_from(vec![pe]);
+/// let gc = GeometryCollection::from(vec![pe]);
 /// println!("{:?}", gc[0]);
 /// ```
 ///
@@ -112,9 +112,11 @@ impl<T: CoordNum> GeometryCollection<T> {
         GeometryCollection::default()
     }
 
-    /// DO NOT USE!
-    /// This fn will be renamed to `new` in the upcoming version.
-    /// This fn is not marked as deprecated because it would require extensive refactoring of the geo code.
+    #[doc(hidden)]
+    #[deprecated(
+        since = "0.7.5",
+        note = "use `GeometryCollection::from(geomtries_vec)` instead"
+    )]
     pub fn new_from(value: Vec<Geometry<T>>) -> Self {
         Self(value)
     }
@@ -300,8 +302,8 @@ where
     /// ```
     /// use geo_types::{GeometryCollection, point};
     ///
-    /// let a = GeometryCollection::new_from(vec![point![x: 1.0, y: 2.0].into()]);
-    /// let b = GeometryCollection::new_from(vec![point![x: 1.0, y: 2.01].into()]);
+    /// let a = GeometryCollection::from(vec![point![x: 1.0, y: 2.0].into()]);
+    /// let b = GeometryCollection::from(vec![point![x: 1.0, y: 2.01].into()]);
     ///
     /// approx::assert_relative_eq!(a, b, max_relative=0.1);
     /// approx::assert_relative_ne!(a, b, max_relative=0.0001);
@@ -342,8 +344,8 @@ where
     /// ```
     /// use geo_types::{GeometryCollection, point};
     ///
-    /// let a = GeometryCollection::new_from(vec![point![x: 0.0, y: 0.0].into()]);
-    /// let b = GeometryCollection::new_from(vec![point![x: 0.0, y: 0.1].into()]);
+    /// let a = GeometryCollection::from(vec![point![x: 0.0, y: 0.0].into()]);
+    /// let b = GeometryCollection::from(vec![point![x: 0.0, y: 0.1].into()]);
     ///
     /// approx::abs_diff_eq!(a, b, epsilon=0.1);
     /// approx::abs_diff_ne!(a, b, epsilon=0.001);

--- a/geo-types/src/lib.rs
+++ b/geo-types/src/lib.rs
@@ -147,10 +147,10 @@ mod tests {
 
         let p = Point::from(c);
 
-        let Point(c2) = p;
+        let c2 = p.coord();
         assert_eq!(c, c2);
-        assert_relative_eq!(c.x, c2.x);
-        assert_relative_eq!(c.y, c2.y);
+        assert_relative_eq!(c.x(), c2.x());
+        assert_relative_eq!(c.y(), c2.y());
 
         let p: Point<f32> = (0f32, 1f32).into();
         assert_relative_eq!(p.x(), 0.);

--- a/geo-types/src/line.rs
+++ b/geo-types/src/line.rs
@@ -12,7 +12,15 @@ use approx::{AbsDiffEq, RelativeEq};
 #[derive(Eq, PartialEq, Clone, Copy, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Line<T: CoordNum> {
+    #[deprecated(
+        since = "0.7.5",
+        note = "Direct field access is deprecated - use `line.start()` or `line.start_mut()` for field access and `Line::new(start, end)` for construction"
+    )]
     pub start: Coordinate<T>,
+    #[deprecated(
+        since = "0.7.5",
+        note = "Direct field access is deprecated - use `line.end()` or `line.end_mut()` for field access and `Line::new(start, end)` for construction"
+    )]
     pub end: Coordinate<T>,
 }
 
@@ -26,22 +34,57 @@ impl<T: CoordNum> Line<T> {
     ///
     /// let line = Line::new(coord! { x: 0., y: 0. }, coord! { x: 1., y: 2. });
     ///
-    /// assert_eq!(line.start, coord! { x: 0., y: 0. });
-    /// assert_eq!(line.end, coord! { x: 1., y: 2. });
+    /// assert_eq!(line.start(), coord! { x: 0., y: 0. });
+    /// assert_eq!(line.end(), coord! { x: 1., y: 2. });
     /// ```
+    #[inline]
     pub fn new<C>(start: C, end: C) -> Self
     where
         C: Into<Coordinate<T>>,
     {
+        // we can delete this `allow(deprecated)` once the fields are no longer pub
+        #[allow(deprecated)]
         Self {
             start: start.into(),
             end: end.into(),
         }
     }
 
+    /// Get the first coordinate of the line.
+    #[inline]
+    pub fn start(&self) -> Coordinate<T> {
+        // we can delete this `allow(deprecated)` once the fields are no longer pub
+        #[allow(deprecated)]
+        self.start
+    }
+
+    /// Mutably borrow the first coordinate of the line.
+    #[inline]
+    pub fn start_mut(&mut self) -> &mut Coordinate<T> {
+        // we can delete this `allow(deprecated)` once the fields are no longer pub
+        #[allow(deprecated)]
+        &mut self.start
+    }
+
+    /// Get the second, and final, coordinate of the line.
+    #[inline]
+    pub fn end(&self) -> Coordinate<T> {
+        // we can delete this `allow(deprecated)` once the fields are no longer pub
+        #[allow(deprecated)]
+        self.end
+    }
+
+    /// Mutably borrow the second, and final, coordinate of the line.
+    #[inline]
+    pub fn end_mut(&mut self) -> &mut Coordinate<T> {
+        // we can delete this `allow(deprecated)` once the fields are no longer pub
+        #[allow(deprecated)]
+        &mut self.end
+    }
+
     /// Calculate the difference in coordinates (Δx, Δy).
     pub fn delta(&self) -> Coordinate<T> {
-        self.end - self.start
+        self.end() - self.start()
     }
 
     /// Calculate the difference in ‘x’ components (Δx).
@@ -56,11 +99,11 @@ impl<T: CoordNum> Line<T> {
     /// # );
     /// # assert_eq!(
     /// #     line.dx(),
-    /// line.end.x - line.start.x
+    /// line.end().x() - line.start().x()
     /// # );
     /// ```
     pub fn dx(&self) -> T {
-        self.delta().x
+        self.delta().x()
     }
 
     /// Calculate the difference in ‘y’ components (Δy).
@@ -75,11 +118,11 @@ impl<T: CoordNum> Line<T> {
     /// # );
     /// # assert_eq!(
     /// #     line.dy(),
-    /// line.end.y - line.start.y
+    /// line.end().y() - line.start().y()
     /// # );
     /// ```
     pub fn dy(&self) -> T {
-        self.delta().y
+        self.delta().y()
     }
 
     /// Calculate the slope (Δy/Δx).
@@ -124,7 +167,7 @@ impl<T: CoordNum> Line<T> {
     /// # );
     /// # assert_eq!(
     /// #     line.determinant(),
-    /// line.start.x * line.end.y - line.start.y * line.end.x
+    /// line.start().x() * line.end().y() - line.start().y() * line.end().x()
     /// # );
     /// ```
     ///
@@ -139,15 +182,15 @@ impl<T: CoordNum> Line<T> {
     /// # );
     /// ```
     pub fn determinant(&self) -> T {
-        self.start.x * self.end.y - self.start.y * self.end.x
+        self.start().x() * self.end().y() - self.start().y() * self.end().x()
     }
 
     pub fn start_point(&self) -> Point<T> {
-        Point::from(self.start)
+        Point::from(self.start())
     }
 
     pub fn end_point(&self) -> Point<T> {
-        Point::from(self.end)
+        Point::from(self.end())
     }
 
     pub fn points(&self) -> (Point<T>, Point<T>) {
@@ -189,8 +232,9 @@ where
         epsilon: Self::Epsilon,
         max_relative: Self::Epsilon,
     ) -> bool {
-        self.start.relative_eq(&other.start, epsilon, max_relative)
-            && self.end.relative_eq(&other.end, epsilon, max_relative)
+        self.start()
+            .relative_eq(&other.start(), epsilon, max_relative)
+            && self.end().relative_eq(&other.end(), epsilon, max_relative)
     }
 }
 
@@ -217,7 +261,8 @@ impl<T: AbsDiffEq<Epsilon = T> + CoordNum> AbsDiffEq for Line<T> {
     /// ```
     #[inline]
     fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
-        self.start.abs_diff_eq(&other.start, epsilon) && self.end.abs_diff_eq(&other.end, epsilon)
+        self.start().abs_diff_eq(&other.start(), epsilon)
+            && self.end().abs_diff_eq(&other.end(), epsilon)
     }
 }
 

--- a/geo-types/src/macros.rs
+++ b/geo-types/src/macros.rs
@@ -55,9 +55,10 @@ macro_rules! point {
 /// [`Coordinate`]: ./struct.Point.html
 #[macro_export]
 macro_rules! coord {
-    (x: $x:expr, y: $y:expr $(,)* ) => {
+    (x: $x:expr, y: $y:expr $(,)* ) => {{
+        #[allow(deprecated)]
         $crate::Coordinate { x: $x, y: $y }
-    };
+    }};
 }
 
 /// Creates a [`LineString`] containing the given coordinates.

--- a/geo-types/src/point.rs
+++ b/geo-types/src/point.rs
@@ -1,4 +1,4 @@
-use crate::{point, CoordFloat, CoordNum, Coordinate};
+use crate::{CoordFloat, CoordNum, Coordinate};
 
 #[cfg(any(feature = "approx", test))]
 use approx::{AbsDiffEq, RelativeEq};
@@ -28,21 +28,30 @@ use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssi
 /// ```
 #[derive(Eq, PartialEq, Clone, Copy, Debug, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct Point<T: CoordNum>(pub Coordinate<T>);
+pub struct Point<T: CoordNum>(
+    #[deprecated(
+        since = "0.7.5",
+        note = "Direct field access is deprecated - use `point.coord()` or `point.coord_mut()` for field access and  `point!(x: 1, y: 2)` or `Point::new(x, y)` for construction"
+    )]
+    pub Coordinate<T>,
+);
 
 impl<T: CoordNum> From<Coordinate<T>> for Point<T> {
+    #[inline]
     fn from(x: Coordinate<T>) -> Self {
         Point(x)
     }
 }
 
 impl<T: CoordNum> From<(T, T)> for Point<T> {
+    #[inline]
     fn from(coords: (T, T)) -> Self {
         Point::new(coords.0, coords.1)
     }
 }
 
 impl<T: CoordNum> From<[T; 2]> for Point<T> {
+    #[inline]
     fn from(coords: [T; 2]) -> Self {
         Point::new(coords[0], coords[1])
     }
@@ -50,13 +59,13 @@ impl<T: CoordNum> From<[T; 2]> for Point<T> {
 
 impl<T: CoordNum> From<Point<T>> for (T, T) {
     fn from(point: Point<T>) -> Self {
-        point.0.into()
+        point.coord().into()
     }
 }
 
 impl<T: CoordNum> From<Point<T>> for [T; 2] {
     fn from(point: Point<T>) -> Self {
-        point.0.into()
+        point.coord().into()
     }
 }
 
@@ -73,8 +82,28 @@ impl<T: CoordNum> Point<T> {
     /// assert_eq!(p.x(), 1.234);
     /// assert_eq!(p.y(), 2.345);
     /// ```
+    #[inline]
     pub fn new(x: T, y: T) -> Self {
-        point! { x: x, y: y }
+        #[allow(deprecated)]
+        {
+            Point(Coordinate { x, y })
+        }
+    }
+
+    /// Return the point's [`Coordinate`].
+    #[inline]
+    pub fn coord(self) -> Coordinate<T> {
+        // we can delete this `allow(deprecated)` once the fields are no longer pub
+        #[allow(deprecated)]
+        self.0
+    }
+
+    /// Mutably borrow the point's [`Coordinate`].
+    #[inline]
+    pub fn coord_mut(&mut self) -> &mut Coordinate<T> {
+        // we can delete this `allow(deprecated)` once the fields are no longer pub
+        #[allow(deprecated)]
+        &mut self.0
     }
 
     /// Returns the x/horizontal component of the point.
@@ -88,8 +117,29 @@ impl<T: CoordNum> Point<T> {
     ///
     /// assert_eq!(p.x(), 1.234);
     /// ```
+    #[inline]
     pub fn x(self) -> T {
+        // we can delete this `allow(deprecated)` once the fields are no longer pub
+        #[allow(deprecated)]
         self.0.x
+    }
+
+    /// Mutably borrow the x/horizontal component of the point.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use geo_types::Point;
+    ///
+    /// let mut p = Point::new(1.0, 2.0);
+    /// *p.x_mut() = 4.0;
+    ///
+    /// assert_eq!(p, Point::new(4.0, 2.0));
+    /// ```
+    #[inline]
+    pub fn x_mut(&mut self) -> &mut T {
+        #[allow(deprecated)]
+        &mut self.0.x
     }
 
     /// Sets the x/horizontal component of the point.
@@ -104,8 +154,9 @@ impl<T: CoordNum> Point<T> {
     ///
     /// assert_eq!(p.x(), 9.876);
     /// ```
+    #[inline]
     pub fn set_x(&mut self, x: T) -> &mut Self {
-        self.0.x = x;
+        *self.x_mut() = x;
         self
     }
 
@@ -120,8 +171,28 @@ impl<T: CoordNum> Point<T> {
     ///
     /// assert_eq!(p.y(), 2.345);
     /// ```
+    #[inline]
     pub fn y(self) -> T {
+        #[allow(deprecated)]
         self.0.y
+    }
+
+    /// Mutably borrow the y/vertical component of the point.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use geo_types::Point;
+    ///
+    /// let mut p = Point::new(1.0, 2.0);
+    /// *p.y_mut() = 4.0;
+    ///
+    /// assert_eq!(p, Point::new(1.0, 4.0));
+    /// ```
+    #[inline]
+    pub fn y_mut(&mut self) -> &mut T {
+        #[allow(deprecated)]
+        &mut self.0.y
     }
 
     /// Sets the y/vertical component of the point.
@@ -136,8 +207,9 @@ impl<T: CoordNum> Point<T> {
     ///
     /// assert_eq!(p.y(), 9.876);
     /// ```
+    #[inline]
     pub fn set_y(&mut self, y: T) -> &mut Self {
-        self.0.y = y;
+        *self.y_mut() = y;
         self
     }
 
@@ -154,8 +226,11 @@ impl<T: CoordNum> Point<T> {
     /// assert_eq!(y, 2.345);
     /// assert_eq!(x, 1.234);
     /// ```
+    #[inline]
     pub fn x_y(self) -> (T, T) {
-        (self.0.x, self.0.y)
+        // we can delete this `allow(deprecated)` once the fields are no longer pub
+        #[allow(deprecated)]
+        self.0.x_y()
     }
     /// Returns the longitude/horizontal component of the point.
     ///
@@ -323,7 +398,7 @@ where
     /// assert_eq!(p.y(), -2.5);
     /// ```
     fn neg(self) -> Self::Output {
-        Point::from(-self.0)
+        Point::from(-self.coord())
     }
 }
 
@@ -343,7 +418,7 @@ impl<T: CoordNum> Add for Point<T> {
     /// assert_eq!(p.y(), 5.0);
     /// ```
     fn add(self, rhs: Self) -> Self::Output {
-        Point::from(self.0 + rhs.0)
+        Point::from(self.coord() + rhs.coord())
     }
 }
 
@@ -362,7 +437,7 @@ impl<T: CoordNum> AddAssign for Point<T> {
     /// assert_eq!(p.y(), 5.0);
     /// ```
     fn add_assign(&mut self, rhs: Self) {
-        self.0 = self.0 + rhs.0;
+        *self.coord_mut() = self.coord() + rhs.coord();
     }
 }
 
@@ -382,7 +457,7 @@ impl<T: CoordNum> Sub for Point<T> {
     /// assert_eq!(p.y(), 0.5);
     /// ```
     fn sub(self, rhs: Self) -> Self::Output {
-        Point::from(self.0 - rhs.0)
+        Point::from(self.coord() - rhs.coord())
     }
 }
 
@@ -401,7 +476,7 @@ impl<T: CoordNum> SubAssign for Point<T> {
     /// assert_eq!(p.y(), 0.0);
     /// ```
     fn sub_assign(&mut self, rhs: Self) {
-        self.0 = self.0 - rhs.0;
+        *self.coord_mut() = self.coord() - rhs.coord();
     }
 }
 
@@ -421,7 +496,7 @@ impl<T: CoordNum> Mul<T> for Point<T> {
     /// assert_eq!(p.y(), 6.0);
     /// ```
     fn mul(self, rhs: T) -> Self::Output {
-        Point::from(self.0 * rhs)
+        Point::from(self.coord() * rhs)
     }
 }
 
@@ -440,7 +515,7 @@ impl<T: CoordNum> MulAssign<T> for Point<T> {
     /// assert_eq!(p.y(), 6.0);
     /// ```
     fn mul_assign(&mut self, rhs: T) {
-        self.0 = self.0 * rhs
+        *self.coord_mut() = self.coord() * rhs
     }
 }
 
@@ -460,7 +535,7 @@ impl<T: CoordNum> Div<T> for Point<T> {
     /// assert_eq!(p.y(), 1.5);
     /// ```
     fn div(self, rhs: T) -> Self::Output {
-        Point::from(self.0 / rhs)
+        Point::from(self.coord() / rhs)
     }
 }
 
@@ -479,7 +554,7 @@ impl<T: CoordNum> DivAssign<T> for Point<T> {
     /// assert_eq!(p.y(), 1.5);
     /// ```
     fn div_assign(&mut self, rhs: T) {
-        self.0 = self.0 / rhs
+        *self.coord_mut() = self.coord() / rhs
     }
 }
 
@@ -512,7 +587,8 @@ where
         epsilon: Self::Epsilon,
         max_relative: Self::Epsilon,
     ) -> bool {
-        self.0.relative_eq(&other.0, epsilon, max_relative)
+        self.coord()
+            .relative_eq(&other.coord(), epsilon, max_relative)
     }
 }
 
@@ -543,7 +619,7 @@ where
     /// ```
     #[inline]
     fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
-        self.0.abs_diff_eq(&other.0, epsilon)
+        self.coord().abs_diff_eq(&other.coord(), epsilon)
     }
 }
 
@@ -563,15 +639,15 @@ where
 
     fn nth(&self, index: usize) -> Self::Scalar {
         match index {
-            0 => self.0.x,
-            1 => self.0.y,
+            0 => self.x(),
+            1 => self.y(),
             _ => unreachable!(),
         }
     }
     fn nth_mut(&mut self, index: usize) -> &mut Self::Scalar {
         match index {
-            0 => &mut self.0.x,
-            1 => &mut self.0.y,
+            0 => self.x_mut(),
+            1 => self.y_mut(),
             _ => unreachable!(),
         }
     }
@@ -592,15 +668,15 @@ where
 
     fn nth(&self, index: usize) -> Self::Scalar {
         match index {
-            0 => self.0.x,
-            1 => self.0.y,
+            0 => self.x(),
+            1 => self.y(),
             _ => unreachable!(),
         }
     }
     fn nth_mut(&mut self, index: usize) -> &mut Self::Scalar {
         match index {
-            0 => &mut self.0.x,
-            1 => &mut self.0.y,
+            0 => self.x_mut(),
+            1 => self.y_mut(),
             _ => unreachable!(),
         }
     }

--- a/geo-types/src/polygon.rs
+++ b/geo-types/src/polygon.rs
@@ -389,7 +389,7 @@ impl<T: CoordNum> Polygon<T> {
     where
         T: Float,
     {
-        (current_vertex + (self.exterior.0.len() - 1) - 1) % (self.exterior.0.len() - 1)
+        (current_vertex + (self.exterior.inner().len() - 1) - 1) % (self.exterior.inner().len() - 1)
     }
 }
 
@@ -418,8 +418,7 @@ impl<T: CoordFloat + Signed> Polygon<T> {
     pub fn is_convex(&self) -> bool {
         let convex = self
             .exterior
-            .0
-            .iter()
+            .coords()
             .enumerate()
             .map(|(idx, _)| {
                 let prev_1 = self.previous_vertex(idx);
@@ -445,11 +444,11 @@ impl<T: CoordNum> From<Rect<T>> for Polygon<T> {
     fn from(r: Rect<T>) -> Self {
         Polygon::new(
             vec![
-                (r.min().x, r.min().y),
-                (r.max().x, r.min().y),
-                (r.max().x, r.max().y),
-                (r.min().x, r.max().y),
-                (r.min().x, r.min().y),
+                (r.min().x(), r.min().y()),
+                (r.max().x(), r.min().y()),
+                (r.max().x(), r.max().y()),
+                (r.min().x(), r.max().y()),
+                (r.min().x(), r.min().y()),
             ]
             .into(),
             Vec::new(),
@@ -459,7 +458,7 @@ impl<T: CoordNum> From<Rect<T>> for Polygon<T> {
 
 impl<T: CoordNum> From<Triangle<T>> for Polygon<T> {
     fn from(t: Triangle<T>) -> Self {
-        Polygon::new(vec![t.0, t.1, t.2, t.0].into(), Vec::new())
+        t.to_polygon()
     }
 }
 

--- a/geo-types/src/private_utils.rs
+++ b/geo-types/src/private_utils.rs
@@ -16,7 +16,7 @@ pub fn line_bounding_rect<T>(line: Line<T>) -> Rect<T>
 where
     T: CoordNum,
 {
-    Rect::new(line.start, line.end)
+    Rect::new(line.start(), line.end())
 }
 
 pub fn get_bounding_rect<I, T>(collection: I) -> Option<Rect<T>>
@@ -26,8 +26,8 @@ where
 {
     let mut iter = collection.into_iter();
     if let Some(pnt) = iter.next() {
-        let mut xrange = (pnt.x, pnt.x);
-        let mut yrange = (pnt.y, pnt.y);
+        let mut xrange = (pnt.x(), pnt.x());
+        let mut yrange = (pnt.y(), pnt.y());
         for pnt in iter {
             let (px, py) = pnt.x_y();
             xrange = get_min_max(px, xrange.0, xrange.1);
@@ -70,16 +70,17 @@ where
     if start == end {
         return line_euclidean_length(Line::new(point, start));
     }
-    let dx = end.x - start.x;
-    let dy = end.y - start.y;
-    let r = ((point.x - start.x) * dx + (point.y - start.y) * dy) / (dx.powi(2) + dy.powi(2));
+    let dx = end.x() - start.x();
+    let dy = end.y() - start.y();
+    let r =
+        ((point.x() - start.x()) * dx + (point.y() - start.y()) * dy) / (dx.powi(2) + dy.powi(2));
     if r <= T::zero() {
         return line_euclidean_length(Line::new(point, start));
     }
     if r >= T::one() {
         return line_euclidean_length(Line::new(point, end));
     }
-    let s = ((start.y - point.y) * dx - (start.x - point.x) * dy) / (dx * dx + dy * dy);
+    let s = ((start.y() - point.y()) * dx - (start.x() - point.x()) * dy) / (dx * dx + dy * dy);
     s.abs() * dx.hypot(dy)
 }
 
@@ -95,11 +96,11 @@ where
     T: CoordFloat,
 {
     // No need to continue if the point is on the LineString, or it's empty
-    if line_string_contains_point(l, p) || l.0.is_empty() {
+    if line_string_contains_point(l, p) || l.inner().is_empty() {
         return T::zero();
     }
     l.lines()
-        .map(|line| line_segment_distance(p.0, line.start, line.end))
+        .map(|line| line_segment_distance(p.coord(), line.start(), line.end()))
         .fold(T::max_value(), |accum, val| accum.min(val))
 }
 
@@ -108,7 +109,7 @@ where
     T: CoordFloat,
     C: Into<Coordinate<T>>,
 {
-    line_segment_distance(p.into(), l.start, l.end)
+    line_segment_distance(p.into(), l.start(), l.end())
 }
 
 pub fn point_contains_point<T>(p1: Point<T>, p2: Point<T>) -> bool
@@ -124,15 +125,15 @@ where
     T: CoordFloat,
 {
     // LineString without points
-    if line_string.0.is_empty() {
+    if line_string.inner().is_empty() {
         return false;
     }
     // LineString with one point equal p
-    if line_string.0.len() == 1 {
+    if line_string.inner().len() == 1 {
         return point_contains_point(Point::from(line_string[0]), point);
     }
     // check if point is a vertex
-    if line_string.0.contains(&point.0) {
+    if line_string.inner().contains(&point.coord()) {
         return true;
     }
     for line in line_string.lines() {
@@ -140,25 +141,25 @@ where
         let tx = if line.dx() == T::zero() {
             None
         } else {
-            Some((point.x() - line.start.x) / line.dx())
+            Some((point.x() - line.start().x()) / line.dx())
         };
         let ty = if line.dy() == T::zero() {
             None
         } else {
-            Some((point.y() - line.start.y) / line.dy())
+            Some((point.y() - line.start().y()) / line.dy())
         };
         let contains = match (tx, ty) {
             (None, None) => {
                 // Degenerate line
-                point.0 == line.start
+                point.coord() == line.start()
             }
             (Some(t), None) => {
                 // Horizontal line
-                point.y() == line.start.y && T::zero() <= t && t <= T::one()
+                point.y() == line.start().y() && T::zero() <= t && t <= T::one()
             }
             (None, Some(t)) => {
                 // Vertical line
-                point.x() == line.start.x && T::zero() <= t && t <= T::one()
+                point.x() == line.start().x() && T::zero() <= t && t <= T::one()
             }
             (Some(t_x), Some(t_y)) => {
                 // All other lines

--- a/geo-types/src/rect.rs
+++ b/geo-types/src/rect.rs
@@ -65,15 +65,15 @@ impl<T: CoordNum> Rect<T> {
     {
         let c1 = c1.into();
         let c2 = c2.into();
-        let (min_x, max_x) = if c1.x < c2.x {
-            (c1.x, c2.x)
+        let (min_x, max_x) = if c1.x() < c2.x() {
+            (c1.x(), c2.x())
         } else {
-            (c2.x, c1.x)
+            (c2.x(), c1.x())
         };
-        let (min_y, max_y) = if c1.y < c2.y {
-            (c1.y, c2.y)
+        let (min_y, max_y) = if c1.y() < c2.y() {
+            (c1.y(), c2.y())
         } else {
-            (c2.y, c1.y)
+            (c2.y(), c1.y())
         };
         Self {
             min: coord! { x: min_x, y: min_y },
@@ -170,7 +170,7 @@ impl<T: CoordNum> Rect<T> {
     /// assert_eq!(rect.width(), 10.);
     /// ```
     pub fn width(self) -> T {
-        self.max().x - self.min().x
+        self.max().x() - self.min().x()
     }
 
     /// Returns the height of the `Rect`.
@@ -188,7 +188,7 @@ impl<T: CoordNum> Rect<T> {
     /// assert_eq!(rect.height(), 10.);
     /// ```
     pub fn height(self) -> T {
-        self.max().y - self.min().y
+        self.max().y() - self.min().y()
     }
 
     /// Create a `Polygon` from the `Rect`.
@@ -216,11 +216,11 @@ impl<T: CoordNum> Rect<T> {
     /// ```
     pub fn to_polygon(self) -> Polygon<T> {
         polygon![
-            (x: self.min.x, y: self.min.y),
-            (x: self.min.x, y: self.max.y),
-            (x: self.max.x, y: self.max.y),
-            (x: self.max.x, y: self.min.y),
-            (x: self.min.x, y: self.min.y),
+            (x: self.min.x(), y: self.min.y()),
+            (x: self.min.x(), y: self.max.y()),
+            (x: self.max.x(), y: self.max.y()),
+            (x: self.max.x(), y: self.min.y()),
+            (x: self.min.x(), y: self.min.y()),
         ]
     }
 
@@ -228,42 +228,42 @@ impl<T: CoordNum> Rect<T> {
         [
             Line::new(
                 coord! {
-                    x: self.min.x,
-                    y: self.min.y,
+                    x: self.min.x(),
+                    y: self.min.y(),
                 },
                 coord! {
-                    x: self.min.x,
-                    y: self.max.y,
-                },
-            ),
-            Line::new(
-                coord! {
-                    x: self.min.x,
-                    y: self.max.y,
-                },
-                coord! {
-                    x: self.max.x,
-                    y: self.max.y,
+                    x: self.min.x(),
+                    y: self.max.y(),
                 },
             ),
             Line::new(
                 coord! {
-                    x: self.max.x,
-                    y: self.max.y,
+                    x: self.min.x(),
+                    y: self.max.y(),
                 },
                 coord! {
-                    x: self.max.x,
-                    y: self.min.y,
+                    x: self.max.x(),
+                    y: self.max.y(),
                 },
             ),
             Line::new(
                 coord! {
-                    x: self.max.x,
-                    y: self.min.y,
+                    x: self.max.x(),
+                    y: self.max.y(),
                 },
                 coord! {
-                    x: self.min.x,
-                    y: self.min.y,
+                    x: self.max.x(),
+                    y: self.min.y(),
+                },
+            ),
+            Line::new(
+                coord! {
+                    x: self.max.x(),
+                    y: self.min.y(),
+                },
+                coord! {
+                    x: self.min.x(),
+                    y: self.min.y(),
                 },
             ),
         ]
@@ -276,7 +276,7 @@ impl<T: CoordNum> Rect<T> {
     }
 
     fn has_valid_bounds(&self) -> bool {
-        self.min.x <= self.max.x && self.min.y <= self.max.y
+        self.min.x() <= self.max.x() && self.min.y() <= self.max.y()
     }
 }
 
@@ -298,8 +298,8 @@ impl<T: CoordFloat> Rect<T> {
     pub fn center(self) -> Coordinate<T> {
         let two = T::one() + T::one();
         coord! {
-            x: (self.max.x + self.min.x) / two,
-            y: (self.max.y + self.min.y) / two,
+            x: (self.max.x() + self.min.x()) / two,
+            y: (self.max.y() + self.min.y()) / two,
         }
     }
 }

--- a/geo-types/src/triangle.rs
+++ b/geo-types/src/triangle.rs
@@ -9,23 +9,82 @@ use approx::{AbsDiffEq, RelativeEq};
 /// vertices must not be collinear and they must be distinct.
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct Triangle<T: CoordNum>(pub Coordinate<T>, pub Coordinate<T>, pub Coordinate<T>);
+pub struct Triangle<T: CoordNum>(
+    #[deprecated(
+        since = "0.7.5",
+        note = "Direct field access is deprecated - use `triangle.vertex_0()` or `triangle.vertex_0_mut()` for field access and `Triangle::new(v0, v1, v2) for construction"
+    )]
+    pub Coordinate<T>,
+    #[deprecated(
+        since = "0.7.5",
+        note = "Direct field access is deprecated - use `triangle.vertex_1()` or `triangle.vertex_1_mut()` for field access and `Triangle::new(v0, v1, v2) for construction"
+    )]
+    pub Coordinate<T>,
+    #[deprecated(
+        since = "0.7.5",
+        note = "Direct field access is deprecated - use `triangle.vertex_2()` or `triangle.vertex_2_mut()` for field access and `Triangle::new(v0, v1, v2) for construction"
+    )]
+    pub Coordinate<T>,
+);
 
 impl<T: CoordNum> Triangle<T> {
-    /// Instantiate Self from the raw content value
-    pub fn new(v1: Coordinate<T>, v2: Coordinate<T>, v3: Coordinate<T>) -> Self {
-        Self(v1, v2, v3)
+    /// Create a new [`Triangle`] with the given [`Coordinate`]s as vertices.
+    #[inline]
+    pub fn new(v0: Coordinate<T>, v1: Coordinate<T>, v2: Coordinate<T>) -> Self {
+        Self(v0, v1, v2)
+    }
+
+    /// Get the first of the triangle's three corners
+    #[inline]
+    pub fn vertex_0(&self) -> Coordinate<T> {
+        #[allow(deprecated)]
+        self.0
+    }
+
+    /// Mutably borrow the first of the triangle's three corners
+    #[inline]
+    pub fn vertex_0_mut(&mut self) -> &mut Coordinate<T> {
+        #[allow(deprecated)]
+        &mut self.0
+    }
+
+    /// Get the second of the triangle's three corners
+    #[inline]
+    pub fn vertex_1(&self) -> Coordinate<T> {
+        #[allow(deprecated)]
+        self.1
+    }
+
+    /// Mutably borrow the second of the triangle's three corners
+    #[inline]
+    pub fn vertex_1_mut(&mut self) -> &mut Coordinate<T> {
+        #[allow(deprecated)]
+        &mut self.1
+    }
+
+    /// Get the third of the triangle's three corners
+    #[inline]
+    pub fn vertex_2(&self) -> Coordinate<T> {
+        #[allow(deprecated)]
+        self.2
+    }
+
+    /// Mutably borrow the third of the triangle's three corners
+    #[inline]
+    pub fn vertex_2_mut(&mut self) -> &mut Coordinate<T> {
+        #[allow(deprecated)]
+        &mut self.2
     }
 
     pub fn to_array(&self) -> [Coordinate<T>; 3] {
-        [self.0, self.1, self.2]
+        [self.vertex_0(), self.vertex_1(), self.vertex_2()]
     }
 
     pub fn to_lines(&self) -> [Line<T>; 3] {
         [
-            Line::new(self.0, self.1),
-            Line::new(self.1, self.2),
-            Line::new(self.2, self.0),
+            Line::new(self.vertex_0(), self.vertex_1()),
+            Line::new(self.vertex_1(), self.vertex_2()),
+            Line::new(self.vertex_2(), self.vertex_0()),
         ]
     }
 
@@ -53,7 +112,12 @@ impl<T: CoordNum> Triangle<T> {
     /// );
     /// ```
     pub fn to_polygon(self) -> Polygon<T> {
-        polygon![self.0, self.1, self.2, self.0]
+        polygon![
+            self.vertex_0(),
+            self.vertex_1(),
+            self.vertex_2(),
+            self.vertex_0()
+        ]
     }
 }
 
@@ -93,13 +157,22 @@ where
         epsilon: Self::Epsilon,
         max_relative: Self::Epsilon,
     ) -> bool {
-        if !self.0.relative_eq(&other.0, epsilon, max_relative) {
+        if !self
+            .vertex_0()
+            .relative_eq(&other.vertex_0(), epsilon, max_relative)
+        {
             return false;
         }
-        if !self.1.relative_eq(&other.1, epsilon, max_relative) {
+        if !self
+            .vertex_1()
+            .relative_eq(&other.vertex_1(), epsilon, max_relative)
+        {
             return false;
         }
-        if !self.2.relative_eq(&other.2, epsilon, max_relative) {
+        if !self
+            .vertex_2()
+            .relative_eq(&other.vertex_2(), epsilon, max_relative)
+        {
             return false;
         }
 
@@ -135,13 +208,13 @@ where
     /// ```
     #[inline]
     fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
-        if !self.0.abs_diff_eq(&other.0, epsilon) {
+        if !self.vertex_0().abs_diff_eq(&other.vertex_0(), epsilon) {
             return false;
         }
-        if !self.1.abs_diff_eq(&other.1, epsilon) {
+        if !self.vertex_1().abs_diff_eq(&other.vertex_1(), epsilon) {
             return false;
         }
-        if !self.2.abs_diff_eq(&other.2, epsilon) {
+        if !self.vertex_2().abs_diff_eq(&other.vertex_2(), epsilon) {
             return false;
         }
 

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -16,6 +16,7 @@ proj-network = ["use-proj", "proj/network"]
 use-serde = ["serde", "geo-types/serde"]
 
 [dependencies]
+# TODO: bump to 0.7.5 before release to adapt to deprecated fields
 geo-types = { version = "0.7.4", features = ["approx", "use-rstar"] }
 geographiclib-rs = "0.2"
 log = "0.4.11"

--- a/geo/benches/relate.rs
+++ b/geo/benches/relate.rs
@@ -9,7 +9,7 @@ use geo::{LineString, Polygon};
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("relate overlapping 50-point polygons", |bencher| {
         let norway = geo_test_fixtures::norway_main::<f32>();
-        let points = norway.0;
+        let points = norway.into_inner();
 
         let sub_polygon = {
             let points = points[0..50].to_vec();

--- a/geo/examples/types.rs
+++ b/geo/examples/types.rs
@@ -1,6 +1,5 @@
 extern crate geo;
 
-use geo::Point;
 use geo_types::point;
 
 fn main() {
@@ -9,6 +8,6 @@ fn main() {
         y: 116.34,
     };
 
-    let Point(coord) = p;
-    println!("Point at ({}, {})", coord.x, coord.y);
+    let coord = p.coord();
+    println!("Point at ({}, {})", coord.x(), coord.y());
 }

--- a/geo/fuzz/fuzz_targets/simplify.rs
+++ b/geo/fuzz/fuzz_targets/simplify.rs
@@ -13,11 +13,11 @@ fuzz_target!(|tuple: (geo_types::Polygon<f32>, f32)| {
 });
 
 fn check_result(original: geo_types::Polygon<f32>, simplified: geo_types::Polygon<f32>) {
-    assert!(simplified.exterior().0.len() <= original.exterior().0.len());
+    assert!(simplified.exterior().inner().len() <= original.exterior().inner().len());
     assert!(simplified.exterior().euclidean_length() <= original.exterior().euclidean_length());
 
     for interior in simplified.interiors() {
-        assert!(simplified.exterior().0.len() <= interior.0.len());
+        assert!(simplified.exterior().inner().len() <= interior.0.len());
         assert!(simplified.exterior().euclidean_length() <= interior.euclidean_length());
     }
 }

--- a/geo/src/algorithm/area.rs
+++ b/geo/src/algorithm/area.rs
@@ -9,13 +9,13 @@ where
 {
     // LineString with less than 3 points is empty, or a
     // single point, or is not closed.
-    if linestring.0.len() < 3 {
+    if linestring.inner().len() < 3 {
         return T::zero();
     }
 
     // Above test ensures the vector has at least 2 elements.
     // We check if linestring is closed, and return 0 otherwise.
-    if linestring.0.first().unwrap() != linestring.0.last().unwrap() {
+    if linestring.inner().first().unwrap() != linestring.inner().last().unwrap() {
         return T::zero();
     }
 
@@ -29,12 +29,12 @@ where
     // of the coordinates, but it is not fool-proof to
     // divide by the length of the linestring (eg. a long
     // line-string with T = u8)
-    let shift = linestring.0[0];
+    let shift = linestring[0];
 
     let mut tmp = T::zero();
     for line in linestring.lines() {
         use crate::algorithm::map_coords::MapCoords;
-        let line = line.map_coords(|(x, y)| (x - shift.x, y - shift.y));
+        let line = line.map_coords(|(x, y)| (x - shift.x(), y - shift.y()));
         tmp = tmp + line.determinant();
     }
 
@@ -190,13 +190,13 @@ where
     T: CoordFloat,
 {
     fn signed_area(&self) -> T {
-        self.0
+        self.polygons()
             .iter()
             .fold(T::zero(), |total, next| total + next.signed_area())
     }
 
     fn unsigned_area(&self) -> T {
-        self.0
+        self.polygons()
             .iter()
             .fold(T::zero(), |total, next| total + next.signed_area().abs())
     }
@@ -247,15 +247,13 @@ where
     T: CoordFloat,
 {
     fn signed_area(&self) -> T {
-        self.0
-            .iter()
+        self.iter()
             .map(|g| g.signed_area())
             .fold(T::zero(), |acc, next| acc + next)
     }
 
     fn unsigned_area(&self) -> T {
-        self.0
-            .iter()
+        self.iter()
             .map(|g| g.unsigned_area())
             .fold(T::zero(), |acc, next| acc + next)
     }

--- a/geo/src/algorithm/bounding_rect.rs
+++ b/geo/src/algorithm/bounding_rect.rs
@@ -25,10 +25,10 @@ pub trait BoundingRect<T: CoordNum> {
     ///
     /// let bounding_rect = line_string.bounding_rect().unwrap();
     ///
-    /// assert_eq!(40.02f64, bounding_rect.min().x);
-    /// assert_eq!(42.02f64, bounding_rect.max().x);
-    /// assert_eq!(116.34, bounding_rect.min().y);
-    /// assert_eq!(118.34, bounding_rect.max().y);
+    /// assert_eq!(40.02f64, bounding_rect.min().x());
+    /// assert_eq!(42.02f64, bounding_rect.max().x());
+    /// assert_eq!(116.34, bounding_rect.min().y());
+    /// assert_eq!(118.34, bounding_rect.max().y());
     /// ```
     fn bounding_rect(&self) -> Self::Output;
 }
@@ -42,7 +42,7 @@ where
     /// Return the bounding rectangle for a `Point`. It will have zero width
     /// and zero height.
     fn bounding_rect(&self) -> Self::Output {
-        Rect::new(self.0, self.0)
+        Rect::new(self.coord(), self.coord())
     }
 }
 
@@ -55,7 +55,7 @@ where
     ///
     /// Return the BoundingRect for a MultiPoint
     fn bounding_rect(&self) -> Self::Output {
-        get_bounding_rect(self.0.iter().map(|p| p.0))
+        get_bounding_rect(self.iter().map(|p| p.coord()))
     }
 }
 
@@ -66,7 +66,7 @@ where
     type Output = Rect<T>;
 
     fn bounding_rect(&self) -> Self::Output {
-        Rect::new(self.start, self.end)
+        Rect::new(self.start(), self.end())
     }
 }
 
@@ -92,7 +92,7 @@ where
     ///
     /// Return the BoundingRect for a MultiLineString
     fn bounding_rect(&self) -> Self::Output {
-        get_bounding_rect(self.iter().flat_map(|line| line.0.iter().cloned()))
+        get_bounding_rect(self.iter().flat_map(|line| line.coords().cloned()))
     }
 }
 
@@ -106,7 +106,7 @@ where
     /// Return the BoundingRect for a Polygon
     fn bounding_rect(&self) -> Self::Output {
         let line = self.exterior();
-        get_bounding_rect(line.0.iter().cloned())
+        get_bounding_rect(line.coords().cloned())
     }
 }
 
@@ -121,7 +121,7 @@ where
     fn bounding_rect(&self) -> Self::Output {
         get_bounding_rect(
             self.iter()
-                .flat_map(|poly| poly.exterior().0.iter().cloned()),
+                .flat_map(|poly| poly.exterior().coords().cloned()),
         )
     }
 }
@@ -193,12 +193,12 @@ where
 fn bounding_rect_merge<T: CoordNum>(a: Rect<T>, b: Rect<T>) -> Rect<T> {
     Rect::new(
         coord! {
-            x: partial_min(a.min().x, b.min().x),
-            y: partial_min(a.min().y, b.min().y),
+            x: partial_min(a.min().x(), b.min().x()),
+            y: partial_min(a.min().y(), b.min().y()),
         },
         coord! {
-            x: partial_max(a.max().x, b.max().x),
-            y: partial_max(a.max().y, b.max().y),
+            x: partial_max(a.max().x(), b.max().x()),
+            y: partial_max(a.max().y(), b.max().y()),
         },
     )
 }

--- a/geo/src/algorithm/bounding_rect.rs
+++ b/geo/src/algorithm/bounding_rect.rs
@@ -322,7 +322,7 @@ mod test {
     fn geometry_collection_bounding_rect_test() {
         assert_eq!(
             Some(Rect::new(coord! { x: 0., y: 0. }, coord! { x: 1., y: 2. })),
-            GeometryCollection::new_from(vec![
+            GeometryCollection::from(vec![
                 Geometry::Point(point! { x: 0., y: 0. }),
                 Geometry::Point(point! { x: 1., y: 2. }),
             ])

--- a/geo/src/algorithm/centroid.rs
+++ b/geo/src/algorithm/centroid.rs
@@ -811,7 +811,7 @@ mod test {
         assert_eq!(multi_point.centroid().unwrap(), point!(x: 1.0, y: 1.0));
 
         let collection =
-            GeometryCollection::new_from(vec![MultiPoint::new(vec![p1, p2, p3]).into(), p0.into()]);
+            GeometryCollection::from(vec![MultiPoint::new(vec![p1, p2, p3]).into(), p0.into()]);
 
         assert_eq!(collection.centroid().unwrap(), point!(x: 1.0, y: 1.0));
     }
@@ -855,8 +855,8 @@ mod test {
 
         let line = Line::new(c(0., 1.), c(1., 3.));
 
-        let g1 = GeometryCollection::new_from(vec![triangle.into(), line.into()]);
-        let g2 = GeometryCollection::new_from(vec![poly.into(), line.into()]);
+        let g1 = GeometryCollection::from(vec![triangle.into(), line.into()]);
+        let g2 = GeometryCollection::from(vec![poly.into(), line.into()]);
         assert_eq!(g1.centroid(), g2.centroid());
     }
 
@@ -867,8 +867,8 @@ mod test {
 
         let line = Line::new(c(0., 1.), c(1., 3.));
 
-        let g1 = GeometryCollection::new_from(vec![rect.into(), line.into()]);
-        let g2 = GeometryCollection::new_from(vec![poly.into(), line.into()]);
+        let g1 = GeometryCollection::from(vec![rect.into(), line.into()]);
+        let g2 = GeometryCollection::from(vec![poly.into(), line.into()]);
         assert_eq!(g1.centroid(), g2.centroid());
     }
 
@@ -893,11 +893,8 @@ mod test {
         );
 
         // collection with rect
-        let mut collection = GeometryCollection::new_from(vec![
-            p(0., 0.).into(),
-            p(6., 0.).into(),
-            p(6., 6.).into(),
-        ]);
+        let mut collection =
+            GeometryCollection::from(vec![p(0., 0.).into(), p(6., 0.).into(), p(6., 6.).into()]);
         // sanity check
         assert_eq!(collection.centroid().unwrap(), point!(x: 4., y: 2.));
 

--- a/geo/src/algorithm/chaikin_smoothing.rs
+++ b/geo/src/algorithm/chaikin_smoothing.rs
@@ -46,8 +46,7 @@ where
 {
     fn chaikin_smoothing(&self, n_iterations: usize) -> Self {
         MultiLineString::new(
-            self.0
-                .iter()
+            self.iter()
                 .map(|ls| ls.chaikin_smoothing(n_iterations))
                 .collect(),
         )
@@ -75,8 +74,7 @@ where
 {
     fn chaikin_smoothing(&self, n_iterations: usize) -> Self {
         MultiPolygon::new(
-            self.0
-                .iter()
+            self.iter()
                 .map(|poly| poly.chaikin_smoothing(n_iterations))
                 .collect(),
         )
@@ -87,21 +85,21 @@ fn smoothen_linestring<T>(linestring: &LineString<T>) -> LineString<T>
 where
     T: CoordFloat + Mul<T> + FromPrimitive,
 {
-    let mut out_coords: Vec<_> = Vec::with_capacity(linestring.0.len() * 2);
+    let mut out_coords: Vec<_> = Vec::with_capacity(linestring.inner().len() * 2);
 
-    if let (Some(first), Some(last)) = (linestring.0.first(), linestring.0.last()) {
+    if let (Some(first), Some(last)) = (linestring.inner().first(), linestring.inner().last()) {
         if first != last {
             // preserve start coordinate when the linestring is open
             out_coords.push(*first);
         }
     }
-    for window_coordinates in linestring.0.windows(2) {
+    for window_coordinates in linestring.inner().windows(2) {
         let (q, r) = smoothen_coordinates(window_coordinates[0], window_coordinates[1]);
         out_coords.push(q);
         out_coords.push(r);
     }
 
-    if let (Some(first), Some(last)) = (linestring.0.first(), linestring.0.last()) {
+    if let (Some(first), Some(last)) = (linestring.inner().first(), linestring.inner().last()) {
         if first != last {
             // preserve the last coordinate of an open linestring
             out_coords.push(*last);
@@ -121,12 +119,12 @@ where
     T: CoordFloat + Mul<T> + FromPrimitive,
 {
     let q = coord! {
-        x: (T::from(0.75).unwrap() * c0.x) + (T::from(0.25).unwrap() * c1.x),
-        y: (T::from(0.75).unwrap() * c0.y) + (T::from(0.25).unwrap() * c1.y),
+        x: (T::from(0.75).unwrap() * c0.x()) + (T::from(0.25).unwrap() * c1.x()),
+        y: (T::from(0.75).unwrap() * c0.y()) + (T::from(0.25).unwrap() * c1.y()),
     };
     let r = coord! {
-        x: (T::from(0.25).unwrap() * c0.x) + (T::from(0.75).unwrap() * c1.x),
-        y: (T::from(0.25).unwrap() * c0.y) + (T::from(0.75).unwrap() * c1.y),
+        x: (T::from(0.25).unwrap() * c0.x()) + (T::from(0.75).unwrap() * c1.x()),
+        y: (T::from(0.25).unwrap() * c0.y()) + (T::from(0.75).unwrap() * c1.y()),
     };
     (q, r)
 }

--- a/geo/src/algorithm/chamberlain_duquette_area.rs
+++ b/geo/src/algorithm/chamberlain_duquette_area.rs
@@ -75,7 +75,7 @@ where
     T: Float + CoordNum,
 {
     let mut total = T::zero();
-    let coords_len = coords.0.len();
+    let coords_len = coords.inner().len();
 
     if coords_len > 2 {
         for i in 0..coords_len {
@@ -92,7 +92,7 @@ where
             let p1 = coords[lower_index];
             let p2 = coords[middle_index];
             let p3 = coords[upper_index];
-            total = total + (p3.x.to_radians() - p1.x.to_radians()) * p2.y.to_radians().sin();
+            total = total + (p3.x().to_radians() - p1.x().to_radians()) * p2.y().to_radians().sin();
         }
 
         total = total

--- a/geo/src/algorithm/closest_point.rs
+++ b/geo/src/algorithm/closest_point.rs
@@ -64,21 +64,21 @@ impl<F: GeoFloat> ClosestPoint<F> for Line<F> {
         //
         // Line equation: P = start + t * (end - start)
 
-        let direction_vector = Point::from(self.end - self.start);
-        let to_p = Point::from(p.0 - self.start);
+        let direction_vector = Point::from(self.end() - self.start());
+        let to_p = Point::from(p.coord() - self.start());
 
         let t = to_p.dot(direction_vector) / direction_vector.dot(direction_vector);
 
         // check the cases where the closest point is "outside" the line
         if t < F::zero() {
-            return Closest::SinglePoint(self.start.into());
+            return Closest::SinglePoint(self.start().into());
         } else if t > F::one() {
-            return Closest::SinglePoint(self.end.into());
+            return Closest::SinglePoint(self.end().into());
         }
 
         let x = direction_vector.x();
         let y = direction_vector.y();
-        let c = Point::from(self.start + (t * x, t * y).into());
+        let c = Point::from(self.start() + (t * x, t * y).into());
 
         if self.intersects(p) {
             Closest::Intersection(c)
@@ -292,7 +292,7 @@ mod tests {
     #[test]
     fn polygon_with_point_on_interior_ring() {
         let poly = holy_polygon();
-        let p = poly.interiors()[0].0[3];
+        let p = poly.interiors()[0][3];
         let should_be = Closest::Intersection(p.into());
 
         let got = poly.closest_point(&p.into());

--- a/geo/src/algorithm/contains/geometry.rs
+++ b/geo/src/algorithm/contains/geometry.rs
@@ -41,6 +41,6 @@ where
     T: GeoNum,
 {
     fn contains(&self, point: &Point<T>) -> bool {
-        self.contains(&point.0)
+        self.contains(&point.coord())
     }
 }

--- a/geo/src/algorithm/contains/line.rs
+++ b/geo/src/algorithm/contains/line.rs
@@ -11,10 +11,10 @@ where
     T: GeoNum,
 {
     fn contains(&self, coord: &Coordinate<T>) -> bool {
-        if self.start == self.end {
-            &self.start == coord
+        if self.start() == self.end() {
+            &self.start() == coord
         } else {
-            coord != &self.start && coord != &self.end && self.intersects(coord)
+            coord != &self.start() && coord != &self.end() && self.intersects(coord)
         }
     }
 }
@@ -24,7 +24,7 @@ where
     T: GeoNum,
 {
     fn contains(&self, p: &Point<T>) -> bool {
-        self.contains(&p.0)
+        self.contains(&p.coord())
     }
 }
 
@@ -33,10 +33,10 @@ where
     T: GeoNum,
 {
     fn contains(&self, line: &Line<T>) -> bool {
-        if line.start == line.end {
-            self.contains(&line.start)
+        if line.start() == line.end() {
+            self.contains(&line.start())
         } else {
-            self.intersects(&line.start) && self.intersects(&line.end)
+            self.intersects(&line.start()) && self.intersects(&line.end())
         }
     }
 }
@@ -48,7 +48,7 @@ where
     fn contains(&self, linestring: &LineString<T>) -> bool {
         // Empty linestring has no interior, and not
         // contained in anything.
-        if linestring.0.is_empty() {
+        if linestring.inner().is_empty() {
             return false;
         }
 
@@ -64,14 +64,14 @@ where
         // are the same. In this case, the interior is this
         // specific point, and it should be contained in the
         // line.
-        let first = linestring.0.first().unwrap();
+        let first = linestring.inner().first().unwrap();
         let mut all_equal = true;
 
         // If all the vertices of the linestring intersect
         // self, then the interior or boundary of the
         // linestring cannot have non-empty intersection
         // with the exterior.
-        let all_intersects = linestring.0.iter().all(|c| {
+        let all_intersects = linestring.coords().all(|c| {
             if c != first {
                 all_equal = false;
             }

--- a/geo/src/algorithm/contains/line_string.rs
+++ b/geo/src/algorithm/contains/line_string.rs
@@ -11,17 +11,17 @@ where
     T: GeoNum,
 {
     fn contains(&self, coord: &Coordinate<T>) -> bool {
-        if self.0.is_empty() {
+        if self.inner().is_empty() {
             return false;
         }
 
-        if self.is_closed() && coord == &self.0[0] {
+        if self.is_closed() && coord == &self[0] {
             return true;
         }
 
         self.lines()
             .enumerate()
-            .any(|(i, line)| line.contains(coord) || (i > 0 && coord == &line.start))
+            .any(|(i, line)| line.contains(coord) || (i > 0 && coord == &line.start()))
     }
 }
 
@@ -30,7 +30,7 @@ where
     T: GeoNum,
 {
     fn contains(&self, p: &Point<T>) -> bool {
-        self.contains(&p.0)
+        self.contains(&p.coord())
     }
 }
 
@@ -39,8 +39,8 @@ where
     T: GeoNum,
 {
     fn contains(&self, line: &Line<T>) -> bool {
-        if line.start == line.end {
-            return self.contains(&line.start);
+        if line.start() == line.end() {
+            return self.contains(&line.start());
         }
 
         // We copy the line as we may truncate the line as
@@ -68,10 +68,10 @@ where
             }
             // Look for a segment that intersects at least
             // one of the end points.
-            let other = if segment.intersects(&line.start) {
-                line.end
-            } else if segment.intersects(&line.end) {
-                line.start
+            let other = if segment.intersects(&line.start()) {
+                line.end()
+            } else if segment.intersects(&line.end()) {
+                line.start()
             } else {
                 continue;
             };
@@ -84,19 +84,19 @@ where
             // otoh, if the line contains one of the ends of
             // the segments, then we truncate the line to
             // the part outside.
-            else if line.contains(&segment.start) {
-                segment.start
-            } else if line.contains(&segment.end) {
-                segment.end
+            else if line.contains(&segment.start()) {
+                segment.start()
+            } else if line.contains(&segment.end()) {
+                segment.end()
             } else {
                 continue;
             };
 
             first_cut = first_cut.or(Some(i));
-            if other == line.start {
-                line.end = new_inside;
+            if other == line.start() {
+                *line.end_mut() = new_inside;
             } else {
-                line.start = new_inside;
+                *line.start_mut() = new_inside;
             }
         }
 

--- a/geo/src/algorithm/contains/point.rs
+++ b/geo/src/algorithm/contains/point.rs
@@ -10,7 +10,7 @@ where
     T: CoordNum,
 {
     fn contains(&self, coord: &Coordinate<T>) -> bool {
-        &self.0 == coord
+        &self.coord() == coord
     }
 }
 
@@ -19,7 +19,7 @@ where
     T: CoordNum,
 {
     fn contains(&self, p: &Point<T>) -> bool {
-        self.contains(&p.0)
+        self.contains(&p.coord())
     }
 }
 

--- a/geo/src/algorithm/contains/polygon.rs
+++ b/geo/src/algorithm/contains/polygon.rs
@@ -24,7 +24,7 @@ where
     T: GeoNum,
 {
     fn contains(&self, p: &Point<T>) -> bool {
-        self.contains(&p.0)
+        self.contains(&p.coord())
     }
 }
 
@@ -73,7 +73,7 @@ where
     T: GeoNum,
 {
     fn contains(&self, p: &Point<T>) -> bool {
-        self.contains(&p.0)
+        self.contains(&p.coord())
     }
 }
 

--- a/geo/src/algorithm/contains/rect.rs
+++ b/geo/src/algorithm/contains/rect.rs
@@ -10,10 +10,10 @@ where
     T: CoordNum,
 {
     fn contains(&self, coord: &Coordinate<T>) -> bool {
-        coord.x > self.min().x
-            && coord.x < self.max().x
-            && coord.y > self.min().y
-            && coord.y < self.max().y
+        coord.x() > self.min().x()
+            && coord.x() < self.max().x()
+            && coord.y() > self.min().y()
+            && coord.y() < self.max().y()
     }
 }
 
@@ -22,7 +22,7 @@ where
     T: CoordNum,
 {
     fn contains(&self, p: &Point<T>) -> bool {
-        self.contains(&p.0)
+        self.contains(&p.coord())
     }
 }
 
@@ -33,9 +33,9 @@ where
     fn contains(&self, other: &Rect<T>) -> bool {
         // TODO: check for degenerate rectangle (which is a line or a point)
         // All points of LineString must be in the polygon ?
-        self.min().x <= other.min().x
-            && self.max().x >= other.max().x
-            && self.min().y <= other.min().y
-            && self.max().y >= other.max().y
+        self.min().x() <= other.min().x()
+            && self.max().x() >= other.max().x()
+            && self.min().y() <= other.min().y()
+            && self.max().y() >= other.max().y()
     }
 }

--- a/geo/src/algorithm/contains/triangle.rs
+++ b/geo/src/algorithm/contains/triangle.rs
@@ -10,7 +10,12 @@ where
     T: GeoNum,
 {
     fn contains(&self, coord: &Coordinate<T>) -> bool {
-        let ls = LineString::new(vec![self.0, self.1, self.2, self.0]);
+        let ls = LineString::new(vec![
+            self.vertex_0(),
+            self.vertex_1(),
+            self.vertex_2(),
+            self.vertex_0(),
+        ]);
         use crate::utils::{coord_pos_relative_to_ring, CoordPos};
         coord_pos_relative_to_ring(*coord, &ls) == CoordPos::Inside
     }
@@ -21,6 +26,6 @@ where
     T: GeoNum,
 {
     fn contains(&self, point: &Point<T>) -> bool {
-        self.contains(&point.0)
+        self.contains(&point.coord())
     }
 }

--- a/geo/src/algorithm/convex_hull/graham.rs
+++ b/geo/src/algorithm/convex_hull/graham.rs
@@ -139,11 +139,11 @@ mod test {
 
     #[test]
     fn graham_test_complex() {
-        test_convexity(geo_test_fixtures::poly1::<f64>().0);
+        test_convexity(geo_test_fixtures::poly1::<f64>().into_inner());
     }
 
     #[test]
     fn quick_hull_test_complex_2() {
-        test_convexity(geo_test_fixtures::poly2::<f64>().0);
+        test_convexity(geo_test_fixtures::poly2::<f64>().into_inner());
     }
 }

--- a/geo/src/algorithm/convex_hull/mod.rs
+++ b/geo/src/algorithm/convex_hull/mod.rs
@@ -47,7 +47,7 @@ where
 {
     type Scalar = T;
     fn convex_hull(&self) -> Polygon<T> {
-        Polygon::new(quick_hull(&mut self.exterior().0.clone()), vec![])
+        Polygon::new(quick_hull(&mut self.exterior().inner().to_vec()), vec![])
     }
 }
 
@@ -58,9 +58,8 @@ where
     type Scalar = T;
     fn convex_hull(&self) -> Polygon<T> {
         let mut aggregated: Vec<_> = self
-            .0
             .iter()
-            .flat_map(|elem| elem.exterior().0.iter().copied())
+            .flat_map(|elem| elem.exterior().coords().copied())
             .collect();
         Polygon::new(quick_hull(&mut aggregated), vec![])
     }
@@ -72,7 +71,7 @@ where
 {
     type Scalar = T;
     fn convex_hull(&self) -> Polygon<T> {
-        Polygon::new(quick_hull(&mut self.0.clone()), vec![])
+        Polygon::new(quick_hull(&mut self.inner().to_vec()), vec![])
     }
 }
 
@@ -82,7 +81,7 @@ where
 {
     type Scalar = T;
     fn convex_hull(&self) -> Polygon<T> {
-        let mut aggregated: Vec<_> = self.iter().flat_map(|elem| elem.clone().0).collect();
+        let mut aggregated: Vec<_> = self.iter().flat_map(|elem| elem.inner().to_vec()).collect();
         Polygon::new(quick_hull(&mut aggregated), vec![])
     }
 }
@@ -93,7 +92,7 @@ where
 {
     type Scalar = T;
     fn convex_hull(&self) -> Polygon<T> {
-        let mut aggregated: Vec<_> = self.iter().map(|p| p.0).collect();
+        let mut aggregated: Vec<_> = self.iter().map(|p| p.coord()).collect();
         Polygon::new(quick_hull(&mut aggregated), vec![])
     }
 }

--- a/geo/src/algorithm/convex_hull/qhull.rs
+++ b/geo/src/algorithm/convex_hull/qhull.rs
@@ -84,18 +84,18 @@ fn hull_set<T>(
     // compute inner product of this with `v` - `p_a` to
     // find the farthest point from the line segment a-b.
     let p_orth = coord! {
-        x: p_a.y - p_b.y,
-        y: p_b.x - p_a.x,
+        x: p_a.y() - p_b.y(),
+        y: p_b.x() - p_a.x(),
     };
 
     let furthest_idx = set
         .iter()
         .map(|pt| {
             let p_diff = coord! {
-                x: pt.x - p_a.x,
-                y: pt.y - p_a.y,
+                x: pt.x() - p_a.x(),
+                y: pt.y() - p_a.y(),
             };
-            p_orth.x * p_diff.x + p_orth.y * p_diff.y
+            p_orth.x() * p_diff.x() + p_orth.y() * p_diff.y()
         })
         .enumerate()
         .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap())
@@ -156,7 +156,7 @@ mod test {
             coord! { x: 0, y: -10 },
         ];
         let res = quick_hull(&mut v);
-        assert_eq!(res.0, correct);
+        assert_eq!(res.inner(), correct);
     }
 
     #[test]
@@ -174,7 +174,7 @@ mod test {
         let correct = vec![(1.0, 0.0), (2.0, 1.0), (1.0, 2.0), (0.0, 1.0), (1.0, 0.0)];
         let v_correct: Vec<_> = correct.iter().map(|e| coord! { x: e.0, y: e.1 }).collect();
         let res = quick_hull(&mut v);
-        assert_eq!(res.0, v_correct);
+        assert_eq!(res.inner(), v_correct);
     }
 
     #[test]
@@ -197,18 +197,18 @@ mod test {
 
     #[test]
     fn quick_hull_test_complex() {
-        let mut coords = geo_test_fixtures::poly1::<f64>().0;
-        let correct = geo_test_fixtures::poly1_hull::<f64>().0;
+        let mut coords = geo_test_fixtures::poly1::<f64>().into_inner();
+        let correct = geo_test_fixtures::poly1_hull::<f64>().into_inner();
         let res = quick_hull(&mut coords);
-        assert_eq!(res.0, correct);
+        assert_eq!(res.inner(), correct);
     }
 
     #[test]
     fn quick_hull_test_complex_2() {
-        let mut coords = geo_test_fixtures::poly2::<f64>().0;
-        let correct = geo_test_fixtures::poly2_hull::<f64>().0;
+        let mut coords = geo_test_fixtures::poly2::<f64>().into_inner();
+        let correct = geo_test_fixtures::poly2_hull::<f64>().into_inner();
         let res = quick_hull(&mut coords);
-        assert_eq!(res.0, correct);
+        assert_eq!(res.inner(), correct);
     }
 
     #[test]

--- a/geo/src/algorithm/convex_hull/test.rs
+++ b/geo/src/algorithm/convex_hull/test.rs
@@ -23,7 +23,7 @@ fn convex_hull_multipoint_test() {
         Coordinate::from((0, -10)),
     ];
     let res = mp.convex_hull();
-    assert_eq!(res.exterior().0, correct);
+    assert_eq!(res.exterior().inner(), correct);
 }
 #[test]
 fn convex_hull_linestring_test() {
@@ -46,7 +46,7 @@ fn convex_hull_linestring_test() {
         Coordinate::from((0.0, -10.0)),
     ];
     let res = mp.convex_hull();
-    assert_eq!(res.exterior().0, correct);
+    assert_eq!(res.exterior().inner(), correct);
 }
 #[test]
 fn convex_hull_multilinestring_test() {
@@ -61,7 +61,7 @@ fn convex_hull_multilinestring_test() {
         Coordinate::from((2.0, 0.0)),
     ];
     let res = mls.convex_hull();
-    assert_eq!(res.exterior().0, correct);
+    assert_eq!(res.exterior().inner(), correct);
 }
 #[test]
 fn convex_hull_multipolygon_test() {
@@ -76,5 +76,5 @@ fn convex_hull_multipolygon_test() {
         Coordinate::from((5.0, 0.0)),
     ];
     let res = mp.convex_hull();
-    assert_eq!(res.exterior().0, correct);
+    assert_eq!(res.exterior().inner(), correct);
 }

--- a/geo/src/algorithm/coordinate_position.rs
+++ b/geo/src/algorithm/coordinate_position.rs
@@ -710,7 +710,7 @@ mod test {
     fn test_collection() {
         let triangle = Triangle::new((0.0, 0.0).into(), (5.0, 10.0).into(), (10.0, 0.0).into());
         let rect = Rect::new((0.0, 0.0), (10.0, 10.0));
-        let collection = GeometryCollection::new_from(vec![triangle.into(), rect.into()]);
+        let collection = GeometryCollection::from(vec![triangle.into(), rect.into()]);
 
         //  outside of both
         assert_eq!(

--- a/geo/src/algorithm/coordinate_position.rs
+++ b/geo/src/algorithm/coordinate_position.rs
@@ -94,7 +94,7 @@ where
         is_inside: &mut bool,
         _boundary_count: &mut usize,
     ) {
-        if &self.0 == coord {
+        if &self.coord() == coord {
             *is_inside = true;
         }
     }
@@ -112,13 +112,13 @@ where
         boundary_count: &mut usize,
     ) {
         // degenerate line is a point
-        if self.start == self.end {
-            self.start
+        if self.start() == self.end() {
+            self.start()
                 .calculate_coordinate_position(coord, is_inside, boundary_count);
             return;
         }
 
-        if coord == &self.start || coord == &self.end {
+        if coord == &self.start() || coord == &self.end() {
             *boundary_count += 1;
         } else if self.intersects(coord) {
             *is_inside = true;
@@ -137,14 +137,14 @@ where
         is_inside: &mut bool,
         boundary_count: &mut usize,
     ) {
-        if self.0.len() < 2 {
+        if self.inner().len() < 2 {
             debug_assert!(false, "invalid line string with less than 2 coords");
             return;
         }
 
-        if self.0.len() == 2 {
+        if self.inner().len() == 2 {
             // line string with two coords is just a line
-            Line::new(self.0[0], self.0[1]).calculate_coordinate_position(
+            Line::new(self[0], self[1]).calculate_coordinate_position(
                 coord,
                 is_inside,
                 boundary_count,
@@ -161,7 +161,7 @@ where
         // A closed linestring has no boundary, per SFS
         if !self.is_closed() {
             // since self.0 is non-empty, safe to `unwrap`
-            if coord == self.0.first().unwrap() || coord == self.0.last().unwrap() {
+            if coord == self.inner().first().unwrap() || coord == self.inner().last().unwrap() {
                 *boundary_count += 1;
                 return;
             }
@@ -220,7 +220,7 @@ where
         is_inside: &mut bool,
         _boundary_count: &mut usize,
     ) {
-        if self.0.iter().any(|p| &p.0 == coord) {
+        if self.iter().any(|p| &p.coord() == coord) {
             *is_inside = true;
         }
     }
@@ -282,7 +282,7 @@ where
         is_inside: &mut bool,
         boundary_count: &mut usize,
     ) {
-        for line_string in &self.0 {
+        for line_string in self {
             line_string.calculate_coordinate_position(coord, is_inside, boundary_count);
         }
     }
@@ -299,7 +299,7 @@ where
         is_inside: &mut bool,
         boundary_count: &mut usize,
     ) {
-        for polygon in &self.0 {
+        for polygon in self {
             polygon.calculate_coordinate_position(coord, is_inside, boundary_count);
         }
     }
@@ -361,13 +361,13 @@ where
     debug_assert!(linestring.is_closed());
 
     // LineString without points
-    if linestring.0.is_empty() {
+    if linestring.inner().is_empty() {
         return CoordPos::Outside;
     }
-    if linestring.0.len() == 1 {
+    if linestring.inner().len() == 1 {
         // If LineString has one point, it will not generate
         // any lines.  So, we handle this edge case separately.
-        return if coord == linestring.0[0] {
+        return if coord == linestring[0] {
             CoordPos::OnBoundary
         } else {
             CoordPos::Outside
@@ -382,12 +382,12 @@ where
         }
 
         // Ignore if the line is strictly to the left of the coord.
-        let max_x = if line.start.x < line.end.x {
-            line.end.x
+        let max_x = if line.start().x() < line.end().x() {
+            line.end().x()
         } else {
-            line.start.x
+            line.start().x()
         };
-        if max_x < coord.x {
+        if max_x < coord.x() {
             continue;
         }
 
@@ -395,7 +395,7 @@ where
         // edge case where the ray would intersect a
         // horizontal segment of the ring infinitely many
         // times, and is irrelevant for the calculation.
-        if line.start.y == line.end.y {
+        if line.start().y() == line.end().y() {
             continue;
         }
 
@@ -410,8 +410,8 @@ where
         //      at the point of intersection
         //   2. if the ray touches a vertex,
         //      but doesn't enter/exit at that point
-        if (line.start.y == coord.y && line.end.y < coord.y)
-            || (line.end.y == coord.y && line.start.y < coord.y)
+        if (line.start().y() == coord.y() && line.end().y() < coord.y())
+            || (line.end().y() == coord.y() && line.start().y() < coord.y())
         {
             continue;
         }
@@ -423,7 +423,7 @@ where
             coord,
             coord! {
                 x: max_x,
-                y: coord.y,
+                y: coord.y(),
             },
         );
         if ray.intersects(&line) {

--- a/geo/src/algorithm/coords_iter.rs
+++ b/geo/src/algorithm/coords_iter.rs
@@ -754,7 +754,7 @@ mod test {
         let (polygon, mut coords) = create_polygon();
         expected_coords.append(&mut coords);
 
-        let actual_coords = GeometryCollection::new_from(vec![
+        let actual_coords = GeometryCollection::from(vec![
             Geometry::LineString(line_string),
             Geometry::Polygon(polygon),
         ])

--- a/geo/src/algorithm/coords_iter.rs
+++ b/geo/src/algorithm/coords_iter.rs
@@ -103,7 +103,7 @@ impl<'a, T: CoordNum> CoordsIter<'a> for Point<T> {
     type Scalar = T;
 
     fn coords_iter(&'a self) -> Self::Iter {
-        iter::once(self.0)
+        iter::once(self.coord())
     }
 
     /// Return the number of coordinates in the `Point`.
@@ -126,7 +126,7 @@ impl<'a, T: CoordNum> CoordsIter<'a> for Line<T> {
     type Scalar = T;
 
     fn coords_iter(&'a self) -> Self::Iter {
-        iter::once(self.start).chain(iter::once(self.end))
+        iter::once(self.start()).chain(iter::once(self.end()))
     }
 
     /// Return the number of coordinates in the `Line`.
@@ -151,12 +151,12 @@ impl<'a, T: CoordNum + 'a> CoordsIter<'a> for LineString<T> {
     type Scalar = T;
 
     fn coords_iter(&'a self) -> Self::Iter {
-        self.0.iter().copied()
+        self.inner().iter().copied()
     }
 
     /// Return the number of coordinates in the `LineString`.
     fn coords_count(&'a self) -> usize {
-        self.0.len()
+        self.inner().len()
     }
 
     fn exterior_coords_iter(&'a self) -> Self::ExteriorIter {
@@ -209,12 +209,12 @@ impl<'a, T: CoordNum + 'a> CoordsIter<'a> for MultiPoint<T> {
     type Scalar = T;
 
     fn coords_iter(&'a self) -> Self::Iter {
-        MapCoordsIter(self.0.iter(), marker::PhantomData).flatten()
+        MapCoordsIter(self.points().iter(), marker::PhantomData).flatten()
     }
 
     /// Return the number of coordinates in the `MultiPoint`.
     fn coords_count(&'a self) -> usize {
-        self.0.len()
+        self.points().len()
     }
 
     fn exterior_coords_iter(&'a self) -> Self::ExteriorIter {
@@ -232,13 +232,12 @@ impl<'a, T: CoordNum + 'a> CoordsIter<'a> for MultiLineString<T> {
     type Scalar = T;
 
     fn coords_iter(&'a self) -> Self::Iter {
-        MapCoordsIter(self.0.iter(), marker::PhantomData).flatten()
+        MapCoordsIter(self.line_strings().iter(), marker::PhantomData).flatten()
     }
 
     /// Return the number of coordinates in the `MultiLineString`.
     fn coords_count(&'a self) -> usize {
-        self.0
-            .iter()
+        self.iter()
             .map(|line_string| line_string.coords_count())
             .sum()
     }
@@ -259,16 +258,16 @@ impl<'a, T: CoordNum + 'a> CoordsIter<'a> for MultiPolygon<T> {
     type Scalar = T;
 
     fn coords_iter(&'a self) -> Self::Iter {
-        MapCoordsIter(self.0.iter(), marker::PhantomData).flatten()
+        MapCoordsIter(self.polygons().iter(), marker::PhantomData).flatten()
     }
 
     /// Return the number of coordinates in the `MultiPolygon`.
     fn coords_count(&'a self) -> usize {
-        self.0.iter().map(|polygon| polygon.coords_count()).sum()
+        self.iter().map(|polygon| polygon.coords_count()).sum()
     }
 
     fn exterior_coords_iter(&'a self) -> Self::ExteriorIter {
-        MapExteriorCoordsIter(self.0.iter(), marker::PhantomData).flatten()
+        MapExteriorCoordsIter(self.polygons().iter(), marker::PhantomData).flatten()
     }
 }
 
@@ -282,18 +281,17 @@ impl<'a, T: CoordNum + 'a> CoordsIter<'a> for GeometryCollection<T> {
     type Scalar = T;
 
     fn coords_iter(&'a self) -> Self::Iter {
-        Box::new(self.0.iter().flat_map(|geometry| geometry.coords_iter()))
+        Box::new(self.iter().flat_map(|geometry| geometry.coords_iter()))
     }
 
     /// Return the number of coordinates in the `GeometryCollection`.
     fn coords_count(&'a self) -> usize {
-        self.0.iter().map(|geometry| geometry.coords_count()).sum()
+        self.iter().map(|geometry| geometry.coords_count()).sum()
     }
 
     fn exterior_coords_iter(&'a self) -> Self::ExteriorIter {
         Box::new(
-            self.0
-                .iter()
+            self.iter()
                 .flat_map(|geometry| geometry.exterior_coords_iter()),
         )
     }
@@ -315,20 +313,20 @@ impl<'a, T: CoordNum + 'a> CoordsIter<'a> for Rect<T> {
 
     fn coords_iter(&'a self) -> Self::Iter {
         iter::once(coord! {
-            x: self.min().x,
-            y: self.min().y,
+            x: self.min().x(),
+            y: self.min().y(),
         })
         .chain(iter::once(coord! {
-            x: self.min().x,
-            y: self.max().y,
+            x: self.min().x(),
+            y: self.max().y(),
         }))
         .chain(iter::once(coord! {
-            x: self.max().x,
-            y: self.max().y,
+            x: self.max().x(),
+            y: self.max().y(),
         }))
         .chain(iter::once(coord! {
-            x: self.max().x,
-            y: self.min().y,
+            x: self.max().x(),
+            y: self.min().y(),
         }))
     }
 
@@ -355,9 +353,9 @@ impl<'a, T: CoordNum + 'a> CoordsIter<'a> for Triangle<T> {
     type Scalar = T;
 
     fn coords_iter(&'a self) -> Self::Iter {
-        iter::once(self.0)
-            .chain(iter::once(self.1))
-            .chain(iter::once(self.2))
+        iter::once(self.vertex_0())
+            .chain(iter::once(self.vertex_1()))
+            .chain(iter::once(self.vertex_2()))
     }
 
     /// Return the number of coordinates in the `Triangle`.

--- a/geo/src/algorithm/dimensions.rs
+++ b/geo/src/algorithm/dimensions.rs
@@ -168,7 +168,7 @@ impl<C: CoordNum> HasDimensions for Line<C> {
     }
 
     fn dimensions(&self) -> Dimensions {
-        if self.start == self.end {
+        if self.start() == self.end() {
             // degenerate line is a point
             Dimensions::ZeroDimensional
         } else {
@@ -177,7 +177,7 @@ impl<C: CoordNum> HasDimensions for Line<C> {
     }
 
     fn boundary_dimensions(&self) -> Dimensions {
-        if self.start == self.end {
+        if self.start() == self.end() {
             // degenerate line is a point, which has no boundary
             Dimensions::Empty
         } else {
@@ -188,16 +188,16 @@ impl<C: CoordNum> HasDimensions for Line<C> {
 
 impl<C: CoordNum> HasDimensions for LineString<C> {
     fn is_empty(&self) -> bool {
-        self.0.is_empty()
+        self.inner().is_empty()
     }
 
     fn dimensions(&self) -> Dimensions {
-        if self.0.is_empty() {
+        if self.inner().is_empty() {
             return Dimensions::Empty;
         }
 
-        let first = self.0[0];
-        if self.0.iter().any(|&coord| first != coord) {
+        let first = self[0];
+        if self.coords().any(|&coord| first != coord) {
             Dimensions::OneDimensional
         } else {
             // all coords are the same - i.e. a point
@@ -256,11 +256,11 @@ impl<C: CoordNum> HasDimensions for Polygon<C> {
 
 impl<C: CoordNum> HasDimensions for MultiPoint<C> {
     fn is_empty(&self) -> bool {
-        self.0.is_empty()
+        self.points().is_empty()
     }
 
     fn dimensions(&self) -> Dimensions {
-        if self.0.is_empty() {
+        if self.points().is_empty() {
             return Dimensions::Empty;
         }
 
@@ -279,7 +279,7 @@ impl<C: CoordNum> HasDimensions for MultiLineString<C> {
 
     fn dimensions(&self) -> Dimensions {
         let mut max = Dimensions::Empty;
-        for line in &self.0 {
+        for line in self {
             match line.dimensions() {
                 Dimensions::Empty => {}
                 Dimensions::ZeroDimensional => max = Dimensions::ZeroDimensional,
@@ -313,7 +313,7 @@ impl<C: CoordNum> HasDimensions for MultiPolygon<C> {
     }
 
     fn dimensions(&self) -> Dimensions {
-        if self.0.is_empty() {
+        if self.polygons().is_empty() {
             return Dimensions::Empty;
         }
 
@@ -321,7 +321,7 @@ impl<C: CoordNum> HasDimensions for MultiPolygon<C> {
     }
 
     fn boundary_dimensions(&self) -> Dimensions {
-        if self.0.is_empty() {
+        if self.polygons().is_empty() {
             return Dimensions::Empty;
         }
 
@@ -331,7 +331,7 @@ impl<C: CoordNum> HasDimensions for MultiPolygon<C> {
 
 impl<C: GeoNum> HasDimensions for GeometryCollection<C> {
     fn is_empty(&self) -> bool {
-        if self.0.is_empty() {
+        if self.geometries().is_empty() {
             true
         } else {
             self.iter().all(Geometry::is_empty)
@@ -375,7 +375,7 @@ impl<C: CoordNum> HasDimensions for Rect<C> {
         if self.min() == self.max() {
             // degenerate rectangle is a point
             Dimensions::ZeroDimensional
-        } else if self.min().x == self.max().x || self.min().y == self.max().y {
+        } else if self.min().x() == self.max().x() || self.min().y() == self.max().y() {
             // degenerate rectangle is a line
             Dimensions::OneDimensional
         } else {
@@ -402,8 +402,8 @@ impl<C: crate::GeoNum> HasDimensions for Triangle<C> {
 
     fn dimensions(&self) -> Dimensions {
         use crate::algorithm::kernels::Kernel;
-        if Collinear == C::Ker::orient2d(self.0, self.1, self.2) {
-            if self.0 == self.1 && self.1 == self.2 {
+        if Collinear == C::Ker::orient2d(self.vertex_0(), self.vertex_1(), self.vertex_2()) {
+            if self.vertex_0() == self.vertex_1() && self.vertex_1() == self.vertex_2() {
                 // degenerate triangle is a point
                 Dimensions::ZeroDimensional
             } else {

--- a/geo/src/algorithm/dimensions.rs
+++ b/geo/src/algorithm/dimensions.rs
@@ -84,14 +84,14 @@ pub trait HasDimensions {
     /// assert_eq!(Dimensions::ZeroDimensional, degenerate_point_rect.dimensions());
     ///
     /// // collections inherit the greatest dimensionality of their elements
-    /// let geometry_collection = GeometryCollection::new_from(vec![degenerate_line_rect.into(), degenerate_point_rect.into()]);
+    /// let geometry_collection = GeometryCollection::from(vec![degenerate_line_rect.into(), degenerate_point_rect.into()]);
     /// assert_eq!(Dimensions::OneDimensional, geometry_collection.dimensions());
     ///
     /// let point = Point::new(10.0, 10.0);
     /// assert_eq!(Dimensions::ZeroDimensional, point.dimensions());
     ///
     /// // An `Empty` dimensionality is distinct from, and less than, being 0-dimensional
-    /// let empty_collection = GeometryCollection::<f32>::new_from(vec![]);
+    /// let empty_collection = GeometryCollection::<f32>::from(vec![]);
     /// assert_eq!(Dimensions::Empty, empty_collection.dimensions());
     /// assert!(empty_collection.dimensions() < point.dimensions());
     /// ```
@@ -123,10 +123,10 @@ pub trait HasDimensions {
     /// assert_eq!(Dimensions::Empty, degenerate_point_rect.boundary_dimensions());
     ///
     /// // collections inherit the greatest dimensionality of their elements
-    /// let geometry_collection = GeometryCollection::new_from(vec![degenerate_line_rect.into(), degenerate_point_rect.into()]);
+    /// let geometry_collection = GeometryCollection::from(vec![degenerate_line_rect.into(), degenerate_point_rect.into()]);
     /// assert_eq!(Dimensions::ZeroDimensional, geometry_collection.boundary_dimensions());
     ///
-    /// let geometry_collection = GeometryCollection::<f32>::new_from(vec![]);
+    /// let geometry_collection = GeometryCollection::<f32>::from(vec![]);
     /// assert_eq!(Dimensions::Empty, geometry_collection.boundary_dimensions());
     /// ```
     fn boundary_dimensions(&self) -> Dimensions;

--- a/geo/src/algorithm/euclidean_length.rs
+++ b/geo/src/algorithm/euclidean_length.rs
@@ -49,8 +49,7 @@ where
     T: CoordFloat + Sum,
 {
     fn euclidean_length(&self) -> T {
-        self.0
-            .iter()
+        self.iter()
             .fold(T::zero(), |total, line| total + line.euclidean_length())
     }
 }

--- a/geo/src/algorithm/extremes.rs
+++ b/geo/src/algorithm/extremes.rs
@@ -21,8 +21,8 @@ use crate::{CoordNum, Coordinate};
 /// let extremes = polygon.extremes().unwrap();
 ///
 /// assert_eq!(extremes.y_max.index, 2);
-/// assert_eq!(extremes.y_max.coord.x, 1.);
-/// assert_eq!(extremes.y_max.coord.y, 2.);
+/// assert_eq!(extremes.y_max.coord.x(), 1.);
+/// assert_eq!(extremes.y_max.coord.y(), 2.);
 /// ```
 pub trait Extremes<'a, T: CoordNum> {
     fn extremes(&'a self) -> Option<Outcome<T>>;
@@ -58,19 +58,19 @@ where
         })?;
 
         for (index, coord) in iter {
-            if coord.x < outcome.x_min.coord.x {
+            if coord.x() < outcome.x_min.coord.x() {
                 outcome.x_min = Extreme { coord, index };
             }
 
-            if coord.y < outcome.y_min.coord.y {
+            if coord.y() < outcome.y_min.coord.y() {
                 outcome.y_min = Extreme { coord, index };
             }
 
-            if coord.x > outcome.x_max.coord.x {
+            if coord.x() > outcome.x_max.coord.x() {
                 outcome.x_max = Extreme { coord, index };
             }
 
-            if coord.y > outcome.y_max.coord.y {
+            if coord.y() > outcome.y_max.coord.y() {
                 outcome.y_max = Extreme { coord, index };
             }
         }

--- a/geo/src/algorithm/geodesic_length.rs
+++ b/geo/src/algorithm/geodesic_length.rs
@@ -66,7 +66,7 @@ impl GeodesicLength<f64> for LineString<f64> {
 impl GeodesicLength<f64> for MultiLineString<f64> {
     fn geodesic_length(&self) -> f64 {
         let mut length = 0.0;
-        for line_string in &self.0 {
+        for line_string in self {
             length += line_string.geodesic_length();
         }
         length

--- a/geo/src/algorithm/haversine_length.rs
+++ b/geo/src/algorithm/haversine_length.rs
@@ -67,8 +67,7 @@ where
     T: CoordFloat + FromPrimitive,
 {
     fn haversine_length(&self) -> T {
-        self.0
-            .iter()
+        self.iter()
             .fold(T::zero(), |total, line| total + line.haversine_length())
     }
 }

--- a/geo/src/algorithm/intersects/coordinate.rs
+++ b/geo/src/algorithm/intersects/coordinate.rs
@@ -16,6 +16,6 @@ where
     T: CoordNum,
 {
     fn intersects(&self, rhs: &Point<T>) -> bool {
-        self == &rhs.0
+        self == &rhs.coord()
     }
 }

--- a/geo/src/algorithm/intersects/line.rs
+++ b/geo/src/algorithm/intersects/line.rs
@@ -8,10 +8,10 @@ where
 {
     fn intersects(&self, rhs: &Coordinate<T>) -> bool {
         // First we check if the point is collinear with the line.
-        T::Ker::orient2d(self.start, self.end, *rhs) == Orientation::Collinear
+        T::Ker::orient2d(self.start(), self.end(), *rhs) == Orientation::Collinear
         // In addition, the point must have _both_ coordinates
         // within the start and end bounds.
-            && point_in_rect(*rhs, self.start, self.end)
+            && point_in_rect(*rhs, self.start(), self.end())
     }
 }
 symmetric_intersects_impl!(Coordinate<T>, Line<T>);
@@ -23,16 +23,16 @@ where
 {
     fn intersects(&self, line: &Line<T>) -> bool {
         // Special case: self is equiv. to a point.
-        if self.start == self.end {
-            return line.intersects(&self.start);
+        if self.start() == self.end() {
+            return line.intersects(&self.start());
         }
 
         // Precondition: start and end are distinct.
 
         // Check if orientation of rhs.{start,end} are different
         // with respect to self.{start,end}.
-        let check_1_1 = T::Ker::orient2d(self.start, self.end, line.start);
-        let check_1_2 = T::Ker::orient2d(self.start, self.end, line.end);
+        let check_1_1 = T::Ker::orient2d(self.start(), self.end(), line.start());
+        let check_1_2 = T::Ker::orient2d(self.start(), self.end(), line.end());
 
         if check_1_1 != check_1_2 {
             // Since the checks are different,
@@ -45,8 +45,8 @@ where
             // exterior of rhs. Now, check the same with
             // self, rhs swapped.
 
-            let check_2_1 = T::Ker::orient2d(line.start, line.end, self.start);
-            let check_2_2 = T::Ker::orient2d(line.start, line.end, self.end);
+            let check_2_1 = T::Ker::orient2d(line.start(), line.end(), self.start());
+            let check_2_2 = T::Ker::orient2d(line.start(), line.end(), self.end());
 
             // By similar argument, there is (exactly) one
             // point on self, collinear with rhs. Thus,
@@ -59,10 +59,10 @@ where
             // Equivalent to 4 point-line intersection
             // checks, but removes the calls to the kernel
             // predicates.
-            point_in_rect(line.start, self.start, self.end)
-                || point_in_rect(line.end, self.start, self.end)
-                || point_in_rect(self.end, line.start, line.end)
-                || point_in_rect(self.end, line.start, line.end)
+            point_in_rect(line.start(), self.start(), self.end())
+                || point_in_rect(line.end(), self.start(), self.end())
+                || point_in_rect(self.end(), line.start(), line.end())
+                || point_in_rect(self.end(), line.start(), line.end())
         } else {
             false
         }

--- a/geo/src/algorithm/intersects/mod.rs
+++ b/geo/src/algorithm/intersects/mod.rs
@@ -542,7 +542,7 @@ mod test {
             coord! { x: 20., y: -10. },
         );
         let geom = Geometry::Point(pt);
-        let gc = GeometryCollection::new_from(vec![geom.clone()]);
+        let gc = GeometryCollection::from(vec![geom.clone()]);
         let multi_point = MultiPoint::new(vec![pt]);
         let multi_ls = MultiLineString::new(vec![ls.clone()]);
         let multi_poly = MultiPolygon::new(vec![poly.clone()]);

--- a/geo/src/algorithm/intersects/mod.rs
+++ b/geo/src/algorithm/intersects/mod.rs
@@ -103,8 +103,8 @@ fn point_in_rect<T>(value: Coordinate<T>, bound_1: Coordinate<T>, bound_2: Coord
 where
     T: CoordNum,
 {
-    value_in_between(value.x, bound_1.x, bound_2.x)
-        && value_in_between(value.y, bound_1.y, bound_2.y)
+    value_in_between(value.x(), bound_1.x(), bound_2.x())
+        && value_in_between(value.y(), bound_1.y(), bound_2.y())
 }
 
 #[cfg(test)]

--- a/geo/src/algorithm/intersects/point.rs
+++ b/geo/src/algorithm/intersects/point.rs
@@ -8,7 +8,7 @@ where
     Coordinate<T>: Intersects<G>,
 {
     fn intersects(&self, rhs: &G) -> bool {
-        self.0.intersects(rhs)
+        self.coord().intersects(rhs)
     }
 }
 

--- a/geo/src/algorithm/intersects/polygon.rs
+++ b/geo/src/algorithm/intersects/polygon.rs
@@ -27,8 +27,8 @@ where
     fn intersects(&self, line: &Line<T>) -> bool {
         self.exterior().intersects(line)
             || self.interiors().iter().any(|inner| inner.intersects(line))
-            || self.intersects(&line.start)
-            || self.intersects(&line.end)
+            || self.intersects(&line.start())
+            || self.intersects(&line.end())
     }
 }
 symmetric_intersects_impl!(Line<T>, Polygon<T>);

--- a/geo/src/algorithm/intersects/rect.rs
+++ b/geo/src/algorithm/intersects/rect.rs
@@ -10,7 +10,8 @@ where
         // self.min <= self.max.
         let bound_1 = self.min();
         let bound_2 = self.max();
-        value_in_range(rhs.x, bound_1.x, bound_2.x) && value_in_range(rhs.y, bound_1.y, bound_2.y)
+        value_in_range(rhs.x(), bound_1.x(), bound_2.x())
+            && value_in_range(rhs.y(), bound_1.y(), bound_2.y())
     }
 }
 symmetric_intersects_impl!(Coordinate<T>, Rect<T>);
@@ -22,11 +23,11 @@ where
     T: CoordNum,
 {
     fn intersects(&self, other: &Rect<T>) -> bool {
-        let x_overlap = value_in_range(self.min().x, other.min().x, other.max().x)
-            || value_in_range(other.min().x, self.min().x, self.max().x);
+        let x_overlap = value_in_range(self.min().x(), other.min().x(), other.max().x())
+            || value_in_range(other.min().x(), self.min().x(), self.max().x());
 
-        let y_overlap = value_in_range(self.min().y, other.min().y, other.max().y)
-            || value_in_range(other.min().y, self.min().y, self.max().y);
+        let y_overlap = value_in_range(self.min().y(), other.min().y(), other.max().y())
+            || value_in_range(other.min().y(), self.min().y(), self.max().y());
 
         x_overlap && y_overlap
     }
@@ -41,11 +42,11 @@ where
     fn intersects(&self, rhs: &Line<T>) -> bool {
         let lt = self.min();
         let rb = self.max();
-        let lb = Coordinate::from((lt.x, rb.y));
-        let rt = Coordinate::from((rb.x, lt.y));
+        let lb = Coordinate::from((lt.x(), rb.y()));
+        let rt = Coordinate::from((rb.x(), lt.y()));
         // If either rhs.{start,end} lies inside Rect, then true
-        self.intersects(&rhs.start)
-            || self.intersects(&rhs.end)
+        self.intersects(&rhs.start())
+            || self.intersects(&rhs.end())
             || Line::new(lt, rt).intersects(rhs)
             || Line::new(rt, rb).intersects(rhs)
             || Line::new(lb, rb).intersects(rhs)

--- a/geo/src/algorithm/is_convex.rs
+++ b/geo/src/algorithm/is_convex.rs
@@ -114,16 +114,16 @@ impl<T: HasKernel> IsConvex for LineString<T> {
         allow_collinear: bool,
         specific_orientation: Option<Orientation>,
     ) -> Option<Orientation> {
-        if !self.is_closed() || self.0.is_empty() {
+        if !self.is_closed() || self.inner().is_empty() {
             None
         } else {
-            is_convex_shaped(&self.0[1..], allow_collinear, specific_orientation)
+            is_convex_shaped(&self[1..], allow_collinear, specific_orientation)
         }
     }
 
     fn is_collinear(&self) -> bool {
-        self.0.is_empty()
-            || is_convex_shaped(&self.0[1..], true, Some(Orientation::Collinear)).is_some()
+        self.inner().is_empty()
+            || is_convex_shaped(&self[1..], true, Some(Orientation::Collinear)).is_some()
     }
 }
 

--- a/geo/src/algorithm/kernels/mod.rs
+++ b/geo/src/algorithm/kernels/mod.rs
@@ -14,7 +14,7 @@ pub trait Kernel<T: CoordNum> {
     /// Gives the orientation of 3 2-dimensional points:
     /// ccw, cw or collinear (None)
     fn orient2d(p: Coordinate<T>, q: Coordinate<T>, r: Coordinate<T>) -> Orientation {
-        let res = (q.x - p.x) * (r.y - q.y) - (q.y - p.y) * (r.x - q.x);
+        let res = (q.x() - p.x()) * (r.y() - q.y()) - (q.y() - p.y()) * (r.x() - q.x());
         if res > Zero::zero() {
             Orientation::CounterClockwise
         } else if res < Zero::zero() {
@@ -25,7 +25,7 @@ pub trait Kernel<T: CoordNum> {
     }
 
     fn square_euclidean_distance(p: Coordinate<T>, q: Coordinate<T>) -> T {
-        (p.x - q.x) * (p.x - q.x) + (p.y - q.y) * (p.y - q.y)
+        (p.x() - q.x()) * (p.x() - q.x()) + (p.y() - q.y()) * (p.y() - q.y())
     }
 
     /// Compute the sign of the dot product of `u` and `v` using
@@ -35,8 +35,8 @@ pub trait Kernel<T: CoordNum> {
     fn dot_product_sign(u: Coordinate<T>, v: Coordinate<T>) -> Orientation {
         let zero = Coordinate::zero();
         let vdash = coord! {
-            x: T::zero() - v.y,
-            y: v.x,
+            x: T::zero() - v.y(),
+            y: v.x(),
         };
         Self::orient2d(zero, u, vdash)
     }

--- a/geo/src/algorithm/kernels/robust.rs
+++ b/geo/src/algorithm/kernels/robust.rs
@@ -20,16 +20,16 @@ where
 
         let orientation = orient2d(
             Coord {
-                x: <f64 as NumCast>::from(p.x).unwrap(),
-                y: <f64 as NumCast>::from(p.y).unwrap(),
+                x: <f64 as NumCast>::from(p.x()).unwrap(),
+                y: <f64 as NumCast>::from(p.y()).unwrap(),
             },
             Coord {
-                x: <f64 as NumCast>::from(q.x).unwrap(),
-                y: <f64 as NumCast>::from(q.y).unwrap(),
+                x: <f64 as NumCast>::from(q.x()).unwrap(),
+                y: <f64 as NumCast>::from(q.y()).unwrap(),
             },
             Coord {
-                x: <f64 as NumCast>::from(r.x).unwrap(),
-                y: <f64 as NumCast>::from(r.y).unwrap(),
+                x: <f64 as NumCast>::from(r.x()).unwrap(),
+                y: <f64 as NumCast>::from(r.y()).unwrap(),
             },
         );
 

--- a/geo/src/algorithm/line_interpolate_point.rs
+++ b/geo/src/algorithm/line_interpolate_point.rs
@@ -46,9 +46,9 @@ where
     fn line_interpolate_point(&self, fraction: T) -> Self::Output {
         if (fraction >= T::zero()) && (fraction <= T::one()) {
             // fraction between 0 and 1, return a point between start and end
-            let diff = self.end - self.start;
-            let r = self.start + diff * (fraction);
-            if r.x.is_finite() && r.y.is_finite() {
+            let diff = self.end() - self.start();
+            let r = self.start() + diff * (fraction);
+            if r.x().is_finite() && r.y().is_finite() {
                 Some(r.into())
             } else {
                 None

--- a/geo/src/algorithm/line_intersection.rs
+++ b/geo/src/algorithm/line_intersection.rs
@@ -69,8 +69,8 @@ where
     }
 
     use crate::kernels::{Kernel, Orientation::*, RobustKernel};
-    let p_q1 = RobustKernel::orient2d(p.start, p.end, q.start);
-    let p_q2 = RobustKernel::orient2d(p.start, p.end, q.end);
+    let p_q1 = RobustKernel::orient2d(p.start(), p.end(), q.start());
+    let p_q2 = RobustKernel::orient2d(p.start(), p.end(), q.end());
     if matches!(
         (p_q1, p_q2),
         (Clockwise, Clockwise) | (CounterClockwise, CounterClockwise)
@@ -78,8 +78,8 @@ where
         return None;
     }
 
-    let q_p1 = RobustKernel::orient2d(q.start, q.end, p.start);
-    let q_p2 = RobustKernel::orient2d(q.start, q.end, p.end);
+    let q_p1 = RobustKernel::orient2d(q.start(), q.end(), p.start());
+    let q_p2 = RobustKernel::orient2d(q.start(), q.end(), p.end());
     if matches!(
         (q_p1, q_p2),
         (Clockwise, Clockwise) | (CounterClockwise, CounterClockwise)
@@ -120,20 +120,20 @@ where
         let intersection: Coordinate<F>;
         // false positives for this overzealous clippy https://github.com/rust-lang/rust-clippy/issues/6747
         #[allow(clippy::suspicious_operation_groupings)]
-        if p.start == q.start || p.start == q.end {
-            intersection = p.start;
-        } else if p.end == q.start || p.end == q.end {
-            intersection = p.end;
+        if p.start() == q.start() || p.start() == q.end() {
+            intersection = p.start();
+        } else if p.end() == q.start() || p.end() == q.end() {
+            intersection = p.end();
             // Now check to see if any endpoint lies on the interior of the other segment.
         } else if p_q1 == Collinear {
-            intersection = q.start;
+            intersection = q.start();
         } else if p_q2 == Collinear {
-            intersection = q.end;
+            intersection = q.end();
         } else if q_p1 == Collinear {
-            intersection = p.start;
+            intersection = p.start();
         } else {
             assert_eq!(q_p2, Collinear);
-            intersection = p.end;
+            intersection = p.end();
         }
         Some(LineIntersection::SinglePoint {
             intersection,
@@ -164,21 +164,21 @@ fn collinear_intersection<F: GeoFloat>(p: Line<F>, q: Line<F>) -> Option<LineInt
     let q_bounds = q.bounding_rect();
     Some(
         match (
-            p_bounds.intersects(&q.start),
-            p_bounds.intersects(&q.end),
-            q_bounds.intersects(&p.start),
-            q_bounds.intersects(&p.end),
+            p_bounds.intersects(&q.start()),
+            p_bounds.intersects(&q.end()),
+            q_bounds.intersects(&p.start()),
+            q_bounds.intersects(&p.end()),
         ) {
             (true, true, _, _) => collinear(q),
             (_, _, true, true) => collinear(p),
-            (true, false, true, false) if q.start == p.start => improper(q.start),
-            (true, _, true, _) => collinear(Line::new(q.start, p.start)),
-            (true, false, false, true) if q.start == p.end => improper(q.start),
-            (true, _, _, true) => collinear(Line::new(q.start, p.end)),
-            (false, true, true, false) if q.end == p.start => improper(q.end),
-            (_, true, true, _) => collinear(Line::new(q.end, p.start)),
-            (false, true, false, true) if q.end == p.end => improper(q.end),
-            (_, true, _, true) => collinear(Line::new(q.end, p.end)),
+            (true, false, true, false) if q.start() == p.start() => improper(q.start()),
+            (true, _, true, _) => collinear(Line::new(q.start(), p.start())),
+            (true, false, false, true) if q.start() == p.end() => improper(q.start()),
+            (true, _, _, true) => collinear(Line::new(q.start(), p.end())),
+            (false, true, true, false) if q.end() == p.start() => improper(q.end()),
+            (_, true, true, _) => collinear(Line::new(q.end(), p.start())),
+            (false, true, false, true) if q.end() == p.end() => improper(q.end()),
+            (_, true, _, true) => collinear(Line::new(q.end(), p.end())),
             _ => return None,
         },
     )
@@ -197,36 +197,36 @@ fn collinear_intersection<F: GeoFloat>(p: Line<F>, q: Line<F>) -> Option<LineInt
 fn nearest_endpoint<F: GeoFloat>(p: Line<F>, q: Line<F>) -> Coordinate<F> {
     use geo_types::private_utils::point_line_euclidean_distance;
 
-    let mut nearest_pt = p.start;
-    let mut min_dist = point_line_euclidean_distance(p.start, q);
+    let mut nearest_pt = p.start();
+    let mut min_dist = point_line_euclidean_distance(p.start(), q);
 
-    let dist = point_line_euclidean_distance(p.end, q);
+    let dist = point_line_euclidean_distance(p.end(), q);
     if dist < min_dist {
         min_dist = dist;
-        nearest_pt = p.end;
+        nearest_pt = p.end();
     }
-    let dist = point_line_euclidean_distance(q.start, p);
+    let dist = point_line_euclidean_distance(q.start(), p);
     if dist < min_dist {
         min_dist = dist;
-        nearest_pt = q.start;
+        nearest_pt = q.start();
     }
-    let dist = point_line_euclidean_distance(q.end, p);
+    let dist = point_line_euclidean_distance(q.end(), p);
     if dist < min_dist {
-        nearest_pt = q.end;
+        nearest_pt = q.end();
     }
     nearest_pt
 }
 
 fn raw_line_intersection<F: GeoFloat>(p: Line<F>, q: Line<F>) -> Option<Coordinate<F>> {
-    let p_min_x = p.start.x.min(p.end.x);
-    let p_min_y = p.start.y.min(p.end.y);
-    let p_max_x = p.start.x.max(p.end.x);
-    let p_max_y = p.start.y.max(p.end.y);
+    let p_min_x = p.start().x().min(p.end().x());
+    let p_min_y = p.start().y().min(p.end().y());
+    let p_max_x = p.start().x().max(p.end().x());
+    let p_max_y = p.start().y().max(p.end().y());
 
-    let q_min_x = q.start.x.min(q.end.x);
-    let q_min_y = q.start.y.min(q.end.y);
-    let q_max_x = q.start.x.max(q.end.x);
-    let q_max_y = q.start.y.max(q.end.y);
+    let q_min_x = q.start().x().min(q.end().x());
+    let q_min_y = q.start().y().min(q.end().y());
+    let q_max_x = q.start().x().max(q.end().x());
+    let q_max_y = q.start().y().max(q.end().y());
 
     let int_min_x = p_min_x.max(q_min_x);
     let int_max_x = p_max_x.min(q_max_x);
@@ -238,14 +238,14 @@ fn raw_line_intersection<F: GeoFloat>(p: Line<F>, q: Line<F>) -> Option<Coordina
     let mid_y = (int_min_y + int_max_y) / two;
 
     // condition ordinate values by subtracting midpoint
-    let p1x = p.start.x - mid_x;
-    let p1y = p.start.y - mid_y;
-    let p2x = p.end.x - mid_x;
-    let p2y = p.end.y - mid_y;
-    let q1x = q.start.x - mid_x;
-    let q1y = q.start.y - mid_y;
-    let q2x = q.end.x - mid_x;
-    let q2y = q.end.y - mid_y;
+    let p1x = p.start().x() - mid_x;
+    let p1y = p.start().y() - mid_y;
+    let p2x = p.end().x() - mid_x;
+    let p2y = p.end().y() - mid_y;
+    let q1x = q.start().x() - mid_x;
+    let q1y = q.start().y() - mid_y;
+    let q2x = q.end().x() - mid_x;
+    let q2y = q.end().y() - mid_y;
 
     // unrolled computation using homogeneous coordinates eqn
     let px = p1y - p2y;

--- a/geo/src/algorithm/line_locate_point.rs
+++ b/geo/src/algorithm/line_locate_point.rs
@@ -55,7 +55,7 @@ where
         let sp: Point<_> = *p - self.start_point();
 
         // direction vector of line, $v$
-        let v: Point<_> = (self.end - self.start).into();
+        let v: Point<_> = (self.end() - self.start()).into();
 
         // $v \cdot v$
         let v_sq = v.dot(v);

--- a/geo/src/algorithm/lines_iter.rs
+++ b/geo/src/algorithm/lines_iter.rs
@@ -69,7 +69,7 @@ pub struct LineStringIter<'a, T: CoordNum>(slice::Windows<'a, Coordinate<T>>);
 
 impl<'a, T: CoordNum> LineStringIter<'a, T> {
     fn new(line_string: &'a LineString<T>) -> Self {
-        Self(line_string.0.windows(2))
+        Self(line_string.inner().windows(2))
     }
 }
 
@@ -96,7 +96,7 @@ impl<'a, T: CoordNum + 'a> LinesIter<'a> for MultiLineString<T> {
     type Iter = MultiLineStringIter<'a, Self::Scalar>;
 
     fn lines_iter(&'a self) -> Self::Iter {
-        MapLinesIter(self.0.iter()).flatten()
+        MapLinesIter(self.line_strings().iter()).flatten()
     }
 }
 
@@ -124,7 +124,7 @@ impl<'a, T: CoordNum + 'a> LinesIter<'a> for MultiPolygon<T> {
     type Iter = MultiPolygonIter<'a, Self::Scalar>;
 
     fn lines_iter(&'a self) -> Self::Iter {
-        MapLinesIter(self.0.iter()).flatten()
+        MapLinesIter(self.polygons().iter()).flatten()
     }
 }
 

--- a/geo/src/algorithm/map_coords.rs
+++ b/geo/src/algorithm/map_coords.rs
@@ -179,7 +179,7 @@ mod modern {
         type Output = Point<NT>;
 
         fn map_coords(&self, func: impl Fn((T, T)) -> (NT, NT) + Copy) -> Self::Output {
-            let new_point = func((self.0.x, self.0.y));
+            let new_point = func((self.x(), self.y()));
             Point::new(new_point.0, new_point.1)
         }
 
@@ -187,25 +187,25 @@ mod modern {
             &self,
             func: impl Fn((T, T)) -> Result<(NT, NT), E>,
         ) -> Result<Self::Output, E> {
-            let new_point = func((self.0.x, self.0.y))?;
+            let new_point = func((self.x(), self.y()))?;
             Ok(Point::new(new_point.0, new_point.1))
         }
     }
 
     impl<T: CoordNum> MapCoordsInPlace<T> for Point<T> {
         fn map_coords_in_place(&mut self, func: impl Fn((T, T)) -> (T, T)) {
-            let new_point = func((self.0.x, self.0.y));
-            self.0.x = new_point.0;
-            self.0.y = new_point.1;
+            let new_point = func((self.x(), self.y()));
+            *self.x_mut() = new_point.0;
+            *self.y_mut() = new_point.1;
         }
 
         fn try_map_coords_in_place<E>(
             &mut self,
             func: impl Fn((T, T)) -> Result<(T, T), E>,
         ) -> Result<(), E> {
-            let new_point = func((self.0.x, self.0.y))?;
-            self.0.x = new_point.0;
-            self.0.y = new_point.1;
+            let new_point = func((self.x(), self.y()))?;
+            *self.x_mut() = new_point.0;
+            *self.y_mut() = new_point.1;
 
             Ok(())
         }
@@ -220,8 +220,8 @@ mod modern {
 
         fn map_coords(&self, func: impl Fn((T, T)) -> (NT, NT) + Copy) -> Self::Output {
             Line::new(
-                self.start_point().map_coords(func).0,
-                self.end_point().map_coords(func).0,
+                self.start_point().map_coords(func).coord(),
+                self.end_point().map_coords(func).coord(),
             )
         }
 
@@ -230,34 +230,34 @@ mod modern {
             func: impl Fn((T, T)) -> Result<(NT, NT), E> + Copy,
         ) -> Result<Self::Output, E> {
             Ok(Line::new(
-                self.start_point().try_map_coords(func)?.0,
-                self.end_point().try_map_coords(func)?.0,
+                self.start_point().try_map_coords(func)?.coord(),
+                self.end_point().try_map_coords(func)?.coord(),
             ))
         }
     }
 
     impl<T: CoordNum> MapCoordsInPlace<T> for Line<T> {
         fn map_coords_in_place(&mut self, func: impl Fn((T, T)) -> (T, T)) {
-            let new_start = func((self.start.x, self.start.y));
-            self.start.x = new_start.0;
-            self.start.y = new_start.1;
+            let new_start = func((self.start().x(), self.start().y()));
+            *self.start().x_mut() = new_start.0;
+            *self.start().y_mut() = new_start.1;
 
-            let new_end = func((self.end.x, self.end.y));
-            self.end.x = new_end.0;
-            self.end.y = new_end.1;
+            let new_end = func((self.end().x(), self.end().y()));
+            *self.end().x_mut() = new_end.0;
+            *self.end().y_mut() = new_end.1;
         }
 
         fn try_map_coords_in_place<E>(
             &mut self,
             func: impl Fn((T, T)) -> Result<(T, T), E>,
         ) -> Result<(), E> {
-            let new_start = func((self.start.x, self.start.y))?;
-            self.start.x = new_start.0;
-            self.start.y = new_start.1;
+            let new_start = func((self.start().x(), self.start().y()))?;
+            *self.start().x_mut() = new_start.0;
+            *self.start().y_mut() = new_start.1;
 
-            let new_end = func((self.end.x, self.end.y))?;
-            self.end.x = new_end.0;
-            self.end.y = new_end.1;
+            let new_end = func((self.end().x(), self.end().y()))?;
+            *self.end().x_mut() = new_end.0;
+            *self.end().y_mut() = new_end.1;
 
             Ok(())
         }
@@ -292,10 +292,10 @@ mod modern {
 
     impl<T: CoordNum> MapCoordsInPlace<T> for LineString<T> {
         fn map_coords_in_place(&mut self, func: impl Fn((T, T)) -> (T, T)) {
-            for p in &mut self.0 {
-                let new_coords = func((p.x, p.y));
-                p.x = new_coords.0;
-                p.y = new_coords.1;
+            for p in &mut self.coords_mut() {
+                let new_coords = func((p.x(), p.y()));
+                *p.x_mut() = new_coords.0;
+                *p.y_mut() = new_coords.1;
             }
         }
 
@@ -303,10 +303,10 @@ mod modern {
             &mut self,
             func: impl Fn((T, T)) -> Result<(T, T), E>,
         ) -> Result<(), E> {
-            for p in &mut self.0 {
-                let new_coords = func((p.x, p.y))?;
-                p.x = new_coords.0;
-                p.y = new_coords.1;
+            for p in &mut self.coords_mut() {
+                let new_coords = func((p.x(), p.y()))?;
+                *p.x_mut() = new_coords.0;
+                *p.y_mut() = new_coords.1;
             }
             Ok(())
         }
@@ -399,8 +399,7 @@ mod modern {
             func: impl Fn((T, T)) -> Result<(NT, NT), E> + Copy,
         ) -> Result<Self::Output, E> {
             Ok(MultiPoint::new(
-                self.0
-                    .iter()
+                self.iter()
                     .map(|p| p.try_map_coords(func))
                     .collect::<Result<Vec<_>, E>>()?,
             ))
@@ -409,7 +408,7 @@ mod modern {
 
     impl<T: CoordNum> MapCoordsInPlace<T> for MultiPoint<T> {
         fn map_coords_in_place(&mut self, func: impl Fn((T, T)) -> (T, T) + Copy) {
-            for p in &mut self.0 {
+            for p in self {
                 p.map_coords_in_place(func);
             }
         }
@@ -418,7 +417,7 @@ mod modern {
             &mut self,
             func: impl Fn((T, T)) -> Result<(T, T), E>,
         ) -> Result<(), E> {
-            for p in &mut self.0 {
+            for p in self {
                 p.try_map_coords_in_place(&func)?;
             }
             Ok(())
@@ -441,8 +440,7 @@ mod modern {
             func: impl Fn((T, T)) -> Result<(NT, NT), E> + Copy,
         ) -> Result<Self::Output, E> {
             Ok(MultiLineString::new(
-                self.0
-                    .iter()
+                self.iter()
                     .map(|l| l.try_map_coords(func))
                     .collect::<Result<Vec<_>, E>>()?,
             ))
@@ -451,8 +449,8 @@ mod modern {
 
     impl<T: CoordNum> MapCoordsInPlace<T> for MultiLineString<T> {
         fn map_coords_in_place(&mut self, func: impl Fn((T, T)) -> (T, T) + Copy) {
-            for p in &mut self.0 {
-                p.map_coords_in_place(func);
+            for line_string in self {
+                line_string.map_coords_in_place(func);
             }
         }
 
@@ -460,8 +458,8 @@ mod modern {
             &mut self,
             func: impl Fn((T, T)) -> Result<(T, T), E>,
         ) -> Result<(), E> {
-            for p in &mut self.0 {
-                p.try_map_coords_in_place(&func)?;
+            for line_string in self {
+                line_string.try_map_coords_in_place(&func)?;
             }
             Ok(())
         }
@@ -483,8 +481,7 @@ mod modern {
             func: impl Fn((T, T)) -> Result<(NT, NT), E> + Copy,
         ) -> Result<Self::Output, E> {
             Ok(MultiPolygon::new(
-                self.0
-                    .iter()
+                self.iter()
                     .map(|p| p.try_map_coords(func))
                     .collect::<Result<Vec<_>, E>>()?,
             ))
@@ -493,7 +490,7 @@ mod modern {
 
     impl<T: CoordNum> MapCoordsInPlace<T> for MultiPolygon<T> {
         fn map_coords_in_place(&mut self, func: impl Fn((T, T)) -> (T, T) + Copy) {
-            for p in &mut self.0 {
+            for p in self {
                 p.map_coords_in_place(func);
             }
         }
@@ -502,7 +499,7 @@ mod modern {
             &mut self,
             func: impl Fn((T, T)) -> Result<(T, T), E>,
         ) -> Result<(), E> {
-            for p in &mut self.0 {
+            for p in self {
                 p.try_map_coords_in_place(&func)?;
             }
             Ok(())
@@ -609,8 +606,7 @@ mod modern {
             func: impl Fn((T, T)) -> Result<(NT, NT), E> + Copy,
         ) -> Result<Self::Output, E> {
             Ok(GeometryCollection::new_from(
-                self.0
-                    .iter()
+                self.iter()
                     .map(|g| g.try_map_coords(func))
                     .collect::<Result<Vec<_>, E>>()?,
             ))
@@ -619,7 +615,7 @@ mod modern {
 
     impl<T: CoordNum> MapCoordsInPlace<T> for GeometryCollection<T> {
         fn map_coords_in_place(&mut self, func: impl Fn((T, T)) -> (T, T) + Copy) {
-            for p in &mut self.0 {
+            for p in self {
                 p.map_coords_in_place(func);
             }
         }
@@ -628,7 +624,7 @@ mod modern {
             &mut self,
             func: impl Fn((T, T)) -> Result<(T, T), E>,
         ) -> Result<(), E> {
-            for p in &mut self.0 {
+            for p in self {
                 p.try_map_coords_in_place(&func)?;
             }
             Ok(())
@@ -678,9 +674,9 @@ mod modern {
         type Output = Triangle<NT>;
 
         fn map_coords(&self, func: impl Fn((T, T)) -> (NT, NT) + Copy) -> Self::Output {
-            let p1 = func(self.0.x_y());
-            let p2 = func(self.1.x_y());
-            let p3 = func(self.2.x_y());
+            let p1 = func(self.vertex_0().x_y());
+            let p2 = func(self.vertex_1().x_y());
+            let p3 = func(self.vertex_2().x_y());
 
             Triangle::new(
                 coord! { x: p1.0, y: p1.1 },
@@ -693,9 +689,9 @@ mod modern {
             &self,
             func: impl Fn((T, T)) -> Result<(NT, NT), E>,
         ) -> Result<Self::Output, E> {
-            let p1 = func(self.0.x_y())?;
-            let p2 = func(self.1.x_y())?;
-            let p3 = func(self.2.x_y())?;
+            let p1 = func(self.vertex_0().x_y())?;
+            let p2 = func(self.vertex_1().x_y())?;
+            let p3 = func(self.vertex_2().x_y())?;
 
             Ok(Triangle::new(
                 coord! { x: p1.0, y: p1.1 },
@@ -707,9 +703,9 @@ mod modern {
 
     impl<T: CoordNum> MapCoordsInPlace<T> for Triangle<T> {
         fn map_coords_in_place(&mut self, func: impl Fn((T, T)) -> (T, T)) {
-            let p1 = func(self.0.x_y());
-            let p2 = func(self.1.x_y());
-            let p3 = func(self.2.x_y());
+            let p1 = func(self.vertex_0().x_y());
+            let p2 = func(self.vertex_1().x_y());
+            let p3 = func(self.vertex_2().x_y());
 
             let mut new_triangle = Triangle::new(
                 coord! { x: p1.0, y: p1.1 },
@@ -724,9 +720,9 @@ mod modern {
             &mut self,
             func: impl Fn((T, T)) -> Result<(T, T), E>,
         ) -> Result<(), E> {
-            let p1 = func(self.0.x_y())?;
-            let p2 = func(self.1.x_y())?;
-            let p3 = func(self.2.x_y())?;
+            let p1 = func(self.vertex_0().x_y())?;
+            let p2 = func(self.vertex_1().x_y())?;
+            let p3 = func(self.vertex_2().x_y())?;
 
             let mut new_triangle = Triangle::new(
                 coord! { x: p1.0, y: p1.1 },
@@ -1042,8 +1038,8 @@ mod test {
     fn linestring() {
         let line1: LineString<f32> = LineString::from(vec![(0., 0.), (1., 2.)]);
         let line2 = line1.map_coords(|(x, y)| (x + 10., y - 100.));
-        assert_relative_eq!(line2.0[0], Coordinate::from((10., -100.)), epsilon = 1e-6);
-        assert_relative_eq!(line2.0[1], Coordinate::from((11., -98.)), epsilon = 1e-6);
+        assert_relative_eq!(line2[0], Coordinate::from((10., -100.)), epsilon = 1e-6);
+        assert_relative_eq!(line2[1], Coordinate::from((11., -98.)), epsilon = 1e-6);
     }
 
     #[test]
@@ -1130,9 +1126,9 @@ mod test {
 
         let mp = MultiPolygon::new(vec![poly1, poly2]);
         let mp2 = mp.map_coords(|(x, y)| (x * 2., y + 100.));
-        assert_eq!(mp2.0.len(), 2);
+        assert_eq!(mp2.polygons().len(), 2);
         assert_relative_eq!(
-            mp2.0[0],
+            mp2.polygons()[0],
             polygon![
                 (x: 0., y: 100.),
                 (x: 20., y: 100.),
@@ -1142,7 +1138,7 @@ mod test {
             ],
         );
         assert_relative_eq!(
-            mp2.0[1],
+            mp2.polygons()[1],
             polygon![
                 exterior: [
                     (x: 22., y: 111.),

--- a/geo/src/algorithm/map_coords.rs
+++ b/geo/src/algorithm/map_coords.rs
@@ -598,14 +598,14 @@ mod modern {
         type Output = GeometryCollection<NT>;
 
         fn map_coords(&self, func: impl Fn((T, T)) -> (NT, NT) + Copy) -> Self::Output {
-            GeometryCollection::new_from(self.iter().map(|g| g.map_coords(func)).collect())
+            GeometryCollection::from(self.iter().map(|g| g.map_coords(func)).collect::<Vec<_>>())
         }
 
         fn try_map_coords<E>(
             &self,
             func: impl Fn((T, T)) -> Result<(NT, NT), E> + Copy,
         ) -> Result<Self::Output, E> {
-            Ok(GeometryCollection::new_from(
+            Ok(GeometryCollection::from(
                 self.iter()
                     .map(|g| g.try_map_coords(func))
                     .collect::<Result<Vec<_>, E>>()?,
@@ -1165,11 +1165,11 @@ mod test {
         let p1 = Geometry::Point(Point::new(10., 10.));
         let line1 = Geometry::LineString(LineString::from(vec![(0., 0.), (1., 2.)]));
 
-        let gc = GeometryCollection::new_from(vec![p1, line1]);
+        let gc = GeometryCollection::from(vec![p1, line1]);
 
         assert_eq!(
             gc.map_coords(|(x, y)| (x + 10., y + 100.)),
-            GeometryCollection::new_from(vec![
+            GeometryCollection::from(vec![
                 Geometry::Point(Point::new(20., 110.)),
                 Geometry::LineString(LineString::from(vec![(10., 100.), (11., 102.)])),
             ])

--- a/geo/src/algorithm/orient.rs
+++ b/geo/src/algorithm/orient.rs
@@ -142,7 +142,7 @@ mod test {
         let oriented_int_ls = LineString::from(oriented_int_raw);
         // build corrected Polygon
         let oriented = orient(&poly1, Direction::Default);
-        assert_eq!(oriented.exterior().0, oriented_ext_ls.0);
-        assert_eq!(oriented.interiors()[0].0, oriented_int_ls.0);
+        assert_eq!(oriented.exterior(), &oriented_ext_ls);
+        assert_eq!(oriented.interiors()[0], oriented_int_ls);
     }
 }

--- a/geo/src/algorithm/relate/geomgraph/edge.rs
+++ b/geo/src/algorithm/relate/geomgraph/edge.rs
@@ -97,8 +97,8 @@ impl<F: GeoFloat> Edge<F> {
                 self.add_intersection(intersection, line, segment_index);
             }
             LineIntersection::Collinear { intersection } => {
-                self.add_intersection(intersection.start, line, segment_index);
-                self.add_intersection(intersection.end, line, segment_index);
+                self.add_intersection(intersection.start(), line, segment_index);
+                self.add_intersection(intersection.end(), line, segment_index);
             }
         }
     }

--- a/geo/src/algorithm/relate/geomgraph/edge_end.rs
+++ b/geo/src/algorithm/relate/geomgraph/edge_end.rs
@@ -53,7 +53,7 @@ where
 {
     pub fn new(coord_0: Coordinate<F>, coord_1: Coordinate<F>, label: Label) -> EdgeEnd<F> {
         let delta = coord_1 - coord_0;
-        let quadrant = Quadrant::new(delta.x, delta.y);
+        let quadrant = Quadrant::new(delta.x(), delta.y());
         EdgeEnd {
             label,
             key: EdgeEndKey {

--- a/geo/src/algorithm/relate/geomgraph/geometry_graph.rs
+++ b/geo/src/algorithm/relate/geomgraph/geometry_graph.rs
@@ -124,7 +124,7 @@ where
             }
             GeometryCow::LineString(line_string) => self.add_line_string(line_string),
             GeometryCow::MultiPoint(multi_point) => {
-                for point in &multi_point.0 {
+                for point in multi_point.points() {
                     self.add_point(point);
                 }
             }
@@ -132,12 +132,12 @@ where
                 // check if this Geometry should obey the Boundary Determination Rule
                 // all collections except MultiPolygons obey the rule
                 self.use_boundary_determination_rule = false;
-                for polygon in &multi_polygon.0 {
+                for polygon in multi_polygon.polygons() {
                     self.add_polygon(polygon);
                 }
             }
             GeometryCow::MultiLineString(multi_line_string) => {
-                for line_string in &multi_line_string.0 {
+                for line_string in multi_line_string.line_strings() {
                     self.add_line_string(line_string);
                 }
             }
@@ -160,9 +160,9 @@ where
             return;
         }
 
-        let mut coords: Vec<Coordinate<F>> = Vec::with_capacity(linear_ring.0.len());
+        let mut coords: Vec<Coordinate<F>> = Vec::with_capacity(linear_ring.inner().len());
         // remove repeated coords
-        for coord in &linear_ring.0 {
+        for coord in linear_ring.coords() {
             if coords.last() != Some(coord) {
                 coords.push(*coord)
             }
@@ -214,8 +214,8 @@ where
             return;
         }
 
-        let mut coords: Vec<Coordinate<F>> = Vec::with_capacity(line_string.0.len());
-        for coord in &line_string.0 {
+        let mut coords: Vec<Coordinate<F>> = Vec::with_capacity(line_string.inner().len());
+        for coord in line_string.coords() {
             if coords.last() != Some(coord) {
                 coords.push(*coord)
             }
@@ -241,11 +241,11 @@ where
     }
 
     fn add_line(&mut self, line: &Line<F>) {
-        self.insert_boundary_point(line.start);
-        self.insert_boundary_point(line.end);
+        self.insert_boundary_point(line.start());
+        self.insert_boundary_point(line.end());
 
         let edge = Edge::new(
-            vec![line.start, line.end],
+            vec![line.start(), line.end()],
             Label::new(
                 self.arg_index,
                 TopologyPosition::line_or_point(CoordPos::Inside),

--- a/geo/src/algorithm/relate/geomgraph/node_map.rs
+++ b/geo/src/algorithm/relate/geomgraph/node_map.rs
@@ -38,10 +38,10 @@ struct NodeKey<F: GeoFloat>(Coordinate<F>);
 
 impl<F: GeoFloat> std::cmp::Ord for NodeKey<F> {
     fn cmp(&self, other: &NodeKey<F>) -> std::cmp::Ordering {
-        debug_assert!(!self.0.x.is_nan());
-        debug_assert!(!self.0.y.is_nan());
-        debug_assert!(!other.0.x.is_nan());
-        debug_assert!(!other.0.y.is_nan());
+        debug_assert!(!self.0.x().is_nan());
+        debug_assert!(!self.0.y().is_nan());
+        debug_assert!(!other.0.x().is_nan());
+        debug_assert!(!other.0.y().is_nan());
         crate::utils::lex_cmp(&self.0, &other.0)
     }
 }
@@ -54,10 +54,10 @@ impl<F: GeoFloat> std::cmp::PartialOrd for NodeKey<F> {
 
 impl<F: GeoFloat> std::cmp::PartialEq for NodeKey<F> {
     fn eq(&self, other: &NodeKey<F>) -> bool {
-        debug_assert!(!self.0.x.is_nan());
-        debug_assert!(!self.0.y.is_nan());
-        debug_assert!(!other.0.x.is_nan());
-        debug_assert!(!other.0.y.is_nan());
+        debug_assert!(!self.0.x().is_nan());
+        debug_assert!(!self.0.y().is_nan());
+        debug_assert!(!other.0.x().is_nan());
+        debug_assert!(!other.0.y().is_nan());
         self.0 == other.0
     }
 }
@@ -80,7 +80,7 @@ where
     /// Note: Coordinates must be non-NaN.
     pub fn insert_node_with_coordinate(&mut self, coord: Coordinate<F>) -> &mut NF::Node {
         debug_assert!(
-            !coord.x.is_nan() && !coord.y.is_nan(),
+            !coord.x().is_nan() && !coord.y().is_nan(),
             "NaN coordinates are not supported"
         );
         let key = NodeKey(coord);

--- a/geo/src/algorithm/relate/geomgraph/robust_line_intersector.rs
+++ b/geo/src/algorithm/relate/geomgraph/robust_line_intersector.rs
@@ -40,33 +40,33 @@ impl RobustLineIntersector {
     /// result of _rounding_ points which lie on the line,
     /// but not safe to use for _truncated_ points.
     pub fn compute_edge_distance<F: GeoFloat>(intersection: Coordinate<F>, line: Line<F>) -> F {
-        let dx = (line.end.x - line.start.x).abs();
-        let dy = (line.end.y - line.start.y).abs();
+        let dx = (line.end().x() - line.start().x()).abs();
+        let dy = (line.end().y() - line.start().y()).abs();
 
         let mut dist: F;
-        if intersection == line.start {
+        if intersection == line.start() {
             dist = F::zero();
-        } else if intersection == line.end {
+        } else if intersection == line.end() {
             if dx > dy {
                 dist = dx;
             } else {
                 dist = dy;
             }
         } else {
-            let intersection_dx = (intersection.x - line.start.x).abs();
-            let intersection_dy = (intersection.y - line.start.y).abs();
+            let intersection_dx = (intersection.x() - line.start().x()).abs();
+            let intersection_dy = (intersection.y() - line.start().y()).abs();
             if dx > dy {
                 dist = intersection_dx;
             } else {
                 dist = intersection_dy;
             }
             // hack to ensure that non-endpoints always have a non-zero distance
-            if dist == F::zero() && intersection != line.start {
+            if dist == F::zero() && intersection != line.start() {
                 dist = intersection_dx.max(intersection_dy);
             }
         }
         debug_assert!(
-            !(dist == F::zero() && intersection != line.start),
+            !(dist == F::zero() && intersection != line.start()),
             "Bad distance calculation"
         );
         dist

--- a/geo/src/algorithm/rotate.rs
+++ b/geo/src/algorithm/rotate.rs
@@ -491,8 +491,8 @@ mod test {
             Coordinate::from((5.672380059021509, 1.2114794859018578)),
             Coordinate::from((4.706454232732441, 1.4702985310043786)),
         ];
-        assert_eq!(rotated.exterior().0, correct_outside);
-        assert_eq!(rotated.interiors()[0].0, correct_inside);
+        assert_eq!(rotated.exterior().inner(), correct_outside);
+        assert_eq!(rotated.interiors()[0].inner(), correct_inside);
 
         // now rotate around center
         let center_expected = polygon![

--- a/geo/src/algorithm/simplify.rs
+++ b/geo/src/algorithm/simplify.rs
@@ -197,8 +197,7 @@ where
     fn simplify_idx(&self, epsilon: &T) -> Vec<usize> {
         calculate_rdp_indices(
             &self
-                .0
-                .iter()
+                .coords()
                 .enumerate()
                 .map(|(idx, coord)| RdpIndex {
                     index: idx,

--- a/geo/src/algorithm/translate.rs
+++ b/geo/src/algorithm/translate.rs
@@ -155,7 +155,7 @@ mod test {
             Coordinate::from((23.0, 19.3)),
             Coordinate::from((22.0, 19.3)),
         ];
-        assert_eq!(rotated.exterior().0, correct_outside);
-        assert_eq!(rotated.interiors()[0].0, correct_inside);
+        assert_eq!(rotated.exterior().inner(), correct_outside);
+        assert_eq!(rotated.interiors()[0].inner(), correct_inside);
     }
 }

--- a/geo/src/algorithm/vincenty_length.rs
+++ b/geo/src/algorithm/vincenty_length.rs
@@ -70,7 +70,7 @@ where
 {
     fn vincenty_length(&self) -> Result<T, FailedToConvergeError> {
         let mut length = T::zero();
-        for line_string in &self.0 {
+        for line_string in self {
             length = length + line_string.vincenty_length()?;
         }
         Ok(length)

--- a/geo/src/algorithm/winding_order.rs
+++ b/geo/src/algorithm/winding_order.rs
@@ -122,11 +122,11 @@ where
         };
 
         use crate::utils::least_index;
-        let i = least_index(&self.0);
+        let i = least_index(self.inner());
 
         let mut next = i;
         increment(&mut next);
-        while self.0[next] == self.0[i] {
+        while self[next] == self[i] {
             if next == i {
                 // We've looped too much. There aren't
                 // enough unique coords to compute orientation.
@@ -137,14 +137,14 @@ where
 
         let mut prev = i;
         decrement(&mut prev);
-        while self.0[prev] == self.0[i] {
+        while self[prev] == self[i] {
             // Note: we don't need to check if prev == i as
             // the previous loop succeeded, and so we have
             // at least two distinct elements in the list
             decrement(&mut prev);
         }
 
-        match K::orient2d(self.0[prev], self.0[i], self.0[next]) {
+        match K::orient2d(self[prev], self[i], self[next]) {
             Orientation::CounterClockwise => Some(WindingOrder::CounterClockwise),
             Orientation::Clockwise => Some(WindingOrder::Clockwise),
             _ => None,
@@ -176,14 +176,14 @@ where
     /// Change this line's points so they are in clockwise winding order
     fn make_cw_winding(&mut self) {
         if let Some(WindingOrder::CounterClockwise) = self.winding_order() {
-            self.0.reverse();
+            self.inner_mut().reverse();
         }
     }
 
     /// Change this line's points so they are in counterclockwise winding order
     fn make_ccw_winding(&mut self) {
         if let Some(WindingOrder::Clockwise) = self.winding_order() {
-            self.0.reverse();
+            self.inner_mut().reverse();
         }
     }
 }
@@ -201,10 +201,10 @@ mod test {
         let c = Point::new(1., 2.);
 
         // Verify open linestrings return None
-        let mut ls = LineString::from(vec![a.0, b.0, c.0]);
+        let mut ls = LineString::from(vec![a.coord(), b.coord(), c.coord()]);
         assert!(ls.winding_order().is_none());
 
-        ls.0.push(ls.0[0]);
+        ls.push(ls[0]);
         assert_eq!(ls.winding_order(), Some(WindingOrder::CounterClockwise));
 
         ls.make_cw_winding();
@@ -219,10 +219,10 @@ mod test {
         let c = Point::new(1, 2);
 
         // Verify open linestrings return None
-        let mut ls = LineString::from(vec![a.0, b.0, c.0]);
+        let mut ls = LineString::from(vec![a.coord(), b.coord(), c.coord()]);
         assert!(ls.winding_order().is_none());
 
-        ls.0.push(ls.0[0]);
+        ls.push(ls[0]);
         assert!(ls.is_ccw());
 
         let ccw_ls: Vec<_> = ls.points_ccw().collect();

--- a/geo/src/utils.rs
+++ b/geo/src/utils.rs
@@ -84,9 +84,10 @@ use std::cmp::Ordering;
 /// Expects none of coordinates to be uncomparable (eg. nan)
 #[inline]
 pub fn lex_cmp<T: CoordNum>(p: &Coordinate<T>, q: &Coordinate<T>) -> Ordering {
-    p.x.partial_cmp(&q.x)
+    p.x()
+        .partial_cmp(&q.x())
         .unwrap()
-        .then(p.y.partial_cmp(&q.y).unwrap())
+        .then(p.y().partial_cmp(&q.y()).unwrap())
 }
 
 /// Compute index of the least point in slice. Comparison is

--- a/jts-test-runner/src/runner.rs
+++ b/jts-test-runner/src/runner.rs
@@ -535,12 +535,12 @@ where
 {
     assert!(r1.is_closed(), "r1 is not closed");
     assert!(r2.is_closed(), "r2 is not closed");
-    if r1.0.len() != r2.0.len() {
+    if r1.inner().len() != r2.inner().len() {
         return false;
     }
-    let len = r1.0.len() - 1;
+    let len = r1.inner().len() - 1;
     (0..len).any(|shift| {
-        (0..len).all(|i| coord_matcher(&r1.0[i], &r2.0[(i + shift) % len]))
-            || (0..len).all(|i| coord_matcher(&r1.0[len - i], &r2.0[(i + shift) % len]))
+        (0..len).all(|i| coord_matcher(&r1[i], &r2[(i + shift) % len]))
+            || (0..len).all(|i| coord_matcher(&r1[len - i], &r2[(i + shift) % len]))
     })
 }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

FIXES #816 

deprecate direct field access for geo-types, plus some other methods to help migrate from direct field access.

This is intended to be a non-breaking change for now, to give people an upgrade window. In an upcoming *breaking* release of geo-types we'll drop pub field access altogether.

This is in pursuit of adding support for 3D/4D geometries. When we do that, we'll leverage generics in a way that is intended to avoid runtime cost for our mostly 2D user base. See https://github.com/georust/geo/issues/5 for more.

This commit includes a bunch of new methods that correspond to the deprecated
field access. See geo-types/CHANGES.md for a summary.

`#[inline]` hints were added to maintain performance (it's actually improved in
some places!)

geo was updated to address all the deprecations.

---

## review

This PR is really big. I think the changes to really scrutinize are in geo-types. Applying it all to `geo` is large but very rote.

I think there's potential to add further methods to make code that uses geo-types a little nicer, but I tried to strike the right balance between minimizing this diff while not committing egregiously worse code that would immediately churn in a followup pr.

## docs

A lot of the work was getting the docs right. You can build them yourself, or check them here:  [doc.tar.gz](https://github.com/georust/geo/files/8548576/doc.tar.gz)
(We should have a CI action that uploads a web accessible preview of the docs... I'll create an issue)

## perf

Cargo bench is mostly unchanged, but surprisingly got a bit better for a couple things - in particular:
```
simplify vwp f32        time:   [1.1719 ms 1.1726 ms 1.1735 ms]
                        change: [-13.607% -13.525% -13.447%] (p = 0.00 < 0.05)
                        Performance has improved.
simplify vwp f64        time:   [1.1721 ms 1.1734 ms 1.1746 ms]
                        change: [-2.8011% -2.6356% -2.4896%] (p = 0.00 < 0.05)
                        Performance has improved.
```

I was curious why this would be. It seems like most of the difference is attributable to inlining the `Rect::new` constructor. Which is pretty wild, because we're not actually giving `Rect::new` any additional inline hints. It's plausible the the new inline hints on Coord are having percolating effects.

I don't have a great way to share that analysis, but here's a screenshot showing the "bottom up" view of rstar::bulk_load while profiling the simplify benches:

<img width="1915" alt="Screen Shot 2022-04-23 at 10 45 33 AM" src="https://user-images.githubusercontent.com/217057/164945643-80f47f1c-dfaa-4675-917b-42d05ab0bd66.png">

Before, on the left, within bulk_load we were spending about 25% of the time in Rect::new. After, it goes away completely.

Heres the entire criterion output if you want a closer look: 
[criterion.tar.gz](https://github.com/georust/geo/files/8548574/criterion.tar.gz)

<details>
<summary>output of `cargo bench --bench "*" -- --baseline main`</summary>

<pre>
$ git rev-parse HEAD
2d2f9734995a59569099d9b4af861f0bbae4e6f4

$ cargo bench --bench "*" -- --baseline main
   Compiling geo-types v0.7.4 (/Users/mkirk/src/georust/geo/geo-types)
   Compiling wkt v0.10.0
   Compiling geo v0.20.1 (/Users/mkirk/src/georust/geo/geo)
   Compiling geo-test-fixtures v0.1.0 (/Users/mkirk/src/georust/geo/geo-test-fixtures)
   Compiling jts-test-runner v0.1.0 (/Users/mkirk/src/georust/geo/jts-test-runner)
    Finished bench [optimized] target(s) in 13.28s
     Running unittests (target/release/deps/area-855e28849021a92f)
Gnuplot not found, using plotters backend
area                    time:   [8.2317 us 8.2349 us 8.2387 us]
                        change: [-1.8445% -1.6177% -1.3895%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe

     Running unittests (target/release/deps/concave_hull-3fc5ee84b9d2bfc5)
Gnuplot not found, using plotters backend
concave hull f32        time:   [3.9138 ms 3.9151 ms 3.9165 ms]
                        change: [-1.3098% -1.1612% -1.0223%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe

concave hull f64        time:   [4.4853 ms 4.4885 ms 4.4918 ms]
                        change: [-0.8010% -0.5925% -0.3983%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

     Running unittests (target/release/deps/contains-63588a9ec8c3ed8b)
Gnuplot not found, using plotters backend
point in polygon        time:   [29.806 ns 29.814 ns 29.823 ns]
                        change: [+0.3900% +0.6508% +0.9131%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 16 outliers among 100 measurements (16.00%)
  3 (3.00%) high mild
  13 (13.00%) high severe

point outside polygon   time:   [5.3372 ns 5.3443 ns 5.3516 ns]
                        change: [-1.1952% -0.8311% -0.4798%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild

     Running unittests (target/release/deps/convex_hull-6cb335bd5faaf6fd)
Gnuplot not found, using plotters backend
convex hull f32         time:   [238.18 us 238.30 us 238.49 us]
                        change: [-0.2670% -0.1761% -0.0908%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe

convex hull f64         time:   [239.44 us 239.49 us 239.53 us]
                        change: [-0.6070% -0.2911% +0.1400%] (p = 0.15 > 0.05)
                        No change in performance detected.
Found 10 outliers among 100 measurements (10.00%)
  4 (4.00%) high mild
  6 (6.00%) high severe

convex hull with collinear random i64
                        time:   [48.715 ms 48.758 ms 48.801 ms]
                        change: [-0.1923% -0.0309% +0.1341%] (p = 0.72 > 0.05)
                        No change in performance detected.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild

     Running unittests (target/release/deps/euclidean_distance-bc6fac8c303d54fc)
Gnuplot not found, using plotters backend
Polygon Euclidean distance RTree f64
                        time:   [27.112 us 27.119 us 27.125 us]
                        change: [-0.6660% -0.4632% -0.2686%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe

Polygon Euclidean distance rotating calipers f64
                        time:   [19.989 us 20.001 us 20.016 us]
                        change: [-0.2129% +0.0192% +0.2731%] (p = 0.88 > 0.05)
                        No change in performance detected.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe

     Running unittests (target/release/deps/extremes-8415e0a254d01d86)
Gnuplot not found, using plotters backend
extremes f32            time:   [16.921 us 16.924 us 16.928 us]
                        change: [-0.8815% -0.6828% -0.5003%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  2 (2.00%) high severe

extremes f64            time:   [16.886 us 16.890 us 16.894 us]
                        change: [-0.4735% -0.3434% -0.2306%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high severe

     Running unittests (target/release/deps/frechet_distance-d39f7fa200ab99dd)
Gnuplot not found, using plotters backend
Benchmarking frechet distance f32: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.3s, enable flat sampling, or reduce sample count to 50.
frechet distance f32    time:   [1.6431 ms 1.6432 ms 1.6435 ms]
                        change: [+0.3392% +0.4194% +0.4921%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 8 outliers among 100 measurements (8.00%)
  7 (7.00%) high mild
  1 (1.00%) high severe

Benchmarking frechet distance f64: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.5s, enable flat sampling, or reduce sample count to 50.
frechet distance f64    time:   [1.6918 ms 1.6920 ms 1.6923 ms]
                        change: [+0.4849% +0.5517% +0.6211%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe

     Running unittests (target/release/deps/geodesic_distance-585ac551a71c3f42)
Gnuplot not found, using plotters backend
geodesic distance f64   time:   [440.72 ns 441.70 ns 442.74 ns]
                        change: [-0.8843% -0.5960% -0.2980%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 17 outliers among 100 measurements (17.00%)
  6 (6.00%) high mild
  11 (11.00%) high severe

     Running unittests (target/release/deps/relate-4e43449cddce0e54)
Gnuplot not found, using plotters backend
relate overlapping 50-point polygons
                        time:   [30.491 us 30.497 us 30.504 us]
                        change: [-0.3225% -0.2631% -0.1989%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 10 outliers among 100 measurements (10.00%)
  3 (3.00%) low mild
  3 (3.00%) high mild
  4 (4.00%) high severe

     Running unittests (target/release/deps/rotate-782ee575c44a9478)
Gnuplot not found, using plotters backend
rotate f32              time:   [42.581 us 42.586 us 42.591 us]
                        change: [-0.0331% +0.0427% +0.1046%] (p = 0.24 > 0.05)
                        No change in performance detected.
Found 12 outliers among 100 measurements (12.00%)
  5 (5.00%) high mild
  7 (7.00%) high severe

rotate f64              time:   [48.764 us 48.774 us 48.785 us]
                        change: [+0.1467% +0.2790% +0.4650%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe

     Running unittests (target/release/deps/simplify-407a9cdfb29cfbcc)
Gnuplot not found, using plotters backend
simplify simple f32     time:   [68.521 us 68.664 us 68.807 us]
                        change: [-0.6969% -0.4201% -0.1588%] (p = 0.00 < 0.05)
                        Change within noise threshold.

simplify simple f64     time:   [86.558 us 86.588 us 86.616 us]
                        change: [-0.3586% -0.2222% -0.0898%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 11 outliers among 100 measurements (11.00%)
  7 (7.00%) low mild
  1 (1.00%) high mild
  3 (3.00%) high severe

     Running unittests (target/release/deps/simplifyvw-2d178e8147bc38c5)
Gnuplot not found, using plotters backend
simplify vw simple f32  time:   [182.08 us 182.61 us 183.15 us]
                        change: [-1.0460% -0.8368% -0.6350%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 11 outliers among 100 measurements (11.00%)
  11 (11.00%) high mild

simplify vw simple f64  time:   [195.62 us 196.35 us 197.20 us]
                        change: [-4.9151% -4.3032% -3.7086%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  9 (9.00%) high mild

Benchmarking simplify vwp f32: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.9s, enable flat sampling, or reduce sample count to 60.
simplify vwp f32        time:   [1.1719 ms 1.1726 ms 1.1735 ms]
                        change: [-13.607% -13.525% -13.447%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

Benchmarking simplify vwp f64: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.9s, enable flat sampling, or reduce sample count to 60.
simplify vwp f64        time:   [1.1721 ms 1.1734 ms 1.1746 ms]
                        change: [-2.8011% -2.6356% -2.4896%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

     Running unittests (target/release/deps/vincenty_distance-719460e9a4e37b64)
Gnuplot not found, using plotters backend
vincenty distance f32   time:   [146.94 ns 146.96 ns 146.98 ns]
                        change: [+0.0507% +0.1035% +0.1589%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe

vincenty distance f64   time:   [253.71 ns 253.77 ns 253.83 ns]
                        change: [+0.0571% +0.1358% +0.2119%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe
</pre>
</details>