### PR TITLE
Implement `From<&Line>` for `LineString`

### DIFF
--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Add new changes here.
+* Implement `From<&Line>` for `LineString`
 
 ## 0.7.9
 

--- a/geo-types/src/geometry/line_string.rs
+++ b/geo-types/src/geometry/line_string.rs
@@ -346,6 +346,12 @@ impl<T: CoordNum, IC: Into<Coord<T>>> From<Vec<IC>> for LineString<T> {
 
 impl<T: CoordNum> From<Line<T>> for LineString<T> {
     fn from(line: Line<T>) -> Self {
+        LineString::from(&line)
+    }
+}
+
+impl<T: CoordNum> From<&Line<T>> for LineString<T> {
+    fn from(line: &Line<T>) -> Self {
         Self(vec![line.start, line.end])
     }
 }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Manual implementation tends to be implemented inline (e.g https://github.com/frewsxcv/geo-bevy/blob/348085c43b58da8f321e04e77fa9bf7d624e60b4/src/lib.rs#L147) as `From<Line>` is possibly more restrictive than necessary. Not sure whether `From<Line>` uses copy over move even if it's an owned parameter.
