### PR TITLE
empty `polygon![]` macro no longer requires including `line_string!` macro

### DIFF
--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## Unreleased
+
+* Fixed: using empty `polygon![]` macro no longer requires including `line_string!` macro
+
 ## 0.7.6
 
 * You may now specify `Geometry` rather than `Geometry<f64>` since we've added

--- a/geo-types/src/macros.rs
+++ b/geo-types/src/macros.rs
@@ -216,7 +216,7 @@ macro_rules! line_string {
 /// [`Polygon`]: ./struct.Polygon.html
 #[macro_export]
 macro_rules! polygon {
-    () => { $crate::Polygon::new(line_string![], vec![]) };
+    () => { $crate::Polygon::new($crate::line_string![], vec![]) };
     (
         exterior: [
             $(( $($exterior_tag:tt : $exterior_val:expr),* $(,)? )),*

--- a/geo/src/algorithm/area.rs
+++ b/geo/src/algorithm/area.rs
@@ -262,7 +262,7 @@ where
 #[cfg(test)]
 mod test {
     use crate::Area;
-    use crate::{coord, line_string, polygon, Line, MultiPolygon, Polygon, Rect, Triangle};
+    use crate::{coord, polygon, Line, MultiPolygon, Polygon, Rect, Triangle};
 
     // Area of the polygon
     #[test]


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
