### PR TITLE
Add new feature to support rstar_0_10

### DIFF
--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -7,6 +7,7 @@
 * POSSIBLY BREAKING: Minimum supported version of Rust (MSRV) is now 1.63
 * Add `no_std` compatibility when the new default `std` feature is disabled
   * <https://github.com/georust/geo/pull/936>
+* Support `rstar` version `0.10` in feature `use-rstar_0_10`.
 
 ## 0.7.8
 

--- a/geo-types/Cargo.toml
+++ b/geo-types/Cargo.toml
@@ -20,6 +20,7 @@ rstar = ["rstar_0_8"]
 use-rstar = ["use-rstar_0_8"]
 use-rstar_0_8 = ["rstar_0_8", "approx"]
 use-rstar_0_9 = ["rstar_0_9", "approx"]
+use-rstar_0_10 = ["rstar_0_10", "approx"]
 
 [dependencies]
 approx = { version = ">= 0.4.0, < 0.6.0", optional = true, default-features = false }
@@ -27,6 +28,7 @@ arbitrary = { version = "1.2.0", optional = true }
 num-traits = { version = "0.2", default-features = false, features = ["libm"] }
 rstar_0_8 = { package = "rstar", version = "0.8", optional = true }
 rstar_0_9 = { package = "rstar", version = "0.9", optional = true }
+rstar_0_10 = { package = "rstar", version = "0.10", optional = true }
 serde = { version = "1", optional = true, default-features = false, features = ["alloc", "derive"] }
 
 [dev-dependencies]

--- a/geo-types/src/geometry/coord.rs
+++ b/geo-types/src/geometry/coord.rs
@@ -390,3 +390,39 @@ where
         }
     }
 }
+
+#[cfg(feature = "rstar_0_10")]
+impl<T> ::rstar_0_10::Point for Coord<T>
+where
+    T: ::num_traits::Float + ::rstar_0_10::RTreeNum,
+{
+    type Scalar = T;
+
+    const DIMENSIONS: usize = 2;
+
+    #[inline]
+    fn generate(mut generator: impl FnMut(usize) -> Self::Scalar) -> Self {
+        coord! {
+            x: generator(0),
+            y: generator(1),
+        }
+    }
+
+    #[inline]
+    fn nth(&self, index: usize) -> Self::Scalar {
+        match index {
+            0 => self.x,
+            1 => self.y,
+            _ => unreachable!(),
+        }
+    }
+
+    #[inline]
+    fn nth_mut(&mut self, index: usize) -> &mut Self::Scalar {
+        match index {
+            0 => &mut self.x,
+            1 => &mut self.y,
+            _ => unreachable!(),
+        }
+    }
+}

--- a/geo-types/src/geometry/line.rs
+++ b/geo-types/src/geometry/line.rs
@@ -221,7 +221,7 @@ impl<T: AbsDiffEq<Epsilon = T> + CoordNum> AbsDiffEq for Line<T> {
     }
 }
 
