### PR TITLE
Ergonomic de-9im specification matching

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## Unreleased
+
+* Add `matches` method to IntersectionMatrix for ergonomic de-9im comparisons.
+  <https://github.com/georust/geo/pull/1043>
+
+
 ## 0.26.0
 
 * Implement "Closest Point" from a `Point` on a `Geometry` using spherical geometry. <https://github.com/georust/geo/pull/958>

--- a/geo/src/algorithm/area.rs
+++ b/geo/src/algorithm/area.rs
@@ -526,6 +526,10 @@ mod test {
             ],
         ];
         // Value from shapely
-        assert_relative_eq!(poly.unsigned_area(), 0.006547948219252177, max_relative = 0.0001);
+        assert_relative_eq!(
+            poly.unsigned_area(),
+            0.006547948219252177,
+            max_relative = 0.0001
+        );
     }
 }

--- a/geo/src/algorithm/relate/geomgraph/intersection_matrix.rs
+++ b/geo/src/algorithm/relate/geomgraph/intersection_matrix.rs
@@ -263,6 +263,15 @@ impl IntersectionMatrix {
     }
 }
 
+/// Build an IntersectionMatrix based on a string specification.
+/// ```
+/// use geo::algorithm::relate::IntersectionMatrix;
+/// use std::str::FromStr;
+///
+/// let intersection_matrix = IntersectionMatrix::from_str("212101212").expect("valid de-9im specification");
+/// assert!(intersection_matrix.is_intersects());
+/// assert!(!intersection_matrix.is_contains());
+/// ```
 impl std::str::FromStr for IntersectionMatrix {
     type Err = InvalidInputError;
     fn from_str(str: &str) -> Result<Self, Self::Err> {


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
