### PR TITLE
Vw refactor

### DIFF
--- a/geo/src/algorithm/simplify_vw.rs
+++ b/geo/src/algorithm/simplify_vw.rs
@@ -8,18 +8,18 @@ use std::collections::BinaryHeap;
 
 use rstar::{RTree, RTreeNum};
 
-/// Store triangle information
-// current is the candidate point for removal
+/// Store triangle information. Area is used for ranking in the priority queue and determining removal
 #[derive(Debug)]
 struct VScore<T, I>
 where
     T: CoordFloat,
 {
     left: usize,
+    /// The current [Point] index in the original [LineString]: The candidate for removal
     current: usize,
     right: usize,
     area: T,
-    // `visvalingam_preserve` uses `intersector`, `visvalingam` does not
+    // `visvalingam_preserve` uses `intersector`, `visvalingam` does not, so it's always false
     intersector: I,
 }
 
@@ -180,6 +180,7 @@ fn recompute_triangles<T>(
         )
         .unsigned_area();
 
+        // This logic only applies to VW-Preserve
         // The current point causes a self-intersection, and this point precedes it
         // we ensure it gets removed next by demoting its area to negative epsilon
         // we check that current_point is less than smallest.current because

--- a/geo/src/algorithm/simplify_vw.rs
+++ b/geo/src/algorithm/simplify_vw.rs
@@ -116,13 +116,12 @@ where
     // While there are still points for which the associated triangle
     // has an area below the epsilon
     while let Some(smallest) = pq.pop() {
-        // This triangle's area is above epsilon, so skip it
         if smallest.area > *epsilon {
             // no need to keep trying: the min-heap ensures that we process triangles in order
             // so if we see one that exceeds the tolerance we're done: everything else is too big
             break;
         }
-        //  This triangle's area is below epsilon: eliminate the associated point
+        //  This triangle's area is below epsilon: the associated point is a candidate for removal
         let (left, right) = adjacent[smallest.current];
         // A point in this triangle has been removed since this VScore
         // was created, so skip it
@@ -181,11 +180,11 @@ fn recompute_triangles<T>(
         .unsigned_area();
 
         // This logic only applies to VW-Preserve
-        // The current point causes a self-intersection, and this point precedes it
+        // smallest.current's removal causes a self-intersection, and this point precedes it
         // we ensure it gets removed next by demoting its area to negative epsilon
         // we check that current_point is less than smallest.current because
         // if it's larger the point in question comes AFTER smallest.current: we only want to remove
-        // the point that comes BEFORE
+        // the point that comes BEFORE smallest.current
         let area = if smallest.intersector && (current_point as usize) < smallest.current {
             -*epsilon
         } else {
@@ -360,7 +359,7 @@ where
         let (_, rr) = adjacent[right as usize];
         adjacent[left as usize] = (ll, right);
         adjacent[right as usize] = (left, rr);
-        // We've got a valid triangle, and its area is smaller than epsilon, so
+        // We've got a valid triangle, and its area is smaller than the tolerance, so
         // remove it from the simulated "linked list"
         adjacent[smallest.current] = (0, 0);
         counter -= 1;

--- a/geo/src/algorithm/simplify_vw.rs
+++ b/geo/src/algorithm/simplify_vw.rs
@@ -254,7 +254,7 @@ where
                     .flat_map(|ring| *ring)
                     .flat_map(|line_string| line_string.lines()),
             )
-            .map(|line| CachedEnvelope::new(line))
+            .map(CachedEnvelope::new)
             .collect::<Vec<_>>(),
     );
 

--- a/geo/src/algorithm/simplify_vw.rs
+++ b/geo/src/algorithm/simplify_vw.rs
@@ -11,7 +11,7 @@ use rstar::{RTree, RTreeNum};
 
 /// Store triangle information. Area is used for ranking in the priority queue and determining removal
 #[derive(Debug)]
-struct VScore<T, I>
+struct VScore<T>
 where
     T: CoordFloat,
 {
@@ -21,35 +21,35 @@ where
     right: usize,
     area: T,
     // `visvalingam_preserve` uses `intersector`, `visvalingam` does not, so it's always false
-    intersector: I,
+    intersector: bool,
 }
 
 // These impls give us a min-heap
-impl<T, I> Ord for VScore<T, I>
+impl<T> Ord for VScore<T>
 where
     T: CoordFloat,
 {
-    fn cmp(&self, other: &VScore<T, I>) -> Ordering {
+    fn cmp(&self, other: &VScore<T>) -> Ordering {
         other.area.partial_cmp(&self.area).unwrap()
     }
 }
 
-impl<T, I> PartialOrd for VScore<T, I>
+impl<T> PartialOrd for VScore<T>
 where
     T: CoordFloat,
 {
-    fn partial_cmp(&self, other: &VScore<T, I>) -> Option<Ordering> {
+    fn partial_cmp(&self, other: &VScore<T>) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl<T, I> Eq for VScore<T, I> where T: CoordFloat {}
+impl<T> Eq for VScore<T> where T: CoordFloat {}
 
-impl<T, I> PartialEq for VScore<T, I>
+impl<T> PartialEq for VScore<T>
 where
     T: CoordFloat,
 {
-    fn eq(&self, other: &VScore<T, I>) -> bool
+    fn eq(&self, other: &VScore<T>) -> bool
     where
         T: CoordFloat,
     {
@@ -113,7 +113,7 @@ where
             right: i + 2,
             intersector: false,
         })
-        .collect::<BinaryHeap<VScore<T, bool>>>();
+        .collect::<BinaryHeap<VScore<T>>>();
     // While there are still points for which the associated triangle
     // has an area below the epsilon
     while let Some(smallest) = pq.pop() {
@@ -155,9 +155,9 @@ where
 /// This is used for both standard and topology-preserving variants.
 #[allow(clippy::too_many_arguments)]
 fn recompute_triangles<T>(
-    smallest: &VScore<T, bool>,
+    smallest: &VScore<T>,
     orig: &LineString<T>,
-    pq: &mut BinaryHeap<VScore<T, bool>>,
+    pq: &mut BinaryHeap<VScore<T>>,
     ll: i32,
     left: i32,
     right: i32,
@@ -328,7 +328,7 @@ where
             right: i + 2,
             intersector: false,
         })
-        .collect::<BinaryHeap<VScore<T, bool>>>();
+        .collect::<BinaryHeap<VScore<T>>>();
 
     // While there are still points for which the associated triangle
     // has an area below the epsilon
@@ -396,7 +396,7 @@ where
 /// the bounding box of the new triangle created by the candidate segment
 fn tree_intersect<T>(
     tree: &RTree<CachedEnvelope<Line<T>>>,
-    triangle: &VScore<T, bool>,
+    triangle: &VScore<T>,
     orig: &[Coord<T>],
 ) -> bool
 where

--- a/geo/src/algorithm/simplify_vw.rs
+++ b/geo/src/algorithm/simplify_vw.rs
@@ -509,7 +509,7 @@ pub trait SimplifyVwIdx<T, Epsilon = T> {
         T: CoordFloat;
 }
 
-/// Simplifies a geometry, preserving its topology by removing self-intersections
+/// Simplifies a geometry, attempting to preserve its topology by removing self-intersections
 ///
 /// An epsilon less than or equal to zero will return an unaltered version of the geometry
 pub trait SimplifyVwPreserve<T, Epsilon = T> {
@@ -528,15 +528,15 @@ pub trait SimplifyVwPreserve<T, Epsilon = T> {
     /// (117.0, 48.0)` and `(117.0, 48.0), (300,0, 40.0)`. By removing it,
     /// a new triangle with indices `(0, 3, 4)` is formed, which does not cause a self-intersection.
     ///
-    /// **Note**: it is possible for the simplification algorithm to displace a Polygon's interior ring outside its shell.
+    /// # Notes
     ///
-    /// **Note**: if removal of a point causes a self-intersection, but the geometry only has `n + 1`
-    /// points remaining (4 for a `LineString`, 5 for a `Polygon`), the point is retained and the
+    /// - It is possible for the simplification algorithm to displace a Polygon's interior ring outside its shell.
+    /// - The algorithm does **not** guarantee a valid output geometry, especially on smaller geometries.
+    /// - If removal of a point causes a self-intersection, but the geometry only has `n + 1`
+    /// points remaining (3 for a `LineString`, 5 for a `Polygon`), the point is retained and the
     /// simplification process ends. This is because there is no guarantee that removal of two points will remove
     /// the intersection, but removal of further points would leave too few points to form a valid geometry.
-    ///
-    /// # Note
-    /// The tolerance used to remove a point is `epsilon`, in keeping with GEOS. JTS uses `epsilon ^ 2`
+    /// - The tolerance used to remove a point is `epsilon`, in keeping with GEOS. JTS uses `epsilon ^ 2`
     ///
     /// # Examples
     ///

--- a/geo/src/algorithm/simplify_vw.rs
+++ b/geo/src/algorithm/simplify_vw.rs
@@ -377,7 +377,10 @@ where
         .collect()
 }
 
-/// check whether a triangle's edges intersect with any other edges of the LineString
+/// Check whether the new candidate line segment intersects with any existing geometry line segments
+///
+/// In order to do this efficiently, the rtree is queried for any existing segments which fall within
+/// the bounding box of the new triangle created by the candidate segment
 fn tree_intersect<T>(tree: &RTree<Line<T>>, triangle: &VScore<T, bool>, orig: &[Coord<T>]) -> bool
 where
     T: CoordFloat + RTreeNum + HasKernel,


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

This is a refactor of both VW and VwPreserve, partially in response to #1049:

- The intersection check logic is now more robust, and uses the existing line-line intersection check from `geo`
- The new triangle calculation logic has been refactored into a function which is now used by both VW and VwPreserve
- Rather than `continuing` with a fresh triangle if a triangle area above epsilon is popped from the min-heap we simply `break` now: there's no need to check any more triangles, since the min-heap ensures that all remaining elements are above epsilon 
- We allow processing to continue until we hit n + 1 now
- Many helpful comments have been added 