-#[cfg(any(feature = "rstar_0_8", feature = "rstar_0_9"))]
+#[cfg(any(feature = "rstar_0_8", feature = "rstar_0_9", feature = "rstar_0_10"))]
 macro_rules! impl_rstar_line {
     ($rstar:ident) => {
         impl<T> ::$rstar::RTreeObject for Line<T>
@@ -253,6 +253,9 @@ impl_rstar_line!(rstar_0_8);
 
 #[cfg(feature = "rstar_0_9")]
 impl_rstar_line!(rstar_0_9);
+
+#[cfg(feature = "rstar_0_10")]
+impl_rstar_line!(rstar_0_10);
 
 #[cfg(test)]
 mod test {

--- a/geo-types/src/geometry/line_string.rs
+++ b/geo-types/src/geometry/line_string.rs
@@ -480,7 +480,7 @@ impl<T: AbsDiffEq<Epsilon = T> + CoordNum> AbsDiffEq for LineString<T> {
     }
 }
 
-#[cfg(any(feature = "rstar_0_8", feature = "rstar_0_9"))]
+#[cfg(any(feature = "rstar_0_8", feature = "rstar_0_9", feature = "rstar_0_10"))]
 macro_rules! impl_rstar_line_string {
     ($rstar:ident) => {
         impl<T> ::$rstar::RTreeObject for LineString<T>
@@ -526,6 +526,9 @@ impl_rstar_line_string!(rstar_0_8);
 
 #[cfg(feature = "rstar_0_9")]
 impl_rstar_line_string!(rstar_0_9);
+
+#[cfg(feature = "rstar_0_10")]
+impl_rstar_line_string!(rstar_0_10);
 
 #[cfg(test)]
 mod test {

--- a/geo-types/src/geometry/point.rs
+++ b/geo-types/src/geometry/point.rs
@@ -645,6 +645,35 @@ where
     }
 }
 
+#[cfg(feature = "rstar_0_10")]
+impl<T> ::rstar_0_10::Point for Point<T>
+where
+    T: ::num_traits::Float + ::rstar_0_10::RTreeNum,
+{
+    type Scalar = T;
+
+    const DIMENSIONS: usize = 2;
+
+    fn generate(mut generator: impl FnMut(usize) -> Self::Scalar) -> Self {
+        Point::new(generator(0), generator(1))
+    }
+
+    fn nth(&self, index: usize) -> Self::Scalar {
+        match index {
+            0 => self.0.x,
+            1 => self.0.y,
+            _ => unreachable!(),
+        }
+    }
+    fn nth_mut(&mut self, index: usize) -> &mut Self::Scalar {
+        match index {
+            0 => &mut self.0.x,
+            1 => &mut self.0.y,
+            _ => unreachable!(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/geo-types/src/geometry/polygon.rs
+++ b/geo-types/src/geometry/polygon.rs
@@ -545,7 +545,7 @@ impl<T: AbsDiffEq<Epsilon = T> + CoordNum> AbsDiffEq for Polygon<T> {
     }
 }
 
-#[cfg(any(feature = "rstar_0_8", feature = "rstar_0_9"))]
+#[cfg(any(feature = "rstar_0_8", feature = "rstar_0_9", feature = "rstar_0_10"))]
 macro_rules! impl_rstar_polygon {
     ($rstar:ident) => {
         impl<T> $rstar::RTreeObject for Polygon<T>
@@ -566,3 +566,6 @@ impl_rstar_polygon!(rstar_0_8);
 
 #[cfg(feature = "rstar_0_9")]
 impl_rstar_polygon!(rstar_0_9);
+
+#[cfg(feature = "rstar_0_10")]
+impl_rstar_polygon!(rstar_0_10);

--- a/geo-types/src/lib.rs
+++ b/geo-types/src/lib.rs
@@ -67,6 +67,7 @@
 //! - `serde`: Allows geometry types to be serialized and deserialized with [Serde]
 //! - `use-rstar_0_8`: Allows geometry types to be inserted into [rstar] R*-trees (`rstar v0.8`)
 //! - `use-rstar_0_9`: Allows geometry types to be inserted into [rstar] R*-trees (`rstar v0.9`)
+//! - `use-rstar_0_10`: Allows geometry types to be inserted into [rstar] R*-trees (`rstar v0.10`)
 //!
 //! This library can be used in `#![no_std]` environments if the default `std` feature is disabled. At
 //! the moment, the `arbitrary` and `use-rstar_0_8` features require `std`. This may change in a
@@ -135,7 +136,7 @@ mod macros;
 #[cfg(feature = "arbitrary")]
 mod arbitrary;
 
-#[cfg(any(feature = "rstar_0_8", feature = "rstar_0_9"))]
+#[cfg(any(feature = "rstar_0_8", feature = "rstar_0_9", feature = "rstar_0_10"))]
 #[doc(hidden)]
 pub mod private_utils;
 
@@ -248,6 +249,21 @@ mod tests {
     fn line_test_0_9() {
         use rstar_0_9::primitives::Line as RStarLine;
         use rstar_0_9::{PointDistance, RTreeObject};
+
+        let rl = RStarLine::new(Point::new(0.0, 0.0), Point::new(5.0, 5.0));
+        let l = Line::new(coord! { x: 0.0, y: 0.0 }, coord! { x: 5., y: 5. });
+        assert_eq!(rl.envelope(), l.envelope());
+        // difference in 15th decimal place
+        assert_relative_eq!(26.0, rl.distance_2(&Point::new(4.0, 10.0)));
+        assert_relative_eq!(25.999999999999996, l.distance_2(&Point::new(4.0, 10.0)));
+    }
+
+    #[cfg(feature = "rstar_0_10")]
+    #[test]
+    /// ensure Line's SpatialObject impl is correct
+    fn line_test_0_10() {
+        use rstar_0_10::primitives::Line as RStarLine;
+        use rstar_0_10::{PointDistance, RTreeObject};
 
         let rl = RStarLine::new(Point::new(0.0, 0.0), Point::new(5.0, 5.0));
         let l = Line::new(coord! { x: 0.0, y: 0.0 }, coord! { x: 5., y: 5. });

--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -9,6 +9,9 @@
 * BREAKING: Update to float_next_after-1.0.0
   <https://github.com/georust/geo/pull/952>
 * POSSIBLY BREAKING: Minimum supported version of Rust (MSRV) is now 1.63
+* BREAKING: Update `rstar` dependency to `0.10.0` and enable `use-rstar_0_10` feature for `geo-types.
+  <https://github.com/georust/geo/pull/987>
+
 
 ## 0.23.1
 

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -18,13 +18,13 @@ use-serde = ["serde", "geo-types/serde"]
 
 [dependencies]
 float_next_after = "1.0.0"
-geo-types = { version = "0.7.8", features = ["approx", "use-rstar_0_9"] }
+geo-types = { version = "0.7.8", features = ["approx", "use-rstar_0_10"] }
 geographiclib-rs = "0.2"
 log = "0.4.11"
 num-traits = "0.2"
 proj = { version = "0.27.0", optional = true }
 robust = "0.2.2"
-rstar = "0.9.3"
+rstar = "0.10.0"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [dev-dependencies]


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Add a new feature `use-rstar_0_10` in `geo-types` and enabled it in `geo`.