### PR TITLE
Fix fast path

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -3,6 +3,8 @@
 ## Unreleased
 * Add densification algorithm for linear geometry components
   * <https://github.com/georust/geo/pull/847>
+* Fix fast path euclidean distance
+  * <https://github.com/georust/pull/848>
 
 ## 0.21.0
 

--- a/geo/src/algorithm/euclidean_distance.rs
+++ b/geo/src/algorithm/euclidean_distance.rs
@@ -1165,4 +1165,35 @@ mod test {
         let point = Point::new(1.0, 0.5);
         assert_relative_eq!(triangle.euclidean_distance(&point), 0.0);
     }
+
+    #[test]
+    fn convex_and_nearest_neighbour_comparison() {
+        let ls1: LineString<f64> = vec![
+            Coordinate::from((57.39453770777941, 307.60533608924663)),
+            Coordinate::from((67.1800355576469, 309.6654408997451)),
+            Coordinate::from((84.89693692793338, 225.5101593908847)),
+            Coordinate::from((75.1114390780659, 223.45005458038628)),
+            Coordinate::from((57.39453770777941, 307.60533608924663)),
+        ]
+        .into();
+        let first_polygon: Polygon<f64> = Polygon::new(ls1, vec![]);
+        let ls2: LineString<f64> = vec![
+            Coordinate::from((138.11769866645008, -45.75134112915392)),
+            Coordinate::from((130.50230476949187, -39.270154833870336)),
+            Coordinate::from((184.94426964987397, 24.699153900578573)),
+            Coordinate::from((192.55966354683218, 18.217967605294987)),
+            Coordinate::from((138.11769866645008, -45.75134112915392)),
+        ]
+        .into();
+        let second_polygon = Polygon::new(ls2, vec![]);
+
+        assert_relative_eq!(
+            first_polygon.euclidean_distance(&second_polygon),
+            224.35357967013238
+        );
+        assert_eq!(
+            min_convex_poly_dist(&first_polygon, &second_polygon),
+            nearest_neighbour_distance(&first_polygon.exterior(), second_polygon.exterior())
+        );
+    }
 }

--- a/geo/src/algorithm/euclidean_distance.rs
+++ b/geo/src/algorithm/euclidean_distance.rs
@@ -1193,7 +1193,7 @@ mod test {
         );
         assert_eq!(
             min_convex_poly_dist(&first_polygon, &second_polygon),
-            nearest_neighbour_distance(&first_polygon.exterior(), second_polygon.exterior())
+            nearest_neighbour_distance(first_polygon.exterior(), second_polygon.exterior())
         );
     }
 }

--- a/geo/src/algorithm/polygon_distance_fast_path.rs
+++ b/geo/src/algorithm/polygon_distance_fast_path.rs
@@ -46,12 +46,13 @@ where
         // we need to spin the calipers equal to the total number of vertices in both polygons
         // alternatively, we can accumulate the total rotation angle and stop when it = 2pi radians
         angle: T::zero(),
+        max_iterations: poly1.exterior().0.len() + poly2.exterior().0.len(),
     };
-    // recall that 360 degrees == 2pi radians
-    let max_angle = T::from(360.0f64.to_radians()).unwrap();
-    while state.angle < max_angle {
+    let mut iterations = 0usize;
+    while iterations <= state.max_iterations {
         nextpoints(&mut state);
         computemin(&mut state);
+        iterations += 1;
     }
     state.dist
 }
@@ -113,6 +114,7 @@ where
     slope: T,
     vertical: bool,
     angle: T,
+    max_iterations: usize,
 }
 
 // much of the following code is ported from Java, copyright 1999 Hormoz Pirzadeh, available at:


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Tracking the angle doesn't always work, but spinning the calipers by the total number of external vertices (previous fix) does. Adds test from https://github.com/georust/geo/pull/731#issuecomment-1159017444
