### PR TITLE
geo-types: Weaken `serde/std` and `approx/std` features

### DIFF
--- a/geo-types/Cargo.toml
+++ b/geo-types/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 
 [features]
 default = ["std"]
-std = ["approx/std", "num-traits/std", "serde/std"]
+std = ["approx?/std", "num-traits/std", "serde?/std"]
 # Prefer `use-rstar` feature rather than enabling rstar directly.
 # rstar integration relies on the optional approx crate, but implicit features cannot yet enable other features.
 # See: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#namespaced-features


### PR DESCRIPTION
Previously, if I wanted only the `std` feature of geo_types, this would enable the `serde` and `approx` features, too. Change these features to be "weak dependency features", so they're only enabled (and their crates pulled in) if the corresponding optional crate is already pulled in for other reasons.

---
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
I'm always eager to optimize my build process, and this would help with that :-)

But I'm not sure if this could potentially be a breaking change? Ideally, it would be a purely internal change, but I'm not sure if it could cause issues for downstream crates / users. And I'm not sure if a CHANGES.md entry would be needed / what it should say?