### PR TITLE
Make `Polygon` fields public.

### DIFF
--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## 0.7.12 (Unrealeased)
+
+* Make `Polygon` fields public.
+
 ## 0.7.11
 * Bump rstar dependency
   <https://github.com/georust/geo/pull/1030>

--- a/geo-types/src/geometry/polygon.rs
+++ b/geo-types/src/geometry/polygon.rs
@@ -69,8 +69,8 @@ use approx::{AbsDiffEq, RelativeEq};
 #[derive(Eq, PartialEq, Clone, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Polygon<T: CoordNum = f64> {
-    exterior: LineString<T>,
-    interiors: Vec<LineString<T>>,
+    pub exterior: LineString<T>,
+    pub interiors: Vec<LineString<T>>,
 }
 
 impl<T: CoordNum> Polygon<T> {


### PR DESCRIPTION
`Polygon::{exterior,interiors}_mut()` are for example insufficient when using closures that return a `Result`.

I do realize that this might cause issues with polygons that aren't closed if instantiation is created without the proper `new` constructor, so there's probably a better way to go about this. I simply chose the method that resulted in the least amount of changes possible.

Example:

```rust
/// Old
impl Transform for Polygon {
    fn transform_coordinates<F: TransformClosure>(&mut self, f: &mut F) -> Result<()> {
        let (mut exterior, mut interiors) = self.clone().into_inner();
        exterior.transform_coordinates(f)?;
        interiors
            .iter_mut()
            .try_for_each(|line_string| line_string.transform_coordinates(f))?;
        *self = Polygon::new(exterior, interiors);
        Ok(())
    }
}

/// New
impl Transform for Polygon {
    fn transform_coordinates<F: TransformClosure>(&mut self, f: &mut F) -> Result<()> {
        self.exterior.transform_coordinates(f)?;
        self.interiors
            .iter_mut()
            .try_for_each(|interior| interior.transform_coordinates(f))
    }
}
``` 
---
- [X] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [X] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.


