### PR TITLE
Implement `Stitch` trait

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -16,7 +16,7 @@
   * <https://github.com/georust/geo/pull/1199>
 * Bump `geo` MSRV to 1.74 and update CI
   * <https://github.com/georust/geo/pull/1201>
-* Add `Stitch` trait which implements a new kind of combining algorithm for geometries
+* Add `StitchTriangles` trait which implements a new kind of combining algorithm for `Triangle`s
   * <https://github.com/georust/geo/pull/1087>
 
 ## 0.28.0

--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -94,6 +94,8 @@
   * <https://github.com/georust/geo/pull/1083>
 * Add `len()` and `is_empty()` to `MultiPoint`
   * <https://github.com/georust/geo/pull/1109>
+* Add `Stitch` trait which implements a new kind of combining algorithm for geometries
+  * <https://github.com/georust/geo/pull/1087>
 
 ## 0.26.0
 

--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -16,6 +16,8 @@
   * <https://github.com/georust/geo/pull/1199>
 * Bump `geo` MSRV to 1.74 and update CI
   * <https://github.com/georust/geo/pull/1201>
+* Add `Stitch` trait which implements a new kind of combining algorithm for geometries
+  * <https://github.com/georust/geo/pull/1087>
 
 ## 0.28.0
 
@@ -94,8 +96,6 @@
   * <https://github.com/georust/geo/pull/1083>
 * Add `len()` and `is_empty()` to `MultiPoint`
   * <https://github.com/georust/geo/pull/1109>
-* Add `Stitch` trait which implements a new kind of combining algorithm for geometries
-  * <https://github.com/georust/geo/pull/1087>
 
 ## 0.26.0
 

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -20,7 +20,7 @@ use-serde = ["serde", "geo-types/serde"]
 
 [dependencies]
 earcutr = { version = "0.4.2", optional = true }
-spade = { version = "2.2.0", optional = true }
+spade = { version = "2.10.0", optional = true }
 float_next_after = "1.0.0"
 geo-types = { version = "0.7.13", features = ["approx", "use-rstar_0_12"] }
 geographiclib-rs = { version = "0.2.3", default-features = false }

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -122,3 +122,7 @@ harness = false
 [[bench]]
 name = "triangulate"
 harness = false
+
+[[bench]]
+name = "stitch"
+harness = false

