### PR TITLE
`no_std` support for `geo-types`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - run: rustup target add thumbv6m-none-eabi
+      - run: rustup target add thumbv7em-none-eabihf
       - run: cargo check --all-targets --no-default-features
       - run: cargo check --lib --target thumbv7em-none-eabihf --no-default-features -F use-rstar_0_9,serde
       - run: cargo test --all-features

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+      - run: rustup target add thumbv6m-none-eabi
       - run: cargo check --all-targets --no-default-features
+      - run: cargo check --lib --target thumbv7em-none-eabihf --no-default-features -F use-rstar_0_9,serde
       - run: cargo test --all-features
 
   geo:

--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -5,6 +5,8 @@
 * Return `DoubleEndedIterator` from `LineString::points` and `LineString::points_mut`
   * <https://github.com/georust/geo/pull/951>
 * POSSIBLY BREAKING: Minimum supported version of Rust (MSRV) is now 1.63
+* Add `no_std` compatibility when the new default `std` feature is disabled
+  * <https://github.com/georust/geo/pull/936>
 
 ## 0.7.8
 

--- a/geo-types/Cargo.toml
+++ b/geo-types/Cargo.toml
@@ -11,6 +11,8 @@ rust-version = "1.63"
 edition = "2021"
 
 [features]
+default = ["std"]
+std = []
 # Prefer `use-rstar` feature rather than enabling rstar directly.
 # rstar integration relies on the optional approx crate, but implicit features cannot yet enable other features.
 # See: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#namespaced-features

--- a/geo-types/Cargo.toml
+++ b/geo-types/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 
 [features]
 default = ["std"]
-std = []
+std = ["approx/std", "num-traits/std", "serde/std"]
 # Prefer `use-rstar` feature rather than enabling rstar directly.
 # rstar integration relies on the optional approx crate, but implicit features cannot yet enable other features.
 # See: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#namespaced-features
@@ -22,12 +22,12 @@ use-rstar_0_8 = ["rstar_0_8", "approx"]
 use-rstar_0_9 = ["rstar_0_9", "approx"]
 
 [dependencies]
-approx = { version = ">= 0.4.0, < 0.6.0", optional = true }
+approx = { version = ">= 0.4.0, < 0.6.0", optional = true, default-features = false }
 arbitrary = { version = "1.2.0", optional = true }
-num-traits = "0.2"
+num-traits = { version = "0.2", default-features = false, features = ["libm"] }
 rstar_0_8 = { package = "rstar", version = "0.8", optional = true }
 rstar_0_9 = { package = "rstar", version = "0.9", optional = true }
-serde = { version = "1", optional = true, features = ["derive"] }
+serde = { version = "1", optional = true, default-features = false, features = ["alloc", "derive"] }
 
 [dev-dependencies]
 approx = ">= 0.4.0, < 0.6.0"

