### PR TITLE
Rename `LineString::exterior_mut` (and `interiors`) to `exterior_mut_ref`. Deprecate old fn.

### DIFF
--- a/geo-types/src/geometry/multi_polygon.rs
+++ b/geo-types/src/geometry/multi_polygon.rs
@@ -223,7 +223,7 @@ mod test {
         ]);
 
         for poly in &mut multi {
-            poly.exterior_mut(|exterior| {
+            poly.exterior_mut_ref(|exterior| {
                 for coord in exterior {
                     coord.x += 1;
                     coord.y += 1;
@@ -232,7 +232,7 @@ mod test {
         }
 
         for poly in multi.iter_mut() {
-            poly.exterior_mut(|exterior| {
+            poly.exterior_mut_ref(|exterior| {
                 for coord in exterior {
                     coord.x += 1;
                     coord.y += 1;

--- a/geo-types/src/geometry/polygon.rs
+++ b/geo-types/src/geometry/polygon.rs
@@ -236,7 +236,63 @@ impl<T: CoordNum> Polygon<T> {
     /// ```
     ///
     /// [will be closed]: #linestring-closing-operation
+    #[deprecated(note = "Renamed to `exterior_mut_ref`. In a future release, `exterior_mut` will be passed an owned `LineString`.")]
     pub fn exterior_mut<F>(&mut self, f: F)
+    where
+        F: FnOnce(&mut LineString<T>),
+    {
+        f(&mut self.exterior);
+        self.exterior.close();
+    }
+
+    /// Execute the provided closure `f`, which is provided with a mutable
+    /// reference to the exterior `LineString` ring.
+    ///
+    /// After the closure executes, the exterior `LineString` [will be closed].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use geo_types::{coord, LineString, Polygon};
+    ///
+    /// let mut polygon = Polygon::new(
+    ///     LineString::from(vec![(0., 0.), (1., 1.), (1., 0.), (0., 0.)]),
+    ///     vec![],
+    /// );
+    ///
+    /// polygon.exterior_mut_ref(|exterior| {
+    ///     exterior.0[1] = coord! { x: 1., y: 2. };
+    /// });
+    ///
+    /// assert_eq!(
+    ///     polygon.exterior(),
+    ///     &LineString::from(vec![(0., 0.), (1., 2.), (1., 0.), (0., 0.),])
+    /// );
+    /// ```
+    ///
+    /// If the first and last `Coord`s of the exterior `LineString` no
+    /// longer match, the `LineString` [will be closed]:
+    ///
+    /// ```
+    /// use geo_types::{coord, LineString, Polygon};
+    ///
+    /// let mut polygon = Polygon::new(
+    ///     LineString::from(vec![(0., 0.), (1., 1.), (1., 0.), (0., 0.)]),
+    ///     vec![],
+    /// );
+    ///
+    /// polygon.exterior_mut_ref(|exterior| {
+    ///     exterior.0[0] = coord! { x: 0., y: 1. };
+    /// });
+    ///
+    /// assert_eq!(
+    ///     polygon.exterior(),
+    ///     &LineString::from(vec![(0., 1.), (1., 1.), (1., 0.), (0., 0.), (0., 1.),])
+    /// );
+    /// ```
+    ///
+    /// [will be closed]: #linestring-closing-operation
+    pub fn exterior_mut_ref<F>(&mut self, f: F)
     where
         F: FnOnce(&mut LineString<T>),
     {
@@ -338,7 +394,87 @@ impl<T: CoordNum> Polygon<T> {
     /// ```
     ///
     /// [will be closed]: #linestring-closing-operation
+    #[deprecated(note = "Renamed to `exterior_mut_ref`. In a future release, `interiors_mut` will be passed an owned `Vec<LineString>`.")]
     pub fn interiors_mut<F>(&mut self, f: F)
+    where
+        F: FnOnce(&mut [LineString<T>]),
+    {
+        f(&mut self.interiors);
+        for interior in &mut self.interiors {
+            interior.close();
+        }
+    }
+
+    /// Execute the provided closure `f`, which is provided with a mutable
+    /// reference to the interior `LineString` rings.
+    ///
+    /// After the closure executes, each of the interior `LineString`s [will be
+    /// closed].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use geo_types::{coord, LineString, Polygon};
+    ///
+    /// let mut polygon = Polygon::new(
+    ///     LineString::from(vec![(0., 0.), (1., 1.), (1., 0.), (0., 0.)]),
+    ///     vec![LineString::from(vec![
+    ///         (0.1, 0.1),
+    ///         (0.9, 0.9),
+    ///         (0.9, 0.1),
+    ///         (0.1, 0.1),
+    ///     ])],
+    /// );
+    ///
+    /// polygon.interiors_mut_ref(|interiors| {
+    ///     interiors[0].0[1] = coord! { x: 0.8, y: 0.8 };
+    /// });
+    ///
+    /// assert_eq!(
+    ///     polygon.interiors(),
+    ///     &[LineString::from(vec![
+    ///         (0.1, 0.1),
+    ///         (0.8, 0.8),
+    ///         (0.9, 0.1),
+    ///         (0.1, 0.1),
+    ///     ])]
+    /// );
+    /// ```
+    ///
+    /// If the first and last `Coord`s of any interior `LineString` no
+    /// longer match, those `LineString`s [will be closed]:
+    ///
+    /// ```
+    /// use geo_types::{coord, LineString, Polygon};
+    ///
+    /// let mut polygon = Polygon::new(
+    ///     LineString::from(vec![(0., 0.), (1., 1.), (1., 0.), (0., 0.)]),
+    ///     vec![LineString::from(vec![
+    ///         (0.1, 0.1),
+    ///         (0.9, 0.9),
+    ///         (0.9, 0.1),
+    ///         (0.1, 0.1),
+    ///     ])],
+    /// );
+    ///
+    /// polygon.interiors_mut_ref(|interiors| {
+    ///     interiors[0].0[0] = coord! { x: 0.1, y: 0.2 };
+    /// });
+    ///
+    /// assert_eq!(
+    ///     polygon.interiors(),
+    ///     &[LineString::from(vec![
+    ///         (0.1, 0.2),
+    ///         (0.9, 0.9),
+    ///         (0.9, 0.1),
+    ///         (0.1, 0.1),
+    ///         (0.1, 0.2),
+    ///     ])]
+    /// );
+    /// ```
+    ///
+    /// [will be closed]: #linestring-closing-operation
+    pub fn interiors_mut_ref<F>(&mut self, f: F)
     where
         F: FnOnce(&mut [LineString<T>]),
     {

--- a/geo-types/src/geometry/polygon.rs
+++ b/geo-types/src/geometry/polygon.rs
@@ -236,7 +236,9 @@ impl<T: CoordNum> Polygon<T> {
     /// ```
     ///
     /// [will be closed]: #linestring-closing-operation
-    #[deprecated(note = "Renamed to `exterior_mut_ref`. In a future release, `exterior_mut` will be passed an owned `LineString`.")]
+    #[deprecated(
+        note = "Renamed to `exterior_mut_ref`. In a future release, `exterior_mut` will be passed an owned `LineString`."
+    )]
     pub fn exterior_mut<F>(&mut self, f: F)
     where
         F: FnOnce(&mut LineString<T>),
@@ -394,7 +396,9 @@ impl<T: CoordNum> Polygon<T> {
     /// ```
     ///
     /// [will be closed]: #linestring-closing-operation
-    #[deprecated(note = "Renamed to `exterior_mut_ref`. In a future release, `interiors_mut` will be passed an owned `Vec<LineString>`.")]
+    #[deprecated(
+        note = "Renamed to `exterior_mut_ref`. In a future release, `interiors_mut` will be passed an owned `Vec<LineString>`."
+    )]
     pub fn interiors_mut<F>(&mut self, f: F)
     where
         F: FnOnce(&mut [LineString<T>]),

--- a/geo/src/algorithm/map_coords.rs
+++ b/geo/src/algorithm/map_coords.rs
@@ -333,11 +333,11 @@ mod modern {
 
     impl<T: CoordNum> MapCoordsInPlace<T> for Polygon<T> {
         fn map_coords_in_place(&mut self, func: impl Fn(Coord<T>) -> Coord<T> + Copy) {
-            self.exterior_mut(|line_string| {
+            self.exterior_mut_ref(|line_string| {
                 line_string.map_coords_in_place(func);
             });
 
-            self.interiors_mut(|line_strings| {
+            self.interiors_mut_ref(|line_strings| {
                 for line_string in line_strings {
                     line_string.map_coords_in_place(func);
                 }
@@ -350,14 +350,14 @@ mod modern {
         ) -> Result<(), E> {
             let mut result = Ok(());
 
-            self.exterior_mut(|line_string| {
+            self.exterior_mut_ref(|line_string| {
                 if let Err(e) = line_string.try_map_coords_in_place(&func) {
                     result = Err(e);
                 }
             });
 
             if result.is_ok() {
-                self.interiors_mut(|line_strings| {
+                self.interiors_mut_ref(|line_strings| {
                     for line_string in line_strings {
                         if let Err(e) = line_string.try_map_coords_in_place(&func) {
                             result = Err(e);

--- a/geo/src/algorithm/remove_repeated_points.rs
+++ b/geo/src/algorithm/remove_repeated_points.rs
@@ -83,8 +83,8 @@ where
 
     /// Remove consecutive repeated points from a Polygon inplace.
     fn remove_repeated_points_mut(&mut self) {
-        self.exterior_mut(|exterior| exterior.remove_repeated_points_mut());
-        self.interiors_mut(|interiors| {
+        self.exterior_mut_ref(|exterior| exterior.remove_repeated_points_mut());
+        self.interiors_mut_ref(|interiors| {
             for interior in interiors {
                 interior.remove_repeated_points_mut();
             }


### PR DESCRIPTION

- [ ] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
In preparation for https://github.com/georust/geo/issues/350.

Eventually we can have these deprecated functions become non-deprecated and be passed owned data.
