### PR TITLE
Make `SimplifyVw` algorithm naming consistent.

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -2,8 +2,10 @@
 
 ## unreleased
 
+* BREAKING: Make `SimplifyVw` naming consistent
+  * <https://github.com/georust/geo/pull/957>
 * BREAKING: Update to float_next_after-1.0.0
-  <https://github.com/georust/geo/pull/952>
+  * <https://github.com/georust/geo/pull/952>
 
 ## 0.23.1
 

--- a/geo/benches/simplifyvw.rs
+++ b/geo/benches/simplifyvw.rs
@@ -4,14 +4,14 @@ extern crate geo;
 
 use criterion::Criterion;
 use geo::prelude::*;
-use geo::simplifyvw::SimplifyVWPreserve;
+use geo::simplify_vw::SimplifyVwPreserve;
 
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("simplify vw simple f32", |bencher| {
         let ls = geo_test_fixtures::louisiana::<f32>();
         bencher.iter(|| {
             criterion::black_box(
-                criterion::black_box(&ls).simplifyvw(criterion::black_box(&0.0005)),
+                criterion::black_box(&ls).simplify_vw(criterion::black_box(&0.0005)),
             );
         });
     });
@@ -20,7 +20,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         let ls = geo_test_fixtures::louisiana::<f64>();
         bencher.iter(|| {
             criterion::black_box(
-                criterion::black_box(&ls).simplifyvw(criterion::black_box(&0.0005)),
+                criterion::black_box(&ls).simplify_vw(criterion::black_box(&0.0005)),
             );
         });
     });
@@ -29,7 +29,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         let ls = geo_test_fixtures::louisiana::<f32>();
         bencher.iter(|| {
             criterion::black_box(
-                criterion::black_box(&ls).simplifyvw_preserve(criterion::black_box(&0.0005)),
+                criterion::black_box(&ls).simplify_vw_preserve(criterion::black_box(&0.0005)),
             );
         });
     });
@@ -38,7 +38,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         let ls = geo_test_fixtures::louisiana::<f64>();
         bencher.iter(|| {
             criterion::black_box(
-                criterion::black_box(&ls).simplifyvw_preserve(criterion::black_box(&0.0005)),
+                criterion::black_box(&ls).simplify_vw_preserve(criterion::black_box(&0.0005)),
             );
         });
     });

--- a/geo/src/algorithm/mod.rs
+++ b/geo/src/algorithm/mod.rs
@@ -188,8 +188,8 @@ pub mod simplify;
 pub use simplify::{Simplify, SimplifyIdx};
 
 /// Simplify `Geometries` using the Visvalingam-Whyatt algorithm. Includes a topology-preserving variant.
-pub mod simplifyvw;
-pub use simplifyvw::{SimplifyVW, SimplifyVWPreserve, SimplifyVwIdx};
+pub mod simplify_vw;
+pub use simplify_vw::{SimplifyVw, SimplifyVwPreserve, SimplifyVwIdx};
 
 /// Transform a geometry using PROJ.
 #[cfg(feature = "use-proj")]

--- a/geo/src/algorithm/mod.rs
+++ b/geo/src/algorithm/mod.rs
@@ -189,7 +189,7 @@ pub use simplify::{Simplify, SimplifyIdx};
 
 /// Simplify `Geometries` using the Visvalingam-Whyatt algorithm. Includes a topology-preserving variant.
 pub mod simplify_vw;
-pub use simplify_vw::{SimplifyVw, SimplifyVwPreserve, SimplifyVwIdx};
+pub use simplify_vw::{SimplifyVw, SimplifyVwIdx, SimplifyVwPreserve};
 
 /// Transform a geometry using PROJ.
 #[cfg(feature = "use-proj")]

--- a/geo/src/algorithm/simplify_vw.rs
+++ b/geo/src/algorithm/simplify_vw.rs
@@ -429,7 +429,7 @@ where
 /// simplified by simplifying all their constituent geometries individually.
 ///
 /// An epsilon less than or equal to zero will return an unaltered version of the geometry.
