### PR TITLE
avoid deprecated methods in latest wkt

### DIFF
--- a/jts-test-runner/Cargo.toml
+++ b/jts-test-runner/Cargo.toml
@@ -10,7 +10,7 @@ include_dir = { version = "0.6.0", features = ["glob"] }
 log = "0.4.14"
 serde =  { version = "1.0.105", features = ["derive"] }
 serde-xml-rs = "0.5.0"
-wkt = { version = "0.10.0", features = ["geo-types", "serde"] }
+wkt = { version = "0.10.3", features = ["geo-types", "serde"] }
 
 [dev-dependencies]
 pretty_env_logger = "0.4.0"

--- a/jts-test-runner/src/input.rs
+++ b/jts-test-runner/src/input.rs
@@ -38,7 +38,7 @@ pub(crate) struct Case {
     #[serde(default)]
     pub(crate) desc: String,
 
-    #[serde(deserialize_with = "wkt::deserialize_geometry")]
+    #[serde(deserialize_with = "wkt::deserialize_wkt")]
     pub(crate) a: Geometry<f64>,
 
     #[serde(deserialize_with = "deserialize_opt_geometry", default)]
@@ -66,7 +66,7 @@ pub struct CentroidInput {
 pub struct ConvexHullInput {
     pub(crate) arg1: String,
 
-    #[serde(rename = "$value", deserialize_with = "wkt::deserialize_geometry")]
+    #[serde(rename = "$value", deserialize_with = "wkt::deserialize_wkt")]
     pub(crate) expected: geo::Geometry<f64>,
 }
 
@@ -215,7 +215,7 @@ where
     D: Deserializer<'de>,
 {
     #[derive(Debug, Deserialize)]
-    struct Wrapper(#[serde(deserialize_with = "wkt::deserialize_geometry")] Geometry<f64>);
+    struct Wrapper(#[serde(deserialize_with = "wkt::deserialize_wkt")] Geometry<f64>);
 
     Option::<Wrapper>::deserialize(deserializer).map(|opt_wrapped| opt_wrapped.map(|w| w.0))
 }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [-] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Adapt to the WKT release that went out earlier today.