### PR TITLE
Update float_next_after to 1.0.0

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## unreleased
 
+* BREAKING: Update to float_next_after-1.0.0
+  <https://github.com/georust/geo/pull/952>
+
 ## 0.23.1
 
 * Update to geo-types-0.7.8 which deprecated `Coordinate` in favor of `Coord`.

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -17,7 +17,7 @@ proj-network = ["use-proj", "proj/network"]
 use-serde = ["serde", "geo-types/serde"]
 
 [dependencies]
-float_next_after = "0.1.5"
+float_next_after = "1.0.0"
 geo-types = { version = "0.7.8", features = ["approx", "use-rstar_0_9"] }
 geographiclib-rs = "0.2"
 log = "0.4.11"

--- a/geo/src/lib.rs
+++ b/geo/src/lib.rs
@@ -275,11 +275,7 @@ pub mod prelude {
 /// }
 /// ```
 pub trait GeoFloat:
-    GeoNum
-    + num_traits::Float
-    + num_traits::Signed
-    + num_traits::Bounded
-    + float_next_after::NextAfter<Self>
+    GeoNum + num_traits::Float + num_traits::Signed + num_traits::Bounded + float_next_after::NextAfter
 {
 }
 impl<T> GeoFloat for T where
@@ -287,7 +283,7 @@ impl<T> GeoFloat for T where
         + num_traits::Float
         + num_traits::Signed
         + num_traits::Bounded
-        + float_next_after::NextAfter<Self>
+        + float_next_after::NextAfter
 {
 }
 


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

The new version of `float_next_after` makes it `no_std` compatible & removes the type parameter.