-pub trait SimplifyVW<T, Epsilon = T> {
+pub trait SimplifyVw<T, Epsilon = T> {
     /// Returns the simplified representation of a geometry, using the [Visvalingam-Whyatt](http://www.tandfonline.com/doi/abs/10.1179/000870493786962263) algorithm
     ///
     /// See [here](https://bost.ocks.org/mike/simplify/) for a graphical explanation
@@ -437,7 +437,7 @@ pub trait SimplifyVW<T, Epsilon = T> {
     /// # Examples
     ///
     /// ```
-    /// use geo::SimplifyVW;
+    /// use geo::SimplifyVw;
     /// use geo::line_string;
     ///
     /// let line_string = line_string![
@@ -448,7 +448,7 @@ pub trait SimplifyVW<T, Epsilon = T> {
     ///     (x: 10.0, y: 10.0),
     /// ];
     ///
-    /// let simplified = line_string.simplifyvw(&30.0);
+    /// let simplified = line_string.simplify_vw(&30.0);
     ///
     /// let expected = line_string![
     ///     (x: 5.0, y: 2.0),
@@ -458,7 +458,7 @@ pub trait SimplifyVW<T, Epsilon = T> {
     ///
     /// assert_eq!(expected, simplified);
     /// ```
-    fn simplifyvw(&self, epsilon: &T) -> Self
+    fn simplify_vw(&self, epsilon: &T) -> Self
     where
         T: CoordFloat;
 }
@@ -488,7 +488,7 @@ pub trait SimplifyVwIdx<T, Epsilon = T> {
     ///     (x: 10.0, y: 10.0),
     /// ];
     ///
-    /// let simplified = line_string.simplifyvw_idx(&30.0);
+    /// let simplified = line_string.simplify_vw_idx(&30.0);
     ///
     /// let expected = vec![
     ///     0_usize,
@@ -498,7 +498,7 @@ pub trait SimplifyVwIdx<T, Epsilon = T> {
     ///
     /// assert_eq!(expected, simplified);
     /// ```
-    fn simplifyvw_idx(&self, epsilon: &T) -> Vec<usize>
+    fn simplify_vw_idx(&self, epsilon: &T) -> Vec<usize>
     where
         T: CoordFloat;
 }
@@ -506,7 +506,7 @@ pub trait SimplifyVwIdx<T, Epsilon = T> {
 /// Simplifies a geometry, preserving its topology by removing self-intersections
 ///
 /// An epsilon less than or equal to zero will return an unaltered version of the geometry.
-pub trait SimplifyVWPreserve<T, Epsilon = T> {
+pub trait SimplifyVwPreserve<T, Epsilon = T> {
     /// Returns the simplified representation of a geometry, using a topology-preserving variant of the
     /// [Visvalingam-Whyatt](http://www.tandfonline.com/doi/abs/10.1179/000870493786962263) algorithm.
     ///
@@ -533,7 +533,7 @@ pub trait SimplifyVWPreserve<T, Epsilon = T> {
     ///
     /// ```
     /// use approx::assert_relative_eq;
-    /// use geo::SimplifyVWPreserve;
+    /// use geo::SimplifyVwPreserve;
     /// use geo::line_string;
     ///
     /// let line_string = line_string![
@@ -547,7 +547,7 @@ pub trait SimplifyVWPreserve<T, Epsilon = T> {
     ///     (x: 301., y: 10.),
     /// ];
     ///
-    /// let simplified = line_string.simplifyvw_preserve(&668.6);
+    /// let simplified = line_string.simplify_vw_preserve(&668.6);
     ///
     /// let expected = line_string![
     ///     (x: 10., y: 60.),
@@ -560,40 +560,40 @@ pub trait SimplifyVWPreserve<T, Epsilon = T> {
     ///
     /// assert_relative_eq!(expected, simplified, epsilon = 1e-6);
     /// ```
-    fn simplifyvw_preserve(&self, epsilon: &T) -> Self
+    fn simplify_vw_preserve(&self, epsilon: &T) -> Self
     where
         T: CoordFloat + RTreeNum;
 }
 
-impl<T> SimplifyVWPreserve<T> for LineString<T>
+impl<T> SimplifyVwPreserve<T> for LineString<T>
 where
     T: CoordFloat + RTreeNum + HasKernel,
 {
-    fn simplifyvw_preserve(&self, epsilon: &T) -> LineString<T> {
+    fn simplify_vw_preserve(&self, epsilon: &T) -> LineString<T> {
         let mut simplified = vwp_wrapper::<_, 2, 4>(self, None, epsilon);
         LineString::from(simplified.pop().unwrap())
     }
 }
 
-impl<T> SimplifyVWPreserve<T> for MultiLineString<T>
+impl<T> SimplifyVwPreserve<T> for MultiLineString<T>
 where
     T: CoordFloat + RTreeNum + HasKernel,
 {
-    fn simplifyvw_preserve(&self, epsilon: &T) -> MultiLineString<T> {
+    fn simplify_vw_preserve(&self, epsilon: &T) -> MultiLineString<T> {
         MultiLineString::new(
             self.0
                 .iter()
-                .map(|l| l.simplifyvw_preserve(epsilon))
+                .map(|l| l.simplify_vw_preserve(epsilon))
                 .collect(),
         )
     }
 }
 
-impl<T> SimplifyVWPreserve<T> for Polygon<T>
+impl<T> SimplifyVwPreserve<T> for Polygon<T>
 where
     T: CoordFloat + RTreeNum + HasKernel,
 {
-    fn simplifyvw_preserve(&self, epsilon: &T) -> Polygon<T> {
+    fn simplify_vw_preserve(&self, epsilon: &T) -> Polygon<T> {
         let mut simplified =
             vwp_wrapper::<_, 4, 6>(self.exterior(), Some(self.interiors()), epsilon);
         let exterior = LineString::from(simplified.remove(0));
@@ -602,25 +602,25 @@ where
     }
 }
 
-impl<T> SimplifyVWPreserve<T> for MultiPolygon<T>
+impl<T> SimplifyVwPreserve<T> for MultiPolygon<T>
 where
     T: CoordFloat + RTreeNum + HasKernel,
 {
-    fn simplifyvw_preserve(&self, epsilon: &T) -> MultiPolygon<T> {
+    fn simplify_vw_preserve(&self, epsilon: &T) -> MultiPolygon<T> {
         MultiPolygon::new(
             self.0
                 .iter()
-                .map(|p| p.simplifyvw_preserve(epsilon))
+                .map(|p| p.simplify_vw_preserve(epsilon))
                 .collect(),
         )
     }
 }
 
-impl<T> SimplifyVW<T> for LineString<T>
+impl<T> SimplifyVw<T> for LineString<T>
 where
     T: CoordFloat,
 {
-    fn simplifyvw(&self, epsilon: &T) -> LineString<T> {
+    fn simplify_vw(&self, epsilon: &T) -> LineString<T> {
         LineString::from(visvalingam(self, epsilon))
     }
 }
@@ -629,47 +629,47 @@ impl<T> SimplifyVwIdx<T> for LineString<T>
 where
     T: CoordFloat,
 {
-    fn simplifyvw_idx(&self, epsilon: &T) -> Vec<usize> {
+    fn simplify_vw_idx(&self, epsilon: &T) -> Vec<usize> {
         visvalingam_indices(self, epsilon)
     }
 }
 
-impl<T> SimplifyVW<T> for MultiLineString<T>
+impl<T> SimplifyVw<T> for MultiLineString<T>
 where
     T: CoordFloat,
 {
-    fn simplifyvw(&self, epsilon: &T) -> MultiLineString<T> {
-        MultiLineString::new(self.iter().map(|l| l.simplifyvw(epsilon)).collect())
+    fn simplify_vw(&self, epsilon: &T) -> MultiLineString<T> {
+        MultiLineString::new(self.iter().map(|l| l.simplify_vw(epsilon)).collect())
     }
 }
 
-impl<T> SimplifyVW<T> for Polygon<T>
+impl<T> SimplifyVw<T> for Polygon<T>
 where
     T: CoordFloat,
 {
-    fn simplifyvw(&self, epsilon: &T) -> Polygon<T> {
+    fn simplify_vw(&self, epsilon: &T) -> Polygon<T> {
         Polygon::new(
-            self.exterior().simplifyvw(epsilon),
+            self.exterior().simplify_vw(epsilon),
             self.interiors()
                 .iter()
-                .map(|l| l.simplifyvw(epsilon))
+                .map(|l| l.simplify_vw(epsilon))
                 .collect(),
         )
     }
 }
 
-impl<T> SimplifyVW<T> for MultiPolygon<T>
+impl<T> SimplifyVw<T> for MultiPolygon<T>
 where
     T: CoordFloat,
 {
-    fn simplifyvw(&self, epsilon: &T) -> MultiPolygon<T> {
-        MultiPolygon::new(self.iter().map(|p| p.simplifyvw(epsilon)).collect())
+    fn simplify_vw(&self, epsilon: &T) -> MultiPolygon<T> {
+        MultiPolygon::new(self.iter().map(|p| p.simplify_vw(epsilon)).collect())
     }
 }
 
 #[cfg(test)]
 mod test {
-    use super::{cartesian_intersect, visvalingam, vwp_wrapper, SimplifyVW, SimplifyVWPreserve};
+    use super::{cartesian_intersect, visvalingam, vwp_wrapper, SimplifyVw, SimplifyVwPreserve};
     use crate::{
         line_string, point, polygon, Coord, LineString, MultiLineString, MultiPolygon, Point,
         Polygon,
@@ -760,7 +760,7 @@ mod test {
             (x: -24.451171875, y: 35.266685523707665)
         ];
         let poly = Polygon::new(outer.clone(), vec![inner]);
-        let simplified = poly.simplifyvw_preserve(&95.4);
+        let simplified = poly.simplify_vw_preserve(&95.4);
         assert_relative_eq!(simplified.exterior(), &outer, epsilon = 1e-6);
     }
     #[test]
@@ -791,7 +791,7 @@ mod test {
             (x: -24.451171875, y: 35.266685523707665)
         ];
         let poly = Polygon::new(outer.clone(), vec![inner]);
-        let simplified = poly.simplifyvw_preserve(&95.4);
+        let simplified = poly.simplify_vw_preserve(&95.4);
         assert_eq!(simplified.exterior(), &outer);
         assert_eq!(simplified.interiors()[0], correct_inner);
     }
@@ -816,7 +816,7 @@ mod test {
         // simplify a longer LineString using the preserve variant
         let points_ls = geo_test_fixtures::vw_orig::<f64>();
         let correct_ls = geo_test_fixtures::vw_simplified::<f64>();
-        let simplified = points_ls.simplifyvw_preserve(&0.0005);
+        let simplified = points_ls.simplify_vw_preserve(&0.0005);
         assert_relative_eq!(simplified, correct_ls, epsilon = 1e-6);
     }
     #[test]
@@ -851,7 +851,7 @@ mod test {
 
         let mline = MultiLineString::new(vec![LineString::from(points_ls)]);
         assert_relative_eq!(
-            mline.simplifyvw(&30.),
+            mline.simplify_vw(&30.),
             MultiLineString::new(vec![LineString::from(correct_ls)]),
             epsilon = 1e-6
         );
@@ -868,7 +868,7 @@ mod test {
             (x: 0., y: 0.),
         ];
 
-        let poly2 = poly.simplifyvw(&10.);
+        let poly2 = poly.simplify_vw(&10.);
 
         assert_relative_eq!(
             poly2,
@@ -897,7 +897,7 @@ mod test {
             vec![],
         )]);
 
-        let mpoly2 = mpoly.simplifyvw(&10.);
+        let mpoly2 = mpoly.simplify_vw(&10.);
 
         assert_relative_eq!(
             mpoly2,

--- a/geo/src/lib.rs
+++ b/geo/src/lib.rs
@@ -62,8 +62,8 @@
 //!
 //! - **[`Simplify`](Simplify)**: Simplify a geometry using the Ramer–Douglas–Peucker algorithm
 //! - **[`SimplifyIdx`](SimplifyIdx)**: Calculate a simplified geometry using the Ramer–Douglas–Peucker algorithm, returning coordinate indices
-//! - **[`SimplifyVW`](SimplifyVW)**: Simplify a geometry using the Visvalingam-Whyatt algorithm
-//! - **[`SimplifyVWPreserve`](SimplifyVWPreserve)**: Simplify a geometry using a topology-preserving variant of the Visvalingam-Whyatt algorithm
+//! - **[`SimplifyVw`](SimplifyVw)**: Simplify a geometry using the Visvalingam-Whyatt algorithm
+//! - **[`SimplifyVwPreserve`](SimplifyVwPreserve)**: Simplify a geometry using a topology-preserving variant of the Visvalingam-Whyatt algorithm
 //! - **[`SimplifyVwIdx`](SimplifyVwIdx)**: Calculate a simplified geometry using a topology-preserving variant of the Visvalingam-Whyatt algorithm, returning coordinate indices
 //!
 //! ## Query


### PR DESCRIPTION


- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Fixes: https://github.com/georust/geo/issues/575

Changed:

* `SimplifyVW` -> `SimplifyVw`
* `SimplifyVWPreserve` -> `SimplifyVwPreserve`
* `simplifyvw` -> `simplify_vw`

Unchanged:

* `SimplifyVwIdx`