### PR TITLE
Adds `GeodesicDestination` and `GeodesicBearing`

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -15,6 +15,10 @@
   <https://github.com/georust/geo/pull/959>
 - Added `GeodesicArea` trait to support geodesic area and perimeter calculations from `geographlib-rs`
   <https://github.com/georust/geo/pull/988>
+- Added `GeodesicDestination` trait to support geodesic destination calculations
+  <https://github.com/georust/geo/pull/991>
+- Added `GeodesicBearing` trait to support geodesic bearing calculations
+  <https://github.com/georust/geo/pull/991>
 
 ## 0.23.1
 

--- a/geo/src/algorithm/geodesic_bearing.rs
+++ b/geo/src/algorithm/geodesic_bearing.rs
@@ -1,0 +1,77 @@
+use crate::{Point};
+use geographiclib_rs::{Geodesic, InverseGeodesic};
+use geo_types::CoordNum;
+
+/// Returns the bearing to another Point in degrees on a geodesic.
+///
+/// This uses the geodesic methods given by [Karney (2013)].
+///
+/// [Karney (2013)]:  https://arxiv.org/pdf/1109.4448.pdf
+pub trait GeodesicBearing<T: CoordNum> {
+    /// Returns the bearing to another Point in degrees, where North is 0° and East is 90°.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[macro_use] extern crate approx;
+    /// #
+    /// use geo::GeodesicBearing;
+    /// use geo::Point;
+    ///
+    /// let p_1 = Point::new(9.177789688110352, 48.776781529534965);
+    /// let p_2 = Point::new(9.274410083250379, 48.84033282787534);
+    /// let bearing = p_1.bearing(p_2);
+    /// assert_relative_eq!(bearing, 45., epsilon = 0.1);
+    /// ```
+    fn bearing(&self, point: Point<T>) -> T;
+
+    /// Returns the bearing and distance to another Point in a (bearing, distance) tuple.
+    /// Bearing is reported in degrees, where North is 0° and East is 90°. Distance is reported in meters.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[macro_use] extern crate approx;
+    /// #
+    /// use geo::Bearing;
+    /// use geo::Point;
+    ///
+    /// let p_1 = Point::new(9.177789688110352, 48.776781529534965);
+    /// let p_2 = Point::new(9.274410083250379, 48.84033282787534);
+    /// let bearing = p_1.bearing(p_2);
+    /// assert_relative_eq!(bearing, 45., epsilon = 1.0e-6);
+    /// ```
+    fn bearing_distance(&self, point: Point<T>) -> (T, T);
+}
+
+impl GeodesicBearing<f64> for Point<f64> {
+    fn bearing(&self, rhs: Point<f64>) -> f64 {
+        let (azi1, _, _) = Geodesic::wgs84().inverse(self.y(), self.x(), rhs.y(), rhs.x());
+        azi1
+    }
+
+    fn bearing_distance(&self, rhs: Point<f64>) -> (f64, f64) {
+        let (distance, azi1, _, _) = Geodesic::wgs84().inverse(self.y(), self.x(), rhs.y(), rhs.x());
+        (azi1, distance)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::point;
+    use crate::GeodesicBearing;
+    use crate::HaversineDestination;
+
+    #[test]
+    fn geodesic_bearing() {
+        let p_1 = point!(x: 9.177789688110352f64, y: 48.776781529534965);
+        let p_2 = p_1.haversine_destination(45., 10000.);
+        let b_1 = p_1.bearing(p_2);
+        assert_relative_eq!(b_1, 45., epsilon = 0.1);
+
+        let p_3 = point!(x: 9., y: 47.);
+        let p_4 = point!(x: 9., y: 48.);
+        let b_2 = p_3.bearing(p_4);
+        assert_relative_eq!(b_2, 0., epsilon = 0.1);
+    }
+}

--- a/geo/src/algorithm/geodesic_bearing.rs
+++ b/geo/src/algorithm/geodesic_bearing.rs
@@ -19,38 +19,43 @@ pub trait GeodesicBearing<T: CoordNum> {
     /// use geo::Point;
     ///
     /// let p_1 = Point::new(9.177789688110352, 48.776781529534965);
-    /// let p_2 = Point::new(9.274410083250379, 48.84033282787534);
-    /// let bearing = p_1.bearing(p_2);
-    /// assert_relative_eq!(bearing, 45., epsilon = 0.1);
+    /// let p_2 = Point::new(9.27411867078536, 48.8403266058781);
+    /// let bearing = p_1.geodesic_bearing(p_2);
+    /// assert_relative_eq!(bearing, 45., epsilon = 1.0e-6);
     /// ```
-    fn bearing(&self, point: Point<T>) -> T;
+    fn geodesic_bearing(&self, point: Point<T>) -> T;
 
     /// Returns the bearing and distance to another Point in a (bearing, distance) tuple.
-    /// Bearing is reported in degrees, where North is 0° and East is 90°. Distance is reported in meters.
+    /// 
+    /// # Units
+    ///
+    /// - `bearing`: degrees, zero degrees is north. East is 90°.
+    /// - `distance`: meters
     ///
     /// # Examples
     ///
     /// ```
     /// # #[macro_use] extern crate approx;
     /// #
-    /// use geo::Bearing;
+    /// use geo::GeodesicBearing;
     /// use geo::Point;
     ///
     /// let p_1 = Point::new(9.177789688110352, 48.776781529534965);
-    /// let p_2 = Point::new(9.274410083250379, 48.84033282787534);
-    /// let bearing = p_1.bearing(p_2);
+    /// let p_2 = Point::new(9.27411867078536, 48.8403266058781);
+    /// let (bearing, distance) = p_1.geodesic_bearing_distance(p_2);
     /// assert_relative_eq!(bearing, 45., epsilon = 1.0e-6);
+    /// assert_relative_eq!(distance, 10000., epsilon = 1.0e-6);
     /// ```
-    fn bearing_distance(&self, point: Point<T>) -> (T, T);
+    fn geodesic_bearing_distance(&self, point: Point<T>) -> (T, T);
 }
 
 impl GeodesicBearing<f64> for Point<f64> {
-    fn bearing(&self, rhs: Point<f64>) -> f64 {
+    fn geodesic_bearing(&self, rhs: Point<f64>) -> f64 {
         let (azi1, _, _) = Geodesic::wgs84().inverse(self.y(), self.x(), rhs.y(), rhs.x());
         azi1
     }
 
-    fn bearing_distance(&self, rhs: Point<f64>) -> (f64, f64) {
+    fn geodesic_bearing_distance(&self, rhs: Point<f64>) -> (f64, f64) {
         let (distance, azi1, _, _) = Geodesic::wgs84().inverse(self.y(), self.x(), rhs.y(), rhs.x());
         (azi1, distance)
     }
@@ -60,18 +65,19 @@ impl GeodesicBearing<f64> for Point<f64> {
 mod test {
     use crate::point;
     use crate::GeodesicBearing;
-    use crate::HaversineDestination;
+    use crate::GeodesicDestination;
 
     #[test]
     fn geodesic_bearing() {
         let p_1 = point!(x: 9.177789688110352f64, y: 48.776781529534965);
-        let p_2 = p_1.haversine_destination(45., 10000.);
-        let b_1 = p_1.bearing(p_2);
-        assert_relative_eq!(b_1, 45., epsilon = 0.1);
+        let p_2 = p_1.geodesic_destination(45., 10000.);
+        let (b_1, d_1) = p_1.geodesic_bearing_distance(p_2);
+        assert_relative_eq!(b_1, 45., epsilon =1.0e-6);
+        assert_relative_eq!(d_1, 10000.0, epsilon = 1.0e-6);
 
         let p_3 = point!(x: 9., y: 47.);
         let p_4 = point!(x: 9., y: 48.);
-        let b_2 = p_3.bearing(p_4);
-        assert_relative_eq!(b_2, 0., epsilon = 0.1);
+        let b_2 = p_3.geodesic_bearing(p_4);
+        assert_relative_eq!(b_2, 0., epsilon = 1.0e-6);
     }
 }

--- a/geo/src/algorithm/geodesic_bearing.rs
+++ b/geo/src/algorithm/geodesic_bearing.rs
@@ -1,6 +1,6 @@
-use crate::{Point};
-use geographiclib_rs::{Geodesic, InverseGeodesic};
+use crate::Point;
 use geo_types::CoordNum;
+use geographiclib_rs::{Geodesic, InverseGeodesic};
 
 /// Returns the bearing to another Point in degrees on a geodesic.
 ///
@@ -26,7 +26,7 @@ pub trait GeodesicBearing<T: CoordNum> {
     fn geodesic_bearing(&self, point: Point<T>) -> T;
 
     /// Returns the bearing and distance to another Point in a (bearing, distance) tuple.
-    /// 
+    ///
     /// # Units
     ///
     /// - `bearing`: degrees, zero degrees is north. East is 90°.
@@ -56,7 +56,8 @@ impl GeodesicBearing<f64> for Point<f64> {
     }
 
     fn geodesic_bearing_distance(&self, rhs: Point<f64>) -> (f64, f64) {
-        let (distance, azi1, _, _) = Geodesic::wgs84().inverse(self.y(), self.x(), rhs.y(), rhs.x());
+        let (distance, azi1, _, _) =
+            Geodesic::wgs84().inverse(self.y(), self.x(), rhs.y(), rhs.x());
         (azi1, distance)
     }
 }
@@ -72,7 +73,7 @@ mod test {
         let p_1 = point!(x: 9.177789688110352f64, y: 48.776781529534965);
         let p_2 = p_1.geodesic_destination(45., 10000.);
         let (b_1, d_1) = p_1.geodesic_bearing_distance(p_2);
-        assert_relative_eq!(b_1, 45., epsilon =1.0e-6);
+        assert_relative_eq!(b_1, 45., epsilon = 1.0e-6);
         assert_relative_eq!(d_1, 10000.0, epsilon = 1.0e-6);
 
         let p_3 = point!(x: 9., y: 47.);

--- a/geo/src/algorithm/geodesic_destination.rs
+++ b/geo/src/algorithm/geodesic_destination.rs
@@ -50,7 +50,11 @@ mod test {
     fn returns_a_new_point() {
         let p_1 = Point::new(9.177789688110352, 48.776781529534965);
         let p_2 = p_1.geodesic_destination(45., 10000.);
-        assert_eq!(p_2, Point::new(9.27411867078536, 48.8403266058781));
+
+        let expected = Point::new(9.27411867078536, 48.8403266058781);
+        assert_relative_eq!(p_2.x(), expected.x(), epsilon = 1.0e-6);
+        assert_relative_eq!(p_2.y(), expected.y(), epsilon = 1.0e-6);
+
         let distance = p_1.geodesic_distance(&p_2);
         assert_relative_eq!(distance, 10000., epsilon = 1.0e-6)
     }

--- a/geo/src/algorithm/geodesic_destination.rs
+++ b/geo/src/algorithm/geodesic_destination.rs
@@ -4,8 +4,9 @@ use geo_types::CoordNum;
 
 /// Returns a new Point using the distance to the existing Point and a bearing for the direction on a geodesic
 ///
-/// *Note*: this implementation uses a mean earth radius of 6371.088 km, based on the [recommendation of
-/// the IUGG](ftp://athena.fsv.cvut.cz/ZFG/grs80-Moritz.pdf)
+/// This uses the geodesic methods given by [Karney (2013)].
+/// 
+/// [Karney (2013)]:  https://arxiv.org/pdf/1109.4448.pdf
 pub trait GeodesicDestination<T: CoordNum> {
     /// Returns a new Point using distance to the existing Point and a bearing for the direction
     ///
@@ -20,7 +21,7 @@ pub trait GeodesicDestination<T: CoordNum> {
     /// use geo::GeodesicDestination;
     /// use geo::Point;
     /// 
-    /// // Determine the point 10000 km NE of JFK - the "direct" geodesic calculation.
+    /// // Determine the point 10000 km NE of JFK.
     /// let jfk = Point::new(-73.78, 40.64);
     /// let northeast_bearing = 45.0;
     /// let distance = 10e6;
@@ -60,5 +61,13 @@ mod test {
         let p_2 = p_1.geodesic_destination(0., 1000.);
         assert_relative_eq!(p_1.x(), p_2.x(), epsilon = 1.0e-6);
         assert!(p_2.y() > p_1.y())
+    }
+
+    #[test]
+    fn bearing_90_is_east() {
+        let p_1 = Point::new(9.177789688110352, 48.776781529534965);
+        let p_2 = p_1.geodesic_destination(90., 1000.);
+        assert_relative_eq!(p_1.y(), p_2.y(), epsilon = 1.0e-6);
+        assert!(p_2.x() > p_1.x())
     }
 }

--- a/geo/src/algorithm/geodesic_destination.rs
+++ b/geo/src/algorithm/geodesic_destination.rs
@@ -2,13 +2,13 @@ use crate::Point;
 use geographiclib_rs::{Geodesic, DirectGeodesic};
 use geo_types::CoordNum;
 
-/// Returns a new Point using the distance to the existing Point and a bearing for the direction on a geodesic
+/// Returns a new Point using the distance to the existing Point and a bearing for the direction on a geodesic.
 ///
 /// This uses the geodesic methods given by [Karney (2013)].
 /// 
 /// [Karney (2013)]:  https://arxiv.org/pdf/1109.4448.pdf
 pub trait GeodesicDestination<T: CoordNum> {
-    /// Returns a new Point using distance to the existing Point and a bearing for the direction
+    /// Returns a new Point using distance to the existing Point and a bearing for the direction.
     ///
     /// # Units
     ///

--- a/geo/src/algorithm/geodesic_destination.rs
+++ b/geo/src/algorithm/geodesic_destination.rs
@@ -1,11 +1,11 @@
 use crate::Point;
-use geographiclib_rs::{Geodesic, DirectGeodesic};
 use geo_types::CoordNum;
+use geographiclib_rs::{DirectGeodesic, Geodesic};
 
 /// Returns a new Point using the distance to the existing Point and a bearing for the direction on a geodesic.
 ///
 /// This uses the geodesic methods given by [Karney (2013)].
-/// 
+///
 /// [Karney (2013)]:  https://arxiv.org/pdf/1109.4448.pdf
 pub trait GeodesicDestination<T: CoordNum> {
     /// Returns a new Point using distance to the existing Point and a bearing for the direction.
@@ -20,12 +20,12 @@ pub trait GeodesicDestination<T: CoordNum> {
     /// ```rust
     /// use geo::GeodesicDestination;
     /// use geo::Point;
-    /// 
+    ///
     /// // Determine the point 10000 km NE of JFK.
     /// let jfk = Point::new(-73.78, 40.64);
     /// let northeast_bearing = 45.0;
     /// let distance = 10e6;
-    /// 
+    ///
     /// let p_1 = jfk.geodesic_destination(northeast_bearing, distance);
     /// use approx::assert_relative_eq;
     /// assert_relative_eq!(p_1.x(), 49.052487092959836);
@@ -50,7 +50,7 @@ mod test {
     fn returns_a_new_point() {
         let p_1 = Point::new(9.177789688110352, 48.776781529534965);
         let p_2 = p_1.geodesic_destination(45., 10000.);
-        assert_eq!(p_2, Point::new(9.27411867078536,  48.8403266058781));
+        assert_eq!(p_2, Point::new(9.27411867078536, 48.8403266058781));
         let distance = p_1.geodesic_distance(&p_2);
         assert_relative_eq!(distance, 10000., epsilon = 1.0e-6)
     }

--- a/geo/src/algorithm/geodesic_destination.rs
+++ b/geo/src/algorithm/geodesic_destination.rs
@@ -1,0 +1,64 @@
+use crate::Point;
+use geographiclib_rs::{Geodesic, DirectGeodesic};
+use geo_types::CoordNum;
+
+/// Returns a new Point using the distance to the existing Point and a bearing for the direction on a geodesic
+///
+/// *Note*: this implementation uses a mean earth radius of 6371.088 km, based on the [recommendation of
+/// the IUGG](ftp://athena.fsv.cvut.cz/ZFG/grs80-Moritz.pdf)
+pub trait GeodesicDestination<T: CoordNum> {
+    /// Returns a new Point using distance to the existing Point and a bearing for the direction
+    ///
+    /// # Units
+    ///
+    /// - `bearing`: degrees, zero degrees is north
+    /// - `distance`: meters
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use geo::GeodesicDestination;
+    /// use geo::Point;
+    /// 
+    /// // Determine the point 10000 km NE of JFK - the "direct" geodesic calculation.
+    /// let jfk = Point::new(-73.78, 40.64);
+    /// let northeast_bearing = 45.0;
+    /// let distance = 10e6;
+    /// 
+    /// let p_1 = jfk.geodesic_destination(northeast_bearing, distance);
+    /// use approx::assert_relative_eq;
+    /// assert_relative_eq!(p_1.x(), 49.052487092959836);
+    /// assert_relative_eq!(p_1.y(), 32.621100463725796);
+    /// ```
+    fn geodesic_destination(&self, bearing: T, distance: T) -> Point<T>;
+}
+
+impl GeodesicDestination<f64> for Point<f64> {
+    fn geodesic_destination(&self, bearing: f64, distance: f64) -> Point<f64> {
+        let (lat, lon) = Geodesic::wgs84().direct(self.y(), self.x(), bearing, distance);
+        Point::new(lon, lat)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::GeodesicDistance;
+
+    #[test]
+    fn returns_a_new_point() {
+        let p_1 = Point::new(9.177789688110352, 48.776781529534965);
+        let p_2 = p_1.geodesic_destination(45., 10000.);
+        assert_eq!(p_2, Point::new(9.27411867078536,  48.8403266058781));
+        let distance = p_1.geodesic_distance(&p_2);
+        assert_relative_eq!(distance, 10000., epsilon = 1.0e-6)
+    }
+
+    #[test]
+    fn bearing_zero_is_north() {
+        let p_1 = Point::new(9.177789688110352, 48.776781529534965);
+        let p_2 = p_1.geodesic_destination(0., 1000.);
+        assert_relative_eq!(p_1.x(), p_2.x(), epsilon = 1.0e-6);
+        assert!(p_2.y() > p_1.y())
+    }
+}

--- a/geo/src/algorithm/geodesic_destination.rs
+++ b/geo/src/algorithm/geodesic_destination.rs
@@ -50,10 +50,8 @@ mod test {
     fn returns_a_new_point() {
         let p_1 = Point::new(9.177789688110352, 48.776781529534965);
         let p_2 = p_1.geodesic_destination(45., 10000.);
-
-        let expected = Point::new(9.27411867078536, 48.8403266058781);
-        assert_relative_eq!(p_2.x(), expected.x(), epsilon = 1.0e-6);
-        assert_relative_eq!(p_2.y(), expected.y(), epsilon = 1.0e-6);
+        
+        assert_relative_eq!(p_2, Point::new(9.27411867078536, 48.8403266058781), epsilon = 1.0e-6);
 
         let distance = p_1.geodesic_distance(&p_2);
         assert_relative_eq!(distance, 10000., epsilon = 1.0e-6)

--- a/geo/src/algorithm/geodesic_destination.rs
+++ b/geo/src/algorithm/geodesic_destination.rs
@@ -50,8 +50,12 @@ mod test {
     fn returns_a_new_point() {
         let p_1 = Point::new(9.177789688110352, 48.776781529534965);
         let p_2 = p_1.geodesic_destination(45., 10000.);
-        
-        assert_relative_eq!(p_2, Point::new(9.27411867078536, 48.8403266058781), epsilon = 1.0e-6);
+
+        assert_relative_eq!(
+            p_2,
+            Point::new(9.27411867078536, 48.8403266058781),
+            epsilon = 1.0e-6
+        );
 
         let distance = p_1.geodesic_distance(&p_2);
         assert_relative_eq!(distance, 10000., epsilon = 1.0e-6)

--- a/geo/src/algorithm/mod.rs
+++ b/geo/src/algorithm/mod.rs
@@ -86,11 +86,11 @@ pub use extremes::Extremes;
 pub mod frechet_distance;
 pub use frechet_distance::FrechetDistance;
 
-/// Calculate the Geodesic distance between two `Point`s.
+/// Calculate the bearing to another `Point` on a geodesic.
 pub mod geodesic_bearing;
 pub use geodesic_bearing::GeodesicBearing;
 
-/// Returns a new Point using a distance and bearing on a geodesic
+/// Returns a new Point using a distance and bearing on a geodesic.
 pub mod geodesic_destination;
 pub use geodesic_destination::GeodesicDestination;
 
@@ -98,7 +98,7 @@ pub use geodesic_destination::GeodesicDestination;
 pub mod geodesic_distance;
 pub use geodesic_distance::GeodesicDistance;
 
-/// Calculate the Geodesic area and perimeter of polygons
+/// Calculate the Geodesic area and perimeter of polygons.
 pub mod geodesic_area;
 pub use geodesic_area::GeodesicArea;
 

--- a/geo/src/algorithm/mod.rs
+++ b/geo/src/algorithm/mod.rs
@@ -87,6 +87,14 @@ pub mod frechet_distance;
 pub use frechet_distance::FrechetDistance;
 
 /// Calculate the Geodesic distance between two `Point`s.
+pub mod geodesic_bearing;
+pub use geodesic_bearing::GeodesicBearing;
+
+/// Returns a new Point using a distance and bearing on a geodesic
+pub mod geodesic_destination;
+pub use geodesic_destination::GeodesicDestination;
+
+/// Calculate the Geodesic distance between two `Point`s.
 pub mod geodesic_distance;
 pub use geodesic_distance::GeodesicDistance;
 

--- a/geo/src/lib.rs
+++ b/geo/src/lib.rs
@@ -70,6 +70,7 @@
 //! ## Query
 //!
 //! - **[`Bearing`](Bearing)**: Calculate the bearing between points
+//! - **[`GeodesicBearing`](GeodesicBearing)**: Calculate the bearing between points on a [geodesic](https://en.wikipedia.org/wiki/Geodesics_on_an_ellipsoid)
 //! - **[`ClosestPoint`](ClosestPoint)**: Find the point on a geometry
 //!   closest to a given point
 //! - **[`IsConvex`](IsConvex)**: Calculate the convexity of a
@@ -142,8 +143,10 @@
 //! ## Miscellaneous
 //!
 //! - **[`Centroid`](Centroid)**: Calculate the centroid of a geometry
-//! - **[`HaversineDestination`](HaversineDestination)**:
-//! - **[`HaversineIntermediate`](HaversineIntermediate)**:
+//! - **[`GeodesicDestination`](GeodesicDestination)**: Given a start point, bearing, and distance, calculate the destination point on a [geodesic](https://en.wikipedia.org/wiki/Geodesics_on_an_ellipsoid)
+//! - **[`GeodesicIntermediate`](GeodesicIntermediate)**: Calculate intermediate points on a [geodesic](https://en.wikipedia.org/wiki/Geodesics_on_an_ellipsoid)
+//! - **[`HaversineDestination`](HaversineDestination)**: Given a start point, bearing, and distance, calculate the destination point on a sphere
+//! - **[`HaversineIntermediate`](HaversineIntermediate)**: Calculate intermediate points on a sphere
 //! - **[`proj`](proj)**: Project geometries with the `proj` crate (requires the `use-proj` feature)
 //! - **[`ChaikinSmoothing`](ChaikinSmoothing)**: Smoothen `LineString`, `Polygon`, `MultiLineString` and `MultiPolygon` using Chaikins algorithm.
 //! - **[`Densify`](Densify)**: Densify linear geometry components by interpolating points


### PR DESCRIPTION
- [X] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [X] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

This adds the following:

1. `GeodesicDestination` trait to complement the `HaversineDestination` trait
2. `GeodesicBearing` trait to complement the `Bearing` trait
3. Adds missing documentation for the  `GeodesicIntermediate` trait