### PR TITLE
bump include_dir to 0.7.2 and fix breaking change.

### DIFF
--- a/jts-test-runner/Cargo.toml
+++ b/jts-test-runner/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 approx = "0.4.0"
 geo = { path = "../geo" }
-include_dir = { version = "0.6.0", features = ["glob"] }
+include_dir = { version = "0.7.2", features = ["glob"] }
 log = "0.4.14"
 serde =  { version = "1.0.105", features = ["derive"] }
 serde-xml-rs = "0.5.0"

--- a/jts-test-runner/src/runner.rs
+++ b/jts-test-runner/src/runner.rs
@@ -7,7 +7,7 @@ use log::{debug, info};
 use super::{input, Operation, Result};
 use geo::{intersects::Intersects, prelude::Contains, Coordinate, Geometry, LineString, Polygon};
 
-const GENERAL_TEST_XML: Dir = include_dir!("resources/testxml/general");
+const GENERAL_TEST_XML: Dir = include_dir!("$CARGO_MANIFEST_DIR/resources/testxml/general");
 
 #[derive(Debug, Default, Clone)]
 pub struct TestRunner {


### PR DESCRIPTION
The change that include_dir has forced on us is that we must convert a relative path into a absolute path

Here is what the include_dir documentation has to say about it. :-

> When invoking the [include_dir!()](https://docs.rs/include_dir/latest/include_dir/macro.include_dir.html) macro you should try to avoid using relative paths because rustc makes no guarantees about the current directory when it is running a procedural macro