### PR TITLE
#849 Bump the minor version of approx.

### DIFF
--- a/geo-bool-ops-benches/Cargo.toml
+++ b/geo-bool-ops-benches/Cargo.toml
@@ -11,7 +11,7 @@ geo-types = { path = "../geo-types" }
 log = "0.4.11"
 
 [dev-dependencies]
-approx = "0.5.1"
+approx = ">= 0.4.0, < 0.6.0"
 criterion = { version = "0.3", features = ["html_reports"] }
 geo-test-fixtures = { path = "../geo-test-fixtures" }
 jts-test-runner = { path = "../jts-test-runner" }

--- a/geo-bool-ops-benches/Cargo.toml
+++ b/geo-bool-ops-benches/Cargo.toml
@@ -11,7 +11,7 @@ geo-types = { path = "../geo-types" }
 log = "0.4.11"
 
 [dev-dependencies]
-approx = "0.4.0"
+approx = "0.5.1"
 criterion = { version = "0.3", features = ["html_reports"] }
 geo-test-fixtures = { path = "../geo-test-fixtures" }
 jts-test-runner = { path = "../jts-test-runner" }

--- a/geo-types/Cargo.toml
+++ b/geo-types/Cargo.toml
@@ -19,7 +19,7 @@ use-rstar_0_8 = ["rstar_0_8", "approx"]
 use-rstar_0_9 = ["rstar_0_9", "approx"]
 
 [dependencies]
-approx = { version = "0.5.1", optional = true }
+approx = { version = ">= 0.4.0, < 0.6.0", optional = true }
 arbitrary = { version = "1", optional = true }
 num-traits = "0.2"
 rstar_0_8 = { package = "rstar", version = "0.8", optional = true }
@@ -27,4 +27,4 @@ rstar_0_9 = { package = "rstar", version = "0.9", optional = true }
 serde = { version = "1", optional = true, features = ["derive"] }
 
 [dev-dependencies]
-approx = "0.5.1"
+approx = ">= 0.4.0, < 0.6.0"

--- a/geo-types/Cargo.toml
+++ b/geo-types/Cargo.toml
@@ -19,7 +19,7 @@ use-rstar_0_8 = ["rstar_0_8", "approx"]
 use-rstar_0_9 = ["rstar_0_9", "approx"]
 
 [dependencies]
-approx = { version = "0.4.0", optional = true }
+approx = { version = "0.5.1", optional = true }
 arbitrary = { version = "1", optional = true }
 num-traits = "0.2"
 rstar_0_8 = { package = "rstar", version = "0.8", optional = true }
@@ -27,4 +27,4 @@ rstar_0_9 = { package = "rstar", version = "0.9", optional = true }
 serde = { version = "1", optional = true, features = ["derive"] }
 
 [dev-dependencies]
-approx = "0.4.0"
+approx = "0.5.1"

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -27,7 +27,7 @@ rstar = "0.9.3"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [dev-dependencies]
-approx = "0.4.0"
+approx = "0.5.1"
 criterion = { version = "0.3", features = ["html_reports"] }
 geo-test-fixtures = { path = "../geo-test-fixtures" }
 jts-test-runner = { path = "../jts-test-runner" }

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -27,7 +27,7 @@ rstar = "0.9.3"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [dev-dependencies]
-approx = "0.5.1"
+approx = ">= 0.4.0, < 0.6.0"
 criterion = { version = "0.3", features = ["html_reports"] }
 geo-test-fixtures = { path = "../geo-test-fixtures" }
 jts-test-runner = { path = "../jts-test-runner" }

--- a/jts-test-runner/Cargo.toml
+++ b/jts-test-runner/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-approx = "0.5.1"
+approx = ">= 0.4.0, < 0.6.0"
 geo = { path = "../geo" }
 include_dir = { version = "0.6.0", features = ["glob"] }
 log = "0.4.14"

--- a/jts-test-runner/Cargo.toml
+++ b/jts-test-runner/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-approx = "0.4.0"
+approx = "0.5.1"
 geo = { path = "../geo" }
 include_dir = { version = "0.6.0", features = ["glob"] }
 log = "0.4.14"


### PR DESCRIPTION
- [x ] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
---

Consitently and in many Cargo.toml files  - bump the minor version of approx.


-approx = "0.4.0"
+approx = "0.5.1"