--- a/geo-types/src/error.rs
+++ b/geo-types/src/error.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use core::fmt;
 
 #[derive(Debug)]
 pub enum Error {
@@ -8,6 +8,7 @@ pub enum Error {
     },
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for Error {}
 
 impl fmt::Display for Error {
@@ -23,7 +24,8 @@ impl fmt::Display for Error {
 #[cfg(test)]
 mod test {
     use crate::{Geometry, Point, Rect};
-    use std::convert::TryFrom;
+    use alloc::string::ToString;
+    use core::convert::TryFrom;
 
     #[test]
     fn error_output() {

--- a/geo-types/src/geometry/coord.rs
+++ b/geo-types/src/geometry/coord.rs
@@ -100,7 +100,7 @@ impl<T: CoordNum> Coord<T> {
     }
 }
 
-use std::ops::{Add, Div, Mul, Neg, Sub};
+use core::ops::{Add, Div, Mul, Neg, Sub};
 
 /// Negate a coordinate.
 ///

--- a/geo-types/src/geometry/geometry_collection.rs
+++ b/geo-types/src/geometry/geometry_collection.rs
@@ -1,9 +1,11 @@
 use crate::{CoordNum, Geometry};
 
+use alloc::vec;
+use alloc::vec::Vec;
 #[cfg(any(feature = "approx", test))]
 use approx::{AbsDiffEq, RelativeEq};
-use std::iter::FromIterator;
-use std::ops::{Index, IndexMut};
+use core::iter::FromIterator;
+use core::ops::{Index, IndexMut};
 
 /// A collection of [`Geometry`](enum.Geometry.html) types.
 ///
@@ -148,7 +150,7 @@ impl<T: CoordNum> IndexMut<usize> for GeometryCollection<T> {
 // structure helper for consuming iterator
 #[derive(Debug)]
 pub struct IntoIteratorHelper<T: CoordNum> {
-    iter: ::std::vec::IntoIter<Geometry<T>>,
+    iter: ::alloc::vec::IntoIter<Geometry<T>>,
 }
 
 // implement the IntoIterator trait for a consuming iterator. Iteration will
@@ -178,7 +180,7 @@ impl<T: CoordNum> Iterator for IntoIteratorHelper<T> {
 // structure helper for non-consuming iterator
 #[derive(Debug)]
 pub struct IterHelper<'a, T: CoordNum> {
-    iter: ::std::slice::Iter<'a, Geometry<T>>,
+    iter: ::core::slice::Iter<'a, Geometry<T>>,
 }
 
 // implement the IntoIterator trait for a non-consuming iterator. Iteration will
@@ -208,7 +210,7 @@ impl<'a, T: CoordNum> Iterator for IterHelper<'a, T> {
 // structure helper for mutable non-consuming iterator
 #[derive(Debug)]
 pub struct IterMutHelper<'a, T: CoordNum> {
-    iter: ::std::slice::IterMut<'a, Geometry<T>>,
+    iter: ::core::slice::IterMut<'a, Geometry<T>>,
 }
 
 // implement the IntoIterator trait for a mutable non-consuming iterator. Iteration will
@@ -323,6 +325,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec;
+
     use crate::{GeometryCollection, Point};
 
     #[test]

--- a/geo-types/src/geometry/line_string.rs
+++ b/geo-types/src/geometry/line_string.rs
@@ -2,8 +2,10 @@
 use approx::{AbsDiffEq, RelativeEq};
 
 use crate::{Coord, CoordNum, Line, Point, Triangle};
-use std::iter::FromIterator;
-use std::ops::{Index, IndexMut};
+use alloc::vec;
+use alloc::vec::Vec;
+use core::iter::FromIterator;
+use core::ops::{Index, IndexMut};
 
 /// An ordered collection of two or more [`Coord`]s, representing a
 /// path between locations.
@@ -136,7 +138,7 @@ pub struct LineString<T: CoordNum = f64>(pub Vec<Coord<T>>);
 
 /// A [`Point`] iterator returned by the `points` method
 #[derive(Debug)]
-pub struct PointsIter<'a, T: CoordNum + 'a>(::std::slice::Iter<'a, Coord<T>>);
+pub struct PointsIter<'a, T: CoordNum + 'a>(::core::slice::Iter<'a, Coord<T>>);
 
 impl<'a, T: CoordNum> Iterator for PointsIter<'a, T> {
     type Item = Point<T>;
@@ -164,7 +166,7 @@ impl<'a, T: CoordNum> DoubleEndedIterator for PointsIter<'a, T> {
 
 /// A [`Coord`] iterator used by the `into_iter` method on a [`LineString`]
 #[derive(Debug)]
-pub struct CoordinatesIter<'a, T: CoordNum + 'a>(::std::slice::Iter<'a, Coord<T>>);
+pub struct CoordinatesIter<'a, T: CoordNum + 'a>(::core::slice::Iter<'a, Coord<T>>);
 
 impl<'a, T: CoordNum> Iterator for CoordinatesIter<'a, T> {
     type Item = &'a Coord<T>;
@@ -358,7 +360,7 @@ impl<T: CoordNum, IC: Into<Coord<T>>> FromIterator<IC> for LineString<T> {
 /// Iterate over all the [`Coord`]s in this [`LineString`].
 impl<T: CoordNum> IntoIterator for LineString<T> {
     type Item = Coord<T>;
-    type IntoIter = ::std::vec::IntoIter<Coord<T>>;
+    type IntoIter = ::alloc::vec::IntoIter<Coord<T>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
@@ -377,9 +379,9 @@ impl<'a, T: CoordNum> IntoIterator for &'a LineString<T> {
 /// Mutably iterate over all the [`Coordinate`]s in this [`LineString`]
 impl<'a, T: CoordNum> IntoIterator for &'a mut LineString<T> {
     type Item = &'a mut Coord<T>;
-    type IntoIter = ::std::slice::IterMut<'a, Coord<T>>;
+    type IntoIter = ::core::slice::IterMut<'a, Coord<T>>;
 
-    fn into_iter(self) -> ::std::slice::IterMut<'a, Coord<T>> {
+    fn into_iter(self) -> ::core::slice::IterMut<'a, Coord<T>> {
         self.0.iter_mut()
     }
 }
@@ -534,14 +536,15 @@ mod test {
     #[test]
     fn test_exact_size() {
         // see https://github.com/georust/geo/issues/762
-        let ls = LineString::new(vec![coord! { x: 0., y: 0. }, coord! { x: 10., y: 0. }]);
+        let first = coord! { x: 0., y: 0. };
+        let ls = LineString::new(vec![first, coord! { x: 10., y: 0. }]);
 
         // reference to force the `impl IntoIterator for &LineString` impl, giving a `CoordinatesIter`
         for c in (&ls).into_iter().rev().skip(1).rev() {
-            println!("{:?}", c);
+            assert_eq!(&first, c);
         }
         for p in ls.points().rev().skip(1).rev() {
-            println!("{:?}", p);
+            assert_eq!(Point::from(first), p);
         }
     }
 

--- a/geo-types/src/geometry/mod.rs
+++ b/geo-types/src/geometry/mod.rs
@@ -29,7 +29,7 @@ use crate::{CoordNum, Error};
 #[cfg(any(feature = "approx", test))]
 use approx::{AbsDiffEq, RelativeEq};
 use core::any::type_name;
-use std::convert::TryFrom;
+use core::convert::TryFrom;
 
 /// An enum representing any possible geometry type.
 ///

--- a/geo-types/src/geometry/multi_line_string.rs
+++ b/geo-types/src/geometry/multi_line_string.rs
@@ -1,8 +1,10 @@
 use crate::{CoordNum, LineString};
 
+use alloc::vec;
+use alloc::vec::Vec;
 #[cfg(any(feature = "approx", test))]
 use approx::{AbsDiffEq, RelativeEq};
-use std::iter::FromIterator;
+use core::iter::FromIterator;
 
 /// A collection of
 /// [`LineString`s](line_string/struct.LineString.html). Can
@@ -81,7 +83,7 @@ impl<T: CoordNum, ILS: Into<LineString<T>>> FromIterator<ILS> for MultiLineStrin
 
 impl<T: CoordNum> IntoIterator for MultiLineString<T> {
     type Item = LineString<T>;
-    type IntoIter = ::std::vec::IntoIter<LineString<T>>;
+    type IntoIter = ::alloc::vec::IntoIter<LineString<T>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
@@ -90,7 +92,7 @@ impl<T: CoordNum> IntoIterator for MultiLineString<T> {
 
 impl<'a, T: CoordNum> IntoIterator for &'a MultiLineString<T> {
     type Item = &'a LineString<T>;
-    type IntoIter = ::std::slice::Iter<'a, LineString<T>>;
+    type IntoIter = ::alloc::slice::Iter<'a, LineString<T>>;
 
     fn into_iter(self) -> Self::IntoIter {
         (self.0).iter()
@@ -99,7 +101,7 @@ impl<'a, T: CoordNum> IntoIterator for &'a MultiLineString<T> {
 
 impl<'a, T: CoordNum> IntoIterator for &'a mut MultiLineString<T> {
     type Item = &'a mut LineString<T>;
-    type IntoIter = ::std::slice::IterMut<'a, LineString<T>>;
+    type IntoIter = ::alloc::slice::IterMut<'a, LineString<T>>;
 
     fn into_iter(self) -> Self::IntoIter {
         (self.0).iter_mut()

--- a/geo-types/src/geometry/multi_point.rs
+++ b/geo-types/src/geometry/multi_point.rs
@@ -3,7 +3,9 @@ use crate::{CoordNum, Point};
 #[cfg(any(feature = "approx", test))]
 use approx::{AbsDiffEq, RelativeEq};
 
-use std::iter::FromIterator;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::iter::FromIterator;
 
 /// A collection of [`Point`s](struct.Point.html). Can
 /// be created from a `Vec` of `Point`s, or from an
@@ -58,7 +60,7 @@ impl<T: CoordNum, IP: Into<Point<T>>> FromIterator<IP> for MultiPoint<T> {
 /// Iterate over the `Point`s in this `MultiPoint`.
 impl<T: CoordNum> IntoIterator for MultiPoint<T> {
     type Item = Point<T>;
-    type IntoIter = ::std::vec::IntoIter<Point<T>>;
+    type IntoIter = ::alloc::vec::IntoIter<Point<T>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
@@ -67,7 +69,7 @@ impl<T: CoordNum> IntoIterator for MultiPoint<T> {
 
 impl<'a, T: CoordNum> IntoIterator for &'a MultiPoint<T> {
     type Item = &'a Point<T>;
-    type IntoIter = ::std::slice::Iter<'a, Point<T>>;
+    type IntoIter = ::alloc::slice::Iter<'a, Point<T>>;
 
     fn into_iter(self) -> Self::IntoIter {
         (self.0).iter()
@@ -76,7 +78,7 @@ impl<'a, T: CoordNum> IntoIterator for &'a MultiPoint<T> {
 
 impl<'a, T: CoordNum> IntoIterator for &'a mut MultiPoint<T> {
     type Item = &'a mut Point<T>;
-    type IntoIter = ::std::slice::IterMut<'a, Point<T>>;
+    type IntoIter = ::alloc::slice::IterMut<'a, Point<T>>;
 
     fn into_iter(self) -> Self::IntoIter {
         (self.0).iter_mut()

--- a/geo-types/src/geometry/multi_polygon.rs
+++ b/geo-types/src/geometry/multi_polygon.rs
@@ -1,8 +1,10 @@
 use crate::{CoordNum, Polygon};
 
+use alloc::vec;
+use alloc::vec::Vec;
 #[cfg(any(feature = "approx", test))]
 use approx::{AbsDiffEq, RelativeEq};
-use std::iter::FromIterator;
+use core::iter::FromIterator;
 
 /// A collection of [`Polygon`s](struct.Polygon.html). Can
 /// be created from a `Vec` of `Polygon`s, or from an
@@ -49,7 +51,7 @@ impl<T: CoordNum, IP: Into<Polygon<T>>> FromIterator<IP> for MultiPolygon<T> {
 
 impl<T: CoordNum> IntoIterator for MultiPolygon<T> {
     type Item = Polygon<T>;
-    type IntoIter = ::std::vec::IntoIter<Polygon<T>>;
+    type IntoIter = ::alloc::vec::IntoIter<Polygon<T>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
@@ -58,7 +60,7 @@ impl<T: CoordNum> IntoIterator for MultiPolygon<T> {
 
 impl<'a, T: CoordNum> IntoIterator for &'a MultiPolygon<T> {
     type Item = &'a Polygon<T>;
-    type IntoIter = ::std::slice::Iter<'a, Polygon<T>>;
+    type IntoIter = ::alloc::slice::Iter<'a, Polygon<T>>;
 
     fn into_iter(self) -> Self::IntoIter {
         (self.0).iter()
@@ -67,7 +69,7 @@ impl<'a, T: CoordNum> IntoIterator for &'a MultiPolygon<T> {
 
 impl<'a, T: CoordNum> IntoIterator for &'a mut MultiPolygon<T> {
     type Item = &'a mut Polygon<T>;
-    type IntoIter = ::std::slice::IterMut<'a, Polygon<T>>;
+    type IntoIter = ::alloc::slice::IterMut<'a, Polygon<T>>;
 
     fn into_iter(self) -> Self::IntoIter {
         (self.0).iter_mut()

--- a/geo-types/src/geometry/point.rs
+++ b/geo-types/src/geometry/point.rs
@@ -3,7 +3,7 @@ use crate::{point, Coord, CoordFloat, CoordNum};
 #[cfg(any(feature = "approx", test))]
 use approx::{AbsDiffEq, RelativeEq};
 
-use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 /// A single point in 2D space.
 ///

--- a/geo-types/src/geometry/polygon.rs
+++ b/geo-types/src/geometry/polygon.rs
@@ -1,4 +1,6 @@
 use crate::{CoordFloat, CoordNum, LineString, Point, Rect, Triangle};
+use alloc::vec;
+use alloc::vec::Vec;
 use num_traits::{Float, Signed};
 
 #[cfg(any(feature = "approx", test))]

--- a/geo-types/src/geometry/rect.rs
+++ b/geo-types/src/geometry/rect.rs
@@ -467,12 +467,13 @@ where
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct InvalidRectCoordinatesError;
 
+#[cfg(feature = "std")]
 #[allow(deprecated)]
 impl std::error::Error for InvalidRectCoordinatesError {}
 
 #[allow(deprecated)]
-impl std::fmt::Display for InvalidRectCoordinatesError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for InvalidRectCoordinatesError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}", RECT_INVALID_BOUNDS_ERROR)
     }
 }

--- a/geo-types/src/lib.rs
+++ b/geo-types/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 #![warn(missing_debug_implementations)]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/georust/meta/master/logo/logo.png")]
 //! The `geo-types` library defines geometric types for the [GeoRust] ecosystem.
@@ -75,9 +76,11 @@
 //! [OGC-SFA]: https://www.ogc.org/standards/sfa
 //! [rstar]: https://github.com/Stoeoef/rstar
 //! [Serde]: https://serde.rs/
+extern crate alloc;
 extern crate num_traits;
+
+use core::fmt::Debug;
 use num_traits::{Float, Num, NumCast};
-use std::fmt::Debug;
 
 #[cfg(feature = "serde")]
 #[macro_use]
@@ -131,10 +134,22 @@ mod arbitrary;
 #[doc(hidden)]
 pub mod private_utils;
 
+#[doc(hidden)]
+pub mod _alloc {
+    //! Needed to access these types from `alloc` in macros when the std feature is
+    //! disabled and the calling context is missing `extern crate alloc`. These are
+    //! _not_ meant for public use.
+
+    pub use ::alloc::boxed::Box;
+    pub use ::alloc::vec;
+}
+
 #[cfg(test)]
 mod tests {
+    use alloc::vec;
+
     use super::*;
-    use std::convert::TryFrom;
+    use core::convert::TryFrom;
 
     #[test]
     fn type_test() {

--- a/geo-types/src/lib.rs
+++ b/geo-types/src/lib.rs
@@ -69,8 +69,8 @@
 //! - `use-rstar_0_9`: Allows geometry types to be inserted into [rstar] R*-trees (`rstar v0.9`)
 //!
 //! This library can be used in `#![no_std]` environments if the default `std` feature is disabled. At
-//! the moment, the `arbitrary` and `use-rstar_0_8` features cannot be used without `std`. This may
-//! change in a future release.
+//! the moment, the `arbitrary` and `use-rstar_0_8` features require `std`. This may change in a
+//! future release.
 //!
 //! [approx]: https://github.com/brendanzab/approx
 //! [arbitrary]: https://github.com/rust-fuzz/arbitrary

--- a/geo-types/src/lib.rs
+++ b/geo-types/src/lib.rs
@@ -61,11 +61,16 @@
 //!
 //! The following optional [Cargo features] are available:
 //!
+//! - `std`: Enables use of the full `std` library. Enabled by default.
 //! - `approx`: Allows geometry types to be checked for approximate equality with [approx]
 //! - `arbitrary`: Allows geometry types to be created from unstructured input with [arbitrary]
 //! - `serde`: Allows geometry types to be serialized and deserialized with [Serde]
 //! - `use-rstar_0_8`: Allows geometry types to be inserted into [rstar] R*-trees (`rstar v0.8`)
 //! - `use-rstar_0_9`: Allows geometry types to be inserted into [rstar] R*-trees (`rstar v0.9`)
+//!
+//! This library can be used in `#![no_std]` environments if the default `std` feature is disabled. At
+//! the moment, the `arbitrary` and `use-rstar_0_8` features cannot be used without `std`. This may
+//! change in a future release.
 //!
 //! [approx]: https://github.com/brendanzab/approx
 //! [arbitrary]: https://github.com/rust-fuzz/arbitrary

--- a/geo-types/src/macros.rs
+++ b/geo-types/src/macros.rs
@@ -140,7 +140,7 @@ macro_rules! line_string {
     ) => {
         $crate::LineString::new(
             <[_]>::into_vec(
-                ::std::boxed::Box::new(
+                $crate::_alloc::Box::new(
                     [$($coord), *]
                 )
             )
@@ -263,7 +263,7 @@ macro_rules! polygon {
                 $($exterior_coord), *
             ],
             <[_]>::into_vec(
-                ::std::boxed::Box::new(
+                $crate::_alloc::Box::new(
                     [
                         $(
                             $crate::line_string![$($interior_coord),*]
@@ -287,7 +287,7 @@ macro_rules! polygon {
     ) => {
         $crate::Polygon::new(
             $crate::line_string![$($coord,)*],
-            vec![],
+            $crate::_alloc::vec![],
         )
     };
 }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

This is my take on `no_std` support. This adds a new `std` that behave similarly to `serde`'s.

Rough overview of my changes:
- For the most part, simply swapping `alloc` or `core` in for `std`.
- Also added a second `doc(hidden)` public module (`_alloc`) to give macros access to `Vec` and `Box` even if the crate they are used from does not have `extern crate alloc`. This could be merged into the existing `private_utils`. It could also be dropped entirely, but that would require modifying the macros to reference `std` when that feature is enabled and the cleanest way I found to do that is still somewhat ugly: match on `()` with `cfg`'d branches.

I've looked some at #426 and the main difference I see is that it adds `core-error` for the `Error` trait, while I've just put that behind the `std` feature. If that is preferred, I can add the dependency.

---

I have also started working on `no_std` support in `geo`, but it's not quite as straight-forward, so I was keeping it for a second PR.

fixes #422, partially supersedes #426