### PR TITLE
Utilize const generics to pass settings to VW algorithm.

### DIFF
--- a/geo/src/algorithm/simplify.rs
+++ b/geo/src/algorithm/simplify.rs
@@ -14,7 +14,10 @@ where
 }
 
 // Wrapper for the RDP algorithm, returning simplified points
-fn rdp<T>(coords: impl Iterator<Item = Coord<T>>, epsilon: &T) -> Vec<Coord<T>>
+fn rdp<T>(
+    coords: impl Iterator<Item = Coord<T>>,
+    epsilon: &T,
+) -> Vec<Coord<T>>
 where
     T: GeoFloat,
 {


### PR DESCRIPTION
Probably a microoptimization, but this makes the stack frames a little bit smaller since we remove an unneeded argument.

- [ ] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
