### PR TITLE
Breaking change, rust v1.59 is not longer supported, simplify

### DIFF
--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -5,13 +5,16 @@
 * Return `DoubleEndedIterator` from `LineString::points` and `LineString::points_mut`
   * <https://github.com/georust/geo/pull/951>
 * POSSIBLY BREAKING: Minimum supported version of Rust (MSRV) is now 1.63
-* Features: removed "use-rstar_0_8" and "use-rstar_0_9", simplified to a new feature "use-rstar" 
-  now that support for rust version 1.59 has been dropped.
+
+## 0.7.9
+ * Now that rust version 1.59 is no longer supported.
+   Features "use-rstar", "use-rstar_0_8", and "use-rstar_0_9" are deprecated.
+   Migration Guide: Use feature "rstar" as a direct replacement.
 
 ## 0.7.8
 
 * Rename `Coordinate` to `Coord`; add deprecated `Coordinate` that is an alias for `Coord`
-* Pin `arbitrary` version to 1.1.3 until our MSRV catches up with its latest release 
+* Pin `arbitrary` version to 1.1.3 until our MSRV catches up with its latest release
 * Add `point.x_mut()` and `point.y_mut()` methods on `Points`
 * Changed license field to [SPDX 2.1 license expression](https://spdx.dev/spdx-specification-21-web-version/#h.jxpfx0ykyb60)
   * <https://github.com/georust/geo/pull/928>

--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -5,6 +5,8 @@
 * Return `DoubleEndedIterator` from `LineString::points` and `LineString::points_mut`
   * <https://github.com/georust/geo/pull/951>
 * POSSIBLY BREAKING: Minimum supported version of Rust (MSRV) is now 1.63
+* Features: removed "use-rstar_0_8" and "use-rstar_0_9", simplified to a new feature "use-rstar" 
+  now that support for rust version 1.59 has been dropped.
 
 ## 0.7.8
 

--- a/geo-types/Cargo.toml
+++ b/geo-types/Cargo.toml
@@ -11,14 +11,23 @@ rust-version = "1.63"
 edition = "2021"
 
 [features]
-use-rstar = ["rstar"]
-
+rstar = ["rstar_0_9"]
+# use-rstar is deprecated in 0.7.9 and will be removed in 0.8.0.
+# Migration guide: Use "rstar" as a direct subsitute.
+use-rstar = ["use-rstar_0_8"]
+# use-rstar_0_8 is deprecated in 0.7.9 and will be removed in 0.8.0.
+# Migration guide: Use "rstar" as a direct subsitute.
+use-rstar_0_8 = ["rstar_0_8", "approx"]
+# use-rstar_0_9 is deprecated in 0.7.9 and will be removed in 0.8.0.
+# Migration guide: Use "rstar" as a direct subsitute.
+use-rstar_0_9 = ["rstar_0_9", "approx"]
 
 [dependencies]
 approx = { version = ">= 0.4.0, < 0.6.0", optional = true }
 arbitrary = { version = "=1.1.3", optional = true }
 num-traits = "0.2"
-rstar = { package = "rstar", version = "0.9", optional = true }
+rstar_0_8 = { package = "rstar", version = "0.8", optional = true }
+rstar_0_9 = { package = "rstar", version = "0.9", optional = true }
 serde = { version = "1", optional = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/geo-types/Cargo.toml
+++ b/geo-types/Cargo.toml
@@ -11,20 +11,14 @@ rust-version = "1.63"
 edition = "2021"
 
 [features]
-# Prefer `use-rstar` feature rather than enabling rstar directly.
-# rstar integration relies on the optional approx crate, but implicit features cannot yet enable other features.
-# See: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#namespaced-features
-rstar = ["rstar_0_8"]
-use-rstar = ["use-rstar_0_8"]
-use-rstar_0_8 = ["rstar_0_8", "approx"]
-use-rstar_0_9 = ["rstar_0_9", "approx"]
+use-rstar = ["rstar"]
+
 
 [dependencies]
 approx = { version = ">= 0.4.0, < 0.6.0", optional = true }
 arbitrary = { version = "=1.1.3", optional = true }
 num-traits = "0.2"
-rstar_0_8 = { package = "rstar", version = "0.8", optional = true }
-rstar_0_9 = { package = "rstar", version = "0.9", optional = true }
+rstar = { package = "rstar", version = "0.9", optional = true }
 serde = { version = "1", optional = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/geo-types/src/geometry/coord.rs
+++ b/geo-types/src/geometry/coord.rs
@@ -319,10 +319,50 @@ where
     }
 }
 
-#[cfg(feature = "rstar")]
-impl<T> ::rstar::Point for Coord<T>
+// TODO: rstar_0_8 is deprecated.
+// this test should be deleted  before the release of version 0.8.0
+#[cfg(feature = "rstar_0_8")]
+impl<T> ::rstar_0_8::Point for Coord<T>
 where
-    T: ::num_traits::Float + ::rstar::RTreeNum,
+    T: ::num_traits::Float + ::rstar_0_8::RTreeNum,
+{
+    type Scalar = T;
+
+    const DIMENSIONS: usize = 2;
+
+    #[inline]
+    fn generate(generator: impl Fn(usize) -> Self::Scalar) -> Self {
+        coord! {
+            x: generator(0),
+            y: generator(1),
+        }
+    }
+
+    #[inline]
+    fn nth(&self, index: usize) -> Self::Scalar {
+        match index {
+            0 => self.x,
+            1 => self.y,
+            _ => unreachable!(),
+        }
+    }
+
+    #[inline]
+    fn nth_mut(&mut self, index: usize) -> &mut Self::Scalar {
+        match index {
+            0 => &mut self.x,
+            1 => &mut self.y,
+            _ => unreachable!(),
+        }
+    }
+}
+
+// TODO: rstar_0_9 is deprecated.
+// this test be adjusted before the release of version 0.8.0
+#[cfg(feature = "rstar_0_9")]
+impl<T> ::rstar_0_9::Point for Coord<T>
+where
+    T: ::num_traits::Float + ::rstar_0_9::RTreeNum,
 {
     type Scalar = T;
 

--- a/geo-types/src/geometry/coord.rs
+++ b/geo-types/src/geometry/coord.rs
@@ -320,7 +320,7 @@ where
 }
 
 // TODO: rstar_0_8 is deprecated.
-// this test should be deleted  before the release of version 0.8.0
+// This test should be deleted  before the release of version 0.8.0
 #[cfg(feature = "rstar_0_8")]
 impl<T> ::rstar_0_8::Point for Coord<T>
 where
@@ -358,7 +358,7 @@ where
 }
 
 // TODO: rstar_0_9 is deprecated.
