### PR TITLE
update CHANGES.md for the default f64 CoordNum

### DIFF
--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -1,5 +1,14 @@
 # Changes
 
+## Unreleased
+
+* You may now specify `Geometry` rather than `Geometry<f64>` since we've added
+  a default trait implementation. You may still explicitly declare the numeric
+  type as f64, or any other implementation of `CoordNum`, but this should save
+  you some typing if you're using f64. The same change applies to `Coordinates`
+  and all the geometry variants, like `Point`, `LineString`, etc.
+  * <https://github.com/georust/geo/pull/832>
+
 ## 0.7.5
 
 * Add `split_x` and `split_y` methods on `Rect`

--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -7,6 +7,12 @@
   * <https://github.com/georust/pull/848>
 * Use robust predicates everywhere in geo
   * <https://github.com/georust/geo/pull/852>
+* You may now specify `Geometry` rather than `Geometry<f64>` since we've added
+  a default trait implementation. You may still explicitly declare the numeric
+  type as f64, or any other implementation of `CoordNum`, but this should save
+  you some typing if you're using f64. The same change applies to `Coordinates`
+  and all the geometry variants, like `Point`, `LineString`, etc.
+  * <https://github.com/georust/geo/pull/832>
 
 ## 0.21.0
 


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [🔥] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

I forgot to include release notes in #832.

I'm ashamed to admit that I must have checked the box instinctively: 
<img width="243" alt="Screen Shot 2022-06-23 at 12 58 56 PM" src="https://user-images.githubusercontent.com/217057/175386750-dd243603-477a-4300-bd6e-2176ed72755e.png">
