### PR TITLE
Set MSRV for geo to 1.58 in cargo.toml

### DIFF
--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -9,6 +9,7 @@ readme = "../README.md"
 keywords = ["gis", "geo", "geography", "geospatial"]
 autobenches = true
 edition = "2021"
+rust-version = "1.58"
 
 [features]
 use-proj = ["proj"]


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

`geo` crate fails to compile on Rust versions lower than `1.58`.