-// this test be adjusted before the release of version 0.8.0
+// This test showld be adjusted before the release of version 0.8.0
 #[cfg(feature = "rstar_0_9")]
 impl<T> ::rstar_0_9::Point for Coord<T>
 where

--- a/geo-types/src/geometry/coord.rs
+++ b/geo-types/src/geometry/coord.rs
@@ -319,46 +319,10 @@ where
     }
 }
 
-#[cfg(feature = "rstar_0_8")]
-impl<T> ::rstar_0_8::Point for Coord<T>
+#[cfg(feature = "rstar")]
+impl<T> ::rstar::Point for Coord<T>
 where
-    T: ::num_traits::Float + ::rstar_0_8::RTreeNum,
-{
-    type Scalar = T;
-
-    const DIMENSIONS: usize = 2;
-
-    #[inline]
-    fn generate(generator: impl Fn(usize) -> Self::Scalar) -> Self {
-        coord! {
-            x: generator(0),
-            y: generator(1),
-        }
-    }
-
-    #[inline]
-    fn nth(&self, index: usize) -> Self::Scalar {
-        match index {
-            0 => self.x,
-            1 => self.y,
-            _ => unreachable!(),
-        }
-    }
-
-    #[inline]
-    fn nth_mut(&mut self, index: usize) -> &mut Self::Scalar {
-        match index {
-            0 => &mut self.x,
-            1 => &mut self.y,
-            _ => unreachable!(),
-        }
-    }
-}
-
-#[cfg(feature = "rstar_0_9")]
-impl<T> ::rstar_0_9::Point for Coord<T>
-where
-    T: ::num_traits::Float + ::rstar_0_9::RTreeNum,
+    T: ::num_traits::Float + ::rstar::RTreeNum,
 {
     type Scalar = T;
 

--- a/geo-types/src/geometry/line.rs
+++ b/geo-types/src/geometry/line.rs
@@ -221,7 +221,7 @@ impl<T: AbsDiffEq<Epsilon = T> + CoordNum> AbsDiffEq for Line<T> {
     }
 }
 
