### PR TITLE
Add `ToRadians` and `ToDegrees` traits. 

### DIFF
--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## Unreleased
+
+* Add `ToRadians` and `ToDegrees` traits. Previous struct methods `Point::to_degrees(self)` and `Point::to_radians(self)` are now behind the respective traits.
+  * <https://github.com/georust/geo/pull/1066>
+
 ## 0.7.11
 * Bump rstar dependency
   <https://github.com/georust/geo/pull/1030>

--- a/geo-types/src/geometry/mod.rs
+++ b/geo-types/src/geometry/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod polygon;
 pub(crate) mod rect;
 pub(crate) mod triangle;
 
+pub mod to_degrees;
 pub mod to_radians;
 
 // re-export all the geometry variants:

--- a/geo-types/src/geometry/mod.rs
+++ b/geo-types/src/geometry/mod.rs
@@ -10,6 +10,8 @@ pub(crate) mod polygon;
 pub(crate) mod rect;
 pub(crate) mod triangle;
 
+pub mod to_radians;
+
 // re-export all the geometry variants:
 #[allow(deprecated)]
 pub use coord::{Coord, Coordinate};

--- a/geo-types/src/geometry/point.rs
+++ b/geo-types/src/geometry/point.rs
@@ -323,24 +323,6 @@ impl<T: CoordFloat> Point<T> {
         let y = y.to_degrees();
         Point::new(x, y)
     }
-
-    /// Converts the (x,y) components of Point to radians
-    ///
-    /// # Example
-    /// ```
-    /// use geo_types::Point;
-    ///
-    /// let p = Point::new(180.0, 341.5);
-    /// let (x, y): (f32, f32) = p.to_radians().x_y();
-    /// assert_eq!(x.round(), 3.0);
-    /// assert_eq!(y.round(), 6.0);
-    /// ```
-    pub fn to_radians(self) -> Self {
-        let (x, y) = self.x_y();
-        let x = x.to_radians();
-        let y = y.to_radians();
-        Point::new(x, y)
-    }
 }
 
 impl<T> Neg for Point<T>

--- a/geo-types/src/geometry/point.rs
+++ b/geo-types/src/geometry/point.rs
@@ -1,4 +1,4 @@
-use crate::{point, Coord, CoordFloat, CoordNum};
+use crate::{point, Coord, CoordNum};
 
 #[cfg(any(feature = "approx", test))]
 use approx::{AbsDiffEq, RelativeEq};
@@ -302,26 +302,6 @@ impl<T: CoordNum> Point<T> {
     pub fn cross_prod(self, point_b: Self, point_c: Self) -> T {
         (point_b.x() - self.x()) * (point_c.y() - self.y())
             - (point_b.y() - self.y()) * (point_c.x() - self.x())
-    }
-}
-
-impl<T: CoordFloat> Point<T> {
-    /// Converts the (x,y) components of Point to degrees
-    ///
-    /// # Example
-    /// ```
-    /// use geo_types::Point;
-    ///
-    /// let p = Point::new(1.234, 2.345);
-    /// let (x, y): (f32, f32) = p.to_degrees().x_y();
-    /// assert_eq!(x.round(), 71.0);
-    /// assert_eq!(y.round(), 134.0);
-    /// ```
-    pub fn to_degrees(self) -> Self {
-        let (x, y) = self.x_y();
-        let x = x.to_degrees();
-        let y = y.to_degrees();
-        Point::new(x, y)
     }
 }
 

