### PR TITLE
deprecate: GeometryCollection::from(single_geom). It doesnt give us much and causes awkwardness downstream.

### DIFF
--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -6,6 +6,8 @@
   * <https://github.com/georust/geo/pull/823>
 * Add support for `Polygon` in `RTree`
   * <https://github.com/georust/geo/pull/351>
+* Deprecate GeometryCollection::from(single_geom) in favor of GeometryCollection::from(vec![single_geom])
+  * <https://github.com/georust/geo/pull/821>
 
 ## 0.7.4
 

--- a/geo-types/src/geometry.rs
+++ b/geo-types/src/geometry.rs
@@ -75,6 +75,13 @@ impl<T: CoordNum> From<MultiPolygon<T>> for Geometry<T> {
     }
 }
 
+// Disabled until we remove the deprecated GeometryCollection::from(single_geom) impl.
+// impl<T: CoordNum> From<GeometryCollection<T>> for Geometry<T> {
+//     fn from(x: GeometryCollection<T>) -> Self {
+//         Self::GeometryCollection(x)
+//     }
+// }
+
 impl<T: CoordNum> From<Rect<T>> for Geometry<T> {
     fn from(x: Rect<T>) -> Self {
         Self::Rect(x)
@@ -215,6 +222,8 @@ try_from_geometry_impl!(
     MultiPoint,
     MultiLineString,
     MultiPolygon,
+    // Disabled until we remove the deprecated GeometryCollection::from(single_geom) impl.
+    // GeometryCollection,
     Rect,
     Triangle
 );

--- a/geo-types/src/geometry_collection.rs
+++ b/geo-types/src/geometry_collection.rs
@@ -108,11 +108,17 @@ impl<T: CoordNum> GeometryCollection<T> {
     }
 }
 
-/// Convert any Geometry (or anything that can be converted to a Geometry) into a
-/// GeometryCollection
+#[deprecated(since = 0.7.5, note = "Use `GeometryCollection::from(vec![geom])` instead.")]
 impl<T: CoordNum, IG: Into<Geometry<T>>> From<IG> for GeometryCollection<T> {
     fn from(x: IG) -> Self {
         Self(vec![x.into()])
+    }
+}
+
+impl<T: CoordNum, IG: Into<Geometry<T>>> From<Vec<IG>> for GeometryCollection<T> {
+    fn from(geoms: Vec<IG>) -> Self {
+        let geoms: Vec<Geometry<_>> = geoms.into_iter().map(Into::into).collect();
+        Self(geoms)
     }
 }
 
@@ -310,5 +316,17 @@ where
 
         let mut mp_zipper = self.into_iter().zip(other.into_iter());
         mp_zipper.all(|(lhs, rhs)| lhs.abs_diff_eq(rhs, epsilon))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{GeometryCollection, Point};
+
+    #[test]
+    fn from_vec() {
+        let gc = GeometryCollection::from(vec![Point::new(1i32, 2)]);
+        let p = Point::try_from(gc[0].clone()).unwrap();
+        assert_eq!(p.y(), 2);
     }
 }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

As with most blanket implementations, the problems are little convoluted to explain.

Maybe easier to explain is that, as is, this implementation is only marginally useful. Having to write `GeometryCollection::new(vec![point])` isn't much more arduous than writing `GeometryCollection::from(point)`, and arguably clearer.

But the actual trouble I hit was while working on the WKT crate (https://github.com/georust/wkt/pull/95, see the second commit in particular).

Here's a simplified example of the kind of thing I was trying to do but can't (without jumping through some hoops):

```
// Any type that can be built from our serialized wkt representation can impl this trait.
trait FromSerialized<T> {
    fn from_wkt(wkt: &str) -> Result<Self>;
}

// A blanket implementation exists for all the things that can be (fallibly)
// built from a Geometry - i.e. all the inner variants (Point, Line, etc., but NOT a GeometryCollection)
impl<T: CoordNum, IG> FromSerialized<T> for IG
where
IG: TryFrom<Geometry<T>> + Into<Geometry<T>> + Default
{
    fn from_wkt(wkt: &str) -> Self {
        let g: Geometry<T> = parse_geometry_from_wkt(wkt);
        let specific = Self::try_from(g).map_err(|_| "e.g. Got LineString, expected Point").unwrap();
        specific
    }
}

fn parse_geometry_from_wkt<T: CoordNum>(wkt: &str) -> Geometry<T> {
    todo!("pretend this does something interesting, like parse WKT")
}

mod tests {
    use crate::{Point, LineString, GeometryCollection};
    use super::{FromWkt};

    #[test]
    fn example() {
        // All geometry variants *except* GeometryCollections can utilize the blanket implementation above.
        let point = Point::from_serialized("POINT(1 2)").unwrap();
        let line_string = LineString::from_wkt("LINESTRING(1 1, 2 2)").unwrap();

        // !!! But GeometryCollection::from_serialized will not compile...
        // ... because it has no `impl TryFrom<Geometry>`, because that impl would conflict (be ambiguous) with the existing
        // (proposed deprecation) `impl TryFrom<Into<Geometry>> for GeometryCollection`
        let geom_collection: GeometryCollection<f64> = GeometryCollection:: from_wkt("GEOMETRYCOLLECTION(("POINT(1 2)))");
    }
}
```

I worked around it in the WKT crate, but [it was awkward](https://github.com/georust/wkt/pull/95/commits/9fecace94f05e46331e9785ad508622f3d9f4b15#diff-1f4c8d43a2fd4d510da5fb47f3421e5457d297b4f3cffa665392e79c4774af2cR109). And I don't think many people would be sad if the conflicting implementation went away.

If people **are** commonly creating GeometryCollections from a single geometry, I think something like `GeometryCollection::from_single(point)` (or whatever) would be less obtrusive.
