### PR TITLE
Add line segmentize trait

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Add `LineStringSegmentize` trait to split a single `LineString` into `n` `LineStrings` as a `MultiLineString`
 * Add `EuclideanDistance` implementations for all remaining geometries.
   * <https://github.com/georust/geo/pull/1029>
 * Add `HausdorffDistance` algorithm trait to calculate the Hausdorff distance between any two geometries.

--- a/geo/src/algorithm/linestring_segment.rs
+++ b/geo/src/algorithm/linestring_segment.rs
@@ -19,7 +19,6 @@ impl LineStringSegmentize for LineString {
             let total_len = self.euclidean_length();
             let densified = self.densify(total_len / (n as f64));
             return densified.line_segmentize(n);
-            // return Some(MultiLineString::new(vec![densified]))
         } else if n_lines == n {
             // if the number of line segments equals n then return the
             // lines as LineStrings
@@ -57,7 +56,10 @@ impl LineStringSegmentize for LineString {
 
         // iterate through each line segment in the LineString
         for (i, segment) in lns.enumerate() {
-            // first line string push the first coord immediately
+            // All iterations only keep track of the second coordinate
+            // in the Line. We need to push the first coordinate in the 
+            // first line string to ensure the linestring starts at the 
+            // correct place
             if i == 0 {
                 ln_vec.push(segment.start)
             }

--- a/geo/src/algorithm/linestring_segment.rs
+++ b/geo/src/algorithm/linestring_segment.rs
@@ -81,9 +81,7 @@ impl LineStringSegmentize for LineString {
             if (cum_length >= segment_length) && (i != (n_lines - 1)) {
                 let remainder = cum_length - segment_length;
                 // if we get None, we exit the function and return None
-                let Some(endpoint) =  segment.line_interpolate_point((length - remainder) / length) else {
-                    return None
-                };
+                let endpoint = segment.line_interpolate_point((length - remainder) / length)?;
 
                 // add final coord to ln_vec
                 ln_vec.push(endpoint.into());

--- a/geo/src/algorithm/linestring_segment.rs
+++ b/geo/src/algorithm/linestring_segment.rs
@@ -8,6 +8,7 @@ use crate::{Coord, Densify, EuclideanLength, LineString, LinesIter, MultiLineStr
 ///
 /// # Examples
 /// ```
+/// use geo::{LineString, MultiLineString, LineStringSegmentize, Coord};
 /// // Create a simple line string
 /// let lns: LineString<f64> = vec![[0.0, 0.0], [1.0, 2.0], [3.0, 6.0]].into();
 /// // Segment it into 6 LineStrings inside of a MultiLineString

--- a/geo/src/algorithm/linestring_segment.rs
+++ b/geo/src/algorithm/linestring_segment.rs
@@ -4,6 +4,32 @@ use crate::{Coord, Densify, EuclideanLength, LineString, LinesIter, MultiLineStr
 /// Segments a LineString into `n` equal length LineStrings as a MultiLineString.
 /// `None` will be returned when `n` is equal to 0 or when a point
 /// cannot be interpolated on a `Line` segment.
+///
+///
+/// # Examples
+/// ```
+/// // Create a simple line string
+/// let lns: LineString<f64> = vec![[0.0, 0.0], [1.0, 2.0], [3.0, 6.0]].into();
+/// // Segment it into 6 LineStrings inside of a MultiLineString
+/// let segmentized = lns.line_segmentize(6).unwrap();
+///
+/// // Recreate the MultiLineString from scratch
+/// // this is the inner vector used to create the MultiLineString
+/// let all_lines = vec![
+///     LineString::new(vec![Coord { x: 0.0, y: 0.0 }, Coord { x: 0.5, y: 1.0 }]),
+///     LineString::new(vec![Coord { x: 0.5, y: 1.0 }, Coord { x: 1.0, y: 2.0 }]),
+///     LineString::new(vec![Coord { x: 1.0, y: 2.0 }, Coord { x: 1.5, y: 3.0 }]),
+///     LineString::new(vec![Coord { x: 1.5, y: 3.0 }, Coord { x: 2.0, y: 4.0 }]),
+///     LineString::new(vec![Coord { x: 2.0, y: 4.0 }, Coord { x: 2.5, y: 5.0 }]),
+///     LineString::new(vec![Coord { x: 2.5, y: 5.0 }, Coord { x: 3.0, y: 6.0 }])
+///     ];
+///
+/// // Create the MultiLineString
+/// let mlns = MultiLineString::new(all_lines);
+///
+/// // Compare the two
+/// assert_eq!(mlns, segmentized);
+///```
 pub trait LineStringSegmentize {
     fn line_segmentize(&self, n: usize) -> Option<MultiLineString>;
 }
@@ -57,9 +83,9 @@ impl LineStringSegmentize for LineString {
         // iterate through each line segment in the LineString
         for (i, segment) in lns.enumerate() {
             // All iterations only keep track of the second coordinate
-            // in the Line. We need to push the first coordinate in the 
-            // first line string to ensure the linestring starts at the 
-            // correct place
+            // in the Line. We need to push the first coordinate in the
+            // first line string to ensure the linestring starts at the
+            // correct place`
             if i == 0 {
                 ln_vec.push(segment.start)
             }

--- a/geo/src/algorithm/linestring_segment.rs
+++ b/geo/src/algorithm/linestring_segment.rs
@@ -14,18 +14,14 @@ impl LineStringSegmentize for LineString {
         let n_lines = self.lines().count();
 
         // Return None if n is 0 or the maximum usize
-        if n == usize::MIN || n == usize::MAX {
-            return None;
-        } else if n_lines < n {
-            // if n is greater than the number of Lines in the
-            // LineString return None
+        if (n == usize::MIN) || (n == usize::MAX) || (n_lines < n) {
             return None;
         } else if n_lines == n {
             // if the number of line segments equals n then return the
             // lines as LineStrings
             let lns = self
                 .lines_iter()
-                .map(|l| LineString::from(l))
+                .map(LineString::from)
                 .collect::<Vec<LineString>>();
 
             return Some(MultiLineString::new(lns));
@@ -119,7 +115,7 @@ impl LineStringSegmentize for LineString {
         // a multi linestring
         let res_lines = res_coords
             .into_iter()
-            .map(|xi| LineString::new(xi))
+            .map(LineString::new)
             .collect::<Vec<LineString>>();
 
         Some(MultiLineString::new(res_lines))

--- a/geo/src/algorithm/linestring_segment.rs
+++ b/geo/src/algorithm/linestring_segment.rs
@@ -139,7 +139,7 @@ mod test {
         let segments = linestring.line_segmentize(5).unwrap();
 
         // assert that there are n linestring segments
-        assert_eq!(segments.clone().0.len(), 5);
+        assert_eq!(segments.0.len(), 5);
 
         // assert that the lines are equal length
         let lens = segments

--- a/geo/src/algorithm/linestring_segment.rs
+++ b/geo/src/algorithm/linestring_segment.rs
@@ -176,14 +176,13 @@ mod test {
         let linestring: LineString = vec![[0.0, 0.0], [1.0, 1.0], [1.0, 2.0], [3.0, 3.0]].into();
         let segments = linestring.line_segmentize(2).unwrap();
 
-        assert_eq!(linestring.euclidean_length(), segments.euclidean_length())
+        assert_relative_eq!(linestring.euclidean_length(), segments.euclidean_length(), epsilon = f64::EPSILON)
     }
 
     #[test]
     fn n_elems() {
         let linestring: LineString = vec![[0.0, 0.0], [1.0, 1.0], [1.0, 2.0], [3.0, 3.0]].into();
         let segments = linestring.line_segmentize(2).unwrap();
-        println!("{:?}", segments.0);
         assert_eq!(segments.0.len(), 2)
     }
 }

--- a/geo/src/algorithm/linestring_segment.rs
+++ b/geo/src/algorithm/linestring_segment.rs
@@ -1,0 +1,189 @@
+use crate::line_interpolate_point::LineInterpolatePoint;
+use crate::{Coord, EuclideanLength, LineString, LinesIter, MultiLineString};
+
+/// Segments a LineString into `n` LineStrings as a MultiLineString.
+/// `None` will be returned when `n` is equal to 0, `n` is larger than the
+///  number of `Line`s that make up the `LineString`, or when a point
+/// cannot be interpolated on a `Line` segment.
+pub trait LineStringSegmentize {
+    fn line_segmentize(&self, n: usize) -> Option<MultiLineString>;
+}
+
+impl LineStringSegmentize for LineString {
+    fn line_segmentize(&self, n: usize) -> Option<MultiLineString> {
+        let n_lines = self.lines().count();
+
+        // Return None if n is 0 or the maximum usize
+        if n == usize::MIN || n == usize::MAX {
+            return None;
+        } else if n_lines < n {
+            // if n is greater than the number of Lines in the
+            // LineString return None
+            return None;
+        } else if n_lines == n {
+            // if the number of line segments equals n then return the
+            // lines as LineStrings
+            let lns = self
+                .lines_iter()
+                .map(|l| LineString::from(l))
+                .collect::<Vec<LineString>>();
+
+            return Some(MultiLineString::new(lns));
+        } else if n == 1 {
+            let mlns = MultiLineString::from(self.clone());
+            return Some(mlns);
+        }
+
+        // Convert X into an iterator of `Lines`
+        let lns = self.lines_iter().peekable();
+
+        // Vec to allocate the  new LineString segments Coord Vec
+        // will be iterated over at end to create new vecs
+        let mut res_coords: Vec<Vec<Coord>> = Vec::with_capacity(n);
+
+        // calculate total length to track cumulative against
+        let total_length = self.euclidean_length().abs();
+
+        // tracks total length
+        let mut cum_length = 0_f64;
+
+        // calculate the target fraction for the first iteration
+        // fraction will change based on each iteration
+        // let mut fraction = (1_f64 / (n as f64)) * (idx as f64);
+        let segment_prop = (1_f64) / (n as f64);
+        let segment_length = total_length * segment_prop;
+        // let mut fraction = segment_prop;
+
+        // // fractional length will change dependent upon which `n` we're on.
+        // let mut fractional_length = total_length * fraction;
+
+        // instantiate the first Vec<Coord>
+        let mut ln_vec: Vec<Coord> = Vec::new();
+
+        // push the first coord in
+        // each subsequent coord will be the end point
+        // let c1 = lns.peek();
+        // ln_vec.push(c1.unwrap().start);
+        //ln_vec.push(lns.nth(0).clone().unwrap().start);
+
+        // iterate through each line segment in the LineString
+        for (i, segment) in lns.enumerate() {
+            // first line string push the first coord immediately
+            if i == 0 {
+                ln_vec.push(segment.start)
+            }
+
+            let length = segment.euclidean_length().abs();
+
+            // update cumulative length
+            cum_length += length;
+
+            if (cum_length >= segment_length) && (i != (n_lines - 1)) {
+                let remainder = cum_length - segment_length;
+                // if we get None, we exit the function and return None
+                let Some(endpoint) =  segment.line_interpolate_point((length - remainder) / length) else {
+                    return None
+                };
+
+                // add final coord to ln_vec
+                ln_vec.push(endpoint.into());
+
+                // now we drain all elements from the vector into an iterator
+                // this will be collected into a vector to be pushed into the
+                // results coord vec of vec
+                let to_push = ln_vec.drain(..);
+
+                // now collect & push this vector into the results vector
+                res_coords.push(to_push.collect::<Vec<Coord>>());
+
+                // now add the last endpoint as the first coord
+                // and the endpoint of the linesegment as well only
+                // if i != n_lines
+                if i != n_lines {
+                    ln_vec.push(endpoint.into());
+                }
+
+                // // we need to adjust our fraction and fractional length
+                // fraction += segment_prop;
+                // fractional_length = total_length * fraction;
+                cum_length = remainder;
+            }
+
+            // push the end coordinate into the Vec<Coord> to continue
+            // building the linestring
+            ln_vec.push(segment.end);
+        }
+
+        // push the last linestring vector which isn't done by the for loop
+        res_coords.push(ln_vec);
+
+        // collect the coords into vectors of LineStrings so we can createa
+        // a multi linestring
+        let res_lines = res_coords
+            .into_iter()
+            .map(|xi| LineString::new(xi))
+            .collect::<Vec<LineString>>();
+
+        Some(MultiLineString::new(res_lines))
+    }
+}
+
+// rather than calculating the sum up until 1, i should calculate
+// the amount per segment. Once we exceed that, we take the remainder
+// of cum_length - segment prop
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{EuclideanLength, LineString};
+
+    #[test]
+    // that 0 returns None and that usize::MAX returns None
+    fn n_is_zero() {
+        let linestring: LineString = vec![[-1.0, 0.0], [0.5, 1.0], [1.0, 2.0]].into();
+        let segments = linestring.line_segmentize(0);
+        assert_eq!(segments.is_none(), true)
+    }
+
+    #[test]
+    fn n_is_max() {
+        let linestring: LineString = vec![[-1.0, 0.0], [0.5, 1.0], [1.0, 2.0]].into();
+        let segments = linestring.line_segmentize(usize::MAX);
+        assert_eq!(segments.is_none(), true)
+    }
+
+    #[test]
+    // test that n > n_lines returns None
+    fn n_greater_than_lines() {
+        let linestring: LineString = vec![[-1.0, 0.0], [0.5, 1.0], [1.0, 2.0]].into();
+        let segments = linestring.line_segmentize(3);
+        assert_eq!(segments.is_none(), true)
+    }
+
+    #[test]
+    // identical line_iter to original
+    fn line_iter() {
+        let linestring: LineString = vec![[-1.0, 0.0], [0.5, 1.0], [1.0, 2.0], [1.0, 3.0]].into();
+
+        let segments = linestring.line_segmentize(3).unwrap();
+
+        assert_eq!(linestring.lines_iter().eq(segments.lines_iter()), true)
+    }
+
+    #[test]
+    // test the cumulative length is the same
+    fn cumul_length() {
+        let linestring: LineString = vec![[0.0, 0.0], [1.0, 1.0], [1.0, 2.0], [3.0, 3.0]].into();
+        let segments = linestring.line_segmentize(2).unwrap();
+
+        assert_eq!(linestring.euclidean_length(), segments.euclidean_length())
+    }
+
+    #[test]
+    fn n_elems() {
+        let linestring: LineString = vec![[0.0, 0.0], [1.0, 1.0], [1.0, 2.0], [3.0, 3.0]].into();
+        let segments = linestring.line_segmentize(2).unwrap();
+        println!("{:?}", segments.0);
+        assert_eq!(segments.0.len(), 2)
+    }
+}

--- a/geo/src/algorithm/linestring_segment.rs
+++ b/geo/src/algorithm/linestring_segment.rs
@@ -136,14 +136,14 @@ mod test {
     fn n_is_zero() {
         let linestring: LineString = vec![[-1.0, 0.0], [0.5, 1.0], [1.0, 2.0]].into();
         let segments = linestring.line_segmentize(0);
-        assert_eq!(segments.is_none(), true)
+        assert!(segments.is_none())
     }
 
     #[test]
     fn n_is_max() {
         let linestring: LineString = vec![[-1.0, 0.0], [0.5, 1.0], [1.0, 2.0]].into();
         let segments = linestring.line_segmentize(usize::MAX);
-        assert_eq!(segments.is_none(), true)
+        assert!(segments.is_none())
     }
 
     #[test]
@@ -151,7 +151,7 @@ mod test {
     fn n_greater_than_lines() {
         let linestring: LineString = vec![[-1.0, 0.0], [0.5, 1.0], [1.0, 2.0]].into();
         let segments = linestring.line_segmentize(3);
-        assert_eq!(segments.is_none(), true)
+        assert!(segments.is_none())
     }
 
     #[test]
@@ -161,7 +161,7 @@ mod test {
 
         let segments = linestring.line_segmentize(3).unwrap();
 
-        assert_eq!(linestring.lines_iter().eq(segments.lines_iter()), true)
+        assert!(linestring.lines_iter().eq(segments.lines_iter()))
     }
 
     #[test]

--- a/geo/src/algorithm/linestring_segment.rs
+++ b/geo/src/algorithm/linestring_segment.rs
@@ -176,7 +176,11 @@ mod test {
         let linestring: LineString = vec![[0.0, 0.0], [1.0, 1.0], [1.0, 2.0], [3.0, 3.0]].into();
         let segments = linestring.line_segmentize(2).unwrap();
 
-        assert_relative_eq!(linestring.euclidean_length(), segments.euclidean_length(), epsilon = f64::EPSILON)
+        assert_relative_eq!(
+            linestring.euclidean_length(),
+            segments.euclidean_length(),
+            epsilon = f64::EPSILON
+        )
     }
 
     #[test]

--- a/geo/src/algorithm/mod.rs
+++ b/geo/src/algorithm/mod.rs
@@ -180,6 +180,10 @@ pub use line_locate_point::LineLocatePoint;
 pub mod lines_iter;
 pub use lines_iter::LinesIter;
 
+/// Split a LineString into n segments
+pub mod linestring_segment;
+pub use linestring_segment::LineStringSegmentize;
+
 /// Apply a function to all `Coord`s of a `Geometry`.
 pub mod map_coords;
 pub use map_coords::{MapCoords, MapCoordsInPlace};

--- a/geo/src/lib.rs
+++ b/geo/src/lib.rs
@@ -150,7 +150,7 @@
 //! ## Miscellaneous
 //!
 //! - **[`Centroid`](Centroid)**: Calculate the centroid of a geometry
-//! - **[`ChaikinSmoothing`](ChaikinSmoothing)**: Smoothen `LineString`, `Polygon`, `MultiLineString` and `MultiPolygon` using Chaikins algorithm.
+//! - **[`ChaikinSmoothing`](ChaikinSmoothing)**: Smoothen `LineString`, `Polygon`, `MultiLineString` and `MultiPolygon` using Chaikin's algorithm.
 //! - **[`Densify`](Densify)**: Densify linear geometry components by interpolating points
 //! - **[`GeodesicDestination`](GeodesicDestination)**: Given a start point, bearing, and distance, calculate the destination point on a [geodesic](https://en.wikipedia.org/wiki/Geodesics_on_an_ellipsoid)
 //! - **[`GeodesicIntermediate`](GeodesicIntermediate)**: Calculate intermediate points on a [geodesic](https://en.wikipedia.org/wiki/Geodesics_on_an_ellipsoid)

--- a/geo/src/lib.rs
+++ b/geo/src/lib.rs
@@ -150,13 +150,14 @@
 //! ## Miscellaneous
 //!
 //! - **[`Centroid`](Centroid)**: Calculate the centroid of a geometry
+//! - **[`ChaikinSmoothing`](ChaikinSmoothing)**: Smoothen `LineString`, `Polygon`, `MultiLineString` and `MultiPolygon` using Chaikins algorithm.
+//! - **[`Densify`](Densify)**: Densify linear geometry components by interpolating points
 //! - **[`GeodesicDestination`](GeodesicDestination)**: Given a start point, bearing, and distance, calculate the destination point on a [geodesic](https://en.wikipedia.org/wiki/Geodesics_on_an_ellipsoid)
 //! - **[`GeodesicIntermediate`](GeodesicIntermediate)**: Calculate intermediate points on a [geodesic](https://en.wikipedia.org/wiki/Geodesics_on_an_ellipsoid)
 //! - **[`HaversineDestination`]**: Given a start point, bearing, and distance, calculate the destination point on a sphere
 //! - **[`HaversineIntermediate`](HaversineIntermediate)**: Calculate intermediate points on a sphere
 //! - **[`proj`](proj)**: Project geometries with the `proj` crate (requires the `use-proj` feature)
-//! - **[`ChaikinSmoothing`](ChaikinSmoothing)**: Smoothen `LineString`, `Polygon`, `MultiLineString` and `MultiPolygon` using Chaikins algorithm.
-//! - **[`Densify`](Densify)**: Densify linear geometry components by interpolating points
+//! - **[`LineStringSegmentize`](LineStringSegmentize)**: Segment a LineString into `n` segments.
 //! - **[`Transform`](Transform)**: Transform a geometry using Proj.
 //! - **[`RemoveRepeatedPoints`](RemoveRepeatedPoints)**: Remove repeated points from a geometry.
 //!


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

This PR adds a new trait `LineStringSegmentize` which provides a method `line_segmentize(n: usize)` to split `LineString`s into`n` equal length LineStrings which are returned as an `Option<MultiLineString>` . This is inspired by the [lwgeom R package](https://r-spatial.github.io/lwgeom/) which wraps liblwgeom from PostGIS. 

