### PR TITLE
chore: remove unused impl of private trait ActiveSet

### DIFF
--- a/geo/src/algorithm/sweep/active.rs
+++ b/geo/src/algorithm/sweep/active.rs
@@ -1,10 +1,4 @@
-use std::{
-    borrow::Borrow,
-    cmp::Ordering,
-    collections::BTreeSet,
-    fmt::Debug,
-    ops::{Bound, Deref},
-};
+use std::{borrow::Borrow, cmp::Ordering, fmt::Debug, ops::Deref};
 
 /// A segment currently active in the sweep.
 ///
@@ -85,42 +79,4 @@ pub(super) trait ActiveSet: Default {
     }
     fn insert_active(&mut self, segment: Self::Seg);
     fn remove_active(&mut self, segment: &Self::Seg);
-}
-
-impl<T: PartialOrd + Debug> ActiveSet for BTreeSet<Active<T>> {
-    type Seg = T;
-
-    fn previous_find<F: FnMut(&Active<Self::Seg>) -> bool>(
-        &self,
-        segment: &Self::Seg,
-        mut f: F,
-    ) -> Option<&Active<Self::Seg>> {
-        self.range::<Active<_>, _>((
-            Bound::Unbounded,
-            Bound::Excluded(Active::active_ref(segment)),
-        ))
-        .rev()
-        .find(|&a| f(a))
-    }
-    fn next_find<F: FnMut(&Active<Self::Seg>) -> bool>(
-        &self,
-        segment: &Self::Seg,
-        mut f: F,
-    ) -> Option<&Active<Self::Seg>> {
-        self.range::<Active<_>, _>((
-            Bound::Excluded(Active::active_ref(segment)),
-            Bound::Unbounded,
-        ))
-        .find(|&a| f(a))
-    }
-
-    fn insert_active(&mut self, segment: Self::Seg) {
-        let result = self.insert(Active(segment));
-        debug_assert!(result);
-    }
-
-    fn remove_active(&mut self, segment: &Self::Seg) {
-        let result = self.remove(Active::active_ref(segment));
-        debug_assert!(result);
-    }
 }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] ~I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.~
---

The motivation for removing this is that it is a bit misleading and confusing when starting to look deeper into the code. I spent quiet some time trying to wrap my head around why we need this but it was simply unused.

This seem to be leftover parts of an earlier implementation. The trait is private, so there is no chance that this will break user code. I also made sure to check that the trait impl for `BTreeSet` isn't used anymore. It has been completely replaced by `VecSet` everywhere.