### PR TITLE
FIX `Densify` trait to avoid panic with empty line string

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -2,15 +2,19 @@
 
 ## Unreleased
 
-* Add `DensifyHaversine` trait to densify spherical line geometry
-* Add `LineStringSegmentize` trait to split a single `LineString` into `n` `LineStrings` as a `MultiLineString`
+* Fix `Densify` trait to avoid panic with empty line string.
+  * <https://github.com/georust/geo/pull/1082>
+* Add `DensifyHaversine` trait to densify spherical line geometry.
+  * <https://github.com/georust/geo/pull/1081>
+* Add `LineStringSegmentize` trait to split a single `LineString` into `n` `LineStrings` as a `MultiLineString`.
+  * <https://github.com/georust/geo/pull/1055>
 * Add `EuclideanDistance` implementations for all remaining geometries.
   * <https://github.com/georust/geo/pull/1029>
 * Add `HausdorffDistance` algorithm trait to calculate the Hausdorff distance between any two geometries.
   * <https://github.com/georust/geo/pull/1041>
 * Add `matches` method to IntersectionMatrix for ergonomic de-9im comparisons.
   * <https://github.com/georust/geo/pull/1043>
-* Simplify `CoordsIter` and `MinimumRotatedRect` `trait`s with GATs by removing an unneeded trait lifetime
+* Simplify `CoordsIter` and `MinimumRotatedRect` `trait`s with GATs by removing an unneeded trait lifetime.
   * <https://github.com/georust/geo/pull/908>
 * Add `ToDegrees` and `ToRadians` traits.
   * <https://github.com/georust/geo/pull/1070>

--- a/geo/src/algorithm/densify.rs
+++ b/geo/src/algorithm/densify.rs
@@ -106,7 +106,12 @@ where
     type Output = LineString<T>;
 
     fn densify(&self, max_distance: T) -> Self::Output {
+        if self.0.is_empty() {
+            return LineString::new(vec![]);
+        }
+
         let mut new_line = vec![];
+
         self.lines()
             .for_each(|line| densify_line(line, &mut new_line, max_distance));
         // we're done, push the last coordinate on to finish
@@ -205,6 +210,14 @@ mod tests {
         let max_dist = 2.0;
         let densified = polygon.densify(max_dist);
         assert_eq!(densified, correct_polygon);
+    }
+
+    #[test]
+    fn test_empty_linestring_densify() {
+        let linestring = LineString::<f64>::new(vec![]);
+        let max_dist = 2.0;
+        let densified = linestring.densify(max_dist);
+        assert!(densified.0.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Followup to https://github.com/georust/geo/pull/1081#discussion_r1348941585
