### PR TITLE
Minor: Clippy fixes.

### DIFF
--- a/geo-types/src/error.rs
+++ b/geo-types/src/error.rs
@@ -15,7 +15,7 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Error::MismatchedGeometry { expected, found } => {
-                write!(f, "Expected a {}, but found a {}", expected, found)
+                write!(f, "Expected a {expected}, but found a {found}")
             }
         }
     }

--- a/geo-types/src/geometry/rect.rs
+++ b/geo-types/src/geometry/rect.rs
@@ -474,7 +474,7 @@ impl std::error::Error for InvalidRectCoordinatesError {}
 #[allow(deprecated)]
 impl core::fmt::Display for InvalidRectCoordinatesError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{}", RECT_INVALID_BOUNDS_ERROR)
+        write!(f, "{RECT_INVALID_BOUNDS_ERROR}")
     }
 }
 

--- a/geo/src/algorithm/relate/geomgraph/geometry_graph.rs
+++ b/geo/src/algorithm/relate/geomgraph/geometry_graph.rs
@@ -308,8 +308,8 @@ where
     ) -> SegmentIntersector<F> {
         let mut segment_intersector = SegmentIntersector::new(line_intersector, false);
         segment_intersector.set_boundary_nodes(
-            self.boundary_nodes().into_iter().cloned().collect(),
-            other.boundary_nodes().into_iter().cloned().collect(),
+            self.boundary_nodes().cloned().collect(),
+            other.boundary_nodes().cloned().collect(),
         );
 
         let mut edge_set_intersector = Self::create_edge_set_intersector();

--- a/geo/src/algorithm/relate/geomgraph/intersection_matrix.rs
+++ b/geo/src/algorithm/relate/geomgraph/intersection_matrix.rs
@@ -175,7 +175,7 @@ impl IntersectionMatrix {
                     '2' => self.0[*a][*b] = self.0[*a][*b].max(Dimensions::TwoDimensional),
                     'F' => {}
                     other => {
-                        let message = format!("expected '0', '1', '2', or 'F'. Found: {}", other);
+                        let message = format!("expected '0', '1', '2', or 'F'. Found: {other}");
                         return Err(InvalidInputError::new(message));
                     }
                 }

--- a/geo/src/algorithm/relate/geomgraph/topology_position.rs
+++ b/geo/src/algorithm/relate/geomgraph/topology_position.rs
@@ -184,8 +184,8 @@ impl TopologyPosition {
     pub fn set_locations(&mut self, new_on: CoordPos, new_left: CoordPos, new_right: CoordPos) {
         match self {
             Self::LineOrPoint { .. } => {
-                error!("invalid assignment dimensions for {:?}", self);
-                debug_assert!(false, "invalid assignment dimensions for {:?}", self);
+                error!("invalid assignment dimensions for {self:?}");
+                debug_assert!(false, "invalid assignment dimensions for {self:?}");
             }
             Self::Area { on, left, right } => {
                 *on = Some(new_on);

--- a/geo/src/algorithm/sweep/segment.rs
+++ b/geo/src/algorithm/sweep/segment.rs
@@ -49,7 +49,6 @@ impl<C: Cross> Segment<C> {
             debug_assert!(
                 p <= r,
                 "intersection point was not ordered within the line: {p:?} <= {r:?} <=> {q:?}",
-                p = p
             );
             if p == r || q == r {
                 // If the intersection is at the end point, the

--- a/jts-test-runner/src/runner.rs
+++ b/jts-test-runner/src/runner.rs
@@ -106,7 +106,7 @@ impl TestRunner {
                         (actual, expected) => {
                             debug!("Centroid failure: actual != expected");
                             let error_description =
-                                format!("expected {:?}, actual: {:?}", expected, actual);
+                                format!("expected {expected:?}, actual: {actual:?}");
                             self.failures.push(TestFailure {
                                 test_case,
                                 error_description,
@@ -126,8 +126,7 @@ impl TestRunner {
                     if relate_actual != *expected {
                         debug!("Contains failure: Relate doesn't match expected");
                         let error_description = format!(
-                            "Contains failure: expected {:?}, relate: {:?}",
-                            expected, relate_actual
+                            "Contains failure: expected {expected:?}, relate: {relate_actual:?}"
                         );
                         self.failures.push(TestFailure {
                             test_case,
@@ -138,8 +137,7 @@ impl TestRunner {
                             "Contains failure: Relate doesn't match Contains trait implementation"
                         );
                         let error_description = format!(
-                            "Contains failure - Relate.is_contains: {:?} doesn't match Contains trait: {:?}",
-                            expected, direct_actual
+                            "Contains failure - Relate.is_contains: {expected:?} doesn't match Contains trait: {direct_actual:?}"
                         );
                         self.failures.push(TestFailure {
                             test_case,
@@ -162,8 +160,7 @@ impl TestRunner {
                     if relate_within_result != *expected {
                         debug!("Within failure: Relate doesn't match expected");
                         let error_description = format!(
-                            "Within failure: expected {:?}, relate: {:?}",
-                            expected, relate_within_result
+                            "Within failure: expected {expected:?}, relate: {relate_within_result:?}"
                         );
                         self.failures.push(TestFailure {
                             test_case,
@@ -172,8 +169,7 @@ impl TestRunner {
                     } else if relate_within_result != within_trait_result {
                         debug!("Within failure: Relate doesn't match Within trait implementation");
                         let error_description = format!(
-                            "Within failure: Relate: {:?}, Within trait: {:?}",
-                            expected, within_trait_result
+                            "Within failure: Relate: {expected:?}, Within trait: {within_trait_result:?}"
                         );
                         self.failures.push(TestFailure {
                             test_case,
@@ -238,7 +234,7 @@ impl TestRunner {
                         Geometry::LineString(ext) => Polygon::new(ext.clone(), vec![]),
                         Geometry::Polygon(p) => p.clone(),
                         _ => {
-                            let error_description = format!("expected result for convex hull is not a polygon or a linestring: {:?}", expected);
+                            let error_description = format!("expected result for convex hull is not a polygon or a linestring: {expected:?}" );
                             self.failures.push(TestFailure {
                                 test_case,
                                 error_description,
@@ -252,7 +248,7 @@ impl TestRunner {
                     } else {
                         debug!("ConvexHull failure: actual != expected");
                         let error_description =
-                            format!("expected {:?}, actual: {:?}", expected, actual_polygon);
+                            format!("expected {expected:?}, actual: {actual_polygon:?}");
                         self.failures.push(TestFailure {
                             test_case,
                             error_description,
@@ -270,20 +266,16 @@ impl TestRunner {
 
                     if direct_actual != *expected {
                         debug!("Intersects failure: direct_actual != expected");
-                        let error_description = format!(
-                            "expected {:?}, direct_actual: {:?}",
-                            expected, direct_actual
-                        );
+                        let error_description =
+                            format!("expected {expected:?}, direct_actual: {direct_actual:?}",);
                         self.failures.push(TestFailure {
                             test_case,
                             error_description,
                         });
                     } else if relate_actual != *expected {
                         debug!("Intersects failure: relate_actual != expected");
-                        let error_description = format!(
-                            "expected {:?}, relate_actual: {:?}",
-                            expected, relate_actual
-                        );
+                        let error_description =
+                            format!("expected {expected:?}, relate_actual: {relate_actual:?}",);
                         self.failures.push(TestFailure {
                             test_case,
                             error_description,
@@ -302,7 +294,7 @@ impl TestRunner {
                     } else {
                         debug!("Relate failure: actual != expected");
                         let error_description =
-                            format!("expected {:?}, actual: {:?}", expected, actual);
+                            format!("expected {expected:?}, actual: {actual:?}");
                         self.failures.push(TestFailure {
                             test_case,
                             error_description,


### PR DESCRIPTION
Minor, I ran

 ```cargo clippy``` 

and fixed lots of trivial issues.

The only one to talk about is 

```
-            self.boundary_nodes().into_iter().cloned().collect(),
-            other.boundary_nodes().into_iter().cloned().collect(),
+            self.boundary_nodes().cloned().collect(),
+            other.boundary_nodes().cloned().collect(),
```

This may or may not lead to a more efficient block copy mechanism being used.. I have not checked the actual performance change.
