### PR TITLE
WIP Implement area functions on geometry traits

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
           # giving us about 6 months of coverage.
           #
           # Minimum supported rust version (MSRV)
-          - "georust/geo-ci:rust-1.63"
+          # - "georust/geo-ci:rust-1.63"
           # Two most recent releases - we omit older ones for expedient CI
           - "georust/geo-ci:rust-1.65"
           - "georust/geo-ci:rust-1.66"
@@ -96,7 +96,7 @@ jobs:
           # giving us about 6 months of coverage.
           #
           # Minimum supported rust version (MSRV)
-          - "georust/geo-ci:rust-1.63"
+          # - "georust/geo-ci:rust-1.63"
           # Two most recent releases - we omit older ones for expedient CI
           - "georust/geo-ci:rust-1.65"
           - "georust/geo-ci:rust-1.66"
@@ -123,7 +123,7 @@ jobs:
           # giving us about 6 months of coverage.
           #
           # Minimum supported rust version (MSRV)
-          - "georust/geo-ci:rust-1.63"
+          # - "georust/geo-ci:rust-1.63"
           # Two most recent releases - we omit older ones for expedient CI
           - "georust/geo-ci:rust-1.65"
           - "georust/geo-ci:rust-1.66"
@@ -149,7 +149,7 @@ jobs:
           # giving us about 6 months of coverage.
           #
           # Minimum supported rust version (MSRV)
-          - "georust/geo-ci:rust-1.63"
+          # - "georust/geo-ci:rust-1.63"
           # Two most recent releases - we omit older ones for expedient CI
           - "georust/geo-ci:rust-1.65"
           - "georust/geo-ci:rust-1.66"

--- a/geo-traits/src/coord.rs
+++ b/geo-traits/src/coord.rs
@@ -1,7 +1,7 @@
 use geo_types::{Coord, CoordNum, Point};
 