-#[cfg(any(feature = "rstar_0_8", feature = "rstar_0_9"))]
+#[cfg(feature = "rstar")]
 macro_rules! impl_rstar_line {
     ($rstar:ident) => {
         impl<T> ::$rstar::RTreeObject for Line<T>
@@ -248,11 +248,8 @@ macro_rules! impl_rstar_line {
     };
 }
 
-#[cfg(feature = "rstar_0_8")]
-impl_rstar_line!(rstar_0_8);
-
-#[cfg(feature = "rstar_0_9")]
-impl_rstar_line!(rstar_0_9);
+#[cfg(feature = "rstar")]
+impl_rstar_line!(rstar);
 
 #[cfg(test)]
 mod test {

--- a/geo-types/src/geometry/line.rs
+++ b/geo-types/src/geometry/line.rs
@@ -221,7 +221,9 @@ impl<T: AbsDiffEq<Epsilon = T> + CoordNum> AbsDiffEq for Line<T> {
     }
 }
 
-#[cfg(feature = "rstar")]
+// TODO: rstar_0_9 and rstar_0_8 are deprecated.
+// This line should be adjusted  before the release of version 0.8.0
+#[cfg(any(feature = "rstar_0_8", feature = "rstar_0_9"))]
 macro_rules! impl_rstar_line {
     ($rstar:ident) => {
         impl<T> ::$rstar::RTreeObject for Line<T>
@@ -248,8 +250,15 @@ macro_rules! impl_rstar_line {
     };
 }
 
-#[cfg(feature = "rstar")]
-impl_rstar_line!(rstar);
+// TODO: rstar_0_8 is deprecated.
+// This line should be removed before the release of version 0.8.0
+#[cfg(feature = "rstar_0_8")]
+impl_rstar_line!(rstar_0_8);
+
+// TODO: rstar_0_9 is deprecated.
+// This line should be updated before the release of version 0.8.0
+#[cfg(feature = "rstar_0_9")]
+impl_rstar_line!(rstar_0_9);
 
 #[cfg(test)]
 mod test {

--- a/geo-types/src/geometry/line_string.rs
+++ b/geo-types/src/geometry/line_string.rs
@@ -478,7 +478,9 @@ impl<T: AbsDiffEq<Epsilon = T> + CoordNum> AbsDiffEq for LineString<T> {
     }
 }
 
-#[cfg(feature = "rstar")]
+// TODO: rstar_0_9 is deprecated.
+// This test be should be adjusted before the release of version 0.8.0
+#[cfg(any(feature = "rstar_0_8", feature = "rstar_0_9"))]
 macro_rules! impl_rstar_line_string {
     ($rstar:ident) => {
         impl<T> ::$rstar::RTreeObject for LineString<T>
@@ -519,8 +521,15 @@ macro_rules! impl_rstar_line_string {
     };
 }
 
-#[cfg(feature = "rstar")]
-impl_rstar_line_string!(rstar);
+// TODO: rstar_0_9 is deprecated.
+// This line should be removed before the release of version 0.8.0
+#[cfg(feature = "rstar_0_8")]
+impl_rstar_line_string!(rstar_0_8);
+
+// TODO: rstar_0_9 is deprecated.
+// This line should be updated before the release of version 0.8.0
+#[cfg(feature = "rstar_0_9")]
+impl_rstar_line_string!(rstar_0_9);
 
 #[cfg(test)]
 mod test {

--- a/geo-types/src/geometry/line_string.rs
+++ b/geo-types/src/geometry/line_string.rs
@@ -478,7 +478,7 @@ impl<T: AbsDiffEq<Epsilon = T> + CoordNum> AbsDiffEq for LineString<T> {
     }
 }
 
-#[cfg(any(feature = "rstar_0_8", feature = "rstar_0_9"))]
+#[cfg(feature = "rstar")]
 macro_rules! impl_rstar_line_string {
     ($rstar:ident) => {
         impl<T> ::$rstar::RTreeObject for LineString<T>
@@ -519,11 +519,8 @@ macro_rules! impl_rstar_line_string {
     };
 }
 
-#[cfg(feature = "rstar_0_8")]
-impl_rstar_line_string!(rstar_0_8);
-
-#[cfg(feature = "rstar_0_9")]
-impl_rstar_line_string!(rstar_0_9);
+#[cfg(feature = "rstar")]
+impl_rstar_line_string!(rstar);
 
 #[cfg(test)]
 mod test {

--- a/geo-types/src/geometry/point.rs
+++ b/geo-types/src/geometry/point.rs
@@ -586,40 +586,10 @@ where
     }
 }
 
-#[cfg(feature = "rstar_0_8")]
-// These are required for rstar RTree
-impl<T> ::rstar_0_8::Point for Point<T>
+#[cfg(feature = "rstar")]
+impl<T> ::rstar::Point for Point<T>
 where
-    T: ::num_traits::Float + ::rstar_0_8::RTreeNum,
-{
-    type Scalar = T;
-
-    const DIMENSIONS: usize = 2;
-
-    fn generate(generator: impl Fn(usize) -> Self::Scalar) -> Self {
-        Point::new(generator(0), generator(1))
-    }
-
-    fn nth(&self, index: usize) -> Self::Scalar {
-        match index {
-            0 => self.0.x,
-            1 => self.0.y,
-            _ => unreachable!(),
-        }
-    }
-    fn nth_mut(&mut self, index: usize) -> &mut Self::Scalar {
-        match index {
-            0 => &mut self.0.x,
-            1 => &mut self.0.y,
-            _ => unreachable!(),
-        }
-    }
-}
-
-#[cfg(feature = "rstar_0_9")]
-impl<T> ::rstar_0_9::Point for Point<T>
-where
-    T: ::num_traits::Float + ::rstar_0_9::RTreeNum,
+    T: ::num_traits::Float + ::rstar::RTreeNum,
 {
     type Scalar = T;
 

--- a/geo-types/src/geometry/point.rs
+++ b/geo-types/src/geometry/point.rs
@@ -586,10 +586,44 @@ where
     }
 }
 
-#[cfg(feature = "rstar")]
-impl<T> ::rstar::Point for Point<T>
+// TODO: rstar_0_8 is deprecated.
+// This should be removed  before the release of version 0.8.0
+#[cfg(feature = "rstar_0_8")]
+// These are required for rstar RTree
+impl<T> ::rstar_0_8::Point for Point<T>
 where
-    T: ::num_traits::Float + ::rstar::RTreeNum,
+    T: ::num_traits::Float + ::rstar_0_8::RTreeNum,
+{
+    type Scalar = T;
+
+    const DIMENSIONS: usize = 2;
+
+    fn generate(generator: impl Fn(usize) -> Self::Scalar) -> Self {
+        Point::new(generator(0), generator(1))
+    }
+
+    fn nth(&self, index: usize) -> Self::Scalar {
+        match index {
+            0 => self.0.x,
+            1 => self.0.y,
+            _ => unreachable!(),
+        }
+    }
+    fn nth_mut(&mut self, index: usize) -> &mut Self::Scalar {
+        match index {
+            0 => &mut self.0.x,
+            1 => &mut self.0.y,
+            _ => unreachable!(),
+        }
+    }
+}
+
+// TODO: rstar_0_9 is deprecated.
+// This line should be updated before the release of version 0.8.0
+#[cfg(feature = "rstar_0_9")]
+impl<T> ::rstar_0_9::Point for Point<T>
+where
+    T: ::num_traits::Float + ::rstar_0_9::RTreeNum,
 {
     type Scalar = T;
 

--- a/geo-types/src/geometry/polygon.rs
+++ b/geo-types/src/geometry/polygon.rs
@@ -543,7 +543,7 @@ impl<T: AbsDiffEq<Epsilon = T> + CoordNum> AbsDiffEq for Polygon<T> {
     }
 }
 
-#[cfg(any(feature = "rstar_0_8", feature = "rstar_0_9"))]
+#[cfg(feature = "rstar")]
 macro_rules! impl_rstar_polygon {
     ($rstar:ident) => {
         impl<T> $rstar::RTreeObject for Polygon<T>
@@ -559,8 +559,5 @@ macro_rules! impl_rstar_polygon {
     };
 }
 
-#[cfg(feature = "rstar_0_8")]
-impl_rstar_polygon!(rstar_0_8);
-
-#[cfg(feature = "rstar_0_9")]
-impl_rstar_polygon!(rstar_0_9);
+#[cfg(feature = "rstar")]
+impl_rstar_polygon!(rstar);

--- a/geo-types/src/geometry/polygon.rs
+++ b/geo-types/src/geometry/polygon.rs
@@ -543,7 +543,9 @@ impl<T: AbsDiffEq<Epsilon = T> + CoordNum> AbsDiffEq for Polygon<T> {
     }
 }
 
-#[cfg(feature = "rstar")]
+// TODO: rstar_0_8 and rstar_0.9 are deprecated.
+// This line should be updated before the release of version 0.8.0
+#[cfg(any(feature = "rstar_0_8", feature = "rstar_0_9"))]
 macro_rules! impl_rstar_polygon {
     ($rstar:ident) => {
         impl<T> $rstar::RTreeObject for Polygon<T>
@@ -559,5 +561,12 @@ macro_rules! impl_rstar_polygon {
     };
 }
 
-#[cfg(feature = "rstar")]
-impl_rstar_polygon!(rstar);
+// TODO: rstar_0_8 is deprecated.
+// This line should be removed before the release of version 0.8.0
+#[cfg(feature = "rstar_0_8")]
+impl_rstar_polygon!(rstar_0_8);
+
+// TODO: rstar_0_9 is deprecated.
+// This line should be updated before the release of version 0.8.0
+#[cfg(feature = "rstar_0_9")]
+impl_rstar_polygon!(rstar_0_9);

--- a/geo-types/src/lib.rs
+++ b/geo-types/src/lib.rs
@@ -63,7 +63,12 @@
 //! - `approx`: Allows geometry types to be checked for approximate equality with [approx]
 //! - `arbitrary`: Allows geometry types to be created from unstructured input with [arbitrary]
 //! - `serde`: Allows geometry types to be serialized and deserialized with [Serde]
-//! - `use-rstar`: Allows geometry types to be inserted into [rstar] R*-trees
+//! - 'rstar' Allows geometry types to be inserted into [rstar] R*-trees.
+//! - `use-rstar_0_8`: (deprected) Allows geometry types to be inserted into [rstar] R*-trees (`rstar v0.8`)
+//! - `use-rstar_0_9`: (dprected) Allows geometry types to be inserted into [rstar] R*-trees (`rstar v0.9`)
+//!
+//!  The features "use-rstar_0_8" and "use-rstar_0_9" are deprected in 0.7.9 and will be removed in 0.8.0
+//!  Migration Guide: use feature "rstar" as a directl replacement.
 //!
 //! [approx]: https://github.com/brendanzab/approx
 //! [arbitrary]: https://github.com/rust-fuzz/arbitrary
@@ -81,6 +86,10 @@ use std::fmt::Debug;
 #[cfg(feature = "serde")]
 #[macro_use]
 extern crate serde;
+
+// TODO: rstar_0_8 is deprected, removed this before the release of version 0.8.0.
+#[cfg(feature = "rstar_0_8")]
+extern crate rstar_0_8;
 
 #[cfg(test)]
 #[macro_use]
@@ -123,7 +132,7 @@ mod macros;
 #[cfg(feature = "arbitrary")]
 mod arbitrary;
 
-#[cfg(feature = "rstar")]
+#[cfg(any(feature = "rstar_0_8", feature = "rstar_0_9"))]
 #[doc(hidden)]
 pub mod private_utils;
 
@@ -203,12 +212,29 @@ mod tests {
         assert_eq!(p.x(), 1_000_000i64);
     }
 
-    #[cfg(feature = "rstar")]
+    // Deprecation rstar_0_8 is deprecated.
+    // This test should be removed before the release of version 0.8.0.
+    #[cfg(feature = "rstar_0_8")]
     #[test]
     /// ensure Line's SpatialObject impl is correct
-    fn line_test_0_9() {
-        use rstar::primitives::Line as RStarLine;
-        use rstar::{PointDistance, RTreeObject};
+    fn line_test() {
+        use rstar_0_8::primitives::Line as RStarLine;
+        use rstar_0_8::{PointDistance, RTreeObject};
+
+        let rl = RStarLine::new(Point::new(0.0, 0.0), Point::new(5.0, 5.0));
+        let l = Line::new(coord! { x: 0.0, y: 0.0 }, coord! { x: 5., y: 5. });
+        assert_eq!(rl.envelope(), l.envelope());
+        // difference in 15th decimal place
+        assert_relative_eq!(26.0, rl.distance_2(&Point::new(4.0, 10.0)));
+        assert_relative_eq!(25.999999999999996, l.distance_2(&Point::new(4.0, 10.0)));
+    }
+
+    #[cfg(any(feature = "rstar_0_9", feature = "rstar"))]
+    #[test]
+    /// ensure Line's SpatialObject impl is correct
+    fn line_test() {
+        use rstar_0_9::primitives::Line as RStarLine;
+        use rstar_0_9::{PointDistance, RTreeObject};
 
         let rl = RStarLine::new(Point::new(0.0, 0.0), Point::new(5.0, 5.0));
         let l = Line::new(coord! { x: 0.0, y: 0.0 }, coord! { x: 5., y: 5. });

--- a/geo-types/src/lib.rs
+++ b/geo-types/src/lib.rs
@@ -212,7 +212,7 @@ mod tests {
         assert_eq!(p.x(), 1_000_000i64);
     }
 
-    // Deprecation rstar_0_8 is deprecated.
+    // TODO: rstar_0_8 is deprecated.
     // This test should be removed before the release of version 0.8.0.
     #[cfg(feature = "rstar_0_8")]
     #[test]
@@ -229,6 +229,8 @@ mod tests {
         assert_relative_eq!(25.999999999999996, l.distance_2(&Point::new(4.0, 10.0)));
     }
 
+    // TODO: rstar_0_9 is deprecated.
+    // This test should be updated before the release of version 0.8.0.
     #[cfg(any(feature = "rstar_0_9", feature = "rstar"))]
     #[test]
     /// ensure Line's SpatialObject impl is correct

--- a/geo-types/src/lib.rs
+++ b/geo-types/src/lib.rs
@@ -63,8 +63,7 @@
 //! - `approx`: Allows geometry types to be checked for approximate equality with [approx]
 //! - `arbitrary`: Allows geometry types to be created from unstructured input with [arbitrary]
 //! - `serde`: Allows geometry types to be serialized and deserialized with [Serde]
-//! - `use-rstar_0_8`: Allows geometry types to be inserted into [rstar] R*-trees (`rstar v0.8`)
-//! - `use-rstar_0_9`: Allows geometry types to be inserted into [rstar] R*-trees (`rstar v0.9`)
+//! - `use-rstar`: Allows geometry types to be inserted into [rstar] R*-trees
 //!
 //! [approx]: https://github.com/brendanzab/approx
 //! [arbitrary]: https://github.com/rust-fuzz/arbitrary
@@ -82,9 +81,6 @@ use std::fmt::Debug;
 #[cfg(feature = "serde")]
 #[macro_use]
 extern crate serde;
-
-#[cfg(feature = "rstar_0_8")]
-extern crate rstar_0_8;
 
 #[cfg(test)]
 #[macro_use]
@@ -127,7 +123,7 @@ mod macros;
 #[cfg(feature = "arbitrary")]
 mod arbitrary;
 
-#[cfg(any(feature = "rstar_0_8", feature = "rstar_0_9"))]
+#[cfg(feature = "rstar")]
 #[doc(hidden)]
 pub mod private_utils;
 
@@ -207,27 +203,12 @@ mod tests {
         assert_eq!(p.x(), 1_000_000i64);
     }
 
-    #[cfg(feature = "rstar_0_8")]
-    #[test]
-    /// ensure Line's SpatialObject impl is correct
-    fn line_test() {
-        use rstar_0_8::primitives::Line as RStarLine;
-        use rstar_0_8::{PointDistance, RTreeObject};
-
-        let rl = RStarLine::new(Point::new(0.0, 0.0), Point::new(5.0, 5.0));
-        let l = Line::new(coord! { x: 0.0, y: 0.0 }, coord! { x: 5., y: 5. });
-        assert_eq!(rl.envelope(), l.envelope());
-        // difference in 15th decimal place
-        assert_relative_eq!(26.0, rl.distance_2(&Point::new(4.0, 10.0)));
-        assert_relative_eq!(25.999999999999996, l.distance_2(&Point::new(4.0, 10.0)));
-    }
-
-    #[cfg(feature = "rstar_0_9")]
+    #[cfg(feature = "rstar")]
     #[test]
     /// ensure Line's SpatialObject impl is correct
     fn line_test_0_9() {
-        use rstar_0_9::primitives::Line as RStarLine;
-        use rstar_0_9::{PointDistance, RTreeObject};
+        use rstar::primitives::Line as RStarLine;
+        use rstar::{PointDistance, RTreeObject};
 
         let rl = RStarLine::new(Point::new(0.0, 0.0), Point::new(5.0, 5.0));
         let l = Line::new(coord! { x: 0.0, y: 0.0 }, coord! { x: 5., y: 5. });

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -18,7 +18,7 @@ use-serde = ["serde", "geo-types/serde"]
 
 [dependencies]
 float_next_after = "1.0.0"
-geo-types = { version = "0.7.8", features = ["approx", "use-rstar_0_9"] }
+geo-types = { version = "0.7.8", features = ["approx", "use-rstar"] }
 geographiclib-rs = "0.2"
 log = "0.4.11"
 num-traits = "0.2"

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -18,7 +18,7 @@ use-serde = ["serde", "geo-types/serde"]
 
 [dependencies]
 float_next_after = "1.0.0"
-geo-types = { version = "0.7.8", features = ["approx", "use-rstar"] }
+geo-types = { version = "0.7.8", features = ["approx", "rstar"] }
 geographiclib-rs = "0.2"
 log = "0.4.11"
 num-traits = "0.2"


### PR DESCRIPTION
By Simplify I mean replace  the "use_rstat_0_8" and "use_rstat_0_9" with a single  "use_rstar".  The namedspace-features issue in no longer relevant.

