### PR TITLE
Add AffineOps trait to transform an entire geometry (plus some tweaks)

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -6,6 +6,7 @@
 * Add `AffineOps` trait allowing the definition and composition of all 2D affine transforms
 * Implement existing affine transform traits using new `AffineOps` trait
   * <https://github.com/georust/geo/pull/866>
+  * <https://github.com/georust/geo/pull/871>
 
 ## 0.22.0
 

--- a/geo/src/algorithm/mod.rs
+++ b/geo/src/algorithm/mod.rs
@@ -165,7 +165,7 @@ pub use skew::Skew;
 
 /// Composable affine operations such as rotate, scale, skew, and translate
 pub mod affine_ops;
-pub use affine_ops::AffineTransform;
+pub use affine_ops::{AffineOps, AffineTransform};
 
 /// Simplify `Geometries` using the Ramer-Douglas-Peucker algorithm.
 pub mod simplify;

--- a/geo/src/algorithm/rotate.rs
+++ b/geo/src/algorithm/rotate.rs
@@ -32,6 +32,13 @@ pub trait Rotate<T> {
     ///
     /// - `angle`: degrees
     ///
+    /// ## Performance
+    ///
+    /// If you will be performing multiple transformations, like [`Scale`](crate::Scale),
+    /// [`Skew`](crate::Skew), [`Translate`](crate::Translate), or [`Rotate`](crate::Rotate), it is more
+    /// efficient to compose the transformations and apply them as a single operation using the
+    /// [`AffineOps`](crate::AffineOps) trait.
+    ///
     /// # Examples
     ///
     /// ```
@@ -64,6 +71,13 @@ pub trait Rotate<T> {
     ///
     /// Positive angles are counter-clockwise, and negative angles are clockwise rotations.
     ///
+    /// ## Performance
+    ///
+    /// If you will be performing multiple transformations, like [`Scale`](crate::Scale),
+    /// [`Skew`](crate::Skew), [`Translate`](crate::Translate), or [`Rotate`](crate::Rotate), it is more
+    /// efficient to compose the transformations and apply them as a single operation using the
+    /// [`AffineOps`](crate::AffineOps) trait.
+    ///
     /// # Units
     ///
     /// - `angle`: degrees
@@ -86,6 +100,13 @@ pub trait RotatePoint<T> {
     /// Rotate a Geometry around an arbitrary point by an angle, given in degrees
     ///
     /// Positive angles are counter-clockwise, and negative angles are clockwise rotations.
+    ///
+    /// ## Performance
+    ///
+    /// If you will be performing multiple transformations, like [`Scale`](crate::Scale),
+    /// [`Skew`](crate::Skew), [`Translate`](crate::Translate), or [`Rotate`](crate::Rotate), it is more
+    /// efficient to compose the transformations and apply them as a single operation using the
+    /// [`AffineOps`](crate::AffineOps) trait.
     ///
     /// # Units
     ///

--- a/geo/src/algorithm/scale.rs
+++ b/geo/src/algorithm/scale.rs
@@ -5,6 +5,13 @@ use crate::{AffineTransform, CoordNum, MapCoords, MapCoordsInPlace, Point};
 /// The point of origin is *usually* given as the 2D bounding box centre of the geometry, but
 /// any coordinate may be specified.
 ///
+/// ## Performance
+///
+/// If you will be performing multiple transformations, like [`Scale`](crate::Scale),
+/// [`Skew`](crate::Skew), [`Translate`](crate::Translate), or [`Rotate`](crate::Rotate), it is more
+/// efficient to compose the transformations and apply them as a single operation using the
+/// [`AffineOps`](crate::AffineOps) trait.
+///
 /// # Examples
 ///
 /// ```
@@ -23,6 +30,7 @@ use crate::{AffineTransform, CoordNum, MapCoords, MapCoordsInPlace, Point};
 ///     (x: 55.0f64, y: 55.0f64)
 /// ]);
 /// ```
+///
 pub trait Scale<T> {
     fn scale(&self, x: T, y: T, origin: Point<T>) -> Self
     where

--- a/geo/src/algorithm/skew.rs
+++ b/geo/src/algorithm/skew.rs
@@ -5,6 +5,13 @@ use crate::{AffineTransform, CoordFloat, CoordNum, MapCoords, MapCoordsInPlace, 
 /// The point of origin is *usually* given as the 2D bounding box centre of the geometry, but
 /// any coordinate may be specified. Angles are given in **degrees**.
 ///
+/// ## Performance
+///
+/// If you will be performing multiple transformations, like [`Scale`](crate::Scale),
+/// [`Skew`](crate::Skew), [`Translate`](crate::Translate), or [`Rotate`](crate::Rotate), it is more
+/// efficient to compose the transformations and apply them as a single operation using the
+/// [`AffineOps`](crate::AffineOps) trait.
+///
 /// # Examples
 ///
 /// ```

--- a/geo/src/algorithm/translate.rs
+++ b/geo/src/algorithm/translate.rs
@@ -4,6 +4,13 @@ use crate::{AffineTransform, CoordNum};
 pub trait Translate<T> {
     /// Translate a Geometry along its axes by the given offsets
     ///
+    /// ## Performance
+    ///
+    /// If you will be performing multiple transformations, like [`Scale`](crate::Scale),
+    /// [`Skew`](crate::Skew), [`Translate`](crate::Translate), or [`Rotate`](crate::Rotate), it is more
+    /// efficient to compose the transformations and apply them as a single operation using the
+    /// [`AffineOps`](crate::AffineOps) trait.
+    ///
     /// # Examples
     ///
     /// ```

--- a/geo/src/lib.rs
+++ b/geo/src/lib.rs
@@ -129,7 +129,7 @@
 //! - **[`Scale`](Scale)**: Scale a geometry up or down by a factor
 //! - **[`Skew`](Skew)**: Skew a geometry by shearing angles along the `x` and `y` dimension
 //! - **[`Translate`](Translate)**: Translate a geometry along its axis
-//! - **[`AffineTransform`](AffineTransform)**: generalised composable affine operations
+//! - **[`AffineOps`](AffineOps)**: generalised composable affine operations
 //!
 //! ## Conversion
 //!


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

As discussed [in this comment](), adds the ability to compose a transformation and apply the thing to an entire geometry (saving users the hassle of having to map_coords themselves:

```rust
let center = ls.bounding_rect().unwrap().center();
let mut transform = AffineTransform::skew(40.0, 40.0, center).rotated(45.0, center);
ls.affine_transform(&transform);
```

I also included some tweaks based on my experience using `AffineTransform` in another project.