### PR TITLE
`Simplify` now generates `Polygon` rings with at least four coordiantes

### DIFF
--- a/geo/src/algorithm/simplify.rs
+++ b/geo/src/algorithm/simplify.rs
@@ -299,7 +299,7 @@ mod test {
             coord! { x: 12.0, y: 100.0 },
         ];
         let compare = vec![coord! {x: 8.0, y: 100.0}, coord! {x: 12.0, y: 100.0}];
-        let simplified = rdp(vec.into_iter(), &1.0);
+        let simplified = rdp::<_, _, 2>(vec.into_iter(), &1.0);
         assert_eq!(simplified, compare);
     }
 

--- a/geo/src/algorithm/simplify.rs
+++ b/geo/src/algorithm/simplify.rs
@@ -301,21 +301,21 @@ mod test {
             coord! { x: 11.0, y: 5.5 },
             coord! { x: 27.8, y: 0.1 },
         ];
-        let simplified = rdp::<_, 2>(vec.into_iter(), &1.0);
+        let simplified = rdp::<_, _, 2>(vec.into_iter(), &1.0);
         assert_eq!(simplified, compare);
     }
     #[test]
     fn rdp_test_empty_linestring() {
         let vec = Vec::new();
         let compare = Vec::new();
-        let simplified = rdp::<_, 2>(vec.into_iter(), &1.0);
+        let simplified = rdp::<_, _, 2>(vec.into_iter(), &1.0);
         assert_eq!(simplified, compare);
     }
     #[test]
     fn rdp_test_two_point_linestring() {
         let vec = vec![coord! { x: 0.0, y: 0.0 }, coord! { x: 27.8, y: 0.1 }];
         let compare = vec![coord! { x: 0.0, y: 0.0 }, coord! { x: 27.8, y: 0.1 }];
-        let simplified = rdp::<_, 2>(vec.into_iter(), &1.0);
+        let simplified = rdp::<_, _, 2>(vec.into_iter(), &1.0);
         assert_eq!(simplified, compare);
     }
 

--- a/geo/src/algorithm/simplify.rs
+++ b/geo/src/algorithm/simplify.rs
@@ -298,9 +298,8 @@ mod test {
             coord! { x: 9.0, y: 100.0 },
             coord! { x: 12.0, y: 100.0 },
         ];
-        let compare = vec![coord! {x: 8.0, y: 100.0}, coord! {x: 12.0, y: 100.0}];
         let simplified = rdp::<_, _, 2>(vec.into_iter(), &1.0);
-        assert_eq!(simplified, compare);
+        assert_eq!(simplified, vec);
     }
 
     #[test]


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Prior to this pull request, running `Simplify` on `Polygon` could generate rings with two coordinates, which would make it no longer a valid ring. This pull request updates `Simplify` to ensure resulting `Polygon` rings always have at least four coordinates.

Fixes #142 