### PR TITLE
Add WindingOrder benchmark

### DIFF
--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -98,3 +98,7 @@ harness = false
 [[bench]]
 name = "rand_line_crossings"
 harness = false
+
+[[bench]]
+name = "winding_order"
+harness = false

--- a/geo/benches/winding_order.rs
+++ b/geo/benches/winding_order.rs
@@ -65,7 +65,7 @@ fn criterion_benchmark(c: &mut criterion::Criterion) {
     });
 
     c.bench_function("winding order: points_ccw (f64)", |bencher| {
-        let ls = geo_test_fixtures::louisiana::<f32>();
+        let ls = geo_test_fixtures::louisiana::<f64>();
 
         bencher.iter(|| {
             let points_iter = criterion::black_box(

--- a/geo/benches/winding_order.rs
+++ b/geo/benches/winding_order.rs
@@ -39,7 +39,7 @@ fn criterion_benchmark(c: &mut criterion::Criterion) {
     });
 
     c.bench_function("winding order: points_cw (f64)", |bencher| {
-        let ls = geo_test_fixtures::louisiana::<f32>();
+        let ls = geo_test_fixtures::louisiana::<f64>();
 
         bencher.iter(|| {
             let points_iter = criterion::black_box(

--- a/geo/benches/winding_order.rs
+++ b/geo/benches/winding_order.rs
@@ -9,9 +9,7 @@ fn criterion_benchmark(c: &mut criterion::Criterion) {
         let ls = geo_test_fixtures::louisiana::<f32>();
 
         bencher.iter(|| {
-            let _ = criterion::black_box(
-                criterion::black_box(&ls).winding_order(),
-            );
+            let _ = criterion::black_box(criterion::black_box(&ls).winding_order());
         });
     });
 
@@ -19,9 +17,7 @@ fn criterion_benchmark(c: &mut criterion::Criterion) {
         let ls = geo_test_fixtures::louisiana::<f64>();
 
         bencher.iter(|| {
-            let _ = criterion::black_box(
-                criterion::black_box(&ls).winding_order(),
-            );
+            let _ = criterion::black_box(criterion::black_box(&ls).winding_order());
         });
     });
 
@@ -29,9 +25,7 @@ fn criterion_benchmark(c: &mut criterion::Criterion) {
         let ls = geo_test_fixtures::louisiana::<f32>();
 
         bencher.iter(|| {
-            let points_iter = criterion::black_box(
-                criterion::black_box(&ls).points_cw(),
-            );
+            let points_iter = criterion::black_box(criterion::black_box(&ls).points_cw());
             for point in points_iter {
                 criterion::black_box(point);
             }
@@ -42,9 +36,7 @@ fn criterion_benchmark(c: &mut criterion::Criterion) {
         let ls = geo_test_fixtures::louisiana::<f64>();
 
         bencher.iter(|| {
-            let points_iter = criterion::black_box(
-                criterion::black_box(&ls).points_cw(),
-            );
+            let points_iter = criterion::black_box(criterion::black_box(&ls).points_cw());
             for point in points_iter {
                 criterion::black_box(point);
             }
@@ -55,9 +47,7 @@ fn criterion_benchmark(c: &mut criterion::Criterion) {
         let ls = geo_test_fixtures::louisiana::<f32>();
 
         bencher.iter(|| {
-            let points_iter = criterion::black_box(
-                criterion::black_box(&ls).points_ccw(),
-            );
+            let points_iter = criterion::black_box(criterion::black_box(&ls).points_ccw());
             for point in points_iter {
                 criterion::black_box(point);
             }
@@ -68,9 +58,7 @@ fn criterion_benchmark(c: &mut criterion::Criterion) {
         let ls = geo_test_fixtures::louisiana::<f64>();
 
         bencher.iter(|| {
-            let points_iter = criterion::black_box(
-                criterion::black_box(&ls).points_ccw(),
-            );
+            let points_iter = criterion::black_box(criterion::black_box(&ls).points_ccw());
             for point in points_iter {
                 criterion::black_box(point);
             }

--- a/geo/benches/winding_order.rs
+++ b/geo/benches/winding_order.rs
@@ -32,7 +32,7 @@ fn criterion_benchmark(c: &mut criterion::Criterion) {
             let points_iter = criterion::black_box(
                 criterion::black_box(&ls).points_cw(),
             );
-            for point in points_iter.0 {
+            for point in points_iter {
                 criterion::black_box(point);
             }
         });
@@ -45,7 +45,7 @@ fn criterion_benchmark(c: &mut criterion::Criterion) {
             let points_iter = criterion::black_box(
                 criterion::black_box(&ls).points_cw(),
             );
-            for point in points_iter.0 {
+            for point in points_iter {
                 criterion::black_box(point);
             }
         });
@@ -58,7 +58,7 @@ fn criterion_benchmark(c: &mut criterion::Criterion) {
             let points_iter = criterion::black_box(
                 criterion::black_box(&ls).points_ccw(),
             );
-            for point in points_iter.0 {
+            for point in points_iter {
                 criterion::black_box(point);
             }
         });
@@ -71,7 +71,7 @@ fn criterion_benchmark(c: &mut criterion::Criterion) {
             let points_iter = criterion::black_box(
                 criterion::black_box(&ls).points_ccw(),
             );
-            for point in points_iter.0 {
+            for point in points_iter {
                 criterion::black_box(point);
             }
         });

--- a/geo/benches/winding_order.rs
+++ b/geo/benches/winding_order.rs
@@ -1,0 +1,82 @@
+#[macro_use]
+extern crate criterion;
+extern crate geo;
+
+use geo::prelude::*;
+
+fn criterion_benchmark(c: &mut criterion::Criterion) {
+    c.bench_function("winding order: winding_order (f32)", |bencher| {
+        let ls = geo_test_fixtures::louisiana::<f32>();
+
+        bencher.iter(|| {
+            let _ = criterion::black_box(
+                criterion::black_box(&ls).winding_order(),
+            );
+        });
+    });
+
+    c.bench_function("winding order: winding_order (f64)", |bencher| {
+        let ls = geo_test_fixtures::louisiana::<f64>();
+
+        bencher.iter(|| {
+            let _ = criterion::black_box(
+                criterion::black_box(&ls).winding_order(),
+            );
+        });
+    });
+
+    c.bench_function("winding order: points_cw (f32)", |bencher| {
+        let ls = geo_test_fixtures::louisiana::<f32>();
+
+        bencher.iter(|| {
+            let points_iter = criterion::black_box(
+                criterion::black_box(&ls).points_cw(),
+            );
+            for point in points_iter.0 {
+                criterion::black_box(point);
+            }
+        });
+    });
+
+    c.bench_function("winding order: points_cw (f64)", |bencher| {
+        let ls = geo_test_fixtures::louisiana::<f32>();
+
+        bencher.iter(|| {
+            let points_iter = criterion::black_box(
+                criterion::black_box(&ls).points_cw(),
+            );
+            for point in points_iter.0 {
+                criterion::black_box(point);
+            }
+        });
+    });
+
+    c.bench_function("winding order: points_ccw (f32)", |bencher| {
+        let ls = geo_test_fixtures::louisiana::<f32>();
+
+        bencher.iter(|| {
+            let points_iter = criterion::black_box(
+                criterion::black_box(&ls).points_ccw(),
+            );
+            for point in points_iter.0 {
+                criterion::black_box(point);
+            }
+        });
+    });
+
+    c.bench_function("winding order: points_ccw (f64)", |bencher| {
+        let ls = geo_test_fixtures::louisiana::<f32>();
+
+        bencher.iter(|| {
+            let points_iter = criterion::black_box(
+                criterion::black_box(&ls).points_ccw(),
+            );
+            for point in points_iter.0 {
+                criterion::black_box(point);
+            }
+        });
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