--- a/geo-types/src/geometry/to_degrees.rs
+++ b/geo-types/src/geometry/to_degrees.rs
@@ -1,0 +1,129 @@
+use super::*;
+
+/// Converts the coordinates of a geometry to degrees
+///
+/// # Example
+/// ```
+/// use geo_types::Point;
+///
+/// let p = Point::new(1.234, 2.345);
+/// let (x, y): (f32, f32) = p.to_degrees().x_y();
+/// assert_eq!(x.round(), 71.0);
+/// assert_eq!(y.round(), 134.0);
+pub trait ToDegrees {
+    fn to_degrees(self) -> Self;
+}
+
+impl ToDegrees for Coord {
+    fn to_degrees(self) -> Self {
+        Self {
+            x: self.x.to_degrees(),
+            y: self.y.to_degrees(),
+        }
+    }
+}
+
+impl ToDegrees for Point {
+    fn to_degrees(self) -> Self {
+        let (x, y) = self.x_y();
+        let x = x.to_degrees();
+        let y = y.to_degrees();
+        Self::new(x, y)
+    }
+}
+
+impl ToDegrees for MultiPoint {
+    fn to_degrees(self) -> Self {
+        self.into_iter().map(|point| point.to_degrees()).collect()
+    }
+}
+
+impl ToDegrees for Line {
+    fn to_degrees(self) -> Self {
+        Self {
+            start: self.start.to_degrees(),
+            end: self.end.to_degrees(),
+        }
+    }
+}
+
+impl ToDegrees for LineString {
+    fn to_degrees(mut self) -> Self {
+        self.0
+            .iter_mut()
+            .for_each(|coord| *coord = coord.to_degrees());
+        self
+    }
+}
+
+impl ToDegrees for MultiLineString {
+    fn to_degrees(self) -> Self {
+        self.into_iter()
+            .map(|line_string| line_string.to_degrees())
+            .collect()
+    }
+}
+
+impl ToDegrees for Polygon {
+    fn to_degrees(self) -> Self {
+        let (exterior, interiors) = self.into_inner();
+        let exterior = exterior.to_degrees();
+        let interiors = interiors
+            .into_iter()
+            .map(|interior| interior.to_degrees())
+            .collect();
+        Self::new(exterior, interiors)
+    }
+}
+
+impl ToDegrees for MultiPolygon {
+    fn to_degrees(self) -> Self {
+        self.into_iter()
+            .map(|polygon| polygon.to_degrees())
+            .collect()
+    }
+}
+
+impl ToDegrees for Rect {
+    fn to_degrees(mut self) -> Self {
+        self.set_min(self.min().to_degrees());
+        self.set_max(self.max().to_degrees());
+        self
+    }
+}
+
+impl ToDegrees for Triangle {
+    fn to_degrees(mut self) -> Self {
+        self.0 = self.0.to_degrees();
+        self.1 = self.1.to_degrees();
+        self.2 = self.2.to_degrees();
+        self
+    }
+}
+
+impl ToDegrees for Geometry {
+    fn to_degrees(self) -> Self {
+        match self {
+            Geometry::Point(geometry) => Geometry::Point(geometry.to_degrees()),
+            Geometry::Line(geometry) => Geometry::Line(geometry.to_degrees()),
+            Geometry::LineString(geometry) => Geometry::LineString(geometry.to_degrees()),
+            Geometry::Polygon(geometry) => Geometry::Polygon(geometry.to_degrees()),
+            Geometry::MultiPoint(geometry) => Geometry::MultiPoint(geometry.to_degrees()),
+            Geometry::MultiLineString(geometry) => Geometry::MultiLineString(geometry.to_degrees()),
+            Geometry::MultiPolygon(geometry) => Geometry::MultiPolygon(geometry.to_degrees()),
+            Geometry::Rect(geometry) => Geometry::Rect(geometry.to_degrees()),
+            Geometry::Triangle(geometry) => Geometry::Triangle(geometry.to_degrees()),
+            Geometry::GeometryCollection(geometry) => {
+                Geometry::GeometryCollection(geometry.to_degrees())
+            }
+        }
+    }
+}
+
+impl ToDegrees for GeometryCollection {
+    fn to_degrees(self) -> Self {
+        self.into_iter()
+            .map(|geometry| geometry.to_degrees())
+            .collect()
+    }
+}

