### PR TITLE
Fix LineSegmentize where number of linestrings is less than n

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Add `LineStringSegmentize` trait to split a single `LineString` into `n` `LineStrings` as a `MultiLineString`
+  * <https://github.com/georust/geo/pull/1055>
 * Add `EuclideanDistance` implementations for all remaining geometries.
   * <https://github.com/georust/geo/pull/1029>
 * Add `HausdorffDistance` algorithm trait to calculate the Hausdorff distance between any two geometries.

--- a/geo/src/algorithm/linestring_segment.rs
+++ b/geo/src/algorithm/linestring_segment.rs
@@ -180,7 +180,6 @@ mod test {
         assert_eq!(segments.0.len(), 4);
 
         assert_eq!(segments.euclidean_length(), linestring.euclidean_length());
-        
     }
     #[test]
     // that 0 returns None and that usize::MAX returns None

--- a/geo/src/algorithm/linestring_segment.rs
+++ b/geo/src/algorithm/linestring_segment.rs
@@ -178,6 +178,9 @@ mod test {
         assert_eq!(segments.0.len(), 3);
         let segments = linestring.line_segmentize(4).unwrap();
         assert_eq!(segments.0.len(), 4);
+
+        assert_eq!(segments.euclidean_length(), linestring.euclidean_length());
+        
     }
     #[test]
     // that 0 returns None and that usize::MAX returns None


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

The bug: `LineStringSegmentize` trait can return `n - 1` LineStrings. This happens when the last `Line` being iterated over needs to be split into 2 separate Lines. 

The fix: previously, the definition did not permit splitting the last `Line` iterator. This PR allows the last Line to be split and checks after the for loop has completed iteration if the length is equal to `n`. 

Closes: https://github.com/georust/geo/issues/1075