### PR TITLE
Vector2DOps fixes

### DIFF
--- a/geo/src/algorithm/vector_ops.rs
+++ b/geo/src/algorithm/vector_ops.rs
@@ -12,7 +12,7 @@ pub trait Vector2DOps<Rhs = Self>
 where
     Self: Sized,
 {
-    type Scalar: CoordNum + Send + Sync;
+    type Scalar: CoordNum;
 
     /// The euclidean distance between this coordinate and the origin
     ///
@@ -119,7 +119,7 @@ where
 
 impl<T> Vector2DOps for Coord<T>
 where
-    T: CoordFloat + Send + Sync,
+    T: CoordFloat,
 {
     type Scalar = T;
 

--- a/geo/src/algorithm/vector_ops.rs
+++ b/geo/src/algorithm/vector_ops.rs
@@ -323,11 +323,11 @@ mod test {
     }
 
     #[test]
-    /// Tests edge cases that were previously failing before switching to cmath::hypot
+    /// Tests edge cases that were previously returning None
+    /// before switching to cmath::hypot
     fn test_try_normalize_edge_cases_1() {
         use float_next_after::NextAfter;
-        // Very Small Input - Normalize returns None because of
-        // rounding-down to zero in the .magnitude() calculation
+        // Very Small Input still returns a value thanks to cmath::hypot
         let a = coord! {
             x: 0.0,
             y: 1e-301_f64
@@ -355,7 +355,7 @@ mod test {
         );
 
         // A large vector where try_normalize still returns Some because we are using cmath::hypot
-        // because the magnitude is just above f64::MAX
+        // even though the magnitude would be just above f64::MAX
         let a = coord! {
             x: f64::sqrt(f64::MAX / 2.0),
             y: f64::sqrt(f64::MAX / 2.0).next_after(f64::INFINITY)

--- a/geo/src/algorithm/vector_ops.rs
+++ b/geo/src/algorithm/vector_ops.rs
@@ -321,10 +321,10 @@ mod test {
             coord! { x: -10.0, y: 8.0 } / f64::sqrt(10.0 * 10.0 + 8.0 * 8.0)
         );
     }
-    
+
     #[test]
     /// Tests edge cases that were previously failing before switching to cmath::hypot
-    fn test_try_normalize_edge_cases_1(){
+    fn test_try_normalize_edge_cases_1() {
         use float_next_after::NextAfter;
         // Very Small Input - Normalize returns None because of
         // rounding-down to zero in the .magnitude() calculation
@@ -377,8 +377,6 @@ mod test {
         // Zero vector - Normalize returns None
         let a = coord! { x: 0.0, y: 0.0 };
         assert_eq!(a.try_normalize(), None);
-
-        
 
         // Where one of the components is NaN try_normalize returns None
         let a = coord! { x: f64::NAN, y: 0.0 };

--- a/geo/src/algorithm/vector_ops.rs
+++ b/geo/src/algorithm/vector_ops.rs
@@ -123,8 +123,8 @@ where
 {
     type Scalar = T;
 
-    fn wedge_product(self, right: Coord<T>) -> Self::Scalar {
-        self.x * right.y - self.y * right.x
+    fn wedge_product(self, other: Coord<T>) -> Self::Scalar {
+        self.x * other.y - self.y * other.x
     }
 
     fn dot_product(self, other: Self) -> Self::Scalar {
@@ -321,7 +321,7 @@ mod test {
             coord! { x: -10.0, y: 8.0 } / f64::sqrt(10.0 * 10.0 + 8.0 * 8.0)
         );
     }
-
+    
     #[test]
     /// Tests edge cases that were previously failing before switching to cmath::hypot
     fn test_try_normalize_edge_cases_1(){

--- a/geo/src/algorithm/vector_ops.rs
+++ b/geo/src/algorithm/vector_ops.rs
@@ -132,7 +132,9 @@ where
     }
 
     fn magnitude(self) -> Self::Scalar {
-        (self.x * self.x + self.y * self.y).sqrt()
+        // Note uses cmath::hypot which avoids 'undue overflow and underflow'
+        // This also increases the range of values for which `.try_normalize()` works
+        Self::Scalar::hypot(self.x, self.y)
     }
 
     fn magnitude_squared(self) -> Self::Scalar {


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
- [x] ran `cargo fmt` then `cargo fmt --all -- --check`
- [x] ran `cargo clippy --all-features --all-targets -- -Dwarnings`
---

Fixing some derps in my previous PR :)

- Removed `Send + Sync` from Scalar type; as far as I can tell these constraints are only needed if the trait uses threads. Removing Send+Sync should not prevent a user from using the trait with a Send+Sync type.
- Switched to `cmath::hypot` for `magnitude()` for instant gain in robustness, and fixed tests to reflect