-pub trait CoordTrait: Send + Sync {
-    type T: CoordNum + Send + Sync;
+pub trait CoordTrait {
+    type T: CoordNum;
 
     /// x component of this coord
     fn x(&self) -> Self::T;
@@ -15,7 +15,7 @@ pub trait CoordTrait: Send + Sync {
     }
 }
 
-impl<T: CoordNum + Send + Sync> CoordTrait for Point<T> {
+impl<T: CoordNum> CoordTrait for Point<T> {
     type T = T;
 
     fn x(&self) -> T {
@@ -27,7 +27,7 @@ impl<T: CoordNum + Send + Sync> CoordTrait for Point<T> {
     }
 }
 
-impl<T: CoordNum + Send + Sync> CoordTrait for &Point<T> {
+impl<T: CoordNum> CoordTrait for &Point<T> {
     type T = T;
 
     fn x(&self) -> T {
@@ -39,7 +39,7 @@ impl<T: CoordNum + Send + Sync> CoordTrait for &Point<T> {
     }
 }
 
-impl<T: CoordNum + Send + Sync> CoordTrait for Coord<T> {
+impl<T: CoordNum> CoordTrait for Coord<T> {
     type T = T;
 
     fn x(&self) -> T {
@@ -51,7 +51,7 @@ impl<T: CoordNum + Send + Sync> CoordTrait for Coord<T> {
     }
 }
 
-impl<T: CoordNum + Send + Sync> CoordTrait for &Coord<T> {
+impl<T: CoordNum> CoordTrait for &Coord<T> {
     type T = T;
 
     fn x(&self) -> T {

--- a/geo-traits/src/coord.rs
+++ b/geo-traits/src/coord.rs
@@ -1,9 +1,7 @@
-use std::ops::{AddAssign, SubAssign};
-
 use geo_types::{Coord, CoordNum, Point};
 
 pub trait CoordTrait: Send + Sync {
-    type T: CoordNum + Send + Sync; // + AddAssign + SubAssign;
+    type T: CoordNum + Send + Sync;
 
     /// x component of this coord
     fn x(&self) -> Self::T;

--- a/geo-traits/src/coord.rs
+++ b/geo-traits/src/coord.rs
@@ -18,11 +18,11 @@ pub trait CoordTrait {
 impl<T: CoordNum> CoordTrait for Point<T> {
     type T = T;
 
-    fn x(&self) -> T {
+    fn x(&self) -> Self::T {
         self.0.x
     }
 
-    fn y(&self) -> T {
+    fn y(&self) -> Self::T {
         self.0.y
     }
 }
@@ -30,11 +30,11 @@ impl<T: CoordNum> CoordTrait for Point<T> {
 impl<T: CoordNum> CoordTrait for &Point<T> {
     type T = T;
 
-    fn x(&self) -> T {
+    fn x(&self) -> Self::T {
         self.0.x
     }
 
-    fn y(&self) -> T {
+    fn y(&self) -> Self::T {
         self.0.y
     }
 }
@@ -42,11 +42,11 @@ impl<T: CoordNum> CoordTrait for &Point<T> {
 impl<T: CoordNum> CoordTrait for Coord<T> {
     type T = T;
 
-    fn x(&self) -> T {
+    fn x(&self) -> Self::T {
         self.x
     }
 
-    fn y(&self) -> T {
+    fn y(&self) -> Self::T {
         self.y
     }
 }
@@ -54,11 +54,11 @@ impl<T: CoordNum> CoordTrait for Coord<T> {
 impl<T: CoordNum> CoordTrait for &Coord<T> {
     type T = T;
 
-    fn x(&self) -> T {
+    fn x(&self) -> Self::T {
         self.x
     }
 
-    fn y(&self) -> T {
+    fn y(&self) -> Self::T {
         self.y
     }
 }

--- a/geo-traits/src/coord.rs
+++ b/geo-traits/src/coord.rs
@@ -1,7 +1,9 @@
+use std::ops::{AddAssign, SubAssign};
+
 use geo_types::{Coord, CoordNum, Point};
 
 pub trait CoordTrait: Send + Sync {
-    type T: CoordNum + Send + Sync;
+    type T: CoordNum + Send + Sync; // + AddAssign + SubAssign;
 
     /// x component of this coord
     fn x(&self) -> Self::T;

--- a/geo-traits/src/geometry.rs
+++ b/geo-traits/src/geometry.rs
@@ -9,7 +9,7 @@ use super::{
 };
 
 #[allow(clippy::type_complexity)]
-pub trait GeometryTrait<'a>: Send + Sync {
+pub trait GeometryTrait<'a> {
     type Point: 'a + PointTrait;
     type LineString: 'a + LineStringTrait<'a>;
     type Polygon: 'a + PolygonTrait<'a>;
@@ -52,7 +52,7 @@ where
     GeometryCollection(&'a GC),
 }
 
-impl<'a, T: CoordNum + Send + Sync + 'a> GeometryTrait<'a> for Geometry<T> {
+impl<'a, T: CoordNum + 'a> GeometryTrait<'a> for Geometry<T> {
     type Point = Point<T>;
     type LineString = LineString<T>;
     type Polygon = Polygon<T>;

--- a/geo-traits/src/geometry.rs
+++ b/geo-traits/src/geometry.rs
@@ -1,5 +1,3 @@
-use std::ops::SubAssign;
-
 use geo_types::{
     CoordNum, Geometry, GeometryCollection, LineString, MultiLineString, MultiPoint, MultiPolygon,
     Point, Polygon,
@@ -54,7 +52,7 @@ where
     GeometryCollection(&'a GC),
 }
 
-impl<'a, T: CoordNum + Send + Sync + SubAssign + 'a> GeometryTrait<'a> for Geometry<T> {
+impl<'a, T: CoordNum + Send + Sync + 'a> GeometryTrait<'a> for Geometry<T> {
     type Point = Point<T>;
     type LineString = LineString<T>;
     type Polygon = Polygon<T>;

--- a/geo-traits/src/geometry.rs
+++ b/geo-traits/src/geometry.rs
@@ -1,3 +1,5 @@
+use std::ops::SubAssign;
+
 use geo_types::{
     CoordNum, Geometry, GeometryCollection, LineString, MultiLineString, MultiPoint, MultiPolygon,
     Point, Polygon,
@@ -52,7 +54,7 @@ where
     GeometryCollection(&'a GC),
 }
 
-impl<'a, T: CoordNum + Send + Sync + 'a> GeometryTrait<'a> for Geometry<T> {
+impl<'a, T: CoordNum + Send + Sync + SubAssign + 'a> GeometryTrait<'a> for Geometry<T> {
     type Point = Point<T>;
     type LineString = LineString<T>;
     type Polygon = Polygon<T>;

--- a/geo-traits/src/geometry.rs
+++ b/geo-traits/src/geometry.rs
@@ -10,13 +10,14 @@ use super::{
 
 #[allow(clippy::type_complexity)]
 pub trait GeometryTrait<'a> {
-    type Point: 'a + PointTrait;
-    type LineString: 'a + LineStringTrait<'a>;
-    type Polygon: 'a + PolygonTrait<'a>;
-    type MultiPoint: 'a + MultiPointTrait<'a>;
-    type MultiLineString: 'a + MultiLineStringTrait<'a>;
-    type MultiPolygon: 'a + MultiPolygonTrait<'a>;
-    type GeometryCollection: 'a + GeometryCollectionTrait<'a>;
+    type T: CoordNum;
+    type Point: 'a + PointTrait<T = Self::T>;
+    type LineString: 'a + LineStringTrait<'a, T = Self::T>;
+    type Polygon: 'a + PolygonTrait<'a, T = Self::T>;
+    type MultiPoint: 'a + MultiPointTrait<'a, T = Self::T>;
+    type MultiLineString: 'a + MultiLineStringTrait<'a, T = Self::T>;
+    type MultiPolygon: 'a + MultiPolygonTrait<'a, T = Self::T>;
+    type GeometryCollection: 'a + GeometryCollectionTrait<'a, T = Self::T>;
 
     fn as_type(
         &'a self,
@@ -53,13 +54,14 @@ where
 }
 
 impl<'a, T: CoordNum + 'a> GeometryTrait<'a> for Geometry<T> {
-    type Point = Point<T>;
-    type LineString = LineString<T>;
-    type Polygon = Polygon<T>;
-    type MultiPoint = MultiPoint<T>;
-    type MultiLineString = MultiLineString<T>;
-    type MultiPolygon = MultiPolygon<T>;
-    type GeometryCollection = GeometryCollection<T>;
+    type T = T;
+    type Point = Point<Self::T>;
+    type LineString = LineString<Self::T>;
+    type Polygon = Polygon<Self::T>;
+    type MultiPoint = MultiPoint<Self::T>;
+    type MultiLineString = MultiLineString<Self::T>;
+    type MultiPolygon = MultiPolygon<Self::T>;
+    type GeometryCollection = GeometryCollection<Self::T>;
 
     fn as_type(
         &'a self,

--- a/geo-traits/src/geometry.rs
+++ b/geo-traits/src/geometry.rs
@@ -36,13 +36,13 @@ pub trait GeometryTrait<'a> {
 #[derive(Debug)]
 pub enum GeometryType<'a, P, L, Y, MP, ML, MY, GC>
 where
-    P: 'a + PointTrait,
-    L: 'a + LineStringTrait<'a>,
-    Y: 'a + PolygonTrait<'a>,
-    MP: 'a + MultiPointTrait<'a>,
-    ML: 'a + MultiLineStringTrait<'a>,
-    MY: 'a + MultiPolygonTrait<'a>,
-    GC: 'a + GeometryCollectionTrait<'a>,
+    P: PointTrait,
+    L: LineStringTrait<'a>,
+    Y: PolygonTrait<'a>,
+    MP: MultiPointTrait<'a>,
+    ML: MultiLineStringTrait<'a>,
+    MY: MultiPolygonTrait<'a>,
+    GC: GeometryCollectionTrait<'a>,
 {
     Point(&'a P),
     LineString(&'a L),

--- a/geo-traits/src/geometry_collection.rs
+++ b/geo-traits/src/geometry_collection.rs
@@ -3,7 +3,7 @@ use geo_types::{CoordNum, Geometry, GeometryCollection};
 use std::iter::Cloned;
 use std::slice::Iter;
 
-pub trait GeometryCollectionTrait<'a>: Send + Sync {
+pub trait GeometryCollectionTrait<'a> {
     type ItemType: 'a + GeometryTrait<'a>;
     type Iter: ExactSizeIterator<Item = Self::ItemType>;
 
@@ -18,7 +18,7 @@ pub trait GeometryCollectionTrait<'a>: Send + Sync {
     fn geometry(&'a self, i: usize) -> Option<Self::ItemType>;
 }
 
-impl<'a, T: CoordNum + Send + Sync + 'a> GeometryCollectionTrait<'a> for GeometryCollection<T> {
+impl<'a, T: CoordNum + 'a> GeometryCollectionTrait<'a> for GeometryCollection<T> {
     type ItemType = Geometry<T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
@@ -35,7 +35,7 @@ impl<'a, T: CoordNum + Send + Sync + 'a> GeometryCollectionTrait<'a> for Geometr
     }
 }
 
-impl<'a, T: CoordNum + Send + Sync + 'a> GeometryCollectionTrait<'a> for &GeometryCollection<T> {
+impl<'a, T: CoordNum + 'a> GeometryCollectionTrait<'a> for &GeometryCollection<T> {
     type ItemType = Geometry<T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 

--- a/geo-traits/src/geometry_collection.rs
+++ b/geo-traits/src/geometry_collection.rs
@@ -12,11 +12,11 @@ pub trait GeometryCollectionTrait<'a> {
     fn geometries(&'a self) -> Self::Iter;
 
     /// The number of geometries in this GeometryCollection
-    fn num_geometries(&'a self) -> usize;
+    fn num_geometries(&self) -> usize;
 
     /// Access to a specified geometry in this GeometryCollection
     /// Will return None if the provided index is out of bounds
-    fn geometry(&'a self, i: usize) -> Option<Self::ItemType>;
+    fn geometry(&self, i: usize) -> Option<Self::ItemType>;
 }
 
 impl<'a, T: CoordNum + 'a> GeometryCollectionTrait<'a> for GeometryCollection<T> {
@@ -28,11 +28,11 @@ impl<'a, T: CoordNum + 'a> GeometryCollectionTrait<'a> for GeometryCollection<T>
         self.0.iter().cloned()
     }
 
-    fn num_geometries(&'a self) -> usize {
+    fn num_geometries(&self) -> usize {
         self.0.len()
     }
 
-    fn geometry(&'a self, i: usize) -> Option<Self::ItemType> {
+    fn geometry(&self, i: usize) -> Option<Self::ItemType> {
         self.0.get(i).cloned()
     }
 }
@@ -46,11 +46,11 @@ impl<'a, T: CoordNum + 'a> GeometryCollectionTrait<'a> for &GeometryCollection<T
         self.0.iter().cloned()
     }
 
-    fn num_geometries(&'a self) -> usize {
+    fn num_geometries(&self) -> usize {
         self.0.len()
     }
 
-    fn geometry(&'a self, i: usize) -> Option<Self::ItemType> {
+    fn geometry(&self, i: usize) -> Option<Self::ItemType> {
         self.0.get(i).cloned()
     }
 }

--- a/geo-traits/src/geometry_collection.rs
+++ b/geo-traits/src/geometry_collection.rs
@@ -1,6 +1,7 @@
 use super::GeometryTrait;
 use geo_types::{CoordNum, Geometry, GeometryCollection};
 use std::iter::Cloned;
+use std::ops::SubAssign;
 use std::slice::Iter;
 
 pub trait GeometryCollectionTrait<'a>: Send + Sync {
@@ -18,7 +19,9 @@ pub trait GeometryCollectionTrait<'a>: Send + Sync {
     fn geometry(&'a self, i: usize) -> Option<Self::ItemType>;
 }
 
-impl<'a, T: CoordNum + Send + Sync + 'a> GeometryCollectionTrait<'a> for GeometryCollection<T> {
+impl<'a, T: CoordNum + Send + Sync + SubAssign + 'a> GeometryCollectionTrait<'a>
+    for GeometryCollection<T>
+{
     type ItemType = Geometry<T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
@@ -35,7 +38,9 @@ impl<'a, T: CoordNum + Send + Sync + 'a> GeometryCollectionTrait<'a> for Geometr
     }
 }
 
-impl<'a, T: CoordNum + Send + Sync + 'a> GeometryCollectionTrait<'a> for &GeometryCollection<T> {
+impl<'a, T: CoordNum + Send + Sync + SubAssign + 'a> GeometryCollectionTrait<'a>
+    for &GeometryCollection<T>
+{
     type ItemType = Geometry<T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 

--- a/geo-traits/src/geometry_collection.rs
+++ b/geo-traits/src/geometry_collection.rs
@@ -4,7 +4,8 @@ use std::iter::Cloned;
 use std::slice::Iter;
 
 pub trait GeometryCollectionTrait<'a> {
-    type ItemType: 'a + GeometryTrait<'a>;
+    type T: CoordNum;
+    type ItemType: 'a + GeometryTrait<'a, T = Self::T>;
     type Iter: ExactSizeIterator<Item = Self::ItemType>;
 
     /// An iterator over the geometries in this GeometryCollection
@@ -19,7 +20,8 @@ pub trait GeometryCollectionTrait<'a> {
 }
 
 impl<'a, T: CoordNum + 'a> GeometryCollectionTrait<'a> for GeometryCollection<T> {
-    type ItemType = Geometry<T>;
+    type T = T;
+    type ItemType = Geometry<Self::T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
     fn geometries(&'a self) -> Self::Iter {
@@ -36,7 +38,8 @@ impl<'a, T: CoordNum + 'a> GeometryCollectionTrait<'a> for GeometryCollection<T>
 }
 
 impl<'a, T: CoordNum + 'a> GeometryCollectionTrait<'a> for &GeometryCollection<T> {
-    type ItemType = Geometry<T>;
+    type T = T;
+    type ItemType = Geometry<Self::T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
     fn geometries(&'a self) -> Self::Iter {

--- a/geo-traits/src/geometry_collection.rs
+++ b/geo-traits/src/geometry_collection.rs
@@ -1,7 +1,6 @@
 use super::GeometryTrait;
 use geo_types::{CoordNum, Geometry, GeometryCollection};
 use std::iter::Cloned;
-use std::ops::SubAssign;
 use std::slice::Iter;
 
 pub trait GeometryCollectionTrait<'a>: Send + Sync {
@@ -19,9 +18,7 @@ pub trait GeometryCollectionTrait<'a>: Send + Sync {
     fn geometry(&'a self, i: usize) -> Option<Self::ItemType>;
 }
 
-impl<'a, T: CoordNum + Send + Sync + SubAssign + 'a> GeometryCollectionTrait<'a>
-    for GeometryCollection<T>
-{
+impl<'a, T: CoordNum + Send + Sync + 'a> GeometryCollectionTrait<'a> for GeometryCollection<T> {
     type ItemType = Geometry<T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
@@ -38,9 +35,7 @@ impl<'a, T: CoordNum + Send + Sync + SubAssign + 'a> GeometryCollectionTrait<'a>
     }
 }
 
-impl<'a, T: CoordNum + Send + Sync + SubAssign + 'a> GeometryCollectionTrait<'a>
-    for &GeometryCollection<T>
-{
+impl<'a, T: CoordNum + Send + Sync + 'a> GeometryCollectionTrait<'a> for &GeometryCollection<T> {
     type ItemType = Geometry<T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 

--- a/geo-traits/src/line_string.rs
+++ b/geo-traits/src/line_string.rs
@@ -2,10 +2,12 @@ use geo_types::{Coord, CoordNum, LineString};
 
 use super::CoordTrait;
 use std::iter::Cloned;
+use std::ops::SubAssign;
 use std::slice::Iter;
 
 pub trait LineStringTrait<'a>: Send + Sync {
-    type ItemType: 'a + CoordTrait;
+    type T: CoordNum + Send + Sync + SubAssign;
+    type ItemType: 'a + CoordTrait<T = Self::T>;
     type Iter: ExactSizeIterator<Item = Self::ItemType>;
 
     /// An iterator over the coords in this LineString
@@ -19,7 +21,8 @@ pub trait LineStringTrait<'a>: Send + Sync {
     fn coord(&'a self, i: usize) -> Option<Self::ItemType>;
 }
 
-impl<'a, T: CoordNum + Send + Sync + 'a> LineStringTrait<'a> for LineString<T> {
+impl<'a, T: CoordNum + Send + Sync + SubAssign + 'a> LineStringTrait<'a> for LineString<T> {
+    type T = T;
     type ItemType = Coord<T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
@@ -36,7 +39,8 @@ impl<'a, T: CoordNum + Send + Sync + 'a> LineStringTrait<'a> for LineString<T> {
     }
 }
 
-impl<'a, T: CoordNum + Send + Sync + 'a> LineStringTrait<'a> for &LineString<T> {
+impl<'a, T: CoordNum + Send + Sync + SubAssign + 'a> LineStringTrait<'a> for &LineString<T> {
+    type T = T;
     type ItemType = Coord<T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 

--- a/geo-traits/src/line_string.rs
+++ b/geo-traits/src/line_string.rs
@@ -4,8 +4,8 @@ use super::CoordTrait;
 use std::iter::Cloned;
 use std::slice::Iter;
 
-pub trait LineStringTrait<'a>: Send + Sync {
-    type T: CoordNum + Send + Sync;
+pub trait LineStringTrait<'a> {
+    type T: CoordNum;
     type ItemType: 'a + CoordTrait<T = Self::T>;
     type Iter: ExactSizeIterator<Item = Self::ItemType>;
 
@@ -13,14 +13,14 @@ pub trait LineStringTrait<'a>: Send + Sync {
     fn coords(&'a self) -> Self::Iter;
 
     /// The number of coords in this LineString
-    fn num_coords(&'a self) -> usize;
+    fn num_coords(&self) -> usize;
 
     /// Access to a specified point in this LineString
     /// Will return None if the provided index is out of bounds
-    fn coord(&'a self, i: usize) -> Option<Self::ItemType>;
+    fn coord(&self, i: usize) -> Option<Self::ItemType>;
 }
 
-impl<'a, T: CoordNum + Send + Sync + 'a> LineStringTrait<'a> for LineString<T> {
+impl<'a, T: CoordNum + 'a> LineStringTrait<'a> for LineString<T> {
     type T = T;
     type ItemType = Coord<T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
@@ -33,12 +33,12 @@ impl<'a, T: CoordNum + Send + Sync + 'a> LineStringTrait<'a> for LineString<T> {
         self.0.len()
     }
 
-    fn coord(&'a self, i: usize) -> Option<Self::ItemType> {
+    fn coord(&self, i: usize) -> Option<Self::ItemType> {
         self.0.get(i).cloned()
     }
 }
 
-impl<'a, T: CoordNum + Send + Sync + 'a> LineStringTrait<'a> for &LineString<T> {
+impl<'a, T: CoordNum + 'a> LineStringTrait<'a> for &LineString<T> {
     type T = T;
     type ItemType = Coord<T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
@@ -51,7 +51,7 @@ impl<'a, T: CoordNum + Send + Sync + 'a> LineStringTrait<'a> for &LineString<T> 
         self.0.len()
     }
 
-    fn coord(&'a self, i: usize) -> Option<Self::ItemType> {
+    fn coord(&self, i: usize) -> Option<Self::ItemType> {
         self.0.get(i).cloned()
     }
 }

--- a/geo-traits/src/line_string.rs
+++ b/geo-traits/src/line_string.rs
@@ -2,11 +2,10 @@ use geo_types::{Coord, CoordNum, LineString};
 
 use super::CoordTrait;
 use std::iter::Cloned;
-use std::ops::SubAssign;
 use std::slice::Iter;
 
 pub trait LineStringTrait<'a>: Send + Sync {
-    type T: CoordNum + Send + Sync + SubAssign;
+    type T: CoordNum + Send + Sync;
     type ItemType: 'a + CoordTrait<T = Self::T>;
     type Iter: ExactSizeIterator<Item = Self::ItemType>;
 
@@ -21,7 +20,7 @@ pub trait LineStringTrait<'a>: Send + Sync {
     fn coord(&'a self, i: usize) -> Option<Self::ItemType>;
 }
 
-impl<'a, T: CoordNum + Send + Sync + SubAssign + 'a> LineStringTrait<'a> for LineString<T> {
+impl<'a, T: CoordNum + Send + Sync + 'a> LineStringTrait<'a> for LineString<T> {
     type T = T;
     type ItemType = Coord<T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
@@ -39,7 +38,7 @@ impl<'a, T: CoordNum + Send + Sync + SubAssign + 'a> LineStringTrait<'a> for Lin
     }
 }
 
-impl<'a, T: CoordNum + Send + Sync + SubAssign + 'a> LineStringTrait<'a> for &LineString<T> {
+impl<'a, T: CoordNum + Send + Sync + 'a> LineStringTrait<'a> for &LineString<T> {
     type T = T;
     type ItemType = Coord<T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;

--- a/geo-traits/src/line_string.rs
+++ b/geo-traits/src/line_string.rs
@@ -22,7 +22,7 @@ pub trait LineStringTrait<'a> {
 
 impl<'a, T: CoordNum + 'a> LineStringTrait<'a> for LineString<T> {
     type T = T;
-    type ItemType = Coord<T>;
+    type ItemType = Coord<Self::T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
     fn coords(&'a self) -> Self::Iter {
@@ -40,7 +40,7 @@ impl<'a, T: CoordNum + 'a> LineStringTrait<'a> for LineString<T> {
 
 impl<'a, T: CoordNum + 'a> LineStringTrait<'a> for &LineString<T> {
     type T = T;
-    type ItemType = Coord<T>;
+    type ItemType = Coord<Self::T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
     fn coords(&'a self) -> Self::Iter {

--- a/geo-traits/src/multi_line_string.rs
+++ b/geo-traits/src/multi_line_string.rs
@@ -12,11 +12,11 @@ pub trait MultiLineStringTrait<'a> {
     fn lines(&'a self) -> Self::Iter;
 
     /// The number of lines in this MultiLineString
-    fn num_lines(&'a self) -> usize;
+    fn num_lines(&self) -> usize;
 
     /// Access to a specified line in this MultiLineString
     /// Will return None if the provided index is out of bounds
-    fn line(&'a self, i: usize) -> Option<Self::ItemType>;
+    fn line(&self, i: usize) -> Option<Self::ItemType>;
 }
 
 impl<'a, T: CoordNum + 'a> MultiLineStringTrait<'a> for MultiLineString<T> {
@@ -28,11 +28,11 @@ impl<'a, T: CoordNum + 'a> MultiLineStringTrait<'a> for MultiLineString<T> {
         self.0.iter().cloned()
     }
 
-    fn num_lines(&'a self) -> usize {
+    fn num_lines(&self) -> usize {
         self.0.len()
     }
 
-    fn line(&'a self, i: usize) -> Option<Self::ItemType> {
+    fn line(&self, i: usize) -> Option<Self::ItemType> {
         self.0.get(i).cloned()
     }
 }
@@ -46,11 +46,11 @@ impl<'a, T: CoordNum + 'a> MultiLineStringTrait<'a> for &MultiLineString<T> {
         self.0.iter().cloned()
     }
 
-    fn num_lines(&'a self) -> usize {
+    fn num_lines(&self) -> usize {
         self.0.len()
     }
 
-    fn line(&'a self, i: usize) -> Option<Self::ItemType> {
+    fn line(&self, i: usize) -> Option<Self::ItemType> {
         self.0.get(i).cloned()
     }
 }

--- a/geo-traits/src/multi_line_string.rs
+++ b/geo-traits/src/multi_line_string.rs
@@ -4,7 +4,8 @@ use std::iter::Cloned;
 use std::slice::Iter;
 
 pub trait MultiLineStringTrait<'a> {
-    type ItemType: 'a + LineStringTrait<'a>;
+    type T: CoordNum;
+    type ItemType: 'a + LineStringTrait<'a, T = Self::T>;
     type Iter: ExactSizeIterator<Item = Self::ItemType>;
 
     /// An iterator over the LineStrings in this MultiLineString
@@ -19,7 +20,8 @@ pub trait MultiLineStringTrait<'a> {
 }
 
 impl<'a, T: CoordNum + 'a> MultiLineStringTrait<'a> for MultiLineString<T> {
-    type ItemType = LineString<T>;
+    type T = T;
+    type ItemType = LineString<Self::T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
     fn lines(&'a self) -> Self::Iter {
@@ -36,7 +38,8 @@ impl<'a, T: CoordNum + 'a> MultiLineStringTrait<'a> for MultiLineString<T> {
 }
 
 impl<'a, T: CoordNum + 'a> MultiLineStringTrait<'a> for &MultiLineString<T> {
-    type ItemType = LineString<T>;
+    type T = T;
+    type ItemType = LineString<Self::T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
     fn lines(&'a self) -> Self::Iter {

--- a/geo-traits/src/multi_line_string.rs
+++ b/geo-traits/src/multi_line_string.rs
@@ -1,7 +1,6 @@
 use super::line_string::LineStringTrait;
 use geo_types::{CoordNum, LineString, MultiLineString};
 use std::iter::Cloned;
-use std::ops::SubAssign;
 use std::slice::Iter;
 
 pub trait MultiLineStringTrait<'a>: Send + Sync {
@@ -19,9 +18,7 @@ pub trait MultiLineStringTrait<'a>: Send + Sync {
     fn line(&'a self, i: usize) -> Option<Self::ItemType>;
 }
 
-impl<'a, T: CoordNum + Send + Sync + SubAssign + 'a> MultiLineStringTrait<'a>
-    for MultiLineString<T>
-{
+impl<'a, T: CoordNum + Send + Sync + 'a> MultiLineStringTrait<'a> for MultiLineString<T> {
     type ItemType = LineString<T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
@@ -38,9 +35,7 @@ impl<'a, T: CoordNum + Send + Sync + SubAssign + 'a> MultiLineStringTrait<'a>
     }
 }
 
-impl<'a, T: CoordNum + Send + Sync + SubAssign + 'a> MultiLineStringTrait<'a>
-    for &MultiLineString<T>
-{
+impl<'a, T: CoordNum + Send + Sync + 'a> MultiLineStringTrait<'a> for &MultiLineString<T> {
     type ItemType = LineString<T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 

--- a/geo-traits/src/multi_line_string.rs
+++ b/geo-traits/src/multi_line_string.rs
@@ -3,7 +3,7 @@ use geo_types::{CoordNum, LineString, MultiLineString};
 use std::iter::Cloned;
 use std::slice::Iter;
 
-pub trait MultiLineStringTrait<'a>: Send + Sync {
+pub trait MultiLineStringTrait<'a> {
     type ItemType: 'a + LineStringTrait<'a>;
     type Iter: ExactSizeIterator<Item = Self::ItemType>;
 
@@ -18,7 +18,7 @@ pub trait MultiLineStringTrait<'a>: Send + Sync {
     fn line(&'a self, i: usize) -> Option<Self::ItemType>;
 }
 
-impl<'a, T: CoordNum + Send + Sync + 'a> MultiLineStringTrait<'a> for MultiLineString<T> {
+impl<'a, T: CoordNum + 'a> MultiLineStringTrait<'a> for MultiLineString<T> {
     type ItemType = LineString<T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
@@ -35,7 +35,7 @@ impl<'a, T: CoordNum + Send + Sync + 'a> MultiLineStringTrait<'a> for MultiLineS
     }
 }
 
-impl<'a, T: CoordNum + Send + Sync + 'a> MultiLineStringTrait<'a> for &MultiLineString<T> {
+impl<'a, T: CoordNum + 'a> MultiLineStringTrait<'a> for &MultiLineString<T> {
     type ItemType = LineString<T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 

--- a/geo-traits/src/multi_line_string.rs
+++ b/geo-traits/src/multi_line_string.rs
@@ -1,6 +1,7 @@
 use super::line_string::LineStringTrait;
 use geo_types::{CoordNum, LineString, MultiLineString};
 use std::iter::Cloned;
+use std::ops::SubAssign;
 use std::slice::Iter;
 
 pub trait MultiLineStringTrait<'a>: Send + Sync {
@@ -18,7 +19,9 @@ pub trait MultiLineStringTrait<'a>: Send + Sync {
     fn line(&'a self, i: usize) -> Option<Self::ItemType>;
 }
 
-impl<'a, T: CoordNum + Send + Sync + 'a> MultiLineStringTrait<'a> for MultiLineString<T> {
+impl<'a, T: CoordNum + Send + Sync + SubAssign + 'a> MultiLineStringTrait<'a>
+    for MultiLineString<T>
+{
     type ItemType = LineString<T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
@@ -35,7 +38,9 @@ impl<'a, T: CoordNum + Send + Sync + 'a> MultiLineStringTrait<'a> for MultiLineS
     }
 }
 
-impl<'a, T: CoordNum + Send + Sync + 'a> MultiLineStringTrait<'a> for &MultiLineString<T> {
+impl<'a, T: CoordNum + Send + Sync + SubAssign + 'a> MultiLineStringTrait<'a>
+    for &MultiLineString<T>
+{
     type ItemType = LineString<T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 

--- a/geo-traits/src/multi_point.rs
+++ b/geo-traits/src/multi_point.rs
@@ -1,7 +1,6 @@
 use super::point::PointTrait;
 use geo_types::{CoordNum, MultiPoint, Point};
 use std::iter::Cloned;
-use std::ops::SubAssign;
 use std::slice::Iter;
 
 pub trait MultiPointTrait<'a>: Send + Sync {
@@ -19,7 +18,7 @@ pub trait MultiPointTrait<'a>: Send + Sync {
     fn point(&'a self, i: usize) -> Option<Self::ItemType>;
 }
 
-impl<'a, T: CoordNum + Send + Sync + SubAssign + 'a> MultiPointTrait<'a> for MultiPoint<T> {
+impl<'a, T: CoordNum + Send + Sync + 'a> MultiPointTrait<'a> for MultiPoint<T> {
     type ItemType = Point<T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
@@ -36,7 +35,7 @@ impl<'a, T: CoordNum + Send + Sync + SubAssign + 'a> MultiPointTrait<'a> for Mul
     }
 }
 
-impl<'a, T: CoordNum + Send + Sync + SubAssign + 'a> MultiPointTrait<'a> for &MultiPoint<T> {
+impl<'a, T: CoordNum + Send + Sync + 'a> MultiPointTrait<'a> for &MultiPoint<T> {
     type ItemType = Point<T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 

--- a/geo-traits/src/multi_point.rs
+++ b/geo-traits/src/multi_point.rs
@@ -1,6 +1,7 @@
 use super::point::PointTrait;
 use geo_types::{CoordNum, MultiPoint, Point};
 use std::iter::Cloned;
+use std::ops::SubAssign;
 use std::slice::Iter;
 
 pub trait MultiPointTrait<'a>: Send + Sync {
@@ -18,7 +19,7 @@ pub trait MultiPointTrait<'a>: Send + Sync {
     fn point(&'a self, i: usize) -> Option<Self::ItemType>;
 }
 
-impl<'a, T: CoordNum + Send + Sync + 'a> MultiPointTrait<'a> for MultiPoint<T> {
+impl<'a, T: CoordNum + Send + Sync + SubAssign + 'a> MultiPointTrait<'a> for MultiPoint<T> {
     type ItemType = Point<T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
@@ -35,7 +36,7 @@ impl<'a, T: CoordNum + Send + Sync + 'a> MultiPointTrait<'a> for MultiPoint<T> {
     }
 }
 
-impl<'a, T: CoordNum + Send + Sync + 'a> MultiPointTrait<'a> for &MultiPoint<T> {
+impl<'a, T: CoordNum + Send + Sync + SubAssign + 'a> MultiPointTrait<'a> for &MultiPoint<T> {
     type ItemType = Point<T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 

--- a/geo-traits/src/multi_point.rs
+++ b/geo-traits/src/multi_point.rs
@@ -12,11 +12,11 @@ pub trait MultiPointTrait<'a> {
     fn points(&'a self) -> Self::Iter;
 
     /// The number of points in this MultiPoint
-    fn num_points(&'a self) -> usize;
+    fn num_points(&self) -> usize;
 
     /// Access to a specified point in this MultiPoint
     /// Will return None if the provided index is out of bounds
-    fn point(&'a self, i: usize) -> Option<Self::ItemType>;
+    fn point(&self, i: usize) -> Option<Self::ItemType>;
 }
 
 impl<'a, T: CoordNum + 'a> MultiPointTrait<'a> for MultiPoint<T> {
@@ -32,7 +32,7 @@ impl<'a, T: CoordNum + 'a> MultiPointTrait<'a> for MultiPoint<T> {
         self.0.len()
     }
 
-    fn point(&'a self, i: usize) -> Option<Self::ItemType> {
+    fn point(&self, i: usize) -> Option<Self::ItemType> {
         self.0.get(i).cloned()
     }
 }
@@ -50,7 +50,7 @@ impl<'a, T: CoordNum + 'a> MultiPointTrait<'a> for &MultiPoint<T> {
         self.0.len()
     }
 
-    fn point(&'a self, i: usize) -> Option<Self::ItemType> {
+    fn point(&self, i: usize) -> Option<Self::ItemType> {
         self.0.get(i).cloned()
     }
 }

--- a/geo-traits/src/multi_point.rs
+++ b/geo-traits/src/multi_point.rs
@@ -4,7 +4,8 @@ use std::iter::Cloned;
 use std::slice::Iter;
 
 pub trait MultiPointTrait<'a> {
-    type ItemType: 'a + PointTrait;
+    type T: CoordNum;
+    type ItemType: 'a + PointTrait<T = Self::T>;
     type Iter: ExactSizeIterator<Item = Self::ItemType>;
 
     /// An iterator over the points in this MultiPoint
@@ -19,7 +20,8 @@ pub trait MultiPointTrait<'a> {
 }
 
 impl<'a, T: CoordNum + 'a> MultiPointTrait<'a> for MultiPoint<T> {
-    type ItemType = Point<T>;
+    type T = T;
+    type ItemType = Point<Self::T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
     fn points(&'a self) -> Self::Iter {
@@ -36,7 +38,8 @@ impl<'a, T: CoordNum + 'a> MultiPointTrait<'a> for MultiPoint<T> {
 }
 
 impl<'a, T: CoordNum + 'a> MultiPointTrait<'a> for &MultiPoint<T> {
-    type ItemType = Point<T>;
+    type T = T;
+    type ItemType = Point<Self::T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
     fn points(&'a self) -> Self::Iter {

--- a/geo-traits/src/multi_point.rs
+++ b/geo-traits/src/multi_point.rs
@@ -3,7 +3,7 @@ use geo_types::{CoordNum, MultiPoint, Point};
 use std::iter::Cloned;
 use std::slice::Iter;
 
-pub trait MultiPointTrait<'a>: Send + Sync {
+pub trait MultiPointTrait<'a> {
     type ItemType: 'a + PointTrait;
     type Iter: ExactSizeIterator<Item = Self::ItemType>;
 
@@ -18,7 +18,7 @@ pub trait MultiPointTrait<'a>: Send + Sync {
     fn point(&'a self, i: usize) -> Option<Self::ItemType>;
 }
 
-impl<'a, T: CoordNum + Send + Sync + 'a> MultiPointTrait<'a> for MultiPoint<T> {
+impl<'a, T: CoordNum + 'a> MultiPointTrait<'a> for MultiPoint<T> {
     type ItemType = Point<T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
@@ -35,7 +35,7 @@ impl<'a, T: CoordNum + Send + Sync + 'a> MultiPointTrait<'a> for MultiPoint<T> {
     }
 }
 
-impl<'a, T: CoordNum + Send + Sync + 'a> MultiPointTrait<'a> for &MultiPoint<T> {
+impl<'a, T: CoordNum + 'a> MultiPointTrait<'a> for &MultiPoint<T> {
     type ItemType = Point<T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 

--- a/geo-traits/src/multi_polygon.rs
+++ b/geo-traits/src/multi_polygon.rs
@@ -1,6 +1,7 @@
 use super::polygon::PolygonTrait;
 use geo_types::{CoordNum, MultiPolygon, Polygon};
 use std::iter::Cloned;
+use std::ops::SubAssign;
 use std::slice::Iter;
 
 pub trait MultiPolygonTrait<'a>: Send + Sync {
@@ -18,7 +19,7 @@ pub trait MultiPolygonTrait<'a>: Send + Sync {
     fn polygon(&'a self, i: usize) -> Option<Self::ItemType>;
 }
 
-impl<'a, T: CoordNum + Send + Sync + 'a> MultiPolygonTrait<'a> for MultiPolygon<T> {
+impl<'a, T: CoordNum + Send + Sync + SubAssign + 'a> MultiPolygonTrait<'a> for MultiPolygon<T> {
     type ItemType = Polygon<T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
@@ -35,7 +36,7 @@ impl<'a, T: CoordNum + Send + Sync + 'a> MultiPolygonTrait<'a> for MultiPolygon<
     }
 }
 
-impl<'a, T: CoordNum + Send + Sync + 'a> MultiPolygonTrait<'a> for &MultiPolygon<T> {
+impl<'a, T: CoordNum + Send + Sync + SubAssign + 'a> MultiPolygonTrait<'a> for &MultiPolygon<T> {
     type ItemType = Polygon<T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 

--- a/geo-traits/src/multi_polygon.rs
+++ b/geo-traits/src/multi_polygon.rs
@@ -12,11 +12,11 @@ pub trait MultiPolygonTrait<'a> {
     fn polygons(&'a self) -> Self::Iter;
 
     /// The number of polygons in this MultiPolygon
-    fn num_polygons(&'a self) -> usize;
+    fn num_polygons(&self) -> usize;
 
     /// Access to a specified polygon in this MultiPolygon
     /// Will return None if the provided index is out of bounds
-    fn polygon(&'a self, i: usize) -> Option<Self::ItemType>;
+    fn polygon(&self, i: usize) -> Option<Self::ItemType>;
 }
 
 impl<'a, T: CoordNum + 'a> MultiPolygonTrait<'a> for MultiPolygon<T> {
@@ -28,11 +28,11 @@ impl<'a, T: CoordNum + 'a> MultiPolygonTrait<'a> for MultiPolygon<T> {
         self.0.iter().cloned()
     }
 
-    fn num_polygons(&'a self) -> usize {
+    fn num_polygons(&self) -> usize {
         self.0.len()
     }
 
-    fn polygon(&'a self, i: usize) -> Option<Self::ItemType> {
+    fn polygon(&self, i: usize) -> Option<Self::ItemType> {
         self.0.get(i).cloned()
     }
 }
@@ -46,11 +46,11 @@ impl<'a, T: CoordNum + 'a> MultiPolygonTrait<'a> for &MultiPolygon<T> {
         self.0.iter().cloned()
     }
 
-    fn num_polygons(&'a self) -> usize {
+    fn num_polygons(&self) -> usize {
         self.0.len()
     }
 
-    fn polygon(&'a self, i: usize) -> Option<Self::ItemType> {
+    fn polygon(&self, i: usize) -> Option<Self::ItemType> {
         self.0.get(i).cloned()
     }
 }

--- a/geo-traits/src/multi_polygon.rs
+++ b/geo-traits/src/multi_polygon.rs
@@ -3,8 +3,8 @@ use geo_types::{CoordNum, MultiPolygon, Polygon};
 use std::iter::Cloned;
 use std::slice::Iter;
 
-pub trait MultiPolygonTrait<'a>: Send + Sync {
-    type T: CoordNum + Send + Sync;
+pub trait MultiPolygonTrait<'a> {
+    type T: CoordNum;
     type ItemType: 'a + PolygonTrait<'a, T = Self::T>;
     type Iter: ExactSizeIterator<Item = Self::ItemType>;
 
@@ -19,7 +19,7 @@ pub trait MultiPolygonTrait<'a>: Send + Sync {
     fn polygon(&'a self, i: usize) -> Option<Self::ItemType>;
 }
 
-impl<'a, T: CoordNum + Send + Sync + 'a> MultiPolygonTrait<'a> for MultiPolygon<T> {
+impl<'a, T: CoordNum + 'a> MultiPolygonTrait<'a> for MultiPolygon<T> {
     type T = T;
     type ItemType = Polygon<T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
@@ -37,7 +37,7 @@ impl<'a, T: CoordNum + Send + Sync + 'a> MultiPolygonTrait<'a> for MultiPolygon<
     }
 }
 
-impl<'a, T: CoordNum + Send + Sync + 'a> MultiPolygonTrait<'a> for &MultiPolygon<T> {
+impl<'a, T: CoordNum + 'a> MultiPolygonTrait<'a> for &MultiPolygon<T> {
     type T = T;
     type ItemType = Polygon<T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;

--- a/geo-traits/src/multi_polygon.rs
+++ b/geo-traits/src/multi_polygon.rs
@@ -21,7 +21,7 @@ pub trait MultiPolygonTrait<'a> {
 
 impl<'a, T: CoordNum + 'a> MultiPolygonTrait<'a> for MultiPolygon<T> {
     type T = T;
-    type ItemType = Polygon<T>;
+    type ItemType = Polygon<Self::T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
     fn polygons(&'a self) -> Self::Iter {
@@ -39,7 +39,7 @@ impl<'a, T: CoordNum + 'a> MultiPolygonTrait<'a> for MultiPolygon<T> {
 
 impl<'a, T: CoordNum + 'a> MultiPolygonTrait<'a> for &MultiPolygon<T> {
     type T = T;
-    type ItemType = Polygon<T>;
+    type ItemType = Polygon<Self::T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
     fn polygons(&'a self) -> Self::Iter {

--- a/geo-traits/src/multi_polygon.rs
+++ b/geo-traits/src/multi_polygon.rs
@@ -1,11 +1,11 @@
 use super::polygon::PolygonTrait;
 use geo_types::{CoordNum, MultiPolygon, Polygon};
 use std::iter::Cloned;
-use std::ops::SubAssign;
 use std::slice::Iter;
 
 pub trait MultiPolygonTrait<'a>: Send + Sync {
-    type ItemType: 'a + PolygonTrait<'a>;
+    type T: CoordNum + Send + Sync;
+    type ItemType: 'a + PolygonTrait<'a, T = Self::T>;
     type Iter: ExactSizeIterator<Item = Self::ItemType>;
 
     /// An iterator over the Polygons in this MultiPolygon
@@ -19,7 +19,8 @@ pub trait MultiPolygonTrait<'a>: Send + Sync {
     fn polygon(&'a self, i: usize) -> Option<Self::ItemType>;
 }
 
-impl<'a, T: CoordNum + Send + Sync + SubAssign + 'a> MultiPolygonTrait<'a> for MultiPolygon<T> {
+impl<'a, T: CoordNum + Send + Sync + 'a> MultiPolygonTrait<'a> for MultiPolygon<T> {
+    type T = T;
     type ItemType = Polygon<T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
@@ -36,7 +37,8 @@ impl<'a, T: CoordNum + Send + Sync + SubAssign + 'a> MultiPolygonTrait<'a> for M
     }
 }
 
-impl<'a, T: CoordNum + Send + Sync + SubAssign + 'a> MultiPolygonTrait<'a> for &MultiPolygon<T> {
+impl<'a, T: CoordNum + Send + Sync + 'a> MultiPolygonTrait<'a> for &MultiPolygon<T> {
+    type T = T;
     type ItemType = Polygon<T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 

--- a/geo-traits/src/point.rs
+++ b/geo-traits/src/point.rs
@@ -1,7 +1,7 @@
 use geo_types::{Coord, CoordNum, Point};
 
-pub trait PointTrait: Send + Sync {
-    type T: CoordNum + Send + Sync;
+pub trait PointTrait {
+    type T: CoordNum;
 
     /// x component of this coord
     fn x(&self) -> Self::T;
@@ -13,7 +13,7 @@ pub trait PointTrait: Send + Sync {
     fn x_y(&self) -> (Self::T, Self::T);
 }
 
-impl<T: CoordNum + Send + Sync> PointTrait for Point<T> {
+impl<T: CoordNum> PointTrait for Point<T> {
     type T = T;
 
     fn x(&self) -> T {
@@ -29,7 +29,7 @@ impl<T: CoordNum + Send + Sync> PointTrait for Point<T> {
     }
 }
 
-impl<T: CoordNum + Send + Sync> PointTrait for &Point<T> {
+impl<T: CoordNum> PointTrait for &Point<T> {
     type T = T;
 
     fn x(&self) -> T {
@@ -45,7 +45,7 @@ impl<T: CoordNum + Send + Sync> PointTrait for &Point<T> {
     }
 }
 
-impl<T: CoordNum + Send + Sync> PointTrait for Coord<T> {
+impl<T: CoordNum> PointTrait for Coord<T> {
     type T = T;
 
     fn x(&self) -> T {
@@ -61,7 +61,7 @@ impl<T: CoordNum + Send + Sync> PointTrait for Coord<T> {
     }
 }
 
-impl<T: CoordNum + Send + Sync> PointTrait for &Coord<T> {
+impl<T: CoordNum> PointTrait for &Coord<T> {
     type T = T;
 
     fn x(&self) -> T {

--- a/geo-traits/src/point.rs
+++ b/geo-traits/src/point.rs
@@ -16,15 +16,15 @@ pub trait PointTrait {
 impl<T: CoordNum> PointTrait for Point<T> {
     type T = T;
 
-    fn x(&self) -> T {
+    fn x(&self) -> Self::T {
         self.0.x
     }
 
-    fn y(&self) -> T {
+    fn y(&self) -> Self::T {
         self.0.y
     }
 
-    fn x_y(&self) -> (T, T) {
+    fn x_y(&self) -> (Self::T, Self::T) {
         (self.0.x, self.0.y)
     }
 }
@@ -32,15 +32,15 @@ impl<T: CoordNum> PointTrait for Point<T> {
 impl<T: CoordNum> PointTrait for &Point<T> {
     type T = T;
 
-    fn x(&self) -> T {
+    fn x(&self) -> Self::T {
         self.0.x
     }
 
-    fn y(&self) -> T {
+    fn y(&self) -> Self::T {
         self.0.y
     }
 
-    fn x_y(&self) -> (T, T) {
+    fn x_y(&self) -> (Self::T, Self::T) {
         (self.0.x, self.0.y)
     }
 }
@@ -48,15 +48,15 @@ impl<T: CoordNum> PointTrait for &Point<T> {
 impl<T: CoordNum> PointTrait for Coord<T> {
     type T = T;
 
-    fn x(&self) -> T {
+    fn x(&self) -> Self::T {
         self.x
     }
 
-    fn y(&self) -> T {
+    fn y(&self) -> Self::T {
         self.y
     }
 
-    fn x_y(&self) -> (T, T) {
+    fn x_y(&self) -> (Self::T, Self::T) {
         (self.x, self.y)
     }
 }
@@ -64,15 +64,15 @@ impl<T: CoordNum> PointTrait for Coord<T> {
 impl<T: CoordNum> PointTrait for &Coord<T> {
     type T = T;
 
-    fn x(&self) -> T {
+    fn x(&self) -> Self::T {
         self.x
     }
 
-    fn y(&self) -> T {
+    fn y(&self) -> Self::T {
         self.y
     }
 
-    fn x_y(&self) -> (T, T) {
+    fn x_y(&self) -> (Self::T, Self::T) {
         (self.x, self.y)
     }
 }

--- a/geo-traits/src/polygon.rs
+++ b/geo-traits/src/polygon.rs
@@ -24,7 +24,7 @@ pub trait PolygonTrait<'a> {
 
 impl<'a, T: CoordNum + 'a> PolygonTrait<'a> for Polygon<T> {
     type T = T;
-    type ItemType = LineString<T>;
+    type ItemType = LineString<Self::T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
     fn exterior(&'a self) -> Self::ItemType {
@@ -46,7 +46,7 @@ impl<'a, T: CoordNum + 'a> PolygonTrait<'a> for Polygon<T> {
 
 impl<'a, T: CoordNum + 'a> PolygonTrait<'a> for &Polygon<T> {
     type T = T;
-    type ItemType = LineString<T>;
+    type ItemType = LineString<Self::T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
     fn exterior(&'a self) -> Self::ItemType {

--- a/geo-traits/src/polygon.rs
+++ b/geo-traits/src/polygon.rs
@@ -1,11 +1,10 @@
 use super::line_string::LineStringTrait;
 use geo_types::{CoordNum, LineString, Polygon};
 use std::iter::Cloned;
-use std::ops::SubAssign;
 use std::slice::Iter;
 
 pub trait PolygonTrait<'a>: Send + Sync {
-    type T: CoordNum + Send + Sync + SubAssign;
+    type T: CoordNum + Send + Sync;
     type ItemType: 'a + LineStringTrait<'a, T = Self::T>;
     type Iter: ExactSizeIterator<Item = Self::ItemType>;
 
@@ -23,7 +22,7 @@ pub trait PolygonTrait<'a>: Send + Sync {
     fn interior(&'a self, i: usize) -> Option<Self::ItemType>;
 }
 
-impl<'a, T: CoordNum + Send + Sync + SubAssign + 'a> PolygonTrait<'a> for Polygon<T> {
+impl<'a, T: CoordNum + Send + Sync + 'a> PolygonTrait<'a> for Polygon<T> {
     type T = T;
     type ItemType = LineString<T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
@@ -45,7 +44,7 @@ impl<'a, T: CoordNum + Send + Sync + SubAssign + 'a> PolygonTrait<'a> for Polygo
     }
 }
 
-impl<'a, T: CoordNum + Send + Sync + SubAssign + 'a> PolygonTrait<'a> for &Polygon<T> {
+impl<'a, T: CoordNum + Send + Sync + 'a> PolygonTrait<'a> for &Polygon<T> {
     type T = T;
     type ItemType = LineString<T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;

--- a/geo-traits/src/polygon.rs
+++ b/geo-traits/src/polygon.rs
@@ -3,8 +3,8 @@ use geo_types::{CoordNum, LineString, Polygon};
 use std::iter::Cloned;
 use std::slice::Iter;
 
-pub trait PolygonTrait<'a>: Send + Sync {
-    type T: CoordNum + Send + Sync;
+pub trait PolygonTrait<'a> {
+    type T: CoordNum;
     type ItemType: 'a + LineStringTrait<'a, T = Self::T>;
     type Iter: ExactSizeIterator<Item = Self::ItemType>;
 
@@ -22,7 +22,7 @@ pub trait PolygonTrait<'a>: Send + Sync {
     fn interior(&'a self, i: usize) -> Option<Self::ItemType>;
 }
 
-impl<'a, T: CoordNum + Send + Sync + 'a> PolygonTrait<'a> for Polygon<T> {
+impl<'a, T: CoordNum + 'a> PolygonTrait<'a> for Polygon<T> {
     type T = T;
     type ItemType = LineString<T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
@@ -44,7 +44,7 @@ impl<'a, T: CoordNum + Send + Sync + 'a> PolygonTrait<'a> for Polygon<T> {
     }
 }
 
-impl<'a, T: CoordNum + Send + Sync + 'a> PolygonTrait<'a> for &Polygon<T> {
+impl<'a, T: CoordNum + 'a> PolygonTrait<'a> for &Polygon<T> {
     type T = T;
     type ItemType = LineString<T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;

--- a/geo-traits/src/polygon.rs
+++ b/geo-traits/src/polygon.rs
@@ -9,17 +9,17 @@ pub trait PolygonTrait<'a> {
     type Iter: ExactSizeIterator<Item = Self::ItemType>;
 
     /// The exterior ring of the polygon
-    fn exterior(&'a self) -> Self::ItemType;
+    fn exterior(&self) -> Self::ItemType;
 
     /// An iterator of the interior rings of this Polygon
     fn interiors(&'a self) -> Self::Iter;
 
     /// The number of interior rings in this Polygon
-    fn num_interiors(&'a self) -> usize;
+    fn num_interiors(&self) -> usize;
 
     /// Access to a specified interior ring in this Polygon
     /// Will return None if the provided index is out of bounds
-    fn interior(&'a self, i: usize) -> Option<Self::ItemType>;
+    fn interior(&self, i: usize) -> Option<Self::ItemType>;
 }
 
 impl<'a, T: CoordNum + 'a> PolygonTrait<'a> for Polygon<T> {
@@ -27,7 +27,7 @@ impl<'a, T: CoordNum + 'a> PolygonTrait<'a> for Polygon<T> {
     type ItemType = LineString<Self::T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
-    fn exterior(&'a self) -> Self::ItemType {
+    fn exterior(&self) -> Self::ItemType {
         Polygon::exterior(self).clone()
     }
 
@@ -35,11 +35,11 @@ impl<'a, T: CoordNum + 'a> PolygonTrait<'a> for Polygon<T> {
         Polygon::interiors(self).iter().cloned()
     }
 
-    fn num_interiors(&'a self) -> usize {
+    fn num_interiors(&self) -> usize {
         Polygon::interiors(self).len()
     }
 
-    fn interior(&'a self, i: usize) -> Option<Self::ItemType> {
+    fn interior(&self, i: usize) -> Option<Self::ItemType> {
         Polygon::interiors(self).get(i).cloned()
     }
 }
@@ -49,7 +49,7 @@ impl<'a, T: CoordNum + 'a> PolygonTrait<'a> for &Polygon<T> {
     type ItemType = LineString<Self::T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
-    fn exterior(&'a self) -> Self::ItemType {
+    fn exterior(&self) -> Self::ItemType {
         Polygon::exterior(self).clone()
     }
 
@@ -57,11 +57,11 @@ impl<'a, T: CoordNum + 'a> PolygonTrait<'a> for &Polygon<T> {
         Polygon::interiors(self).iter().cloned()
     }
 
-    fn num_interiors(&'a self) -> usize {
+    fn num_interiors(&self) -> usize {
         Polygon::interiors(self).len()
     }
 
-    fn interior(&'a self, i: usize) -> Option<Self::ItemType> {
+    fn interior(&self, i: usize) -> Option<Self::ItemType> {
         Polygon::interiors(self).get(i).cloned()
     }
 }

--- a/geo-traits/src/polygon.rs
+++ b/geo-traits/src/polygon.rs
@@ -1,10 +1,12 @@
 use super::line_string::LineStringTrait;
 use geo_types::{CoordNum, LineString, Polygon};
 use std::iter::Cloned;
+use std::ops::SubAssign;
 use std::slice::Iter;
 
 pub trait PolygonTrait<'a>: Send + Sync {
-    type ItemType: 'a + LineStringTrait<'a>;
+    type T: CoordNum + Send + Sync + SubAssign;
+    type ItemType: 'a + LineStringTrait<'a, T = Self::T>;
     type Iter: ExactSizeIterator<Item = Self::ItemType>;
 
     /// The exterior ring of the polygon
@@ -21,7 +23,8 @@ pub trait PolygonTrait<'a>: Send + Sync {
     fn interior(&'a self, i: usize) -> Option<Self::ItemType>;
 }
 
-impl<'a, T: CoordNum + Send + Sync + 'a> PolygonTrait<'a> for Polygon<T> {
+impl<'a, T: CoordNum + Send + Sync + SubAssign + 'a> PolygonTrait<'a> for Polygon<T> {
+    type T = T;
     type ItemType = LineString<T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 
@@ -42,7 +45,8 @@ impl<'a, T: CoordNum + Send + Sync + 'a> PolygonTrait<'a> for Polygon<T> {
     }
 }
 
-impl<'a, T: CoordNum + Send + Sync + 'a> PolygonTrait<'a> for &Polygon<T> {
+impl<'a, T: CoordNum + Send + Sync + SubAssign + 'a> PolygonTrait<'a> for &Polygon<T> {
+    type T = T;
     type ItemType = LineString<T>;
     type Iter = Cloned<Iter<'a, Self::ItemType>>;
 

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -21,6 +21,7 @@ use-serde = ["serde", "geo-types/serde"]
 earcutr = { version = "0.4.2", optional = true }
 float_next_after = "1.0.0"
 geo-types = { version = "0.7.9", features = ["approx", "use-rstar_0_10"] }
+geo-traits = { path = "../geo-traits" }
 geographiclib-rs = { version = "0.2.3", default-features = false }
 log = "0.4.11"
 num-traits = "0.2"

--- a/geo/src/algorithm/area.rs
+++ b/geo/src/algorithm/area.rs
@@ -75,7 +75,7 @@ where
     let shift = linestring.coord(0).unwrap();
 
     let mut tmp = T::zero();
-    for i in (0..linestring.num_coords()).step_by(2) {
+    for i in 0..linestring.num_coords() - 1 {
         let mut c1 = Coord {
             x: linestring.coord(i).unwrap().x(),
             y: linestring.coord(i).unwrap().y(),

--- a/geo/src/algorithm/area.rs
+++ b/geo/src/algorithm/area.rs
@@ -151,7 +151,7 @@ where
     }
 
     fn unsigned_area(&self) -> T {
-        unsigned_area_polygon(self)
+        self.signed_area().abs()
     }
 }
 

--- a/geo/src/algorithm/area.rs
+++ b/geo/src/algorithm/area.rs
@@ -76,7 +76,7 @@ pub(crate) fn twice_signed_ring_area_trait<'a>(linestring: &'a impl LineStringTr
         c1.0 -= shift.x();
         c1.1 -= shift.y();
 
-        let mut c2 = linestring.coord(i).unwrap().x_y();
+        let mut c2 = linestring.coord(i + 1).unwrap().x_y();
         c2.0 -= shift.x();
         c2.1 -= shift.y();
 

--- a/geo/src/algorithm/area.rs
+++ b/geo/src/algorithm/area.rs
@@ -72,13 +72,13 @@ pub(crate) fn twice_signed_ring_area_trait<'a>(linestring: &'a impl LineStringTr
 
     let mut tmp = 0_f64;
     for i in (0..linestring.num_coords()).step_by(2) {
-        let mut c1 = linestring.coord(i).unwrap().x_y();
-        c1.0 -= shift.x();
-        c1.1 -= shift.y();
+        let mut c1 = Coord { x: linestring.coord(i).unwrap().x(), y: linestring.coord(i).unwrap().y() };
+        c1.x -= shift.x();
+        c1.y -= shift.y();
 
-        let mut c2 = linestring.coord(i + 1).unwrap().x_y();
-        c2.0 -= shift.x();
-        c2.1 -= shift.y();
+        let mut c2 = Coord { x: linestring.coord(i + 1).unwrap().x(), y: linestring.coord(i + 1).unwrap().y() };
+        c2.x -= shift.x();
+        c2.y -= shift.y();
 
         let line = Line::from([c1, c2]);
         tmp += line.determinant();

--- a/geo/src/algorithm/area.rs
+++ b/geo/src/algorithm/area.rs
@@ -42,11 +42,9 @@ where
     tmp
 }
 
-pub(crate) fn twice_signed_ring_area_trait<'a, T>(
-    linestring: &'a impl LineStringTrait<'a, T = T>,
-) -> T
+pub(crate) fn twice_signed_ring_area_trait<'a, T>(linestring: &impl LineStringTrait<'a, T = T>) -> T
 where
-    T: CoordNum + SubAssign + AddAssign,
+    T: CoordNum,
 {
     // LineString with less than 3 points is empty, or a
     // single point, or is not closed.
@@ -82,18 +80,18 @@ where
             x: linestring.coord(i).unwrap().x(),
             y: linestring.coord(i).unwrap().y(),
         };
-        c1.x -= shift.x();
-        c1.y -= shift.y();
+        c1.x = c1.x - shift.x();
+        c1.y = c1.y - shift.y();
 
         let mut c2 = Coord {
             x: linestring.coord(i + 1).unwrap().x(),
             y: linestring.coord(i + 1).unwrap().y(),
         };
-        c2.x -= shift.x();
-        c2.y -= shift.y();
+        c2.x = c2.x - shift.x();
+        c2.y = c2.y - shift.y();
 
         let line = Line::new(c1, c2);
-        tmp += line.determinant();
+        tmp = tmp + line.determinant();
     }
 
     tmp
@@ -143,9 +141,9 @@ where
 }
 
 // Calculation of simple (no interior holes) Polygon area
-pub(crate) fn get_linestring_area_trait<'a, T>(linestring: &'a impl LineStringTrait<'a, T = T>) -> T
+pub(crate) fn get_linestring_area_trait<'a, T>(linestring: &impl LineStringTrait<'a, T = T>) -> T
 where
-    T: CoordFloat + SubAssign + AddAssign,
+    T: CoordFloat,
 {
     twice_signed_ring_area_trait(linestring) / (T::one() + T::one())
 }
@@ -197,7 +195,7 @@ where
     T: CoordFloat,
 {
     fn signed_area(&self) -> T {
-        let area = get_linestring_area(self.exterior());
+        let area = get_linestring_area_trait(self.exterior());
 
         // We could use winding order here, but that would
         // result in computing the shoelace formula twice.


### PR DESCRIPTION
### Change list

- Remove `Send + Sync` restriction on `T` on the trait. I don't know whether this restriction makes sense here. I originally added it because rust-postgis [included it](https://github.com/andelf/rust-postgis/blob/f25925fae51050000df8eb66af3ba554949f94b5/src/types.rs). But it appeared that `CoordFloat` doesn't include those trait bounds so it was easier in this context to remove them.
- Add fully parametrized `T: CoordNum` on each trait, and define other item types in terms of `T`. I needed to do this so that some algorithms could enforce `CoordFloat` and not just `CoordNum`. 
    I'm not sure if `type ItemType = LineString<Self::T>;` on the `impl` is necessary instead of `type ItemType = LineString<T>;`.
- Implement pure functions for most combinations of geometry type + signed/unsigned area.
- Drop 1.63 CI from this branch


### Questions:

- Is there a simple way with lifetimes to fix this `temporary value dropped while borrowed` error? It's on [this line](https://github.com/kylebarron/geo/blob/fd62519c82551e408c0b654408d17ccb64b7d1a0/geo/src/algorithm/area.rs#L226). I'm not sure if this is an issue with the trait design or implementation or with my code