### PR TITLE
Add 1.70, 1.71 to CI, bump MSRV to 1.65

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
       matrix:
         container_image:
           # Use the latest stable version. No need for older versions.
-          - "georust/geo-ci:proj-9.2.1-rust-1.70"
+          - "georust/geo-ci:proj-9.2.1-rust-1.72"
     container:
       image: ${{ matrix.container_image }}
     steps:
@@ -77,10 +77,10 @@ jobs:
           # giving us about 6 months of coverage.
           #
           # Minimum supported rust version (MSRV)
-          - "georust/geo-ci:proj-9.2.1-rust-1.63"
+          - "georust/geo-ci:proj-9.2.1-rust-1.65"
           # Two most recent releases - we omit older ones for expedient CI
-          - "georust/geo-ci:proj-9.2.1-rust-1.69"
-          - "georust/geo-ci:proj-9.2.1-rust-1.70"
+          - "georust/geo-ci:proj-9.2.1-rust-1.71"
+          - "georust/geo-ci:proj-9.2.1-rust-1.72"
     container:
       image: ${{ matrix.container_image }}
     steps:
@@ -105,10 +105,10 @@ jobs:
           # giving us about 6 months of coverage.
           #
           # Minimum supported rust version (MSRV)
-          - "georust/geo-ci:proj-9.2.1-rust-1.63"
+          - "georust/geo-ci:proj-9.2.1-rust-1.65"
           # Two most recent releases - we omit older ones for expedient CI
-          - "georust/geo-ci:proj-9.2.1-rust-1.69"
-          - "georust/geo-ci:proj-9.2.1-rust-1.70"
+          - "georust/geo-ci:proj-9.2.1-rust-1.71"
+          - "georust/geo-ci:proj-9.2.1-rust-1.72"
     container:
       image: ${{ matrix.container_image }}
     steps:
@@ -132,10 +132,10 @@ jobs:
           # giving us about 6 months of coverage.
           #
           # Minimum supported rust version (MSRV)
-          - "georust/geo-ci:proj-9.2.1-rust-1.63"
+          - "georust/geo-ci:proj-9.2.1-rust-1.65"
           # Two most recent releases - we omit older ones for expedient CI
-          - "georust/geo-ci:proj-9.2.1-rust-1.69"
-          - "georust/geo-ci:proj-9.2.1-rust-1.70"
+          - "georust/geo-ci:proj-9.2.1-rust-1.71"
+          - "georust/geo-ci:proj-9.2.1-rust-1.72"
     container:
       image: ${{ matrix.container_image }}
     steps:
@@ -155,7 +155,7 @@ jobs:
       matrix:
         container_image:
           # Fuzz only on latest
-          - "georust/geo-ci:proj-9.2.1-rust-1.70"
+          - "georust/geo-ci:proj-9.2.1-rust-1.72"
     container:
       image: ${{ matrix.container_image }}
     steps:
@@ -168,7 +168,7 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     container:
-      image: georust/geo-ci:proj-9.2.1-rust-1.70
+      image: georust/geo-ci:proj-9.2.1-rust-1.72
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/geo-postgis/Cargo.toml
+++ b/geo-postgis/Cargo.toml
@@ -8,7 +8,7 @@ documentation = "https://docs.rs/geo-postgis/"
 readme = "../README.md"
 keywords = ["gis", "geo", "geography", "geospatial", "postgis"]
 description = "Conversion between `geo-types` and `postgis` types."
-rust-version = "1.63"
+rust-version = "1.65"
 edition = "2021"
 
 [dependencies]

--- a/geo-types/Cargo.toml
+++ b/geo-types/Cargo.toml
@@ -7,7 +7,7 @@ documentation = "https://docs.rs/geo-types/"
 readme = "../README.md"
 keywords = ["gis", "geo", "geography", "geospatial"]
 description = "Geospatial primitive data types"
-rust-version = "1.63"
+rust-version = "1.65"
 edition = "2021"
 
 [features]

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -9,7 +9,7 @@ readme = "../README.md"
 keywords = ["gis", "geo", "geography", "geospatial"]
 autobenches = true
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.65"
 categories = ["science::geo"]
 
 [features]


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

1.65 was released more than 10 months ago: https://blog.rust-lang.org/2022/11/03/Rust-1.65.0.html

Notably (for me anyway because I keep trying to use it) this means we can use [let/else syntax](https://rust-lang.github.io/rfcs/3137-let-else.html). 

As a reminder, our policy has been to support at least the last 6 months (STABLE + 3 prior), but I usually bump it conservatively to whatever feature is causing annoyance. 