--- a/geo-types/src/geometry/to_radians.rs
+++ b/geo-types/src/geometry/to_radians.rs
@@ -1,0 +1,129 @@
+use super::*;
+
+/// Converts the coordinates of a geometry to radians
+///
+/// # Example
+/// ```
+/// use geo_types::Point;
+///
+/// let p = Point::new(180.0, 341.5);
+/// let (x, y): (f32, f32) = p.to_radians().x_y();
+/// assert_eq!(x.round(), 3.0);
+/// assert_eq!(y.round(), 6.0);
+pub trait ToRadians {
+    fn to_radians(self) -> Self;
+}
+
+impl ToRadians for Coord {
+    fn to_radians(self) -> Self {
+        Self {
+            x: self.x.to_radians(),
+            y: self.y.to_radians(),
+        }
+    }
+}
+
+impl ToRadians for Point {
+    fn to_radians(self) -> Self {
+        let (x, y) = self.x_y();
+        let x = x.to_radians();
+        let y = y.to_radians();
+        Self::new(x, y)
+    }
+}
+
+impl ToRadians for MultiPoint {
+    fn to_radians(self) -> Self {
+        self.into_iter().map(|point| point.to_radians()).collect()
+    }
+}
+
+impl ToRadians for Line {
+    fn to_radians(self) -> Self {
+        Self {
+            start: self.start.to_radians(),
+            end: self.end.to_radians(),
+        }
+    }
+}
+
+impl ToRadians for LineString {
+    fn to_radians(mut self) -> Self {
+        self.0
+            .iter_mut()
+            .for_each(|coord| *coord = coord.to_radians());
+        self
+    }
+}
+
+impl ToRadians for MultiLineString {
+    fn to_radians(self) -> Self {
+        self.into_iter()
+            .map(|line_string| line_string.to_radians())
+            .collect()
+    }
+}
+
+impl ToRadians for Polygon {
+    fn to_radians(self) -> Self {
+        let (exterior, interiors) = self.into_inner();
+        let exterior = exterior.to_radians();
+        let interiors = interiors
+            .into_iter()
+            .map(|interior| interior.to_radians())
+            .collect();
+        Self::new(exterior, interiors)
+    }
+}
+
+impl ToRadians for MultiPolygon {
+    fn to_radians(self) -> Self {
+        self.into_iter()
+            .map(|polygon| polygon.to_radians())
+            .collect()
+    }
+}
+
+impl ToRadians for Rect {
+    fn to_radians(mut self) -> Self {
+        self.set_min(self.min().to_radians());
+        self.set_max(self.max().to_radians());
+        self
+    }
+}
+
+impl ToRadians for Triangle {
+    fn to_radians(mut self) -> Self {
+        self.0 = self.0.to_radians();
+        self.1 = self.1.to_radians();
+        self.2 = self.2.to_radians();
+        self
+    }
+}
+
+impl ToRadians for Geometry {
+    fn to_radians(self) -> Self {
+        match self {
+            Geometry::Point(geometry) => Geometry::Point(geometry.to_radians()),
+            Geometry::Line(geometry) => Geometry::Line(geometry.to_radians()),
+            Geometry::LineString(geometry) => Geometry::LineString(geometry.to_radians()),
+            Geometry::Polygon(geometry) => Geometry::Polygon(geometry.to_radians()),
+            Geometry::MultiPoint(geometry) => Geometry::MultiPoint(geometry.to_radians()),
+            Geometry::MultiLineString(geometry) => Geometry::MultiLineString(geometry.to_radians()),
+            Geometry::MultiPolygon(geometry) => Geometry::MultiPolygon(geometry.to_radians()),
+            Geometry::Rect(geometry) => Geometry::Rect(geometry.to_radians()),
+            Geometry::Triangle(geometry) => Geometry::Triangle(geometry.to_radians()),
+            Geometry::GeometryCollection(geometry) => {
+                Geometry::GeometryCollection(geometry.to_radians())
+            }
+        }
+    }
+}
+
+impl ToRadians for GeometryCollection {
+    fn to_radians(self) -> Self {
+        self.into_iter()
+            .map(|geometry| geometry.to_radians())
+            .collect()
+    }
+}


### PR DESCRIPTION
Previous struct methods `Point::to_degrees(self)` and `Point::to_radians(self)` are now behind the respective traits.

---
- [X] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [X] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.

