### PR TITLE
Fixed issued reported by "cargo outdated".

### DIFF
--- a/geo-bool-ops-benches/Cargo.toml
+++ b/geo-bool-ops-benches/Cargo.toml
@@ -12,7 +12,7 @@ log = "0.4.11"
 
 [dev-dependencies]
 approx = ">= 0.4.0, < 0.6.0"
-criterion = { version = "0.3", features = ["html_reports"] }
+criterion = { version = "0.4", features = ["html_reports"] }
 geo-test-fixtures = { path = "../geo-test-fixtures" }
 jts-test-runner = { path = "../jts-test-runner" }
 pretty_env_logger = "0.4"
@@ -25,10 +25,10 @@ serde = "1.0.137"
 serde_json = "1.0.81"
 serde_derive = "1.0.137"
 glob = "0.3.0"
-gt_prev = { version = "0.6.2" , package = "geo-types" }
+gt_prev = { version = "0.6.2", package = "geo-types" }
 geo-booleanop = "0.3.2"
 wkt = "0.10.1"
-geojson = { version = "0.23.0", features = [ "geo-types" ] }
+geojson = { version = "0.24.0", features = ["geo-types"] }
 
 [[bench]]
 name = "boolean_ops"

--- a/geo-types/Cargo.toml
+++ b/geo-types/Cargo.toml
@@ -22,7 +22,7 @@ use-rstar_0_9 = ["rstar_0_9", "approx"]
 approx = { version = ">= 0.4.0, < 0.6.0", optional = true }
 arbitrary = { version = "=1.2.2", optional = true }
 num-traits = "0.2"
-rstar_0_8 = { package = "rstar", version = "0.9", optional = true }
+rstar_0_8 = { package = "rstar", version = "0.8", optional = true }
 rstar_0_9 = { package = "rstar", version = "0.9", optional = true }
 serde = { version = "1", optional = true, features = ["derive"] }
 

--- a/geo-types/Cargo.toml
+++ b/geo-types/Cargo.toml
@@ -20,9 +20,9 @@ use-rstar_0_9 = ["rstar_0_9", "approx"]
 
 [dependencies]
 approx = { version = ">= 0.4.0, < 0.6.0", optional = true }
-arbitrary = { version = "=1.1.3", optional = true }
+arbitrary = { version = "=1.2.2", optional = true }
 num-traits = "0.2"
-rstar_0_8 = { package = "rstar", version = "0.8", optional = true }
+rstar_0_8 = { package = "rstar", version = "0.9", optional = true }
 rstar_0_9 = { package = "rstar", version = "0.9", optional = true }
 serde = { version = "1", optional = true, features = ["derive"] }
 

--- a/geo-types/Cargo.toml
+++ b/geo-types/Cargo.toml
@@ -20,7 +20,7 @@ use-rstar_0_9 = ["rstar_0_9", "approx"]
 
 [dependencies]
 approx = { version = ">= 0.4.0, < 0.6.0", optional = true }
-arbitrary = { version = "=1.2.2", optional = true }
+arbitrary = { version = "=1.1.3", optional = true }
 num-traits = "0.2"
 rstar_0_8 = { package = "rstar", version = "0.8", optional = true }
 rstar_0_9 = { package = "rstar", version = "0.9", optional = true }

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -29,7 +29,7 @@ serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 approx = ">= 0.4.0, < 0.6.0"
-criterion = { version = "0.3", features = ["html_reports"] }
+criterion = { version = "0.4", features = ["html_reports"] }
 geo-test-fixtures = { path = "../geo-test-fixtures" }
 jts-test-runner = { path = "../jts-test-runner" }
 pretty_env_logger = "0.4"

--- a/jts-test-runner/Cargo.toml
+++ b/jts-test-runner/Cargo.toml
@@ -8,8 +8,8 @@ approx = ">= 0.4.0, < 0.6.0"
 geo = { path = "../geo" }
 include_dir = { version = "0.7.2", features = ["glob"] }
 log = "0.4.14"
-serde =  { version = "1.0.105", features = ["derive"] }
-serde-xml-rs = "0.5.0"
+serde = { version = "1.0.105", features = ["derive"] }
+serde-xml-rs = "0.6.0"
 wkt = { version = "0.10.3", features = ["geo-types", "serde"] }
 
 [dev-dependencies]


### PR DESCRIPTION
I ran
```
cargo outdated
```

the warning list scrolled off the page... so I suggest its time for a little maintenance TLC

I am working of a crates that depends on this one .. and when I run 

```
cargo tree
```

Doing this would streamline my tree structure, ( reduce the number of crates download which differ only in  version number. ) 


