### PR TITLE
Remove unnecessary `extern crate` declarations.

### DIFF
--- a/geo-types/src/lib.rs
+++ b/geo-types/src/lib.rs
@@ -84,7 +84,6 @@
 //! [rstar]: https://github.com/Stoeoef/rstar
 //! [Serde]: https://serde.rs/
 extern crate alloc;
-extern crate num_traits;
 
 use core::fmt::Debug;
 use num_traits::{Float, Num, NumCast};
@@ -92,9 +91,6 @@ use num_traits::{Float, Num, NumCast};
 #[cfg(feature = "serde")]
 #[macro_use]
 extern crate serde;
-
-#[cfg(feature = "rstar_0_8")]
-extern crate rstar_0_8;
 
 #[cfg(test)]
 #[macro_use]

--- a/geo/benches/area.rs
+++ b/geo/benches/area.rs
@@ -1,8 +1,4 @@
-#[macro_use]
-extern crate criterion;
-extern crate geo;
-
-use criterion::Criterion;
+use criterion::{criterion_group, criterion_main, Criterion};
 use geo::Area;
 use geo::Polygon;
 

--- a/geo/benches/concave_hull.rs
+++ b/geo/benches/concave_hull.rs
@@ -1,8 +1,4 @@
-#[macro_use]
-extern crate criterion;
-extern crate geo;
-
-use criterion::Criterion;
+use criterion::{criterion_group, criterion_main, Criterion};
 use geo::ConcaveHull;
 use geo::{Coord, CoordNum};
 

--- a/geo/benches/contains.rs
+++ b/geo/benches/contains.rs
@@ -1,12 +1,6 @@
-#[macro_use]
-extern crate criterion;
-#[macro_use]
-extern crate geo;
-
+use criterion::{criterion_group, criterion_main, Criterion};
 use geo::contains::Contains;
