### PR TITLE
default impl for CoordNum in Geometries

### DIFF
--- a/geo-postgis/src/from_postgis.rs
+++ b/geo-postgis/src/from_postgis.rs
@@ -15,7 +15,7 @@ pub trait FromPostgis<T> {
     fn from_postgis(_: T) -> Self;
 }
 
-impl<'a, T> FromPostgis<&'a T> for Point<f64>
+impl<'a, T> FromPostgis<&'a T> for Point
 where
     T: postgis::Point,
 {
@@ -23,12 +23,12 @@ where
         Point::new(pt.x(), pt.y())
     }
 }
-impl<'a, T> FromPostgis<&'a T> for LineString<f64>
+impl<'a, T> FromPostgis<&'a T> for LineString
 where
     T: postgis::LineString<'a>,
 {
     fn from_postgis(ls: &'a T) -> Self {
-        let ret: Vec<Point<f64>> = ls.points().map(Point::from_postgis).collect();
+        let ret: Vec<Point> = ls.points().map(Point::from_postgis).collect();
         LineString::from(ret)
     }
 }
@@ -50,7 +50,7 @@ where
         Some(Polygon::new(exterior, rings))
     }
 }
-impl<'a, T> FromPostgis<&'a T> for MultiPoint<f64>
+impl<'a, T> FromPostgis<&'a T> for MultiPoint
 where
     T: postgis::MultiPoint<'a>,
 {
@@ -59,7 +59,7 @@ where
         MultiPoint::new(ret)
     }
 }
-impl<'a, T> FromPostgis<&'a T> for MultiLineString<f64>
+impl<'a, T> FromPostgis<&'a T> for MultiLineString
 where
     T: postgis::MultiLineString<'a>,
 {
@@ -68,7 +68,7 @@ where
         MultiLineString::new(ret)
     }
 }
-impl<'a, T> FromPostgis<&'a T> for MultiPolygon<f64>
+impl<'a, T> FromPostgis<&'a T> for MultiPolygon
 where
     T: postgis::MultiPolygon<'a>,
 {
@@ -79,7 +79,7 @@ where
         MultiPolygon::new(ret)
     }
 }
-impl<'a, T> FromPostgis<&'a GeometryCollectionT<T>> for GeometryCollection<f64>
+impl<'a, T> FromPostgis<&'a GeometryCollectionT<T>> for GeometryCollection
 where
     T: postgis::Point + postgis::ewkb::EwkbRead,
 {
@@ -94,7 +94,7 @@ where
         GeometryCollection::new_from(geoms)
     }
 }
-impl<'a, T> FromPostgis<&'a GeometryT<T>> for Option<Geometry<f64>>
+impl<'a, T> FromPostgis<&'a GeometryT<T>> for Option<Geometry>
 where
     T: postgis::Point + postgis::ewkb::EwkbRead,
 {

--- a/geo-postgis/src/to_postgis.rs
+++ b/geo-postgis/src/to_postgis.rs
@@ -19,18 +19,18 @@ pub trait ToPostgis<T> {
     }
 }
 
