### PR TITLE
Minor: Fixed resolver lint warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,13 @@
 [workspace]
-members = ["geo", "geo-types", "geo-postgis", "geo-test-fixtures", "jts-test-runner", "geo-bool-ops-benches"]
+resolver = "2"
+members = [
+  "geo",
+  "geo-types",
+  "geo-postgis",
+  "geo-test-fixtures",
+  "jts-test-runner",
+  "geo-bool-ops-benches",
+]
 
 [patch.crates-io]
 


### PR DESCRIPTION
Removed this lint warning 

```
warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
```