--- a/geo/benches/stitch.rs
+++ b/geo/benches/stitch.rs
@@ -1,17 +1,24 @@
-use criterion::{criterion_group, criterion_main, Criterion};
-use geo::stitch::StitchTriangles;
-use geo::TriangulateSpade;
-
-fn criterion_benchmark(c: &mut Criterion) {
-    c.bench_function("stitch", |bencher| {
-        let p = geo_test_fixtures::east_baton_rouge::<f32>();
-        let tris = p.unconstrained_triangulation().unwrap();
-
-        bencher.iter(|| {
-            criterion::black_box(criterion::black_box(&tris).stitch_triangulation().unwrap());
-        });
-    });
+// This needs a public export for the stitchtriangles trait. For now we decided to make it private
+// so this benchmark is commented out. In case you need it and the trait still isn't public yet,
+// you need to temporarily change that to make this benchmark work again.
+//
+// use criterion::{criterion_group, criterion_main, criterion};
+// use geo::stitch::StitchTriangles;
+// use geo::TriangulateSpade;
+//
+// fn criterion_benchmark(c: &mut criterion) {
+//     c.bench_function("stitch", |bencher| {
+//         let p = geo_test_fixtures::east_baton_rouge::<f32>();
+//         let tris = p.unconstrained_triangulation().unwrap();
+//
+//         bencher.iter(|| {
+//             criterion::black_box(criterion::black_box(&tris).stitch_triangulation().unwrap());
+//         });
+//     });
+// }
+//
+// criterion_group!(benches, criterion_benchmark);
+// criterion_main!(benches);
+fn main() {
+    println!("Placeholder");
 }
-
-criterion_group!(benches, criterion_benchmark);
-criterion_main!(benches);

--- a/geo/benches/stitch.rs
+++ b/geo/benches/stitch.rs
@@ -1,0 +1,17 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use geo::stitch::Stitch;
+use geo::TriangulateSpade;
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("stitch", |bencher| {
+        let p = geo_test_fixtures::east_baton_rouge::<f32>();
+        let tris = p.unconstrained_triangulation().unwrap();
+
+        bencher.iter(|| {
+            criterion::black_box(criterion::black_box(&tris).stitch_together().unwrap());
+        });
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/geo/benches/stitch.rs
+++ b/geo/benches/stitch.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use geo::stitch::Stitch;
+use geo::stitch::StitchTriangles;
 use geo::TriangulateSpade;
 
 fn criterion_benchmark(c: &mut Criterion) {
@@ -8,7 +8,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         let tris = p.unconstrained_triangulation().unwrap();
 
         bencher.iter(|| {
-            criterion::black_box(criterion::black_box(&tris).stitch_together().unwrap());
+            criterion::black_box(criterion::black_box(&tris).stitch_triangulation().unwrap());
         });
     });
 }

--- a/geo/src/algorithm/mod.rs
+++ b/geo/src/algorithm/mod.rs
@@ -236,6 +236,10 @@ pub use simplify::{Simplify, SimplifyIdx};
 pub mod simplify_vw;
 pub use simplify_vw::{SimplifyVw, SimplifyVwIdx, SimplifyVwPreserve};
 
+/// Stitch together geometries with adjacent sides. Alternative to unioning geometries.
+pub mod stitch;
+pub use stitch::Stitch;
+
 /// Transform a geometry using PROJ.
 #[cfg(feature = "use-proj")]
 pub mod transform;

--- a/geo/src/algorithm/mod.rs
+++ b/geo/src/algorithm/mod.rs
@@ -237,8 +237,7 @@ pub mod simplify_vw;
 pub use simplify_vw::{SimplifyVw, SimplifyVwIdx, SimplifyVwPreserve};
 
 /// Stitch together triangles with adjacent sides. Alternative to unioning triangles via BooleanOps.
-pub mod stitch;
-pub use stitch::StitchTriangles;
+pub(crate) mod stitch;
 
 /// Transform a geometry using PROJ.
 #[cfg(feature = "use-proj")]

--- a/geo/src/algorithm/mod.rs
+++ b/geo/src/algorithm/mod.rs
@@ -238,7 +238,7 @@ pub use simplify_vw::{SimplifyVw, SimplifyVwIdx, SimplifyVwPreserve};
 
 /// Stitch together geometries with adjacent sides. Alternative to unioning geometries.
 pub mod stitch;
-pub use stitch::Stitch;
+pub use stitch::StitchTriangles;
 
 /// Transform a geometry using PROJ.
 #[cfg(feature = "use-proj")]

--- a/geo/src/algorithm/mod.rs
+++ b/geo/src/algorithm/mod.rs
@@ -237,6 +237,7 @@ pub mod simplify_vw;
 pub use simplify_vw::{SimplifyVw, SimplifyVwIdx, SimplifyVwPreserve};
 
 /// Stitch together triangles with adjacent sides. Alternative to unioning triangles via BooleanOps.
+#[allow(dead_code)]
 pub(crate) mod stitch;
 
 /// Transform a geometry using PROJ.

--- a/geo/src/algorithm/mod.rs
+++ b/geo/src/algorithm/mod.rs
@@ -236,7 +236,7 @@ pub use simplify::{Simplify, SimplifyIdx};
 pub mod simplify_vw;
 pub use simplify_vw::{SimplifyVw, SimplifyVwIdx, SimplifyVwPreserve};
 
-/// Stitch together geometries with adjacent sides. Alternative to unioning geometries.
+/// Stitch together triangles with adjacent sides. Alternative to unioning triangles via BooleanOps.
 pub mod stitch;
 pub use stitch::StitchTriangles;
 

--- a/geo/src/algorithm/stitch.rs
+++ b/geo/src/algorithm/stitch.rs
@@ -26,7 +26,17 @@ pub(crate) type PolygonStitchingResult<T> = Result<T, LineStitchingError>;
 
 // ========= Main Algo ============
 
+/// Trait to stitch together split up polygons.
 pub trait Stitch<T: GeoFloat> {
+    // 🚧🚧 TODO 🚧🚧 : it might make sense to have a separate method in this trait which
+    // doesn't do the fixup and instead assumes that the polygon is well formed to prevent
+    // extensive cloning
+    //
+    /// This stitching only happens along identical edges which are located in two separate
+    /// geometries. This also means that if you want to do something more general like a
+    /// [`Boolean Operation Union`](https://en.wikipedia.org/wiki/Boolean_operations_on_polygons)
+    /// you should use the trait `BooleanOps` or `SpadeBoolops`. In contrast, the `stitch_together`
+    /// trait method has a comparatively smaller footprint than those other boolean operation traits.
     fn stitch_together(&self) -> PolygonStitchingResult<MultiPolygon<T>>;
 }
 
@@ -76,9 +86,6 @@ macro_rules! impl_stitch {
 impl_stitch! {
     Polygon<T> => self
     fn stitch_together(&self) -> PolygonStitchingResult<MultiPolygon<T>> {
-        // 🚧🚧 TODO 🚧🚧 : it might make sense to have a separate method in this trait which
-        // doesn't do the fixup and instead assumes that the polygon is well formed to prevent
-        // extensive cloning
         let polys = self
             .iter()
             .map(|&poly| fix_orientation(poly.clone()))

--- a/geo/src/algorithm/stitch.rs
+++ b/geo/src/algorithm/stitch.rs
@@ -29,16 +29,21 @@ pub(crate) type PolygonStitchingResult<T> = Result<T, LineStitchingError>;
 /// Trait to stitch together split up polygons.
 pub trait Stitch<T: GeoFloat> {
     /// This stitching only happens along identical edges which are located in two separate
-    /// geometries. This also means that if you want to do something more general like a
-    /// [`Boolean Operation Union`](https://en.wikipedia.org/wiki/Boolean_operations_on_polygons)
-    /// you should use the trait `BooleanOps` or `SpadeBoolops`. In contrast, the `stitch_together`
-    /// trait method has a comparatively smaller footprint than those other boolean operation traits.
+    /// geometries.
+    ///
+    /// ┌─────x        ┌─────┐
+    /// │    /│        │     │
+    /// │   / │        │     │
+    /// │  /  │  ───►  │     │
+    /// │ /   │        │     │
+    /// │/    │        │     │
+    /// x─────┘        └─────┘
     ///
     /// # Examples
     ///
     /// ```
     /// use geo::Stitch;
-    /// use geo::{Coord, Triangle};
+    /// use geo::{Coord, Triangle, Rect};
     ///
     /// let tri1 = Triangle::from([
     ///     Coord { x: 0.0, y: 0.0 },
@@ -62,7 +67,17 @@ pub trait Stitch<T: GeoFloat> {
     /// let poly = mp.0[0].clone();
     /// // 4 coords + 1 duplicate for closed-ness
     /// assert_eq!(poly.exterior().0.len(), 4 + 1);
+    ///
+    /// let expected = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 1.0, y: 1.0 }).to_polygon();
+    ///
+    /// assert_eq!(poly, expected);
     /// ```
+    ///
+    /// # Additional Notes
+    ///
+    /// If you want to do something more general like a
+    /// [`Boolean Operation Union`](https://en.wikipedia.org/wiki/Boolean_operations_on_polygons)
+    /// you should use the trait `BooleanOps` or `SpadeBoolops`.
     fn stitch_together(&self) -> PolygonStitchingResult<MultiPolygon<T>>;
 }
 

--- a/geo/src/algorithm/stitch.rs
+++ b/geo/src/algorithm/stitch.rs
@@ -458,4 +458,46 @@ mod polygon_stitching_tests {
         assert_eq!(result.0.len(), 1);
         assert_eq!(result.0[0].interiors().len(), 1);
     }
+
+    #[test]
+    fn inner_banana_produces_hole() {
+        let poly = Polygon::new(
+            LineString::new(vec![
+                Coord { x: 0.0, y: 0.0 },
+                Coord { x: 4.0, y: 0.0 },
+                Coord { x: 3.0, y: 2.0 },
+                Coord { x: 5.0, y: 2.0 },
+                Coord { x: 4.0, y: 0.0 },
+                Coord { x: 8.0, y: 0.0 },
+                Coord { x: 4.0, y: 4.0 },
+            ]),
+            vec![],
+        );
+
+        let result = vec![poly].stitch_together().unwrap();
+
+        assert_eq!(result.0.len(), 1);
+        assert_eq!(result.0[0].interiors().len(), 1);
+    }
+
+    #[test]
+    fn outer_banana_doesnt_produce_hole() {
+        let poly = Polygon::new(
+            LineString::new(vec![
+                Coord { x: 0.0, y: 0.0 },
+                Coord { x: 4.0, y: 0.0 },
+                Coord { x: 3.0, y: -2.0 },
+                Coord { x: 5.0, y: -2.0 },
+                Coord { x: 4.0, y: 0.0 },
+                Coord { x: 8.0, y: 0.0 },
+                Coord { x: 4.0, y: 4.0 },
+            ]),
+            vec![],
+        );
+
+        let result = vec![poly].stitch_together().unwrap();
+
+        assert_eq!(result.0.len(), 1);
+        assert_eq!(result.0[0].interiors().len(), 0);
+    }
 }

--- a/geo/src/algorithm/stitch.rs
+++ b/geo/src/algorithm/stitch.rs
@@ -43,7 +43,7 @@ pub trait Stitch<T: GeoFloat> {
     ///
     /// ```
     /// use geo::Stitch;
-    /// use geo::{Coord, Triangle, Rect};
+    /// use geo::{Coord, Triangle, polygon};
     ///
     /// let tri1 = Triangle::from([
     ///     Coord { x: 0.0, y: 0.0 },
@@ -68,7 +68,12 @@ pub trait Stitch<T: GeoFloat> {
     /// // 4 coords + 1 duplicate for closed-ness
     /// assert_eq!(poly.exterior().0.len(), 4 + 1);
     ///
-    /// let expected = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 1.0, y: 1.0 }).to_polygon();
+    /// let expected = polygon![
+    ///     Coord { x: 0.0, y: 1.0 },
+    ///     Coord { x: 0.0, y: 0.0 },
+    ///     Coord { x: 1.0, y: 0.0 },
+    ///     Coord { x: 1.0, y: 1.0 },
+    /// ];
     ///
     /// assert_eq!(poly, expected);
     /// ```

--- a/geo/src/algorithm/stitch.rs
+++ b/geo/src/algorithm/stitch.rs
@@ -1,0 +1,304 @@
+use std::collections::HashMap;
+
+use geo_types::{Coord, Line, LineString, MultiPolygon, Polygon};
+
+use crate::{Contains, CoordsIter, GeoFloat, LinesIter};
+
+// ========= Error Type ============
+
+#[derive(Debug)]
+pub enum LineStitchingError {
+    IncompleteRing,
+    InvalidGeometry,
+    MissingParent,
+    NoExtremum,
+}
+
+impl std::fmt::Display for LineStitchingError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+impl std::error::Error for LineStitchingError {}
+
+pub(crate) type PolygonStitchingResult<T> = Result<T, LineStitchingError>;
+
+// ========= Main Algo ============
+
+pub trait Stitch<'a, T: GeoFloat> {
+    fn stitch_together(&'a self) -> PolygonStitchingResult<MultiPolygon<T>>;
+}
+
+impl<'a, 'b, T, G> Stitch<'a, T> for Vec<G>
+where
+    'b: 'a,
+    T: GeoFloat,
+    G: LinesIter<'a, Scalar = T>,
+{
+    fn stitch_together(&'a self) -> PolygonStitchingResult<MultiPolygon<T>> {
+        let lines = self
+            .iter()
+            .flat_map(|part| part.lines_iter())
+            .collect::<Vec<_>>();
+
+        let boundary_lines = find_boundary_lines(lines);
+        let stitched_multipolygon = stitch_multipolygon_from_lines(boundary_lines)?;
+
+        let polys = stitched_multipolygon
+            .into_iter()
+            .map(find_and_fix_holes_in_exterior)
+            .collect::<Vec<_>>();
+
+        Ok(MultiPolygon::new(polys))
+    }
+}
+
+impl<'a, 'b, T, G> Stitch<'a, T> for &[G]
+where
+    'b: 'a,
+    T: GeoFloat,
+    G: LinesIter<'a, Scalar = T>,
+{
+    fn stitch_together(&'a self) -> PolygonStitchingResult<MultiPolygon<T>> {
+        let lines = self
+            .iter()
+            .flat_map(|part| part.lines_iter())
+            .collect::<Vec<_>>();
+
+        let boundary_lines = find_boundary_lines(lines);
+        let stitched_multipolygon = stitch_multipolygon_from_lines(boundary_lines)?;
+
+        let polys = stitched_multipolygon
+            .into_iter()
+            .map(find_and_fix_holes_in_exterior)
+            .collect::<Vec<_>>();
+
+        Ok(MultiPolygon::new(polys))
+    }
+}
+
+/// checks whether the to lines are equal or inverted forms of each other
+fn same_line<T: GeoFloat>(l1: &Line<T>, l2: &Line<T>) -> bool {
+    l1 == l2 || l1 == &Line::new(l2.end, l2.start)
+}
+
+/// given a collection of lines from multiple polygons, this returns all but the shared lines
+fn find_boundary_lines<T: GeoFloat>(lines: Vec<Line<T>>) -> Vec<Line<T>> {
+    lines
+        .iter()
+        .enumerate()
+        // only collect lines that don't have a duplicate in the set
+        .filter_map(|(i, line)| {
+            (!lines
+                .iter()
+                .enumerate()
+                .filter(|&(j, _)| j != i)
+                .any(|(_, l)| same_line(line, l)))
+            .then_some(*line)
+        })
+        .collect::<Vec<_>>()
+}
+
+/// Inputs to this function is a unordered set of polygons have been split from a multipolygon
+/// This function will return an invalid multipolygon if the provided parts were not a result of splitting
+pub fn stitch_multipolygon_from_parts<T: GeoFloat>(
+    parts: &[Polygon<T>],
+) -> PolygonStitchingResult<MultiPolygon<T>> {
+    let lines = parts
+        .iter()
+        .flat_map(|part| part.lines_iter())
+        .collect::<Vec<Line<T>>>();
+
+    let boundary_lines = find_boundary_lines(lines);
+    stitch_multipolygon_from_lines(boundary_lines).map(|mut mp| {
+        mp.iter_mut().for_each(|poly| {
+            *poly = find_and_fix_holes_in_exterior(poly.clone());
+        });
+        mp
+    })
+}
+
+/// finds holes in polygon exterior and fixes them
+///
+/// This is important for scenarios like the banana polygon. Which is considered invalid
+/// https://www.postgis.net/workshops/postgis-intro/validity.html#repairing-invalidity
+pub fn find_and_fix_holes_in_exterior<F: GeoFloat>(mut poly: Polygon<F>) -> Polygon<F> {
+    // find rings
+    let mut rings = vec![];
+    let mut points = vec![];
+    for p in poly.exterior() {
+        if let Some(i) = points.iter().position(|&c| c == p) {
+            rings.push(
+                points
+                    .drain(i..)
+                    .chain(std::iter::once(p))
+                    .cloned()
+                    .collect::<Vec<_>>(),
+            );
+        }
+        points.push(p);
+    }
+    rings.push(points.into_iter().cloned().collect::<Vec<_>>());
+
+    let mut rings = rings
+        .into_iter()
+        .map(|cs| Polygon::new(LineString::new(cs), vec![]))
+        // filter out degenerate polygons which may be produced from the code above
+        .filter(|p| p.coords_count() >= 3)
+        .collect::<Vec<_>>();
+
+    // if exterior ring exists that contains all other rings, recreate the poly with:
+    //
+    // - exterior ring as exterior
+    // - other rings are counted to interiors
+    // - previously existing interiors are preserved
+    if let Some(outer_index) = rings
+        .iter()
+        .enumerate()
+        .find(|(i, ring)| {
+            rings
+                .iter()
+                .enumerate()
+                .filter(|(j, _)| i != j)
+                .all(|(_, other)| ring.contains(other))
+        })
+        .map(|(i, _)| i)
+    {
+        let exterior = rings.remove(outer_index).exterior().clone();
+        let interiors = poly
+            .interiors()
+            .iter()
+            .cloned()
+            .chain(rings.into_iter().map(|p| p.exterior().clone()))
+            .collect::<Vec<_>>();
+        poly = Polygon::new(exterior, interiors);
+    }
+    poly
+}
+
+/// Inputs to this function is a unordered set of lines that must form a valid multipolygon
+pub fn stitch_multipolygon_from_lines<F: GeoFloat>(
+    lines: Vec<Line<F>>,
+) -> PolygonStitchingResult<MultiPolygon<F>> {
+    let rings = stitch_rings_from_lines(lines)?;
+
+    // Associates every ring with its parents (the rings that contain it)
+    let mut parents: HashMap<usize, Vec<usize>> = HashMap::default();
+
+    for (current_ring_idx, ring) in rings.iter().enumerate() {
+        let parent_idxs = rings
+            .iter()
+            .enumerate()
+            .filter(|(other_idx, _)| current_ring_idx != *other_idx)
+            .filter_map(|(idx, maybe_parent)| {
+                Polygon::new(maybe_parent.clone(), vec![])
+                    .contains(ring)
+                    .then_some(idx)
+            })
+            .collect::<Vec<_>>();
+        parents.insert(current_ring_idx, parent_idxs);
+    }
+
+    // Associates outer rings with their inner rings
+    let mut polygons_idxs: HashMap<usize, Vec<usize>> = HashMap::default();
+
+    // For each ring, we check how many parents it has  otherwise it's an outer ring
+    //
+    // This is important in the scenarios of "donuts" where you have an outer donut shaped
+    // polygon which completely contains a smaller polygon inside its hole
+    for (ring_index, parent_idxs) in parents.iter() {
+        let parent_count = parent_idxs.len();
+
+        // if it has an even number of parents, it's an outer ring so we can just add it if it's
+        // missing
+        if parent_count % 2 == 0 {
+            polygons_idxs.entry(*ring_index).or_default();
+        }
+
+        // if it has an odd number of parents, it's an inner ring
+        //
+        // to find the specific outer ring it is related to, we search for the direct parent. The
+        // direct parent of the current ring has itself the most parents from all available
+        // parents, so find it by max
+        if let Some(direct_parent) = parent_idxs.iter().max_by_key(|parent_idx| {
+            parents
+                .get(parent_idx)
+                .map(|grandparents| grandparents.len())
+                .unwrap_or_default()
+        }) {
+            polygons_idxs
+                .entry(*direct_parent)
+                .or_default()
+                .push(*ring_index);
+        }
+    }
+
+    // lookup rings by index and create polygons
+    let polygons = polygons_idxs
+        .into_iter()
+        .map(|(parent, children)| {
+            (
+                rings[parent].clone(),
+                children
+                    .into_iter()
+                    .map(|child| rings[child].clone())
+                    .collect::<Vec<_>>(),
+            )
+        })
+        .map(|(exterior, interiors)| Polygon::new(exterior, interiors));
+
+    Ok(polygons.collect())
+}
+
+// ============== Helpers ================
+
+pub fn stitch_rings_from_lines<F: GeoFloat>(
+    lines: Vec<Line<F>>,
+) -> PolygonStitchingResult<Vec<LineString<F>>> {
+    let mut ring_parts: Vec<Vec<Coord<F>>> = lines
+        .iter()
+        .map(|line| vec![line.start, line.end])
+        .collect();
+
+    let mut rings: Vec<LineString<F>> = vec![];
+    while !ring_parts.is_empty() {
+        let (j, res) = ring_parts
+            .iter()
+            .enumerate()
+            .skip(1)
+            .find_map(|(j, part)| try_stitch(&ring_parts[0], part).map(|res| (j, res)))
+            .ok_or(LineStitchingError::IncompleteRing)?;
+
+        if res.first() == res.last() && !res.is_empty() {
+            rings.push(LineString::new(res));
+        } else {
+            ring_parts.push(res);
+        }
+
+        ring_parts.remove(j);
+        ring_parts.remove(0);
+    }
+
+    Ok(rings)
+}
+
+fn try_stitch<F: GeoFloat>(a: &[Coord<F>], b: &[Coord<F>]) -> Option<Vec<Coord<F>>> {
+    let a_first = a.first()?;
+    let a_last = a.last()?;
+    let b_first = b.first()?;
+    let b_last = b.last()?;
+
+    let a = || a.iter();
+    let b = || b.iter();
+
+    // X -> _  |  X -> _
+    (a_first == b_first)
+        .then(|| a().rev().chain(b().skip(1)).cloned().collect())
+        // X -> _  |  _ -> X
+        .or_else(|| (a_first == b_last).then(|| b().chain(a().skip(1)).cloned().collect()))
+        // _ -> X  |  X -> _
+        .or_else(|| (a_last == b_first).then(|| a().chain(b().skip(1)).cloned().collect()))
+        // _ -> X  |  _ -> X
+        .or_else(|| (a_last == b_last).then(|| a().chain(b().rev().skip(1)).cloned().collect()))
+}

--- a/geo/src/algorithm/stitch.rs
+++ b/geo/src/algorithm/stitch.rs
@@ -313,7 +313,7 @@ fn try_stitch<F: GeoFloat>(a: &[Coord<F>], b: &[Coord<F>]) -> Option<Vec<Coord<F
 #[cfg(test)]
 mod polygon_stitching_tests {
 
-    use crate::TriangulateEarcut;
+    use crate::{Area, TriangulateEarcut};
 
     use super::*;
     use geo_types::*;
@@ -342,8 +342,68 @@ mod polygon_stitching_tests {
             })
             .concat();
 
-        let result = stitch_multipolygon_from_parts(&tris).unwrap();
+        let result = tris.stitch_together().unwrap();
 
         assert!(mp.contains(&result) && result.contains(&mp));
+    }
+
+    #[test]
+    fn stitch_triangles_at_point() {
+        _ = pretty_env_logger::try_init();
+        let tri1 = Triangle::from([
+            Coord { x: 0.0, y: 0.0 },
+            Coord { x: 1.0, y: 0.0 },
+            Coord { x: 0.0, y: 1.0 },
+        ]);
+        let tri2 = Triangle::from([
+            Coord { x: 0.0, y: 0.0 },
+            Coord { x: -1.0, y: 0.0 },
+            Coord { x: 0.0, y: -1.0 },
+        ]);
+
+        let result_1 = vec![tri1, tri2].stitch_together().unwrap();
+
+        let tri1 = Triangle::from([
+            Coord { x: 0.0, y: 0.0 },
+            Coord { x: 0.0, y: 1.0 },
+            Coord { x: 1.0, y: 0.0 },
+        ]);
+        let tri2 = Triangle::from([
+            Coord { x: 0.0, y: 0.0 },
+            Coord { x: -1.0, y: 0.0 },
+            Coord { x: 0.0, y: -1.0 },
+        ]);
+
+        let result_2 = vec![tri1, tri2].stitch_together().unwrap();
+
+        let tri1 = Triangle::from([
+            Coord { x: 0.0, y: 0.0 },
+            Coord { x: 0.0, y: 1.0 },
+            Coord { x: 1.0, y: 0.0 },
+        ]);
+        let tri2 = Triangle::from([
+            Coord { x: 0.0, y: 0.0 },
+            Coord { x: 0.0, y: -1.0 },
+            Coord { x: -1.0, y: 0.0 },
+        ]);
+
+        let result_3 = vec![tri1, tri2].stitch_together().unwrap();
+
+        let tri1 = Triangle::from([
+            Coord { x: 0.0, y: 0.0 },
+            Coord { x: 1.0, y: 0.0 },
+            Coord { x: 0.0, y: 1.0 },
+        ]);
+        let tri2 = Triangle::from([
+            Coord { x: 0.0, y: 0.0 },
+            Coord { x: 0.0, y: -1.0 },
+            Coord { x: -1.0, y: 0.0 },
+        ]);
+
+        let result_4 = vec![tri1, tri2].stitch_together().unwrap();
+
+        assert_eq!(result_1.unsigned_area(), result_2.unsigned_area());
+        assert_eq!(result_2.unsigned_area(), result_3.unsigned_area());
+        assert_eq!(result_3.unsigned_area(), result_4.unsigned_area());
     }
 }

--- a/geo/src/algorithm/stitch.rs
+++ b/geo/src/algorithm/stitch.rs
@@ -28,15 +28,41 @@ pub(crate) type PolygonStitchingResult<T> = Result<T, LineStitchingError>;
 
 /// Trait to stitch together split up polygons.
 pub trait Stitch<T: GeoFloat> {
-    // 🚧🚧 TODO 🚧🚧 : it might make sense to have a separate method in this trait which
-    // doesn't do the fixup and instead assumes that the polygon is well formed to prevent
-    // extensive cloning
-    //
     /// This stitching only happens along identical edges which are located in two separate
     /// geometries. This also means that if you want to do something more general like a
     /// [`Boolean Operation Union`](https://en.wikipedia.org/wiki/Boolean_operations_on_polygons)
     /// you should use the trait `BooleanOps` or `SpadeBoolops`. In contrast, the `stitch_together`
     /// trait method has a comparatively smaller footprint than those other boolean operation traits.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use geo::Stitch;
+    /// use geo::{Coord, Triangle};
+    ///
+    /// let tri1 = Triangle::from([
+    ///     Coord { x: 0.0, y: 0.0 },
+    ///     Coord { x: 1.0, y: 0.0 },
+    ///     Coord { x: 0.0, y: 1.0 },
+    /// ]);
+    /// let tri2 = Triangle::from([
+    ///     Coord { x: 1.0, y: 1.0 },
+    ///     Coord { x: 1.0, y: 0.0 },
+    ///     Coord { x: 0.0, y: 1.0 },
+    /// ]);
+    ///
+    /// let result = vec![tri1, tri2].stitch_together();
+    ///
+    /// assert!(result.is_ok());
+    ///
+    /// let mp = result.unwrap();
+    ///
+    /// assert_eq!(mp.0.len(), 1);
+    ///
+    /// let poly = mp.0[0].clone();
+    /// // 4 coords + 1 duplicate for closed-ness
+    /// assert_eq!(poly.exterior().0.len(), 4 + 1);
+    /// ```
     fn stitch_together(&self) -> PolygonStitchingResult<MultiPolygon<T>>;
 }
 
@@ -432,9 +458,9 @@ mod polygon_stitching_tests {
         ])
         .to_polygon();
         let mut tri2 = Triangle::from([
-            Coord { x: 0.0, y: 0.0 },
-            Coord { x: -1.0, y: 0.0 },
-            Coord { x: 0.0, y: -1.0 },
+            Coord { x: 1.0, y: 1.0 },
+            Coord { x: 1.0, y: 0.0 },
+            Coord { x: 0.0, y: 1.0 },
         ])
         .to_polygon();
 

--- a/geo/src/algorithm/stitch.rs
+++ b/geo/src/algorithm/stitch.rs
@@ -146,30 +146,11 @@ fn find_boundary_lines<T: GeoFloat>(lines: Vec<Line<T>>) -> Vec<Line<T>> {
         .collect::<Vec<_>>()
 }
 
-/// Inputs to this function is a unordered set of polygons have been split from a multipolygon
-/// This function will return an invalid multipolygon if the provided parts were not a result of splitting
-pub fn stitch_multipolygon_from_parts<T: GeoFloat>(
-    parts: &[Polygon<T>],
-) -> PolygonStitchingResult<MultiPolygon<T>> {
-    let lines = parts
-        .iter()
-        .flat_map(|part| part.lines_iter())
-        .collect::<Vec<Line<T>>>();
-
-    let boundary_lines = find_boundary_lines(lines);
-    stitch_multipolygon_from_lines(boundary_lines).map(|mut mp| {
-        mp.iter_mut().for_each(|poly| {
-            *poly = find_and_fix_holes_in_exterior(poly.clone());
-        });
-        mp
-    })
-}
-
 /// finds holes in polygon exterior and fixes them
 ///
 /// This is important for scenarios like the banana polygon. Which is considered invalid
 /// https://www.postgis.net/workshops/postgis-intro/validity.html#repairing-invalidity
-pub fn find_and_fix_holes_in_exterior<F: GeoFloat>(mut poly: Polygon<F>) -> Polygon<F> {
+fn find_and_fix_holes_in_exterior<F: GeoFloat>(mut poly: Polygon<F>) -> Polygon<F> {
     // find rings
     let mut rings = vec![];
     let mut points = vec![];
@@ -224,7 +205,7 @@ pub fn find_and_fix_holes_in_exterior<F: GeoFloat>(mut poly: Polygon<F>) -> Poly
 }
 
 /// Inputs to this function is a unordered set of lines that must form a valid multipolygon
-pub fn stitch_multipolygon_from_lines<F: GeoFloat>(
+fn stitch_multipolygon_from_lines<F: GeoFloat>(
     lines: Vec<Line<F>>,
 ) -> PolygonStitchingResult<MultiPolygon<F>> {
     let rings = stitch_rings_from_lines(lines)?;
@@ -304,7 +285,7 @@ pub fn stitch_multipolygon_from_lines<F: GeoFloat>(
 
 // ============== Helpers ================
 
-pub fn stitch_rings_from_lines<F: GeoFloat>(
+fn stitch_rings_from_lines<F: GeoFloat>(
     lines: Vec<Line<F>>,
 ) -> PolygonStitchingResult<Vec<LineString<F>>> {
     let mut ring_parts: Vec<Vec<Coord<F>>> = lines

--- a/geo/src/algorithm/stitch.rs
+++ b/geo/src/algorithm/stitch.rs
@@ -31,6 +31,7 @@ pub trait Stitch<T: GeoFloat> {
     /// This stitching only happens along identical edges which are located in two separate
     /// geometries.
     ///
+    /// ```text
     /// ┌─────x        ┌─────┐
     /// │    /│        │     │
     /// │   / │        │     │
@@ -38,6 +39,7 @@ pub trait Stitch<T: GeoFloat> {
     /// │ /   │        │     │
     /// │/    │        │     │
     /// x─────┘        └─────┘
+    /// ```
     ///
     /// # Examples
     ///

--- a/geo/src/algorithm/stitch.rs
+++ b/geo/src/algorithm/stitch.rs
@@ -272,7 +272,7 @@ fn stitch_multipolygon_from_lines<F: GeoFloat>(
     let mut polygons_idxs: HashMap<usize, Vec<usize>> = HashMap::default();
 
     // the direct parent is the parent ring which has itself the most parent rings
-    fn find_direct_parents(
+    fn find_direct_parent(
         parent_rings: &[usize],
         parents_of: &HashMap<usize, Vec<usize>>,
     ) -> Option<usize> {
@@ -305,7 +305,7 @@ fn stitch_multipolygon_from_lines<F: GeoFloat>(
         // if it has an odd number of parents, it's an inner ring
 
         // to find the specific outer ring it is related to, we search for the direct parent.
-        let maybe_direct_parent = find_direct_parents(parent_idxs, &parents_of);
+        let maybe_direct_parent = find_direct_parent(parent_idxs, &parents_of);
 
         // As stated above the amount of parents here is odd, so it's at least one.
         // Since every ring is registered in the `parents` hashmap, we find at least one element

--- a/geo/src/algorithm/stitch.rs
+++ b/geo/src/algorithm/stitch.rs
@@ -168,8 +168,7 @@ fn same_line<T: GeoFloat>(l1: &Line<T>, l2: &Line<T>) -> bool {
 /// - inner lines: these are all non-boundary lines. They are not unique and have exactly one
 /// duplicate on one adjacent polygon in the collection (as long as the input is valid!)
 fn find_boundary_lines<T: GeoFloat>(lines: Vec<Line<T>>) -> Vec<Line<T>> {
-    let init = Vec::with_capacity(lines.len());
-    lines.into_iter().fold(init, |mut lines, new_line| {
+    lines.into_iter().fold(Vec::new(), |mut lines, new_line| {
         if let Some(idx) = lines.iter().position(|line| same_line(line, &new_line)) {
             lines.remove(idx);
         } else {

--- a/geo/src/algorithm/stitch.rs
+++ b/geo/src/algorithm/stitch.rs
@@ -401,7 +401,7 @@ fn try_stitch<F: GeoFloat>(a: &[Coord<F>], b: &[Coord<F>]) -> Option<Vec<Coord<F
 #[cfg(test)]
 mod polygon_stitching_tests {
 
-    use crate::{Area, TriangulateEarcut, Winding};
+    use crate::{Relate, TriangulateEarcut, Winding};
 
     use super::*;
     use geo_types::*;
@@ -425,7 +425,7 @@ mod polygon_stitching_tests {
 
         let result = tris.stitch_triangulation().unwrap();
 
-        assert!(mp.contains(&result) && result.contains(&mp));
+        assert!(mp.relate(&result).is_equal_topo());
     }
 
     #[test]
@@ -476,9 +476,9 @@ mod polygon_stitching_tests {
             .stitch_triangulation()
             .unwrap();
 
-        assert_eq!(result_1.unsigned_area(), result_2.unsigned_area());
-        assert_eq!(result_2.unsigned_area(), result_3.unsigned_area());
-        assert_eq!(result_3.unsigned_area(), result_4.unsigned_area());
+        assert!(result_1.relate(&result_2).is_equal_topo());
+        assert!(result_2.relate(&result_3).is_equal_topo());
+        assert!(result_3.relate(&result_4).is_equal_topo());
     }
 
     #[test]

--- a/geo/src/algorithm/stitch.rs
+++ b/geo/src/algorithm/stitch.rs
@@ -52,7 +52,7 @@ pub trait StitchTriangles<T: GeoFloat> {
     /// # Examples
     ///
     /// ```
-    /// use geo::Stitch;
+    /// use geo::StitchTriangles;
     /// use geo::{Coord, Triangle, polygon};
     ///
     /// let tri1 = Triangle::from([
@@ -66,7 +66,7 @@ pub trait StitchTriangles<T: GeoFloat> {
     ///     Coord { x: 0.0, y: 1.0 },
     /// ]);
     ///
-    /// let result = vec![tri1, tri2].stitch_together();
+    /// let result = vec![tri1, tri2].stitch_triangulation();
     ///
     /// assert!(result.is_ok());
     ///
@@ -79,10 +79,10 @@ pub trait StitchTriangles<T: GeoFloat> {
     /// assert_eq!(poly.exterior().0.len(), 4 + 1);
     ///
     /// let expected = polygon![
+    ///     Coord { x: 1.0, y: 1.0 },
     ///     Coord { x: 0.0, y: 1.0 },
     ///     Coord { x: 0.0, y: 0.0 },
     ///     Coord { x: 1.0, y: 0.0 },
-    ///     Coord { x: 1.0, y: 1.0 },
     /// ];
     ///
     /// assert_eq!(poly, expected);

--- a/geo/src/algorithm/stitch.rs
+++ b/geo/src/algorithm/stitch.rs
@@ -192,16 +192,15 @@ fn same_line<T: GeoFloat>(l1: &Line<T>, l2: &Line<T>) -> bool {
 
 /// given a collection of lines from multiple polygons, this returns all but the shared lines
 fn find_boundary_lines<T: GeoFloat>(lines: Vec<Line<T>>) -> Vec<Line<T>> {
-    let enumerated_lines = || lines.iter().enumerate();
-    enumerated_lines()
-        // only collect lines that don't have a duplicate in the set
-        .filter_map(|(i, line)| {
-            let same_line_exists = enumerated_lines()
-                .filter(|&(j, _)| j != i)
-                .any(|(_, l)| same_line(line, l));
-            (!same_line_exists).then_some(*line)
-        })
-        .collect::<Vec<_>>()
+    let init = Vec::with_capacity(lines.len());
+    lines.into_iter().fold(init, |mut lines, new_line| {
+        if let Some(idx) = lines.iter().position(|line| same_line(line, &new_line)) {
+            lines.remove(idx);
+        } else {
+            lines.push(new_line);
+        }
+        lines
+    })
 }
 
 // Notes for future: This probably belongs into a `Validify` trait or something

--- a/geo/src/algorithm/stitch.rs
+++ b/geo/src/algorithm/stitch.rs
@@ -249,6 +249,7 @@ fn find_and_fix_holes_in_exterior<F: GeoFloat>(mut poly: Polygon<F>) -> Polygon<
         .map(|cs| Polygon::new(LineString::new(cs), vec![]))
         .collect::<Vec<_>>();
 
+    // PERF: O(n^2) maybe someone can reduce this. Please benchmark!
     fn find_outmost_ring<F: GeoFloat>(rings: &[Polygon<F>]) -> Option<usize> {
         let enumerated_rings = || rings.iter().enumerate();
         enumerated_rings()
@@ -360,6 +361,7 @@ fn stitch_multipolygon_from_lines<F: GeoFloat>(
     let polygons = polygons_idxs
         .into_iter()
         .map(|(parent_idx, children_idxs)| {
+            // PERF: extensive cloning here, maybe someone can improve this. Please benchmark!
             let exterior = rings[parent_idx].clone();
             let interiors = children_idxs
                 .into_iter()

--- a/geo/src/algorithm/stitch.rs
+++ b/geo/src/algorithm/stitch.rs
@@ -135,7 +135,7 @@ fn ccw_lines<T: GeoFloat>(tri: &Triangle<T>) -> [Line<T>; 3] {
     }
 }
 
-/// checks whether the to lines are equal or inverted forms of each other
+/// checks whether the two lines are equal or inverted forms of each other
 #[inline]
 fn same_line<T: GeoFloat>(l1: &Line<T>, l2: &Line<T>) -> bool {
     (l1.start == l2.start && l1.end == l2.end) || (l1.start == l2.end && l2.start == l1.end)

--- a/geo/src/algorithm/stitch.rs
+++ b/geo/src/algorithm/stitch.rs
@@ -48,41 +48,43 @@ pub(crate) trait StitchTriangles<T: GeoFloat> {
     ///
     /// # Examples
     ///
-    /// ```
-    /// use geo::StitchTriangles;
-    /// use geo::{Coord, Triangle, polygon};
+    /// ```no_run
+    /// // commented this out since the trait is private and the doc test will fail
     ///
-    /// let tri1 = Triangle::from([
-    ///     Coord { x: 0.0, y: 0.0 },
-    ///     Coord { x: 1.0, y: 0.0 },
-    ///     Coord { x: 0.0, y: 1.0 },
-    /// ]);
-    /// let tri2 = Triangle::from([
-    ///     Coord { x: 1.0, y: 1.0 },
-    ///     Coord { x: 1.0, y: 0.0 },
-    ///     Coord { x: 0.0, y: 1.0 },
-    /// ]);
+    /// //use geo::StitchTriangles;
+    /// //use geo::{Coord, Triangle, polygon};
     ///
-    /// let result = vec![tri1, tri2].stitch_triangulation();
+    /// //let tri1 = Triangle::from([
+    /// //    Coord { x: 0.0, y: 0.0 },
+    /// //    Coord { x: 1.0, y: 0.0 },
+    /// //    Coord { x: 0.0, y: 1.0 },
+    /// //]);
+    /// //let tri2 = Triangle::from([
+    /// //    Coord { x: 1.0, y: 1.0 },
+    /// //    Coord { x: 1.0, y: 0.0 },
+    /// //    Coord { x: 0.0, y: 1.0 },
+    /// //]);
     ///
-    /// assert!(result.is_ok());
+    /// //let result = vec![tri1, tri2].stitch_triangulation();
     ///
-    /// let mp = result.unwrap();
+    /// //assert!(result.is_ok());
     ///
-    /// assert_eq!(mp.0.len(), 1);
+    /// //let mp = result.unwrap();
     ///
-    /// let poly = mp.0[0].clone();
-    /// // 4 coords + 1 duplicate for closed-ness
-    /// assert_eq!(poly.exterior().0.len(), 4 + 1);
+    /// //assert_eq!(mp.0.len(), 1);
     ///
-    /// let expected = polygon![
-    ///     Coord { x: 1.0, y: 1.0 },
-    ///     Coord { x: 0.0, y: 1.0 },
-    ///     Coord { x: 0.0, y: 0.0 },
-    ///     Coord { x: 1.0, y: 0.0 },
-    /// ];
+    /// //let poly = mp.0[0].clone();
+    /// //// 4 coords + 1 duplicate for closed-ness
+    /// //assert_eq!(poly.exterior().0.len(), 4 + 1);
     ///
-    /// assert_eq!(poly, expected);
+    /// //let expected = polygon![
+    /// //    Coord { x: 1.0, y: 1.0 },
+    /// //    Coord { x: 0.0, y: 1.0 },
+    /// //    Coord { x: 0.0, y: 0.0 },
+    /// //    Coord { x: 1.0, y: 0.0 },
+    /// //];
+    ///
+    /// //assert_eq!(poly, expected);
     /// ```
     ///
     /// # Additional Notes

--- a/geo/src/algorithm/stitch.rs
+++ b/geo/src/algorithm/stitch.rs
@@ -185,9 +185,9 @@ fn fix_orientation<T: GeoFloat>(mut poly: Polygon<T>) -> Polygon<T> {
 }
 
 /// checks whether the to lines are equal or inverted forms of each other
+#[inline]
 fn same_line<T: GeoFloat>(l1: &Line<T>, l2: &Line<T>) -> bool {
-    let flipped_l2 = Line::new(l2.end, l2.start);
-    l1 == l2 || l1 == &flipped_l2
+    (l1.start == l2.start && l1.end == l2.end) || (l1.start == l2.end && l2.start == l1.end)
 }
 
 /// given a collection of lines from multiple polygons, this returns all but the shared lines

--- a/geo/src/algorithm/stitch.rs
+++ b/geo/src/algorithm/stitch.rs
@@ -190,7 +190,13 @@ fn same_line<T: GeoFloat>(l1: &Line<T>, l2: &Line<T>) -> bool {
     (l1.start == l2.start && l1.end == l2.end) || (l1.start == l2.end && l2.start == l1.end)
 }
 
-/// given a collection of lines from multiple polygons, this returns all but the shared lines
+/// given a collection of lines from multiple polygons which partition an area we can have two
+/// kinds of lines:
+///
+/// - boundary lines: these are the unique lines on the boundary of the compound shape which is
+/// formed by the collection of polygons
+/// - inner lines: these are all non-boundary lines. They are not unique and have exactly one
+/// duplicate on one adjacent polygon in the collection (as long as the input is valid!)
 fn find_boundary_lines<T: GeoFloat>(lines: Vec<Line<T>>) -> Vec<Line<T>> {
     let init = Vec::with_capacity(lines.len());
     lines.into_iter().fold(init, |mut lines, new_line| {

--- a/geo/src/algorithm/stitch.rs
+++ b/geo/src/algorithm/stitch.rs
@@ -330,10 +330,10 @@ fn stitch_multipolygon_from_lines<F: GeoFloat>(
 
         // the direct parent is the parent which has itself the most parents
         fn find_direct_parents(
-            parents_indexs: &[usize],
+            parent_idxs: &[usize],
             parents: &HashMap<usize, Vec<usize>>,
         ) -> Option<usize> {
-            parents_indexs
+            parent_idxs
                 .iter()
                 .filter_map(|parent_idx| {
                     parents

--- a/geo/src/algorithm/stitch.rs
+++ b/geo/src/algorithm/stitch.rs
@@ -231,9 +231,7 @@ fn find_and_fix_holes_in_exterior<F: GeoFloat>(mut poly: Polygon<F>) -> Polygon<
             poly.exterior()
                 .into_iter()
                 .fold((vec![], vec![]), |(mut points, mut rings), coord| {
-                    if let Some(ring) = detect_if_rings_closed_with_point(&mut points, coord) {
-                        rings.push(ring);
-                    }
+                    rings.extend(detect_if_rings_closed_with_point(&mut points, coord));
                     points.push(coord);
                     (points, rings)
                 });

--- a/geo/src/algorithm/stitch.rs
+++ b/geo/src/algorithm/stitch.rs
@@ -41,8 +41,8 @@ pub(crate) trait StitchTriangles<T: GeoFloat> {
     ///
     /// # Pre Conditions
     ///
-    /// - All the given triangles must be unique. If you're not sure about that, deduplicate before
-    ///   calling the algorithm!
+    /// - The triangles in the input must not overlap! This also forbids identical triangles in the
+    ///   input set. If you want to do a union on overlapping triangles then c.f. [`SpadeBoolops`].
     /// - Input triangles should be valid polygons. For a definition of validity
     ///   c.f. <https://www.postgis.net/workshops/postgis-intro/validity.html>
     ///

--- a/geo/src/algorithm/stitch.rs
+++ b/geo/src/algorithm/stitch.rs
@@ -355,7 +355,7 @@ fn stitch_rings_from_lines<F: GeoFloat>(
 
     let mut rings: Vec<LineString<F>> = vec![];
     // terminates since every loop we'll merge two elements into one so the total number of
-    // elements decreases each loop by one
+    // elements decreases each loop by at least one (two in the case of completing a ring)
     while let Some(last_part) = ring_parts.pop() {
         let (j, compound_part) = ring_parts
             .iter()

--- a/geo/src/algorithm/stitch.rs
+++ b/geo/src/algorithm/stitch.rs
@@ -94,7 +94,7 @@ pub(crate) trait StitchTriangles<T: GeoFloat> {
     /// will result in a single polygon without interiors instead of a polygon with a single
     /// interior
     ///
-    /// ```
+    /// ```text
     /// ┌────────x────────┐
     /// │\....../ \....../│
     /// │.\..../   \..../.│

--- a/geo/src/algorithm/stitch.rs
+++ b/geo/src/algorithm/stitch.rs
@@ -47,7 +47,7 @@ pub trait StitchTriangles<T: GeoFloat> {
     /// - All the given triangles must be unique. If you're not sure about that, deduplicate before
     ///   calling the algorithm!
     /// - Input triangles should be valid polygons. For a definition of validity
-    ///   c.f. https://www.postgis.net/workshops/postgis-intro/validity.html
+    ///   c.f. <https://www.postgis.net/workshops/postgis-intro/validity.html>
     ///
     /// # Examples
     ///

--- a/geo/src/algorithm/stitch.rs
+++ b/geo/src/algorithm/stitch.rs
@@ -89,9 +89,43 @@ pub(crate) trait StitchTriangles<T: GeoFloat> {
     ///
     /// # Additional Notes
     ///
+    /// Stitching triangles which result in a polygon with a hole which touches the outline
+    /// (mentioned here [banana polygon](https://postgis.net/workshops/postgis-intro/validity.html#repairing-invalidity))
+    /// will result in a single polygon without interiors instead of a polygon with a single
+    /// interior
+    ///
+    /// ```
+    /// ┌────────x────────┐
+    /// │\....../ \....../│
+    /// │.\..../   \..../.│
+    /// │..\../     \../..│
+    /// │...\/       \/...│
+    /// │...───────────...│
+    /// │../\....^..../\..│
+    /// │./..\../.\../..\.│
+    /// │/....\/...\/....\│
+    /// └─────────────────┘
+    ///                    
+    ///     │    │    │    
+    ///     ▼    ▼    ▼    
+    ///                    
+    /// ┌────────x────────┐
+    /// │       / \       │
+    /// │      /   \      │
+    /// │     /     \     │
+    /// │    /       \    │
+    /// │   ───────────   │
+    /// │                 │
+    /// │                 │
+    /// │                 │
+    /// └─────────────────┘
+    /// ```
+    ///
+    /// ---
+    ///
     /// If you want to do something more general like a
     /// [`Boolean Operation Union`](https://en.wikipedia.org/wiki/Boolean_operations_on_polygons)
-    /// you should use the trait `BooleanOps` or `SpadeBoolops`.
+    /// you should use the trait [`BooleanOps`] or [`SpadeBoolops`].
     fn stitch_triangulation(&self) -> TriangleStitchingResult<MultiPolygon<T>>;
 }
 

--- a/geo/src/algorithm/stitch.rs
+++ b/geo/src/algorithm/stitch.rs
@@ -8,7 +8,7 @@ use crate::{Contains, GeoFloat};
 // ========= Error Type ============
 
 #[derive(Debug)]
-pub enum LineStitchingError {
+pub(crate) enum LineStitchingError {
     IncompleteRing(&'static str),
 }
 
@@ -25,7 +25,7 @@ pub(crate) type TriangleStitchingResult<T> = Result<T, LineStitchingError>;
 // ========= Main Algo ============
 
 /// Trait to stitch together split up triangles.
-pub trait StitchTriangles<T: GeoFloat> {
+pub(crate) trait StitchTriangles<T: GeoFloat> {
     /// This stitching only happens along identical edges which are located in two separate
     /// geometries. Please read about the required pre conditions of the inputs!
     ///

--- a/geo/src/algorithm/stitch.rs
+++ b/geo/src/algorithm/stitch.rs
@@ -10,9 +10,6 @@ use crate::{Contains, GeoFloat};
 #[derive(Debug)]
 pub enum LineStitchingError {
     IncompleteRing(&'static str),
-    InvalidGeometry(&'static str),
-    MissingParent,
-    NoExtremum,
 }
 
 impl std::fmt::Display for LineStitchingError {


### PR DESCRIPTION
This is an implementation of a trait which offers functionality to stitch up geometry parts that were split at some point of time. It's an alternative to boolean operations which doesn't panic and returns user friendly errors instead.

This is mostly used within the new [`SpadeBoolops` trait](https://github.com/georust/geo/pull/1089) which needs to stitch together some parts of a triangulation. Hence, this trait is mostly used on triangles but isn't constraint on those and was implemented here for a more general scenario. Here are some rough visuals of what the operation does

![image](https://github.com/georust/geo/assets/26892280/eca99b9d-6854-4782-add3-f4e73f1f42a9)

---

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.

---

TODOs

- [x] add docs for main trait
- [x] Add simple benchmarks 
- [x] try to optimize performance