-impl ToPostgis<ewkb::Point> for Coordinate<f64> {
+impl ToPostgis<ewkb::Point> for Coordinate {
     fn to_postgis_with_srid(&self, srid: Option<i32>) -> ewkb::Point {
         ewkb::Point::new(self.x, self.y, srid)
     }
 }
 
-impl ToPostgis<ewkb::Point> for Point<f64> {
+impl ToPostgis<ewkb::Point> for Point {
     fn to_postgis_with_srid(&self, srid: Option<i32>) -> ewkb::Point {
         ewkb::Point::new(self.x(), self.y(), srid)
     }
 }
-impl ToPostgis<ewkb::LineString> for Line<f64> {
+impl ToPostgis<ewkb::LineString> for Line {
     fn to_postgis_with_srid(&self, srid: Option<i32>) -> ewkb::LineString {
         let points = vec![
             self.start_point().to_postgis_with_srid(srid),
@@ -67,7 +67,7 @@ to_postgis_impl!(MultiPolygon, ewkb::MultiPolygon, polygons);
 to_postgis_impl!(MultiLineString, ewkb::MultiLineString, lines);
 to_postgis_impl!(MultiPoint, ewkb::MultiPoint, points);
 to_postgis_impl!(LineString, ewkb::LineString, points);
-impl ToPostgis<ewkb::Geometry> for Geometry<f64> {
+impl ToPostgis<ewkb::Geometry> for Geometry {
     fn to_postgis_with_srid(&self, srid: Option<i32>) -> ewkb::Geometry {
         match *self {
             Geometry::Point(ref p) => ewkb::GeometryT::Point(p.to_postgis_with_srid(srid)),

--- a/geo-types/src/coordinate.rs
+++ b/geo-types/src/coordinate.rs
@@ -238,7 +238,7 @@ use num_traits::Zero;
 /// use geo_types::Coordinate;
 /// use num_traits::Zero;
 ///
-/// let p: Coordinate<f64> = Zero::zero();
+/// let p: Coordinate = Zero::zero();
 ///
 /// assert_eq!(p.x, 0.);
 /// assert_eq!(p.y, 0.);

--- a/geo-types/src/coordinate.rs
+++ b/geo-types/src/coordinate.rs
@@ -25,7 +25,7 @@ use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 /// [vector space]: //en.wikipedia.org/wiki/Vector_space
 #[derive(Eq, PartialEq, Clone, Copy, Debug, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct Coordinate<T: CoordNum> {
+pub struct Coordinate<T: CoordNum = f64> {
     pub x: T,
     pub y: T,
 }

--- a/geo-types/src/error.rs
+++ b/geo-types/src/error.rs
@@ -38,7 +38,7 @@ mod test {
         let failure = Point::try_from(rect_geometry).unwrap_err();
         assert_eq!(
             failure.to_string(),
-            "Expected a geo_types::point::Point<f64>, but found a geo_types::rect::Rect<f64>"
+            "Expected a geo_types::point::Point, but found a geo_types::rect::Rect"
         );
     }
 }

--- a/geo-types/src/geometry.rs
+++ b/geo-types/src/geometry.rs
@@ -20,7 +20,7 @@ use std::convert::TryFrom;
 /// use std::convert::TryFrom;
 /// use geo_types::{Point, point, Geometry, GeometryCollection};
 /// let p = point!(x: 1.0, y: 1.0);
-/// let pe: Geometry<f64> = p.into();
+/// let pe: Geometry = p.into();
 /// let pn = Point::try_from(pe).unwrap();
 /// ```
 ///

--- a/geo-types/src/geometry.rs
+++ b/geo-types/src/geometry.rs
@@ -26,7 +26,7 @@ use std::convert::TryFrom;
 ///
 #[derive(Eq, PartialEq, Clone, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum Geometry<T: CoordNum> {
+pub enum Geometry<T: CoordNum = f64> {
     Point(Point<T>),
     Line(Line<T>),
     LineString(LineString<T>),

--- a/geo-types/src/geometry_collection.rs
+++ b/geo-types/src/geometry_collection.rs
@@ -71,7 +71,7 @@ use std::ops::{Index, IndexMut};
 ///
 #[derive(Eq, PartialEq, Clone, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct GeometryCollection<T: CoordNum>(pub Vec<Geometry<T>>);
+pub struct GeometryCollection<T: CoordNum = f64>(pub Vec<Geometry<T>>);
 
 // Implementing Default by hand because T does not have Default restriction
 // todo: consider adding Default as a CoordNum requirement

--- a/geo-types/src/lib.rs
+++ b/geo-types/src/lib.rs
@@ -1,14 +1,40 @@
 #![warn(missing_debug_implementations)]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/georust/meta/master/logo/logo.png")]
-//! The `geo-types` library provides geospatial primitive types for the [GeoRust] ecosystem.
+//! The `geo-types` library defines geometric types for the [GeoRust] ecosystem.
 //!
 //! In most cases, you will only need to use this crate if you’re a crate author and want
 //! compatibility with other GeoRust crates. Otherwise, the [`geo`](https://crates.io/crates/geo)
-//! crate re-exports these types and provides geospatial algorithms.
+//! crate re-exports these types and additionally provides geospatial algorithms.
 //!
 //! # Types
 //!
 //! - **[`Coordinate`]**: A two-dimensional coordinate. All geometry types are composed of [`Coordinate`]s, though [`Coordinate`] itself is not a [`Geometry`] type.
+//!
+//! By default, coordinates are 64-bit floating point numbers, but this is generic, and you may specify any numeric type that implements [`CoordNum`] or [`CoordFloat`]. As well as f64, this includes common numeric types like f32, i32, i64, etc.
+//!
+//! ```rust
+//! use geo_types::Point;
+//!
+//! // Geometries are f64 by default
+//! let point: Point = Point::new(1.0, 2.0);
+//! assert_eq!(std::mem::size_of::<Point>(), 64 * 2 / 8);
+//!
+//! // You can be explicit about the numeric type.
+//! let f64_point: Point<f64> = Point::new(1.0, 2.0);
+//! assert_eq!(std::mem::size_of::<Point<f64>>(), 64 * 2 / 8);
+//!
+//! // Or specify some non-default numeric type
+//! let f32_point: Point<f32> = Point::new(1.0, 2.0);
+//! assert_eq!(std::mem::size_of::<Point<f32>>(), 32 * 2 / 8);
+//!
+//! // Integer geometries are supported too, though not all
+//! // algorithms will be implemented for all numeric types.
+//! let i32_point: Point<i32> = Point::new(1, 2);
+//! assert_eq!(std::mem::size_of::<Point<i32>>(), 32 * 2 / 8);
+//! ```
+//!
+//! ## Geometries
+//!
 //! - **[`Point`]**: A single point represented by one [`Coordinate`]
 //! - **[`MultiPoint`]**: A collection of [`Point`]s
 //! - **[`Line`]**: A line segment represented by two [`Coordinate`]s

--- a/geo-types/src/line.rs
+++ b/geo-types/src/line.rs
@@ -11,7 +11,7 @@ use approx::{AbsDiffEq, RelativeEq};
 /// `LineString` with the two end points.
 #[derive(Eq, PartialEq, Clone, Copy, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct Line<T: CoordNum> {
+pub struct Line<T: CoordNum = f64> {
     pub start: Coordinate<T>,
     pub end: Coordinate<T>,
 }

--- a/geo-types/src/line_string.rs
+++ b/geo-types/src/line_string.rs
@@ -132,7 +132,7 @@ use std::ops::{Index, IndexMut};
 
 #[derive(Eq, PartialEq, Clone, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct LineString<T: CoordNum>(pub Vec<Coordinate<T>>);
+pub struct LineString<T: CoordNum = f64>(pub Vec<Coordinate<T>>);
 
 /// A [`Point`] iterator returned by the `points` method
 #[derive(Debug)]

--- a/geo-types/src/line_string.rs
+++ b/geo-types/src/line_string.rs
@@ -63,7 +63,7 @@ use std::ops::{Index, IndexMut};
 /// ```
 /// use geo_types::LineString;
 ///
-/// let line_string: LineString<f64> = vec![[0., 0.], [10., 0.]].into();
+/// let line_string: LineString = vec![[0., 0.], [10., 0.]].into();
 /// ```
 //
 /// Or by `collect`ing from a [`Coordinate`] iterator

--- a/geo-types/src/multi_line_string.rs
+++ b/geo-types/src/multi_line_string.rs
@@ -33,7 +33,7 @@ use std::iter::FromIterator;
 /// of a closed `MultiLineString` is always empty.
 #[derive(Eq, PartialEq, Clone, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct MultiLineString<T: CoordNum>(pub Vec<LineString<T>>);
+pub struct MultiLineString<T: CoordNum = f64>(pub Vec<LineString<T>>);
 
 impl<T: CoordNum> MultiLineString<T> {
     /// Instantiate Self from the raw content value

--- a/geo-types/src/multi_point.rs
+++ b/geo-types/src/multi_point.rs
@@ -30,7 +30,7 @@ use std::iter::FromIterator;
 /// ```
 #[derive(Eq, PartialEq, Clone, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct MultiPoint<T: CoordNum>(pub Vec<Point<T>>);
+pub struct MultiPoint<T: CoordNum = f64>(pub Vec<Point<T>>);
 
 impl<T: CoordNum, IP: Into<Point<T>>> From<IP> for MultiPoint<T> {
     /// Convert a single `Point` (or something which can be converted to a `Point`) into a

--- a/geo-types/src/multi_polygon.rs
+++ b/geo-types/src/multi_polygon.rs
@@ -27,7 +27,7 @@ use std::iter::FromIterator;
 /// predicates that operate on it.
 #[derive(Eq, PartialEq, Clone, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct MultiPolygon<T: CoordNum>(pub Vec<Polygon<T>>);
+pub struct MultiPolygon<T: CoordNum = f64>(pub Vec<Polygon<T>>);
 
 impl<T: CoordNum, IP: Into<Polygon<T>>> From<IP> for MultiPolygon<T> {
     fn from(x: IP) -> Self {

--- a/geo-types/src/point.rs
+++ b/geo-types/src/point.rs
@@ -28,7 +28,7 @@ use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssi
 /// ```
 #[derive(Eq, PartialEq, Clone, Copy, Debug, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct Point<T: CoordNum>(pub Coordinate<T>);
+pub struct Point<T: CoordNum = f64>(pub Coordinate<T>);
 
 impl<T: CoordNum> From<Coordinate<T>> for Point<T> {
     fn from(x: Coordinate<T>) -> Self {

--- a/geo-types/src/point.rs
+++ b/geo-types/src/point.rs
@@ -22,9 +22,9 @@ use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssi
 ///
 /// ```
 /// use geo_types::{coord, Point};
-/// let p1: Point<f64> = (0., 1.).into();
+/// let p1: Point = (0., 1.).into();
 /// let c = coord! { x: 10., y: 20. };
-/// let p2: Point<f64> = c.into();
+/// let p2: Point = c.into();
 /// ```
 #[derive(Eq, PartialEq, Clone, Copy, Debug, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/geo-types/src/polygon.rs
+++ b/geo-types/src/polygon.rs
@@ -66,7 +66,7 @@ use approx::{AbsDiffEq, RelativeEq};
 /// [`LineString`]: line_string/struct.LineString.html
 #[derive(Eq, PartialEq, Clone, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct Polygon<T: CoordNum> {
+pub struct Polygon<T: CoordNum = f64> {
     exterior: LineString<T>,
     interiors: Vec<LineString<T>>,
 }

--- a/geo-types/src/rect.rs
+++ b/geo-types/src/rect.rs
@@ -39,7 +39,7 @@ use approx::{AbsDiffEq, RelativeEq};
 /// ```
 #[derive(Eq, PartialEq, Clone, Copy, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct Rect<T: CoordNum> {
+pub struct Rect<T: CoordNum = f64> {
     min: Coordinate<T>,
     max: Coordinate<T>,
 }

--- a/geo-types/src/triangle.rs
+++ b/geo-types/src/triangle.rs
@@ -9,7 +9,7 @@ use approx::{AbsDiffEq, RelativeEq};
 /// vertices must not be collinear and they must be distinct.
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct Triangle<T: CoordNum>(pub Coordinate<T>, pub Coordinate<T>, pub Coordinate<T>);
+pub struct Triangle<T: CoordNum = f64>(pub Coordinate<T>, pub Coordinate<T>, pub Coordinate<T>);
 
 impl<T: CoordNum> Triangle<T> {
     /// Instantiate Self from the raw content value

--- a/geo/benches/geodesic_distance.rs
+++ b/geo/benches/geodesic_distance.rs
@@ -6,8 +6,8 @@ use geo::prelude::*;
 
 fn criterion_benchmark(c: &mut criterion::Criterion) {
     c.bench_function("geodesic distance f64", |bencher| {
-        let a = geo::Point::<f64>::new(17.107558, 48.148636);
-        let b = geo::Point::<f64>::new(16.372477, 48.208810);
+        let a = geo::Point::new(17.107558, 48.148636);
+        let b = geo::Point::new(16.372477, 48.208810);
 
         bencher.iter(|| {
             criterion::black_box(

--- a/geo/benches/intersection.rs
+++ b/geo/benches/intersection.rs
@@ -8,8 +8,8 @@ use geo::intersects::Intersects;
 use geo::MultiPolygon;
 
 fn criterion_benchmark(c: &mut Criterion) {
-    let plot_polygons: MultiPolygon<f64> = geo_test_fixtures::nl_plots();
-    let zone_polygons: MultiPolygon<f64> = geo_test_fixtures::nl_zones();
+    let plot_polygons: MultiPolygon = geo_test_fixtures::nl_plots();
+    let zone_polygons: MultiPolygon = geo_test_fixtures::nl_zones();
 
     c.bench_function("intersection", |bencher| {
         bencher.iter(|| {

--- a/geo/benches/vincenty_distance.rs
+++ b/geo/benches/vincenty_distance.rs
@@ -17,8 +17,8 @@ fn criterion_benchmark(c: &mut criterion::Criterion) {
     });
 
     c.bench_function("vincenty distance f64", |bencher| {
-        let a = geo::Point::<f64>::new(17.107558, 48.148636);
-        let b = geo::Point::<f64>::new(16.372477, 48.208810);
+        let a = geo::Point::new(17.107558, 48.148636);
+        let b = geo::Point::new(16.372477, 48.208810);
 
         bencher.iter(|| {
             let _ = criterion::black_box(

--- a/geo/examples/concavehull-usage.rs
+++ b/geo/examples/concavehull-usage.rs
@@ -5,7 +5,7 @@ use geo_types::MultiPoint;
 use std::fs::File;
 use std::io::Write;
 
-fn generate_polygon_str(coords: &[Coordinate<f64>]) -> String {
+fn generate_polygon_str(coords: &[Coordinate]) -> String {
     let mut points_str = String::from("");
     for coord in coords {
         points_str.push_str(format!("{},{} ", coord.x, coord.y).as_ref());
@@ -16,7 +16,7 @@ fn generate_polygon_str(coords: &[Coordinate<f64>]) -> String {
     );
 }
 
-fn generate_consecutive_circles(coords: &[Coordinate<f64>]) -> String {
+fn generate_consecutive_circles(coords: &[Coordinate]) -> String {
     let mut circles_str = String::from("");
     for coord in coords {
         circles_str.push_str(
@@ -34,7 +34,7 @@ fn produce_file_content(start_str: &str, mid_str: &str) -> String {
 }
 
 //Move the points such that they're clustered around the center of the image
-fn move_points_in_viewbox(width: f64, height: f64, points: Vec<Point<f64>>) -> Vec<Point<f64>> {
+fn move_points_in_viewbox(width: f64, height: f64, points: Vec<Point>) -> Vec<Point> {
     let mut new_points = vec![];
     for point in points {
         new_points.push(Point::new(
@@ -45,7 +45,7 @@ fn move_points_in_viewbox(width: f64, height: f64, points: Vec<Point<f64>>) -> V
     new_points
 }
 
-fn map_points_to_coords(points: Vec<Point<f64>>) -> Vec<Coordinate<f64>> {
+fn map_points_to_coords(points: Vec<Point>) -> Vec<Coordinate> {
     points.iter().map(|point| point.0).collect()
 }
 

--- a/geo/src/algorithm/bearing.rs
+++ b/geo/src/algorithm/bearing.rs
@@ -16,8 +16,8 @@ pub trait Bearing<T: CoordFloat> {
     /// use geo::Bearing;
     /// use geo::Point;
     ///
-    /// let p_1 = Point::<f64>::new(9.177789688110352, 48.776781529534965);
-    /// let p_2 = Point::<f64>::new(9.274410083250379, 48.84033282787534);
+    /// let p_1 = Point::new(9.177789688110352, 48.776781529534965);
+    /// let p_2 = Point::new(9.274410083250379, 48.84033282787534);
     /// let bearing = p_1.bearing(p_2);
     /// assert_relative_eq!(bearing, 45., epsilon = 1.0e-6);
     /// ```

--- a/geo/src/algorithm/centroid.rs
+++ b/geo/src/algorithm/centroid.rs
@@ -154,7 +154,7 @@ where
 /// use geo::Centroid;
 /// use geo::{MultiPoint, Point};
 ///
-/// let empty: Vec<Point<f64>> = Vec::new();
+/// let empty: Vec<Point> = Vec::new();
 /// let empty_multi_points: MultiPoint<_> = empty.into();
 /// assert_eq!(empty_multi_points.centroid(), None);
 ///
@@ -519,13 +519,13 @@ mod test {
     // Tests: Centroid of MultiLineString
     #[test]
     fn empty_multilinestring_test() {
-        let mls: MultiLineString<f64> = MultiLineString::new(vec![]);
+        let mls: MultiLineString = MultiLineString::new(vec![]);
         let centroid = mls.centroid();
         assert!(centroid.is_none());
     }
     #[test]
     fn multilinestring_with_empty_line_test() {
-        let mls: MultiLineString<f64> = MultiLineString::new(vec![line_string![]]);
+        let mls: MultiLineString = MultiLineString::new(vec![line_string![]]);
         let centroid = mls.centroid();
         assert!(centroid.is_none());
     }
@@ -535,7 +535,7 @@ mod test {
             x: 40.02f64,
             y: 116.34,
         };
-        let mls: MultiLineString<f64> = MultiLineString::new(vec![
+        let mls: MultiLineString = MultiLineString::new(vec![
             line_string![coord],
             line_string![coord],
             line_string![coord],
@@ -552,7 +552,7 @@ mod test {
             (x: 10., y: 1.),
             (x: 11., y: 1.)
         ];
-        let mls: MultiLineString<f64> = MultiLineString::new(vec![linestring]);
+        let mls: MultiLineString = MultiLineString::new(vec![linestring]);
         assert_relative_eq!(mls.centroid().unwrap(), point! { x: 6., y: 1. });
     }
     #[test]
@@ -748,6 +748,7 @@ mod test {
     fn empty_multipolygon_polygon_test() {
         assert!(MultiPolygon::<f64>::new(Vec::new()).centroid().is_none());
     }
+
     #[test]
     fn multipolygon_one_polygon_test() {
         let linestring =

--- a/geo/src/algorithm/concave_hull.rs
+++ b/geo/src/algorithm/concave_hull.rs
@@ -374,7 +374,7 @@ mod test {
     #[test]
     fn concave_hull_norway_test() {
         let norway = geo_test_fixtures::norway_main::<f64>();
-        let norway_concave_hull: LineString<f64> = geo_test_fixtures::norway_concave_hull::<f64>();
+        let norway_concave_hull: LineString = geo_test_fixtures::norway_concave_hull::<f64>();
         let res = norway.concave_hull(2.0);
         assert_eq!(res.exterior(), &norway_concave_hull);
     }

--- a/geo/src/algorithm/contains/mod.rs
+++ b/geo/src/algorithm/contains/mod.rs
@@ -501,17 +501,17 @@ mod test {
     #[test]
     // https://github.com/georust/geo/issues/473
     fn triangle_contains_collinear_points() {
-        let origin: Coordinate<f64> = (0., 0.).into();
+        let origin: Coordinate = (0., 0.).into();
         let tri = Triangle::new(origin, origin, origin);
-        let pt: Point<f64> = (0., 1.23456).into();
+        let pt: Point = (0., 1.23456).into();
         assert!(!tri.contains(&pt));
-        let pt: Point<f64> = (0., 0.).into();
+        let pt: Point = (0., 0.).into();
         assert!(!tri.contains(&pt));
-        let origin: Coordinate<f64> = (0., 0.).into();
+        let origin: Coordinate = (0., 0.).into();
         let tri = Triangle::new((1., 1.).into(), origin, origin);
-        let pt: Point<f64> = (1., 1.).into();
+        let pt: Point = (1., 1.).into();
         assert!(!tri.contains(&pt));
-        let pt: Point<f64> = (0.5, 0.5).into();
+        let pt: Point = (0.5, 0.5).into();
         assert!(!tri.contains(&pt));
     }
 }

--- a/geo/src/algorithm/coords_iter.rs
+++ b/geo/src/algorithm/coords_iter.rs
@@ -766,11 +766,11 @@ mod test {
         assert_eq!(expected_coords, actual_coords);
     }
 
-    fn create_point() -> (Point<f64>, Vec<Coordinate<f64>>) {
+    fn create_point() -> (Point, Vec<Coordinate>) {
         (point!(x: 1., y: 2.), vec![coord! { x: 1., y: 2. }])
     }
 
-    fn create_triangle() -> (Triangle<f64>, Vec<Coordinate<f64>>) {
+    fn create_triangle() -> (Triangle, Vec<Coordinate>) {
         (
             Triangle::new(
                 coord! { x: 1., y: 2. },
@@ -785,7 +785,7 @@ mod test {
         )
     }
 
-    fn create_rect() -> (Rect<f64>, Vec<Coordinate<f64>>) {
+    fn create_rect() -> (Rect, Vec<Coordinate>) {
         (
             Rect::new(coord! { x: 1., y: 2. }, coord! { x: 3., y: 4. }),
             vec![
@@ -797,7 +797,7 @@ mod test {
         )
     }
 
-    fn create_line_string() -> (LineString<f64>, Vec<Coordinate<f64>>) {
+    fn create_line_string() -> (LineString, Vec<Coordinate>) {
         (
             line_string![
                 (x: 1., y: 2.),
@@ -807,7 +807,7 @@ mod test {
         )
     }
 
-    fn create_polygon() -> (Polygon<f64>, Vec<Coordinate<f64>>) {
+    fn create_polygon() -> (Polygon<f64>, Vec<Coordinate>) {
         (
             polygon!(
                 exterior: [(x: 0., y: 0.), (x: 5., y: 10.), (x: 10., y: 0.), (x: 0., y: 0.)],

--- a/geo/src/algorithm/dimensions.rs
+++ b/geo/src/algorithm/dimensions.rs
@@ -52,7 +52,7 @@ pub trait HasDimensions {
     /// ]);
     /// assert!(!line_string.is_empty());
     ///
-    /// let empty_line_string: LineString<f64> = LineString::new(vec![]);
+    /// let empty_line_string: LineString = LineString::new(vec![]);
     /// assert!(empty_line_string.is_empty());
     ///
     /// let point = Point::new(0.0, 0.0);

--- a/geo/src/algorithm/euclidean_distance.rs
+++ b/geo/src/algorithm/euclidean_distance.rs
@@ -844,7 +844,7 @@ mod test {
     #[test]
     fn distance1_test() {
         assert_relative_eq!(
-            Point::<f64>::new(0., 0.).euclidean_distance(&Point::<f64>::new(1., 0.)),
+            Point::new(0., 0.).euclidean_distance(&Point::new(1., 0.)),
             1.
         );
     }

--- a/geo/src/algorithm/geodesic_distance.rs
+++ b/geo/src/algorithm/geodesic_distance.rs
@@ -39,8 +39,8 @@ pub trait GeodesicDistance<T, Rhs = Self> {
     fn geodesic_distance(&self, rhs: &Rhs) -> T;
 }
 
-impl GeodesicDistance<f64> for Point<f64> {
-    fn geodesic_distance(&self, rhs: &Point<f64>) -> f64 {
+impl GeodesicDistance<f64> for Point {
+    fn geodesic_distance(&self, rhs: &Point) -> f64 {
         Geodesic::wgs84().inverse(self.y(), self.x(), rhs.y(), rhs.x())
     }
 }

--- a/geo/src/algorithm/geodesic_intermediate.rs
+++ b/geo/src/algorithm/geodesic_intermediate.rs
@@ -14,8 +14,8 @@ pub trait GeodesicIntermediate<T: CoordFloat> {
     /// use geo::GeodesicIntermediate;
     /// use geo::Point;
     ///
-    /// let p1 = Point::<f64>::new(10.0, 20.0);
-    /// let p2 = Point::<f64>::new(125.0, 25.0);
+    /// let p1 = Point::new(10.0, 20.0);
+    /// let p2 = Point::new(125.0, 25.0);
     /// let i20 = p1.geodesic_intermediate(&p2, 0.2);
     /// let i50 = p1.geodesic_intermediate(&p2, 0.5);
     /// let i80 = p1.geodesic_intermediate(&p2, 0.8);
@@ -36,8 +36,8 @@ pub trait GeodesicIntermediate<T: CoordFloat> {
     ) -> Vec<Point<T>>;
 }
 
-impl GeodesicIntermediate<f64> for Point<f64> {
-    fn geodesic_intermediate(&self, other: &Point<f64>, f: f64) -> Point<f64> {
+impl GeodesicIntermediate<f64> for Point {
+    fn geodesic_intermediate(&self, other: &Point, f: f64) -> Point {
         let g = Geodesic::wgs84();
         let (total_distance, azi1, _azi2, _a12) =
             g.inverse(self.y(), self.x(), other.y(), other.x());
@@ -49,10 +49,10 @@ impl GeodesicIntermediate<f64> for Point<f64> {
 
     fn geodesic_intermediate_fill(
         &self,
-        other: &Point<f64>,
+        other: &Point,
         max_dist: f64,
         include_ends: bool,
-    ) -> Vec<Point<f64>> {
+    ) -> Vec<Point> {
         let g = Geodesic::wgs84();
         let (total_distance, azi1, _azi2, _a12) =
             g.inverse(self.y(), self.x(), other.y(), other.x());
@@ -93,8 +93,8 @@ mod tests {
 
     #[test]
     fn f_is_zero_or_one_test() {
-        let p1 = Point::<f64>::new(10.0, 20.0);
-        let p2 = Point::<f64>::new(15.0, 25.0);
+        let p1 = Point::new(10.0, 20.0);
+        let p2 = Point::new(15.0, 25.0);
         let i0 = p1.geodesic_intermediate(&p2, 0.0);
         let i100 = p1.geodesic_intermediate(&p2, 1.0);
         assert_relative_eq!(i0, p1, epsilon = 1.0e-6);
@@ -103,8 +103,8 @@ mod tests {
 
     #[test]
     fn various_f_values_test() {
-        let p1 = Point::<f64>::new(10.0, 20.0);
-        let p2 = Point::<f64>::new(125.0, 25.0);
+        let p1 = Point::new(10.0, 20.0);
+        let p2 = Point::new(125.0, 25.0);
         let i20 = p1.geodesic_intermediate(&p2, 0.2);
         let i50 = p1.geodesic_intermediate(&p2, 0.5);
         let i80 = p1.geodesic_intermediate(&p2, 0.8);
@@ -118,8 +118,8 @@ mod tests {
 
     #[test]
     fn should_add_i50_test() {
-        let p1 = Point::<f64>::new(30.0, 40.0);
-        let p2 = Point::<f64>::new(40.0, 50.0);
+        let p1 = Point::new(30.0, 40.0);
+        let p2 = Point::new(40.0, 50.0);
         let max_dist = 1000000.0; // meters
         let include_ends = true;
         let i50 = p1.geodesic_intermediate(&p2, 0.5);

--- a/geo/src/algorithm/geodesic_length.rs
+++ b/geo/src/algorithm/geodesic_length.rs
@@ -24,7 +24,7 @@ pub trait GeodesicLength<T, RHS = Self> {
     /// use geo::prelude::*;
     /// use geo::LineString;
     ///
-    /// let linestring = LineString::<f64>::from(vec![
+    /// let linestring = LineString::from(vec![
     ///     // New York City
     ///     (-74.006, 40.7128),
     ///     // London
@@ -45,7 +45,7 @@ pub trait GeodesicLength<T, RHS = Self> {
     fn geodesic_length(&self) -> T;
 }
 
-impl GeodesicLength<f64> for Line<f64> {
+impl GeodesicLength<f64> for Line {
     /// The units of the returned value is meters.
     fn geodesic_length(&self) -> f64 {
         let (start, end) = self.points();
@@ -53,7 +53,7 @@ impl GeodesicLength<f64> for Line<f64> {
     }
 }
 
-impl GeodesicLength<f64> for LineString<f64> {
+impl GeodesicLength<f64> for LineString {
     fn geodesic_length(&self) -> f64 {
         let mut length = 0.0;
         for line in self.lines() {
@@ -63,7 +63,7 @@ impl GeodesicLength<f64> for LineString<f64> {
     }
 }
 
-impl GeodesicLength<f64> for MultiLineString<f64> {
+impl GeodesicLength<f64> for MultiLineString {
     fn geodesic_length(&self) -> f64 {
         let mut length = 0.0;
         for line_string in &self.0 {

--- a/geo/src/algorithm/haversine_destination.rs
+++ b/geo/src/algorithm/haversine_destination.rs
@@ -19,9 +19,9 @@ pub trait HaversineDestination<T: CoordFloat> {
     /// use geo::HaversineDestination;
     /// use geo::Point;
     ///
-    /// let p_1 = Point::<f64>::new(9.177789688110352, 48.776781529534965);
+    /// let p_1 = Point::new(9.177789688110352, 48.776781529534965);
     /// let p_2 = p_1.haversine_destination(45., 10000.);
-    /// assert_eq!(p_2, Point::<f64>::new(9.274409949623548, 48.84033274015048))
+    /// assert_eq!(p_2, Point::new(9.274409949623548, 48.84033274015048))
     /// ```
     fn haversine_destination(&self, bearing: T, distance: T) -> Point<T>;
 }
@@ -56,16 +56,16 @@ mod test {
 
     #[test]
     fn returns_a_new_point() {
-        let p_1 = Point::<f64>::new(9.177789688110352, 48.776781529534965);
+        let p_1 = Point::new(9.177789688110352, 48.776781529534965);
         let p_2 = p_1.haversine_destination(45., 10000.);
-        assert_eq!(p_2, Point::<f64>::new(9.274409949623548, 48.84033274015048));
+        assert_eq!(p_2, Point::new(9.274409949623548, 48.84033274015048));
         let distance = p_1.haversine_distance(&p_2);
         assert_relative_eq!(distance, 10000., epsilon = 1.0e-6)
     }
 
     #[test]
     fn direct_and_indirect_destinations_are_close() {
-        let p_1 = Point::<f64>::new(9.177789688110352, 48.776781529534965);
+        let p_1 = Point::new(9.177789688110352, 48.776781529534965);
         let p_2 = p_1.haversine_destination(45., 10000.);
         let square_edge = { pow(10000., 2) / 2f64 }.sqrt();
         let p_3 = p_1.haversine_destination(0., square_edge);

--- a/geo/src/algorithm/haversine_distance.rs
+++ b/geo/src/algorithm/haversine_distance.rs
@@ -63,8 +63,8 @@ mod test {
 
     #[test]
     fn distance1_test() {
-        let a = Point::<f64>::new(0., 0.);
-        let b = Point::<f64>::new(1., 0.);
+        let a = Point::new(0., 0.);
+        let b = Point::new(1., 0.);
         assert_relative_eq!(
             a.haversine_distance(&b),
             111195.0802335329_f64,
@@ -86,8 +86,8 @@ mod test {
     #[test]
     fn distance3_test() {
         // this input comes from issue #100
-        let a = Point::<f64>::new(-77.036585, 38.897448);
-        let b = Point::<f64>::new(-77.009080, 38.889825);
+        let a = Point::new(-77.036585, 38.897448);
+        let b = Point::new(-77.009080, 38.889825);
         assert_relative_eq!(
             a.haversine_distance(&b),
             2526.823504306046_f64,

--- a/geo/src/algorithm/haversine_intermediate.rs
+++ b/geo/src/algorithm/haversine_intermediate.rs
@@ -14,8 +14,8 @@ pub trait HaversineIntermediate<T: CoordFloat> {
     /// use geo::HaversineIntermediate;
     /// use geo::Point;
     ///
-    /// let p1 = Point::<f64>::new(10.0, 20.0);
-    /// let p2 = Point::<f64>::new(125.0, 25.0);
+    /// let p1 = Point::new(10.0, 20.0);
+    /// let p2 = Point::new(125.0, 25.0);
     /// let i20 = p1.haversine_intermediate(&p2, 0.2);
     /// let i50 = p1.haversine_intermediate(&p2, 0.5);
     /// let i80 = p1.haversine_intermediate(&p2, 0.8);
@@ -169,8 +169,8 @@ mod test {
 
     #[test]
     fn f_is_zero_or_one_test() {
-        let p1 = Point::<f64>::new(10.0, 20.0);
-        let p2 = Point::<f64>::new(15.0, 25.0);
+        let p1 = Point::new(10.0, 20.0);
+        let p2 = Point::new(15.0, 25.0);
         let i0 = p1.haversine_intermediate(&p2, 0.0);
         let i100 = p1.haversine_intermediate(&p2, 1.0);
         assert_relative_eq!(i0.x(), p1.x(), epsilon = 1.0e-6);
@@ -181,8 +181,8 @@ mod test {
 
     #[test]
     fn various_f_values_test() {
-        let p1 = Point::<f64>::new(10.0, 20.0);
-        let p2 = Point::<f64>::new(125.0, 25.0);
+        let p1 = Point::new(10.0, 20.0);
+        let p2 = Point::new(125.0, 25.0);
         let i20 = p1.haversine_intermediate(&p2, 0.2);
         let i50 = p1.haversine_intermediate(&p2, 0.5);
         let i80 = p1.haversine_intermediate(&p2, 0.8);
@@ -199,8 +199,8 @@ mod test {
 
     #[test]
     fn should_be_north_pole_test() {
-        let p1 = Point::<f64>::new(0.0, 10.0);
-        let p2 = Point::<f64>::new(180.0, 10.0);
+        let p1 = Point::new(0.0, 10.0);
+        let p2 = Point::new(180.0, 10.0);
         let i50 = p1.haversine_intermediate(&p2, 0.5);
         let i50_should = Point::new(90.0, 90.0);
         assert_relative_eq!(i50.x(), i50_should.x(), epsilon = 1.0e-6);
@@ -209,8 +209,8 @@ mod test {
 
     #[test]
     fn should_be_start_end_test() {
-        let p1 = Point::<f64>::new(30.0, 40.0);
-        let p2 = Point::<f64>::new(40.0, 50.0);
+        let p1 = Point::new(30.0, 40.0);
+        let p2 = Point::new(40.0, 50.0);
         let max_dist = 1500000.0; // meters
         let include_ends = true;
         let route = p1.haversine_intermediate_fill(&p2, max_dist, include_ends);
@@ -219,8 +219,8 @@ mod test {
 
     #[test]
     fn should_add_i50_test() {
-        let p1 = Point::<f64>::new(30.0, 40.0);
-        let p2 = Point::<f64>::new(40.0, 50.0);
+        let p1 = Point::new(30.0, 40.0);
+        let p2 = Point::new(40.0, 50.0);
         let max_dist = 1000000.0; // meters
         let include_ends = true;
         let i50 = p1.clone().haversine_intermediate(&p2, 0.5);
@@ -230,8 +230,8 @@ mod test {
 
     #[test]
     fn should_add_i25_i50_i75_test() {
-        let p1 = Point::<f64>::new(30.0, 40.0);
-        let p2 = Point::<f64>::new(40.0, 50.0);
+        let p1 = Point::new(30.0, 40.0);
+        let p2 = Point::new(40.0, 50.0);
         let max_dist = 400000.0; // meters
         let include_ends = true;
         let i25 = p1.clone().haversine_intermediate(&p2, 0.25);

--- a/geo/src/algorithm/intersects/mod.rs
+++ b/geo/src/algorithm/intersects/mod.rs
@@ -147,7 +147,7 @@ mod test {
     }
     #[test]
     fn empty_all_linestring_test() {
-        let empty: LineString<f64> = line_string![];
+        let empty: LineString = line_string![];
         assert!(!empty.intersects(&empty));
     }
     #[test]
@@ -550,8 +550,8 @@ mod test {
     #[test]
     fn exhaustive_compile_test() {
         use geo_types::{GeometryCollection, Triangle};
-        let pt: Point<f64> = Point::new(0., 0.);
-        let ln: Line<f64> = Line::new((0., 0.), (1., 1.));
+        let pt: Point = Point::new(0., 0.);
+        let ln: Line = Line::new((0., 0.), (1., 1.));
         let ls = line_string![(0., 0.).into(), (1., 1.).into()];
         let poly = Polygon::new(LineString::from(vec![(0., 0.), (1., 1.), (1., 0.)]), vec![]);
         let rect = Rect::new(coord! { x: 10., y: 20. }, coord! { x: 30., y: 10. });

--- a/geo/src/algorithm/is_convex.rs
+++ b/geo/src/algorithm/is_convex.rs
@@ -211,7 +211,7 @@ mod tests {
     fn test_corner_cases() {
         // This is just tested to ensure there is no panic
         // due to out-of-index access
-        let empty: LineString<f64> = line_string!();
+        let empty: LineString = line_string!();
         assert!(empty.is_collinear());
         assert!(!empty.is_convex());
         assert!(!empty.is_strictly_ccw_convex());

--- a/geo/src/algorithm/line_interpolate_point.rs
+++ b/geo/src/algorithm/line_interpolate_point.rs
@@ -18,7 +18,7 @@ use std::ops::AddAssign;
 /// use geo::{LineString, point};
 /// use geo::LineInterpolatePoint;
 ///
-/// let linestring: LineString<f64> = vec![
+/// let linestring: LineString = vec![
 ///     [-1.0, 0.0],
 ///     [0.0, 0.0],
 ///     [0.0, 1.0]
@@ -210,7 +210,7 @@ mod test {
     #[test]
     fn test_line_interpolate_point_linestring() {
         // some finite examples
-        let linestring: LineString<f64> = vec![[-1.0, 0.0], [0.0, 0.0], [1.0, 0.0]].into();
+        let linestring: LineString = vec![[-1.0, 0.0], [0.0, 0.0], [1.0, 0.0]].into();
         assert_eq!(
             linestring.line_interpolate_point(0.0),
             Some(point!(x: -1.0, y: 0.0))
@@ -243,7 +243,7 @@ mod test {
         );
         assert_eq!(linestring.line_interpolate_point(Float::nan()), None);
 
-        let linestring: LineString<f64> = vec![[-1.0, 0.0], [0.0, 0.0], [0.0, 1.0]].into();
+        let linestring: LineString = vec![[-1.0, 0.0], [0.0, 0.0], [0.0, 1.0]].into();
         assert_eq!(
             linestring.line_interpolate_point(0.5),
             Some(point!(x: 0.0, y: 0.0))
@@ -254,26 +254,25 @@ mod test {
         );
 
         // linestrings with nans/infs
-        let linestring: LineString<f64> = vec![[-1.0, 0.0], [0.0, Float::nan()], [0.0, 1.0]].into();
+        let linestring: LineString = vec![[-1.0, 0.0], [0.0, Float::nan()], [0.0, 1.0]].into();
         assert_eq!(linestring.line_interpolate_point(0.5), None);
         assert_eq!(linestring.line_interpolate_point(1.5), None);
         assert_eq!(linestring.line_interpolate_point(-1.0), None);
 
-        let linestring: LineString<f64> =
-            vec![[-1.0, 0.0], [0.0, Float::infinity()], [0.0, 1.0]].into();
+        let linestring: LineString = vec![[-1.0, 0.0], [0.0, Float::infinity()], [0.0, 1.0]].into();
         assert_eq!(linestring.line_interpolate_point(0.5), None);
         assert_eq!(linestring.line_interpolate_point(1.5), None);
         assert_eq!(linestring.line_interpolate_point(-1.0), None);
 
-        let linestring: LineString<f64> =
+        let linestring: LineString =
             vec![[-1.0, 0.0], [0.0, Float::neg_infinity()], [0.0, 1.0]].into();
         assert_eq!(linestring.line_interpolate_point(0.5), None);
         assert_eq!(linestring.line_interpolate_point(1.5), None);
         assert_eq!(linestring.line_interpolate_point(-1.0), None);
 
         // Empty line
-        let coords: Vec<Point<f64>> = Vec::new();
-        let linestring: LineString<f64> = coords.into();
+        let coords: Vec<Point> = Vec::new();
+        let linestring: LineString = coords.into();
         assert_eq!(linestring.line_interpolate_point(0.5), None);
     }
 
@@ -281,7 +280,7 @@ mod test {
     fn test_matches_closest_point() {
         // line_locate_point should return the fraction to the closest point,
         // so interpolating the line with that fraction should yield the closest point
-        let linestring: LineString<f64> = vec![[-1.0, 0.0], [0.5, 1.0], [1.0, 2.0]].into();
+        let linestring: LineString = vec![[-1.0, 0.0], [0.5, 1.0], [1.0, 2.0]].into();
         let pt = point!(x: 0.7, y: 0.7);
         let frac = linestring
             .line_locate_point(&pt)

--- a/geo/src/algorithm/line_intersection.rs
+++ b/geo/src/algorithm/line_intersection.rs
@@ -400,8 +400,8 @@ mod test {
     /// > Succeeds using DD and Shewchuk orientation
     #[test]
     fn test_tomas_fa_1() {
-        let line_1 = Line::<f64>::new(coord! { x: -42.0, y: 163.2 }, coord! { x: 21.2, y: 265.2 });
-        let line_2 = Line::<f64>::new(coord! { x: -26.2, y: 188.7 }, coord! { x: 37.0, y: 290.7 });
+        let line_1 = Line::new(coord! { x: -42.0, y: 163.2 }, coord! { x: 21.2, y: 265.2 });
+        let line_2 = Line::new(coord! { x: -26.2, y: 188.7 }, coord! { x: 37.0, y: 290.7 });
         let actual = line_intersection(line_1, line_2);
         let expected = None;
         assert_eq!(actual, expected);
@@ -414,8 +414,8 @@ mod test {
     /// > Fails using original JTS DeVillers determine orientation test.
     #[test]
     fn test_tomas_fa_2() {
-        let line_1 = Line::<f64>::new(coord! { x: -5.9, y: 163.1 }, coord! { x: 76.1, y: 250.7 });
-        let line_2 = Line::<f64>::new(coord! { x: 14.6, y: 185.0 }, coord! { x: 96.6, y: 272.6 });
+        let line_1 = Line::new(coord! { x: -5.9, y: 163.1 }, coord! { x: 76.1, y: 250.7 });
+        let line_2 = Line::new(coord! { x: 14.6, y: 185.0 }, coord! { x: 96.6, y: 272.6 });
         let actual = line_intersection(line_1, line_2);
         let expected = None;
         assert_eq!(actual, expected);

--- a/geo/src/algorithm/line_locate_point.rs
+++ b/geo/src/algorithm/line_locate_point.rs
@@ -19,7 +19,7 @@ use std::ops::AddAssign;
 /// use geo::{LineString, point};
 /// use geo::LineLocatePoint;
 ///
-/// let linestring: LineString<f64> = vec![
+/// let linestring: LineString = vec![
 ///     [-1.0, 0.0],
 ///     [0.0, 0.0],
 ///     [0.0, 1.0]
@@ -174,12 +174,12 @@ mod test {
         assert_eq!(line.line_locate_point(&point), None);
 
         // zero length line
-        let line: Line<f64> = Line::new(coord! { x: 1.0, y: 1.0 }, coord! { x: 1.0, y: 1.0 });
+        let line: Line = Line::new(coord! { x: 1.0, y: 1.0 }, coord! { x: 1.0, y: 1.0 });
         let pt = point!(x: 2.0, y: 2.0);
         assert_eq!(line.line_locate_point(&pt), Some(0.0));
 
         // another concrete example
-        let line: Line<f64> = Line::new(coord! { x: 0.0, y: 0.0 }, coord! { x: 10.0, y: 0.0 });
+        let line: Line = Line::new(coord! { x: 0.0, y: 0.0 }, coord! { x: 10.0, y: 0.0 });
         let pt = Point::new(555.0, 555.0);
         assert_eq!(line.line_locate_point(&pt), Some(1.0));
         let pt = Point::new(10.0000001, 0.0);
@@ -191,7 +191,7 @@ mod test {
     #[test]
     fn test_line_locate_point_linestring() {
         // finite example using the ring
-        let ring: LineString<f64> = geo_test_fixtures::ring::<f64>();
+        let ring: LineString = geo_test_fixtures::ring::<f64>();
         let pt = point!(x: 10.0, y: 1.0);
         assert_eq!(ring.line_locate_point(&pt), Some(0.0));
 
@@ -212,7 +212,7 @@ mod test {
         assert_eq!(ring.line_locate_point(&pt), None);
 
         // point is equidistant to two line segments - return the fraction from the first closest
-        let line: LineString<f64> = LineString::new(vec![
+        let line: LineString = LineString::new(vec![
             (0.0, 0.0).into(),
             (1.0, 0.0).into(),
             (1.0, 1.0).into(),
@@ -221,7 +221,7 @@ mod test {
         let pt = point!(x: 0.0, y: 0.5);
         assert_eq!(line.line_locate_point(&pt), Some(0.0));
 
-        let line: LineString<f64> = LineString::new(vec![
+        let line: LineString = LineString::new(vec![
             (1.0, 1.0).into(),
             (1.0, 1.0).into(),
             (1.0, 1.0).into(),
@@ -230,7 +230,7 @@ mod test {
         assert_eq!(line.line_locate_point(&pt), Some(0.0));
 
         // line contains inf or nan
-        let line: LineString<f64> = LineString::new(vec![
+        let line: LineString = LineString::new(vec![
             coord! { x: 1.0, y: 1.0 },
             coord! {
                 x: Float::nan(),
@@ -241,7 +241,7 @@ mod test {
         let pt = point!(x: 2.0, y: 2.0);
         assert_eq!(line.line_locate_point(&pt), None);
 
-        let line: LineString<f64> = LineString::new(vec![
+        let line: LineString = LineString::new(vec![
             coord! { x: 1.0, y: 1.0 },
             coord! {
                 x: Float::infinity(),
@@ -251,7 +251,7 @@ mod test {
         ]);
         let pt = point!(x: 2.0, y: 2.0);
         assert_eq!(line.line_locate_point(&pt), None);
-        let line: LineString<f64> = LineString::new(vec![
+        let line: LineString = LineString::new(vec![
             coord! { x: 1.0, y: 1.0 },
             coord! {
                 x: Float::neg_infinity(),

--- a/geo/src/algorithm/lines_iter.rs
+++ b/geo/src/algorithm/lines_iter.rs
@@ -178,8 +178,8 @@ mod test {
 
     #[test]
     fn test_empty_line_string() {
-        let ls: LineString<f64> = line_string![];
-        assert_eq!(Vec::<Line<f64>>::new(), ls.lines_iter().collect::<Vec<_>>());
+        let ls: LineString = line_string![];
+        assert_eq!(Vec::<Line>::new(), ls.lines_iter().collect::<Vec<_>>());
     }
 
     #[test]

--- a/geo/src/algorithm/map_coords.rs
+++ b/geo/src/algorithm/map_coords.rs
@@ -62,9 +62,6 @@ mod modern {
         /// # use approx::assert_relative_eq;
         ///
         /// let SCALE_FACTOR: f64 = 1000000.0;
-        /// let p1: Point<f32> = Point::new(10.0f32, 20.0f32);
-        /// let p2: Point<f64> = p1.map_coords(|Coordinate { x, y }| (x as f64, y as f64).into());
-        ///
         /// let floating_point_geom: Point<f64> = Point::new(10.15f64, 20.05f64);
         /// let fixed_point_geom: Point<i32> = floating_point_geom.map_coords(|Coordinate { x, y }| {
         ///     Coordinate { x: (x * SCALE_FACTOR) as i32, y: (y * SCALE_FACTOR) as i32 }

--- a/geo/src/algorithm/map_coords.rs
+++ b/geo/src/algorithm/map_coords.rs
@@ -62,6 +62,8 @@ mod modern {
         /// # use approx::assert_relative_eq;
         ///
         /// let SCALE_FACTOR: f64 = 1000000.0;
+        /// let p1: Point<f32> = Point::new(10.0f32, 20.0f32);
+        /// let p2: Point<f64> = p1.map_coords(|Coordinate { x, y }| (x as f64, y as f64).into());
         ///
         /// let floating_point_geom: Point<f64> = Point::new(10.15f64, 20.05f64);
         /// let fixed_point_geom: Point<i32> = floating_point_geom.map_coords(|Coordinate { x, y }| {

--- a/geo/src/algorithm/relate/geomgraph/intersection_matrix.rs
+++ b/geo/src/algorithm/relate/geomgraph/intersection_matrix.rs
@@ -226,7 +226,7 @@ impl IntersectionMatrix {
     /// use geo_types::{LineString, Rect, line_string};
     /// use geo::{coordinate_position::CoordPos, dimensions::Dimensions, relate::Relate};
     ///
-    /// let line_string: LineString<f64> = line_string![(x: 0.0, y: 0.0), (x: 10.0, y: 0.0), (x: 5.0, y: 5.0)];
+    /// let line_string: LineString = line_string![(x: 0.0, y: 0.0), (x: 10.0, y: 0.0), (x: 5.0, y: 5.0)];
     /// let rect = Rect::new((0.0, 0.0), (5.0, 5.0));
     ///
     /// let intersection = line_string.relate(&rect);

--- a/geo/src/algorithm/relate/relate_operation.rs
+++ b/geo/src/algorithm/relate/relate_operation.rs
@@ -437,7 +437,7 @@ mod test {
 
     #[test]
     fn test_disjoint() {
-        let square_a: Geometry<f64> = polygon![
+        let square_a: Geometry = polygon![
             (x: 0., y: 0.),
             (x: 0., y: 20.),
             (x: 20., y: 20.),
@@ -446,7 +446,7 @@ mod test {
         ]
         .into();
 
-        let square_b: Geometry<f64> = polygon![
+        let square_b: Geometry = polygon![
             (x: 55., y: 55.),
             (x: 50., y: 60.),
             (x: 60., y: 60.),
@@ -467,7 +467,7 @@ mod test {
 
     #[test]
     fn test_a_contains_b() {
-        let square_a: Geometry<f64> = polygon![
+        let square_a: Geometry = polygon![
             (x: 0., y: 0.),
             (x: 0., y: 20.),
             (x: 20., y: 20.),
@@ -476,7 +476,7 @@ mod test {
         ]
         .into();
 
-        let square_b: Geometry<f64> = polygon![
+        let square_b: Geometry = polygon![
             (x: 5., y: 5.),
             (x: 5., y: 10.),
             (x: 10., y: 10.),
@@ -497,7 +497,7 @@ mod test {
 
     #[test]
     fn test_a_overlaps_b() {
-        let square_a: Geometry<f64> = polygon![
+        let square_a: Geometry = polygon![
             (x: 0., y: 0.),
             (x: 0., y: 20.),
             (x: 20., y: 20.),
@@ -506,7 +506,7 @@ mod test {
         ]
         .into();
 
-        let square_b: Geometry<f64> = polygon![
+        let square_b: Geometry = polygon![
             (x: 5., y: 5.),
             (x: 5., y: 30.),
             (x: 30., y: 30.),

--- a/geo/src/algorithm/rotate.rs
+++ b/geo/src/algorithm/rotate.rs
@@ -584,7 +584,7 @@ mod test {
             (x: 20., y: 20.),
             (x: 40., y: 20.)
         ];
-        let multi_line_string: MultiLineString<f64> = MultiLineString::new(vec![ls1, ls2]);
+        let multi_line_string: MultiLineString = MultiLineString::new(vec![ls1, ls2]);
 
         // Results match with Shapely for `centroid`
         let expected_around_centroid = MultiLineString::new(vec![
@@ -606,7 +606,7 @@ mod test {
         );
 
         // Results match with Shapely for `center`
-        let expected_around_center: MultiLineString<f64> = MultiLineString::new(vec![
+        let expected_around_center: MultiLineString = MultiLineString::new(vec![
             line_string![
                 (x: -1.213203435596426, y: 17.07106781186548),
                 (x: 0.2010101267766693, y: 17.07106781186548),
@@ -635,7 +635,7 @@ mod test {
 
     #[test]
     fn test_rotate_multipolygon_around_centroid() {
-        let multipolygon: MultiPolygon<f64> = vec![
+        let multipolygon: MultiPolygon = vec![
             polygon![
                 (x: 0., y: 0.),
                 (x: 10., y: 0.),
@@ -653,7 +653,7 @@ mod test {
         ]
         .into();
 
-        let expected_centroid: MultiPolygon<f64> = vec![
+        let expected_centroid: MultiPolygon = vec![
             polygon![
                 (x: 0., y: 0.),
                 (x: 7.0710678118654755, y: 7.071067811865475),
@@ -682,7 +682,7 @@ mod test {
 
     #[test]
     fn test_rotate_multipolygons() {
-        let multipolygon: MultiPolygon<f64> = vec![
+        let multipolygon: MultiPolygon = vec![
             polygon![
                (x: 1., y: 1. ),
                (x: 2., y: 1. ),
@@ -700,7 +700,7 @@ mod test {
         ]
         .into();
 
-        let expected_center: MultiPolygon<f64> = vec![
+        let expected_center: MultiPolygon = vec![
             polygon![
                 (x: -0.2360967926537398, y: 2.610912703473988),
                 (x: 0.7298290336353284, y: 2.352093658371467),
@@ -718,7 +718,7 @@ mod test {
         ]
         .into();
 
-        let expected_centroid: MultiPolygon<f64> = vec![
+        let expected_centroid: MultiPolygon = vec![
             polygon![
                 (x: -0.1016007672888048, y: 3.05186627999456),
                 (x: 0.8643250590002634, y: 2.793047234892039),
@@ -752,12 +752,12 @@ mod test {
     #[test]
     fn test_rotate_empty_geometries_error_gracefully() {
         // line string
-        let empty_linestring: LineString<f64> = line_string![];
+        let empty_linestring: LineString = line_string![];
         let rotated_empty_linestring = empty_linestring.rotate_around_centroid(90.);
         assert_eq!(empty_linestring, rotated_empty_linestring);
 
         // multi line string
-        let empty_multilinestring: MultiLineString<f64> = MultiLineString::<f64>::new(vec![]);
+        let empty_multilinestring: MultiLineString = MultiLineString::new(vec![]);
         let rotated_empty_multilinestring = empty_multilinestring.rotate_around_centroid(90.);
         assert_eq!(empty_multilinestring, rotated_empty_multilinestring);
 
@@ -767,7 +767,7 @@ mod test {
         assert_eq!(empty_polygon, rotated_empty_polygon);
 
         // multi polygon
-        let empty_multipolygon: MultiPolygon<f64> = Vec::<Polygon<f64>>::new().into();
+        let empty_multipolygon: MultiPolygon = Vec::<Polygon<f64>>::new().into();
         let rotated_empty_multipolygon = empty_multipolygon.rotate_around_centroid(90.);
         assert_eq!(empty_multipolygon, rotated_empty_multipolygon);
     }

--- a/geo/src/algorithm/vincenty_distance.rs
+++ b/geo/src/algorithm/vincenty_distance.rs
@@ -183,8 +183,8 @@ mod test {
 
     #[test]
     fn test_vincenty_distance_1() {
-        let a = Point::<f64>::new(17.072561, 48.154563);
-        let b = Point::<f64>::new(17.072562, 48.154564);
+        let a = Point::new(17.072561, 48.154563);
+        let b = Point::new(17.072562, 48.154564);
         assert_relative_eq!(
             a.vincenty_distance(&b).unwrap(),
             0.13378944117648012,
@@ -194,8 +194,8 @@ mod test {
 
     #[test]
     fn test_vincenty_distance_2() {
-        let a = Point::<f64>::new(17.072561, 48.154563);
-        let b = Point::<f64>::new(17.064064, 48.158800);
+        let a = Point::new(17.072561, 48.154563);
+        let b = Point::new(17.064064, 48.158800);
         assert_relative_eq!(
             a.vincenty_distance(&b).unwrap(),
             788.4148295236967,
@@ -205,8 +205,8 @@ mod test {
 
     #[test]
     fn test_vincenty_distance_3() {
-        let a = Point::<f64>::new(17.107558, 48.148636);
-        let b = Point::<f64>::new(16.372477, 48.208810);
+        let a = Point::new(17.107558, 48.148636);
+        let b = Point::new(16.372477, 48.208810);
         assert_relative_eq!(
             a.vincenty_distance(&b).unwrap(),
             55073.68246366003,
@@ -216,8 +216,8 @@ mod test {
 
     #[test]
     fn test_vincenty_distance_equatorial() {
-        let a = Point::<f64>::new(0.0, 0.0);
-        let b = Point::<f64>::new(100.0, 0.0);
+        let a = Point::new(0.0, 0.0);
+        let b = Point::new(100.0, 0.0);
         assert_relative_eq!(
             a.vincenty_distance(&b).unwrap(),
             11131949.079,
@@ -227,15 +227,15 @@ mod test {
 
     #[test]
     fn test_vincenty_distance_coincident() {
-        let a = Point::<f64>::new(12.3, 4.56);
-        let b = Point::<f64>::new(12.3, 4.56);
+        let a = Point::new(12.3, 4.56);
+        let b = Point::new(12.3, 4.56);
         assert_relative_eq!(a.vincenty_distance(&b).unwrap(), 0.0, epsilon = 1.0e-3);
     }
 
     #[test]
     fn test_vincenty_distance_antipodal() {
-        let a = Point::<f64>::new(2.0, 4.0);
-        let b = Point::<f64>::new(-178.0, -4.0);
+        let a = Point::new(2.0, 4.0);
+        let b = Point::new(-178.0, -4.0);
         assert_eq!(a.vincenty_distance(&b), Err(FailedToConvergeError))
     }
 }

--- a/jts-test-runner/Cargo.toml
+++ b/jts-test-runner/Cargo.toml
@@ -10,7 +10,7 @@ include_dir = { version = "0.6.0", features = ["glob"] }
 log = "0.4.14"
 serde =  { version = "1.0.105", features = ["derive"] }
 serde-xml-rs = "0.5.0"
-wkt = { version = "0.10.0", features = ["geo-types", "serde"] }
+wkt = { version = "0.10.3", features = ["geo-types", "serde"] }
 
 [dev-dependencies]
 pretty_env_logger = "0.4.0"

--- a/jts-test-runner/src/input.rs
+++ b/jts-test-runner/src/input.rs
@@ -38,7 +38,7 @@ pub(crate) struct Case {
     #[serde(default)]
     pub(crate) desc: String,
 
-    #[serde(deserialize_with = "wkt::deserialize_geometry")]
+    #[serde(deserialize_with = "wkt::deserialize_wkt")]
     pub(crate) a: Geometry<f64>,
 
     #[serde(deserialize_with = "deserialize_opt_geometry", default)]
@@ -66,7 +66,7 @@ pub struct CentroidInput {
 pub struct ConvexHullInput {
     pub(crate) arg1: String,
 
-    #[serde(rename = "$value", deserialize_with = "wkt::deserialize_geometry")]
+    #[serde(rename = "$value", deserialize_with = "wkt::deserialize_wkt")]
     pub(crate) expected: geo::Geometry<f64>,
 }
 
@@ -215,7 +215,7 @@ where
     D: Deserializer<'de>,
 {
     #[derive(Debug, Deserialize)]
-    struct Wrapper(#[serde(deserialize_with = "wkt::deserialize_geometry")] Geometry<f64>);
+    struct Wrapper(#[serde(deserialize_with = "wkt::deserialize_wkt")] Geometry<f64>);
 
     Option::<Wrapper>::deserialize(deserializer).map(|opt_wrapped| opt_wrapped.map(|w| w.0))
 }

--- a/jts-test-runner/src/input.rs
+++ b/jts-test-runner/src/input.rs
@@ -39,10 +39,10 @@ pub(crate) struct Case {
     pub(crate) desc: String,
 
     #[serde(deserialize_with = "wkt::deserialize_wkt")]
-    pub(crate) a: Geometry<f64>,
+    pub(crate) a: Geometry,
 
     #[serde(deserialize_with = "deserialize_opt_geometry", default)]
-    pub(crate) b: Option<Geometry<f64>>,
+    pub(crate) b: Option<Geometry>,
 
     #[serde(rename = "test", default)]
     pub(crate) tests: Vec<Test>,
@@ -59,7 +59,7 @@ pub struct CentroidInput {
     pub(crate) arg1: String,
 
     #[serde(rename = "$value", deserialize_with = "wkt::deserialize_point")]
-    pub(crate) expected: Option<geo::Point<f64>>,
+    pub(crate) expected: Option<geo::Point>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -67,7 +67,7 @@ pub struct ConvexHullInput {
     pub(crate) arg1: String,
 
     #[serde(rename = "$value", deserialize_with = "wkt::deserialize_wkt")]
-    pub(crate) expected: geo::Geometry<f64>,
+    pub(crate) expected: geo::Geometry,
 }
 
 #[derive(Debug, Deserialize)]
@@ -122,26 +122,26 @@ pub(crate) enum OperationInput {
 #[derive(Debug, Clone)]
 pub(crate) enum Operation {
     Centroid {
-        subject: Geometry<f64>,
-        expected: Option<Point<f64>>,
+        subject: Geometry,
+        expected: Option<Point>,
     },
     Contains {
-        subject: Geometry<f64>,
-        target: Geometry<f64>,
+        subject: Geometry,
+        target: Geometry,
         expected: bool,
     },
     ConvexHull {
-        subject: Geometry<f64>,
-        expected: Geometry<f64>,
+        subject: Geometry,
+        expected: Geometry,
     },
     Intersects {
-        subject: Geometry<f64>,
-        clip: Geometry<f64>,
+        subject: Geometry,
+        clip: Geometry,
         expected: bool,
     },
     Relate {
-        a: Geometry<f64>,
-        b: Geometry<f64>,
+        a: Geometry,
+        b: Geometry,
         expected: IntersectionMatrix,
     },
 }
@@ -210,12 +210,12 @@ impl OperationInput {
 
 pub fn deserialize_opt_geometry<'de, D>(
     deserializer: D,
-) -> std::result::Result<Option<Geometry<f64>>, D::Error>
+) -> std::result::Result<Option<Geometry>, D::Error>
 where
     D: Deserializer<'de>,
 {
     #[derive(Debug, Deserialize)]
-    struct Wrapper(#[serde(deserialize_with = "wkt::deserialize_wkt")] Geometry<f64>);
+    struct Wrapper(#[serde(deserialize_with = "wkt::deserialize_wkt")] Geometry);
 
     Option::<Wrapper>::deserialize(deserializer).map(|opt_wrapped| opt_wrapped.map(|w| w.0))
 }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Ok firstly, this might be controversial. I spent very little time on it, so I'm happy to let it sit for a while, or just walk away from it.

99% of the time when I'm using geo/geo-types I want an f64. I suspect most downstream users are also generally using f64. It finally occurred to me that we could just make that the default and save some typing. People that want other geometry types can continue to specify `<f32>/<i32>/<usize>` whatever.

The major downside I see is that if people are implementing traits for geo-types, they might inadvertently constrain their impls to f64 when they might actually prefer to make them generic. Personally, that doesn't strike me as a huge concern, but maybe others feel differently.