### PR TITLE
Handle NaN gracefully when closing LineString

### DIFF
--- a/geo-types/src/geometry/coordinate.rs
+++ b/geo-types/src/geometry/coordinate.rs
@@ -95,6 +95,41 @@ impl<T: CoordNum> Coordinate<T> {
     pub fn x_y(&self) -> (T, T) {
         (self.x, self.y)
     }
+
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use geo_types::coord;
+    ///
+    /// let c1 = coord! {
+    ///     x: 40.02f64,
+    ///     y: f64::NAN,
+    /// };
+    /// let c2 = coord! {
+    ///     x: 40.02f64,
+    ///     y: f64::NAN,
+    /// };
+    ///
+    /// assert!(c1 != c2);
+    /// assert!(c1.partial_eq_ignoring_nan(c2));
+    /// ```
+    pub(crate) fn partial_eq_ignoring_nan(&self, other: &Coordinate<T>) -> bool {
+        match (is_nan(self.x), is_nan(other.x)) {
+            (false, false) if self.x != other.x => return false,
+            (true, false) | (false, true) => return false,
+            _ => (),
+        }
+        match (is_nan(self.y), is_nan(other.y)) {
+            (false, false) if self.y != other.y => return false,
+            (true, false) | (false, true) => return false,
+            _ => (),
+        }
+        true
+    }
+}
+
+fn is_nan<T: CoordNum>(t: T) -> bool {
+    t + T::zero() != t
 }
 
 use std::ops::{Add, Div, Mul, Neg, Sub};

--- a/geo-types/src/geometry/line_string.rs
+++ b/geo-types/src/geometry/line_string.rs
@@ -331,7 +331,11 @@ impl<T: CoordNum> LineString<T> {
     /// seems to be no reason to maintain the separate behavior for [`LineString`]s used in
     /// non-`LinearRing` contexts.
     pub fn is_closed(&self) -> bool {
-        self.0.first() == self.0.last()
+        match (self.0.first(), self.0.last()) {
+            (Some(first), Some(last)) => first.partial_eq_ignoring_nan(last),
+            (None, None) => true,
+            _ => false,
+        }
     }
 }
 
@@ -616,5 +620,15 @@ mod test {
         let expected = LineString::new(vec![start, end]);
 
         assert_eq!(expected, LineString::from(line));
+    }
+
+    #[test]
+    fn test_close_with_nan() {
+        let start = coord! { x: 0., y: f32::NAN };
+        let end = coord! { x: 0., y: f32::NAN };
+        let mut line_string = LineString::new(vec![start, end]);
+        assert_eq!(2, line_string.0.len());
+        line_string.close();
+        assert_eq!(2, line_string.0.len());
     }
 }


### PR DESCRIPTION
- [ ] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Prior to this commit:

```rust
let start = coord! { x: 0., y: f32::NAN };
let end = coord! { x: 0., y: f32::NAN };
let mut line_string = LineString::new(vec![start, end]);
assert_eq!(2, line_string.0.len());
line_string.close();
assert_eq!(3, line_string.0.len());
```

After this commit:

```rust
let start = coord! { x: 0., y: f32::NAN };
let end = coord! { x: 0., y: f32::NAN };
let mut line_string = LineString::new(vec![start, end]);
assert_eq!(2, line_string.0.len());
line_string.close();
assert_eq!(2, line_string.0.len());
```

This is because `NaN != NaN`