### PR TITLE
release geo 0.22.1 (a minor bug fix release)

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 0.22.1
+
+* Fix some floating point issues with `BoolOps`
+  * <https://github.com/georust/geo/pull/869>
+
 ## 0.22.0
 
 * Add densification algorithm for linear geometry components

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "geo"
 description = "Geospatial primitives and algorithms"
-version = "0.22.0"
+version = "0.22.1"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/georust/geo"
 documentation = "https://docs.rs/geo/"


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

This only includes https://github.com/georust/geo/pull/869, which was already merged into main, but there are some other changes in main that would make this a major release (the third in a month!). 

I'd prefer to release this bug-fix release ASAP, and then feel better about letting the fresh changes in `main` settle for a little bit longer before another major breaking release.
