### PR TITLE
Add fallible alternatives to `Polygon::{exterior,interiors}_mut`

### DIFF
--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## Unrealeased
+
+* Add `Polygon::try_exterior_mut` and `Polygon::try_interiors_mut`.
+  <https://github.com/georust/geo/pull/1071>
+
 ## 0.7.11
 * Bump rstar dependency
   <https://github.com/georust/geo/pull/1030>

--- a/geo-types/src/geometry/polygon.rs
+++ b/geo-types/src/geometry/polygon.rs
@@ -246,6 +246,16 @@ impl<T: CoordNum> Polygon<T> {
         self.exterior.close();
     }
 
+    /// Fallible alternative to [`exterior_mut`](Polygon::exterior_mut).
+    pub fn try_exterior_mut<F, E>(&mut self, f: F) -> Result<(), E>
+    where
+        F: FnOnce(&mut LineString<T>) -> Result<(), E>,
+    {
+        f(&mut self.exterior)?;
+        self.exterior.close();
+        Ok(())
+    }
+
     /// Return a slice of the interior `LineString` rings.
     ///
     /// # Examples
@@ -348,6 +358,18 @@ impl<T: CoordNum> Polygon<T> {
         for interior in &mut self.interiors {
             interior.close();
         }
+    }
+
+    /// Fallible alternative to [`interiors_mut`](Self::interiors_mut).
+    pub fn try_interiors_mut<F, E>(&mut self, f: F) -> Result<(), E>
+    where
+        F: FnOnce(&mut [LineString<T>]) -> Result<(), E>,
+    {
+        f(&mut self.interiors)?;
+        for interior in &mut self.interiors {
+            interior.close();
+        }
+        Ok(())
     }
 
     /// Add an interior ring to the `Polygon`.


### PR DESCRIPTION
Some background: https://github.com/georust/geo/pull/1065

---
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.

