### PR TITLE
Minor: clippy - removed calls to .into_iter() where no needed.

### DIFF
--- a/geo-types/src/geometry/geometry_collection.rs
+++ b/geo-types/src/geometry/geometry_collection.rs
@@ -318,7 +318,7 @@ where
             return false;
         }
 
-        let mut mp_zipper = self.into_iter().zip(other.into_iter());
+        let mut mp_zipper = self.into_iter().zip(other);
         mp_zipper.all(|(lhs, rhs)| lhs.abs_diff_eq(rhs, epsilon))
     }
 }

--- a/geo-types/src/geometry/multi_line_string.rs
+++ b/geo-types/src/geometry/multi_line_string.rs
@@ -189,7 +189,7 @@ where
             return false;
         }
 
-        let mut mp_zipper = self.into_iter().zip(other.into_iter());
+        let mut mp_zipper = self.into_iter().zip(other);
         mp_zipper.all(|(lhs, rhs)| lhs.abs_diff_eq(rhs, epsilon))
     }
 }

--- a/geo-types/src/geometry/multi_point.rs
+++ b/geo-types/src/geometry/multi_point.rs
@@ -170,7 +170,7 @@ where
             return false;
         }
 
-        let mut mp_zipper = self.into_iter().zip(other.into_iter());
+        let mut mp_zipper = self.into_iter().zip(other);
         mp_zipper.all(|(lhs, rhs)| lhs.abs_diff_eq(rhs, epsilon))
     }
 }

--- a/geo-types/src/geometry/multi_polygon.rs
+++ b/geo-types/src/geometry/multi_polygon.rs
@@ -166,7 +166,7 @@ where
             return false;
         }
 
-        let mut mp_zipper = self.into_iter().zip(other.into_iter());
+        let mut mp_zipper = self.into_iter().zip(other);
         mp_zipper.all(|(lhs, rhs)| lhs.abs_diff_eq(rhs, epsilon))
     }
 }

--- a/geo/src/algorithm/monotone/builder.rs
+++ b/geo/src/algorithm/monotone/builder.rs
@@ -2,7 +2,7 @@
 //!
 //! This implementation is based on these awesome [lecture notes] by David
 //! Mount.  The broad idea is to run a left-right planar sweep on the segments
-//! of the polygon and try to iteratively extend parallel monotone chains.  
+//! of the polygon and try to iteratively extend parallel monotone chains.
 //!
 //! [lecture notes]:
 //! //www.cs.umd.edu/class/spring2020/cmsc754/Lects/lect05-triangulate.pdf
@@ -41,7 +41,7 @@ impl<T: GeoNum> Builder<T> {
             let (ext, ints) = polygon.into_inner();
             Some(ext)
                 .into_iter()
-                .chain(ints.into_iter())
+                .chain(ints)
                 .flat_map(|ls| -> Vec<_> { ls.lines().collect() })
                 .filter_map(|line| {
                     if line.start == line.end {


### PR DESCRIPTION
The clippy ruleset has improved.

We can remove calls to .into_iter() in a few places.




