### PR TITLE
prepare for geo-0.23.1 non-breaking release

### DIFF
--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## unreleased
+
 ## 0.7.8
 
 * Rename `Coordinate` to `Coord`; add deprecated `Coordinate` that is an alias for `Coord`

--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## unreleased
+
 ## 0.23.1
 
 * Update to geo-types-0.7.8 which deprecated `Coordinate` in favor of `Coord`.

--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 0.23.1
 
+* Update to geo-types-0.7.8 which deprecated `Coordinate` in favor of `Coord`.
+  <https://github.com/georust/geo/pull/924>
 * Added doc for Transform trait to root docs index.
 * Fixed an issues where calculating the convex hull of 3 collinear points
   would include all 3.

--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -1,6 +1,7 @@
 # Changes
 
-## Unreleased
+## 0.23.1
+
 * Added doc for Transform trait to root docs index.
 * Fixed an issues where calculating the convex hull of 3 collinear points
   would include all 3.

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "geo"
 description = "Geospatial primitives and algorithms"
-version = "0.23.0"
+version = "0.23.1"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/georust/geo"
 documentation = "https://docs.rs/geo/"


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Anything else we should be waiting for before release?

Diff: https://github.com/georust/geo/compare/geo-0.23.0...release/geo-0.23.1