-use geo::{polygon, Line, Point, Polygon};
-
-use criterion::Criterion;
+use geo::{point, polygon, Line, Point, Polygon};
 
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("point in simple polygon", |bencher| {

--- a/geo/benches/convex_hull.rs
+++ b/geo/benches/convex_hull.rs
@@ -1,8 +1,4 @@
-#[macro_use]
-extern crate criterion;
-extern crate geo;
-
-use criterion::Criterion;
+use criterion::{criterion_group, criterion_main, Criterion};
 use geo::prelude::*;
 use geo::{Coord, CoordNum};
 

--- a/geo/benches/euclidean_distance.rs
+++ b/geo/benches/euclidean_distance.rs
@@ -1,8 +1,5 @@
-#[macro_use]
-extern crate criterion;
-extern crate geo;
-use geo::convex_hull::ConvexHull;
-use geo::euclidean_distance::EuclideanDistance;
+use criterion::{criterion_group, criterion_main};
+use geo::algorithm::{ConvexHull, EuclideanDistance};
 use geo::{polygon, Polygon};
 
 fn criterion_benchmark(c: &mut criterion::Criterion) {

--- a/geo/benches/extremes.rs
+++ b/geo/benches/extremes.rs
@@ -1,8 +1,4 @@
-#[macro_use]
-extern crate criterion;
-extern crate geo;
-
-use criterion::Criterion;
+use criterion::{criterion_group, criterion_main, Criterion};
 use geo::prelude::*;
 use geo::Polygon;
 

--- a/geo/benches/frechet_distance.rs
+++ b/geo/benches/frechet_distance.rs
@@ -1,6 +1,4 @@
-#[macro_use]
-extern crate criterion;
-extern crate geo;
+use criterion::{criterion_group, criterion_main};
 use geo::frechet_distance::FrechetDistance;
 
 fn criterion_benchmark(c: &mut criterion::Criterion) {

--- a/geo/benches/geodesic_distance.rs
+++ b/geo/benches/geodesic_distance.rs
@@ -1,8 +1,5 @@
-#[macro_use]
-extern crate criterion;
-extern crate geo;
-
-use geo::prelude::*;
+use criterion::{criterion_group, criterion_main};
+use geo::algorithm::GeodesicDistance;
 
 fn criterion_benchmark(c: &mut criterion::Criterion) {
     c.bench_function("geodesic distance f64", |bencher| {

--- a/geo/benches/intersection.rs
+++ b/geo/benches/intersection.rs
@@ -1,9 +1,4 @@
-#[macro_use]
-extern crate criterion;
-extern crate geo;
-extern crate geo_test_fixtures;
-
-use criterion::Criterion;
+use criterion::{criterion_group, criterion_main, Criterion};
 use geo::intersects::Intersects;
 use geo::MultiPolygon;
 

--- a/geo/benches/monotone_subdiv.rs
+++ b/geo/benches/monotone_subdiv.rs
@@ -1,8 +1,3 @@
-#[macro_use]
-extern crate criterion;
-
-extern crate geo;
-
 use std::fmt::Display;
 use std::panic::catch_unwind;
 
@@ -11,7 +6,9 @@ use geo::coordinate_position::CoordPos;
 use geo::monotone::monotone_subdivision;
 use geo::{CoordinatePosition, MapCoords, Polygon};
 
-use criterion::{BatchSize, BenchmarkGroup, BenchmarkId, Criterion};
+use criterion::{
+    criterion_group, criterion_main, BatchSize, BenchmarkGroup, BenchmarkId, Criterion,
+};
 use geo_types::{Coord, Rect};
 use wkt::ToWkt;
 

--- a/geo/benches/relate.rs
+++ b/geo/benches/relate.rs
@@ -1,12 +1,6 @@
-#[macro_use]
-extern crate criterion;
-extern crate geo;
-
-use crate::geo::relate::Relate;
-use crate::geo::rotate::Rotate;
-use crate::geo::translate::Translate;
-use criterion::{BatchSize, Criterion};
-use geo::{LineString, Polygon};
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use geo::algorithm::{Relate, Rotate, Translate};
+use geo::geometry::{LineString, Polygon};
 
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("relate overlapping 50-point polygons", |bencher| {

--- a/geo/benches/rotate.rs
+++ b/geo/benches/rotate.rs
@@ -1,8 +1,4 @@
-#[macro_use]
-extern crate criterion;
-extern crate geo;
-
-use criterion::Criterion;
+use criterion::{criterion_group, criterion_main, Criterion};
 use geo::prelude::*;
 
 fn criterion_benchmark(c: &mut Criterion) {

--- a/geo/benches/simplify.rs
+++ b/geo/benches/simplify.rs
@@ -1,8 +1,4 @@
-#[macro_use]
-extern crate criterion;
-extern crate geo;
-
-use criterion::Criterion;
+use criterion::{criterion_group, criterion_main, Criterion};
 use geo::simplify::Simplify;
 
 fn criterion_benchmark(c: &mut Criterion) {

--- a/geo/benches/simplifyvw.rs
+++ b/geo/benches/simplifyvw.rs
@@ -1,8 +1,4 @@
-#[macro_use]
-extern crate criterion;
-extern crate geo;
-
-use criterion::Criterion;
+use criterion::{criterion_group, criterion_main, Criterion};
 use geo::prelude::*;
 use geo::simplify_vw::SimplifyVwPreserve;
 

--- a/geo/benches/vincenty_distance.rs
+++ b/geo/benches/vincenty_distance.rs
@@ -1,8 +1,5 @@
-#[macro_use]
-extern crate criterion;
-extern crate geo;
-
-use geo::prelude::*;
+use criterion::{criterion_group, criterion_main};
+use geo::algorithm::VincentyDistance;
 
 fn criterion_benchmark(c: &mut criterion::Criterion) {
     c.bench_function("vincenty distance f32", |bencher| {

--- a/geo/benches/winding_order.rs
+++ b/geo/benches/winding_order.rs
@@ -1,8 +1,5 @@
-#[macro_use]
-extern crate criterion;
-extern crate geo;
-
-use geo::prelude::*;
+use criterion::{criterion_group, criterion_main};
+use geo::algorithm::Winding;
 
 fn criterion_benchmark(c: &mut criterion::Criterion) {
     c.bench_function("winding order: winding_order (f32)", |bencher| {

--- a/geo/examples/algorithm.rs
+++ b/geo/examples/algorithm.rs
@@ -1,7 +1,4 @@
-#[macro_use]
-extern crate geo;
-
-use geo::Centroid;
+use geo::{line_string, Centroid};
 
 fn main() {
     let linestring = geo::line_string![

--- a/geo/examples/types.rs
+++ b/geo/examples/types.rs
@@ -1,5 +1,3 @@
-extern crate geo;
-
 use geo::Point;
 use geo_types::point;
 

--- a/geo/src/algorithm/bearing.rs
+++ b/geo/src/algorithm/bearing.rs
@@ -9,8 +9,7 @@ pub trait Bearing<T: CoordFloat> {
     /// # Examples
     ///
     /// ```
-    /// # #[macro_use] extern crate approx;
-    /// #
+    /// # use approx::assert_relative_eq;
     /// use geo::Bearing;
     /// use geo::Point;
     ///

--- a/geo/src/algorithm/geodesic_bearing.rs
+++ b/geo/src/algorithm/geodesic_bearing.rs
@@ -13,8 +13,7 @@ pub trait GeodesicBearing<T: CoordNum> {
     /// # Examples
     ///
     /// ```
-    /// # #[macro_use] extern crate approx;
-    /// #
+    /// # use approx::assert_relative_eq;
     /// use geo::GeodesicBearing;
     /// use geo::Point;
     ///
@@ -35,8 +34,7 @@ pub trait GeodesicBearing<T: CoordNum> {
     /// # Examples
     ///
     /// ```
-    /// # #[macro_use] extern crate approx;
-    /// #
+    /// # use approx::assert_relative_eq;
     /// use geo::GeodesicBearing;
     /// use geo::Point;
     ///

--- a/geo/src/algorithm/geodesic_intermediate.rs
+++ b/geo/src/algorithm/geodesic_intermediate.rs
@@ -9,8 +9,7 @@ pub trait GeodesicIntermediate<T: CoordFloat> {
     /// # Examples
     ///
     /// ```
-    /// # #[macro_use] extern crate approx;
-    /// #
+    /// # use approx::assert_relative_eq;
     /// use geo::GeodesicIntermediate;
     /// use geo::Point;
     ///

--- a/geo/src/algorithm/haversine_bearing.rs
+++ b/geo/src/algorithm/haversine_bearing.rs
@@ -11,8 +11,7 @@ pub trait HaversineBearing<T: CoordFloat> {
     /// # Examples
     ///
     /// ```
-    /// # #[macro_use] extern crate approx;
-    /// #
+    /// # use approx::assert_relative_eq;
     /// use geo::HaversineBearing;
     /// use geo::Point;
     ///

--- a/geo/src/algorithm/haversine_intermediate.rs
+++ b/geo/src/algorithm/haversine_intermediate.rs
@@ -9,8 +9,7 @@ pub trait HaversineIntermediate<T: CoordFloat> {
     /// # Examples
     ///
     /// ```
-    /// # #[macro_use] extern crate approx;
-    /// #
+    /// # use approx::assert_relative_eq;
     /// use geo::HaversineIntermediate;
     /// use geo::Point;
     ///

--- a/geo/src/algorithm/k_nearest_concave_hull.rs
+++ b/geo/src/algorithm/k_nearest_concave_hull.rs
@@ -323,7 +323,7 @@ where
 mod tests {
     use super::*;
     use crate::coords_iter::CoordsIter;
-    use crate::geo_types::coord;
+    use geo_types::coord;
 
     #[test]
     fn coord_ordering() {

--- a/geo/src/algorithm/line_intersection.rs
+++ b/geo/src/algorithm/line_intersection.rs
@@ -312,7 +312,7 @@ fn proper_intersection<F: GeoFloat>(p: Line<F>, q: Line<F>) -> Coord<F> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::geo_types::coord;
+    use geo_types::coord;
 
     /// Based on JTS test `testCentralEndpointHeuristicFailure`
     /// > Following cases were failures when using the CentralEndpointIntersector heuristic.

--- a/geo/src/algorithm/line_locate_point.rs
+++ b/geo/src/algorithm/line_locate_point.rs
@@ -109,8 +109,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::geo_types::coord;
-    use crate::point;
+    use crate::{coord, point};
     use num_traits::Float;
 
     #[test]

--- a/geo/src/algorithm/relate/geomgraph/index/rstar_edge_set_intersector.rs
+++ b/geo/src/algorithm/relate/geomgraph/index/rstar_edge_set_intersector.rs
@@ -26,7 +26,7 @@ where
     F: GeoFloat + rstar::RTreeNum,
 {
     fn new(i: usize, edge: &'a RefCell<Edge<F>>) -> Self {
-        use crate::rstar::RTreeObject;
+        use rstar::RTreeObject;
         let p1 = edge.borrow().coords()[i];
         let p2 = edge.borrow().coords()[i + 1];
         Self {

--- a/geo/src/algorithm/relate/geomgraph/robust_line_intersector.rs
+++ b/geo/src/algorithm/relate/geomgraph/robust_line_intersector.rs
@@ -1,8 +1,8 @@
 use super::{LineIntersection, LineIntersector};
 use crate::kernels::{Kernel, Orientation, RobustKernel};
-use crate::num_traits::Zero;
 use crate::{BoundingRect, Contains, Intersects};
 use crate::{Coord, GeoFloat, Line, Rect};
+use num_traits::Zero;
 
 /// A robust version of [LineIntersector](traits.LineIntersector).
 #[derive(Clone)]

--- a/geo/src/algorithm/simplify.rs
+++ b/geo/src/algorithm/simplify.rs
@@ -299,8 +299,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::geo_types::coord;
-    use crate::{line_string, polygon};
+    use crate::{coord, line_string, polygon};
 
     #[test]
     fn recursion_test() {

--- a/geo/src/lib.rs
+++ b/geo/src/lib.rs
@@ -197,14 +197,9 @@
 //! [proj crate file download]: https://docs.rs/proj/*/proj/#grid-file-download
 //! [Serde]: https://serde.rs/
 
-extern crate geo_types;
-extern crate num_traits;
 #[cfg(feature = "use-serde")]
 #[macro_use]
 extern crate serde;
-#[cfg(feature = "use-proj")]
-extern crate proj;
-extern crate rstar;
 
 pub use crate::algorithm::*;
 pub use crate::types::Closest;


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [n/a] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

`extern crate` used to be needed for any dependency and to use macros. As of rust 2018, this is no longer true.

The remaining use cases we have for `extern crate` are rare:

1. importing macros into the global namespace for frequently used macros
2. for sysroot crates like alloc

