### PR TITLE
created a simpler syntax for macros for test fixtures

### DIFF
--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 0.7.12
+
+* Simpler syntax for `line_string` and `polygon` macros, like in WKT format.
+  * <https://github.com/georust/geo/pull/1061>
+
 ## 0.7.11
 * Bump rstar dependency
   <https://github.com/georust/geo/pull/1030>

--- a/geo-types/src/macros.rs
+++ b/geo-types/src/macros.rs
@@ -71,10 +71,10 @@ macro_rules! coord {
 /// Creating a [`LineString`] with WKT-like syntax:
 /// 
 /// ```
-/// use geo_types::{line_string, coord};
+/// use geo_types::line_string;
 /// let ls = line_string![76.9454 43.2497, 76.9636 43.2308, 77.0591 43.1575, 77.1108 43.1131];
 ///
-/// assert_eq!(ls[1], coord! {
+/// assert_eq!(ls[1], geo_types::coord! {
 ///     x: 76.9636,
 ///     y: 43.2308
 /// });
@@ -83,7 +83,7 @@ macro_rules! coord {
 /// Creating a [`LineString`], supplying x/y values:
 ///
 /// ```
-/// use geo_types::{line_string, coord};
+/// use geo_types::line_string;
 ///
 /// let ls = line_string![
 ///     (x: -21.95156, y: 64.1446),
@@ -92,7 +92,7 @@ macro_rules! coord {
 ///     (x: -21.951445, y: 64.145508),
 /// ];
 ///
-/// assert_eq!(ls[1], coord! {
+/// assert_eq!(ls[1], geo_types::coord! {
 ///     x: -21.951,
 ///     y: 64.14479
 /// });
@@ -101,9 +101,9 @@ macro_rules! coord {
 /// Creating a [`LineString`], supplying [`Coord`]s:
 ///
 /// ```
-/// use geo_types::{line_string, coord};
+/// use geo_types::line_string;
 ///
-/// let coord1 = coord! {
+/// let coord1 = geo_types::coord! {
 ///     x: -21.95156,
 ///     y: 64.1446,
 /// };
@@ -124,7 +124,7 @@ macro_rules! coord {
 ///
 /// assert_eq!(
 ///     ls[1],
-///     coord! {
+///     geo_types::coord! {
 ///         x: -21.951,
 ///         y: 64.14479
 ///     }
@@ -184,7 +184,7 @@ macro_rules! line_string {
 /// Creating a [`Polygon'] with WKT-like syntax:
 /// 
 /// ```
-/// use geo_types::{polygon, coord};
+/// use geo_types::polygon;
 /// 
 /// let simple_poly = polygon!(0.0 0.0, 30.0 0.0, 30.0 30.0, 0.0 30.0, 0.0 0.0);
 /// assert_eq!(simple_poly.exterior()[1], geo_types::coord!{ x: 30.0, y: 0.0 });
@@ -246,14 +246,14 @@ macro_rules! line_string {
 macro_rules! polygon {
     () => { $crate::Polygon::new($crate::line_string![], vec![]) };
     ($($x:literal $y:literal),+) => {
-        polygon!($(coord! { x: $x, y: $y }),+)
+        polygon!($($crate::coord! { x: $x, y: $y }),+)
     };
     ([$($xi:literal $yi:literal),+ $(,)?], $([$($xo:literal $yo:literal),+ $(,)?]),*) => {
         polygon!(
-            exterior: [$(coord!(x: $xi, y: $yi)),+],
+            exterior: [$($crate::coord!(x: $xi, y: $yi)),+],
             interiors: [
                 $([
-                    $(coord!(x: $xo, y: $yo),)+
+                    $($crate::coord!(x: $xo, y: $yo),)+
                 ]),*
             ]
         )

--- a/geo-types/src/macros.rs
+++ b/geo-types/src/macros.rs
@@ -67,9 +67,9 @@ macro_rules! coord {
 /// ```
 ///
 /// # Examples
-/// 
+///
 /// Creating a [`LineString`] with WKT-like syntax:
-/// 
+///
 /// ```
 /// use geo_types::line_string;
 /// let ls = line_string![76.9454 43.2497, 76.9636 43.2308, 77.0591 43.1575, 77.1108 43.1131];
@@ -180,25 +180,25 @@ macro_rules! line_string {
 /// ```
 ///
 /// # Examples
-/// 
+///
 /// Creating a [`Polygon'] with WKT-like syntax:
-/// 
+///
 /// ```
 /// use geo_types::polygon;
-/// 
+///
 /// let simple_poly = polygon!(0.0 0.0, 30.0 0.0, 30.0 30.0, 0.0 30.0, 0.0 0.0);
 /// assert_eq!(simple_poly.exterior()[1], geo_types::coord!{ x: 30.0, y: 0.0 });
 /// assert_eq!(simple_poly.interiors().len(), 0);
-/// 
+///
 /// let poly_with_hole = polygon!([0.0 0.0, 30.0 0.0, 30.0 30.0, 0.0 30.0, 0.0 0.0], [10.0 10.0, 20.0 10.0, 20.0 20.0, 10.0 20.0, 10.0 10.0]);
 /// assert_eq!(poly_with_hole.interiors()[0][1], geo_types::coord!{ x: 20.0, y: 10.0 });
 /// ```
-/// 
+///
 /// Creating a [`Polygon`] without interior rings, supplying x/y values:
 ///
 /// ```
 /// use geo_types::polygon;
-/// 
+///
 /// let poly = polygon![
 ///     (x: -111., y: 45.),
 ///     (x: -111., y: 41.),
@@ -423,9 +423,12 @@ mod test {
         assert_eq!(p.interiors()[0][0], coord! { x: 3, y: 4 });
 
         let simple_poly = polygon!(0.0 0.0, 30.0 0.0, 30.0 30.0, 0.0 30.0, 0.0 0.0);
-        assert_eq!(simple_poly.exterior()[1], coord!{ x: 30.0, y: 0.0 });
+        assert_eq!(simple_poly.exterior()[1], coord! { x: 30.0, y: 0.0 });
 
         let poly_with_hole = polygon!([0.0 0.0, 30.0 0.0, 30.0 30.0, 0.0 30.0, 0.0 0.0], [10.0 10.0, 20.0 10.0, 20.0 20.0, 10.0 20.0, 10.0 10.0]);
-        assert_eq!(poly_with_hole.interiors()[0][1], coord!{ x: 20.0, y: 10.0 });
+        assert_eq!(
+            poly_with_hole.interiors()[0][1],
+            coord! { x: 20.0, y: 10.0 }
+        );
     }
 }

--- a/geo-types/src/macros.rs
+++ b/geo-types/src/macros.rs
@@ -107,15 +107,15 @@ macro_rules! coord {
 ///     x: -21.95156,
 ///     y: 64.1446,
 /// };
-/// let coord2 = coord! {
+/// let coord2 = geo_types::coord! {
 ///     x: -21.951,
 ///     y: 64.14479,
 /// };
-/// let coord3 = coord! {
+/// let coord3 = geo_types::coord! {
 ///     x: -21.95044,
 ///     y: 64.14527,
 /// };
-/// let coord4 = coord! {
+/// let coord4 = geo_types::coord! {
 ///     x: -21.951445,
 ///     y: 64.145508,
 /// };


### PR DESCRIPTION
- [+] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [+] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

## The Problem

Creating Point/LineString/Polygon objects in geo-types seems very tedious. Macros don't seem to facilitate usage:

```
let ls = line_string![
    (x: -21.95156, y: 64.1446),
    (x: -21.951, y: 64.14479),
    (x: -21.95044, y: 64.14527),
    (x: -21.951445, y: 64.145508),
];
```

Retyping or duplicating x/y for each coord, also with all its parenthesis, feels insane.

I had to write some tests and ended up (1) first making a function that accepts `&[(f32, f32)]` and calls `LineString::from` inside, then (2) writing a macros with much simpler syntax, like in Well-Known Text format:
```
LINESTRING (76.940862 43.259595,76.940210 43.260048,76.939658 43.260287,76.939471 43.260082,76.939224 43.259770,76.939195 43.259505))
```

## Proposal 

Here's the shorter syntax in macro that I propose with this PR. It's very close to WKT:
```
let ls = line_string![21.95156 64.1446, -21.951 64.14479, -21.95044 64.14527, -21.951445 64.145508];

// typical test cases:
let ls = line_string![0.0 0.0, 100.0 0.0, 100.0 100.0, 200.0 100.0];
```

Compare to WKT:
```
LINESTRING (76.940862 43.259595,76.940210 43.260048,76.939658 43.260287)
```

Here's a similar syntax for polygon:
```
// just outer ring:
let poly1 = polygon!(0.0 0.0, 10.0 0.0, 10.0 10.0, 0.0 10.0, 0.0 0.0);
// outer ring & inner rings are enclosed in square brackets:
let poly2 = polygon!(
    [0.0 0.0, 10.0 0.0, 10.0 10.0, 0.0 10.0, 0.0 0.0], // outer
    [1.0 1.0, 2.0 1.0, 2.0 2.0, 1.0 2.0, 1.0 1.0], // inner
    [6.0 6.0, 7.0 6.0, 7.0 7.0, 6.0 7.0, 6.0 6.0], // inner
);
```
I want to underline that this **syntax is intended for test fixtures**, not for "working" code, that's why it has literals, rather than expressions (the latter would not compile with a space between them). For working code, I feel like `LineString::from(&[something like coords])` is enough for most cases, where you assemble linestrings from some other sources of coords.

## Criticism and alternatives

Another way would be to use `wkt` crate and parse some coord fixtures from strings -- well, I'd prefer to have less dependencies, and this way is still tedious, like this:

```
let ls: LineString<f32> = wkt::from_wkt("LINESTRING(my coords literal)").unwrap();
```

Forseeing some criticism, I see the comma isn't so readable and it's hard to visually split coord pairs, but it's very convenient to write tests by copying text from CSV files with WKT, e.g. from QGIS.

Also, I have my poly written in one line -- reason is to keep code compact, and to see an entire test case in one screen.

## Testing

Wrote doctests and added test cases in test module, all tests pass.
