### PR TITLE
prepare for geo-types 0.7.8 release

### DIFF
--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -1,12 +1,14 @@
 # Changes
 
-## Unreleased
+## 0.7.8
 
 * Rename `Coordinate` to `Coord`; add deprecated `Coordinate` that is an alias for `Coord`
 * Pin `arbitrary` version to 1.1.3 until our MSRV catches up with its latest release 
 * Add `point.x_mut()` and `point.y_mut()` methods on `Points`
 * Changed license field to [SPDX 2.1 license expression](https://spdx.dev/spdx-specification-21-web-version/#h.jxpfx0ykyb60)
   * <https://github.com/georust/geo/pull/928>
+* Fix typo in deprecated attribute, which will become a compiler error in a future version of rustc.
+  * <https://github.com/georust/geo/pull/932>
 
 ## 0.7.7
 

--- a/geo-types/Cargo.toml
+++ b/geo-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geo-types"
-version = "0.7.7"
+version = "0.7.8"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/georust/geo"
 documentation = "https://docs.rs/geo-types/"

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -18,7 +18,7 @@ use-serde = ["serde", "geo-types/serde"]
 
 [dependencies]
 float_next_after = "0.1.5"
-geo-types = { version = "0.7.7", features = ["approx", "use-rstar_0_9"] }
+geo-types = { version = "0.7.8", features = ["approx", "use-rstar_0_9"] }
 geographiclib-rs = "0.2"
 log = "0.4.11"
 num-traits = "0.2"


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Is there anything else folks want to wait for before the next (non-breaking) geo-types release?

There's one spicy bug fix #932, for which downstream users will otherwise eventually hit a compiler error (in ~1 month until beta, +6 more weeks for stable), so it'd be good to get that rolling out.

