### PR TITLE
Incoming breakage: Replace an invalid `#[deprecated]` attribute with a doc comment

### DIFF
--- a/geo-types/src/geometry/geometry_collection.rs
+++ b/geo-types/src/geometry/geometry_collection.rs
@@ -108,7 +108,9 @@ impl<T: CoordNum> GeometryCollection<T> {
     }
 }
 
-#[deprecated(since = 0.7.5, note = "Use `GeometryCollection::from(vec![geom])` instead.")]
+/// **DO NOT USE!** Deprecated since 0.7.5.
+///
+/// Use `GeometryCollection::from(vec![geom])` instead.
 impl<T: CoordNum, IG: Into<Geometry<T>>> From<IG> for GeometryCollection<T> {
     fn from(x: IG) -> Self {
         Self(vec![x.into()])


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

`#[deprecated]` attributes on `impl` blocks do not have any effect and normally the deny-by-default lint `useless_deprecated` would be triggered with the message *this `#[deprecated]` annotation has no effect*.
However, there is a bug in the current version of the Rust compiler that makes it ignore the attribute entirely if it is *malformed*
which is the case for the `#[deprecated]` attached to the `From` impl for `GeometryCollection` (the version is not surrounded by double quotes).
I've replaced the attribute with a documentation comment similar to the one for the softly deprecated associated function `GeometryCollection::new_from`.

---

The compiler bug is about to be fixed (rust-lang/rust#104148) and the malformed attribute will soon become a hard error.
This future breakage was found with the help of [crater](https://github.com/rust-lang/crater) (see the [build log](https://crater-reports.s3.amazonaws.com/pr-104148/try%23692571811df96d28cfa90e2b8cdf3be7e99c44e1/reg/geo-types-0.7.7/log.txt)).