### PR TITLE
Add rhumb-line operations

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -18,6 +18,8 @@
   * <https://github.com/georust/geo/pull/908>
 * Add `ToDegrees` and `ToRadians` traits.
   * <https://github.com/georust/geo/pull/1070>
+* Add rhumb-line operations analogous to several current haversine operations: `RhumbBearing`, `RhumbDestination`, `RhumbDistance`, `RhumbIntermediate`, `RhumbLength`.
+  * <https://github.com/georust/geo/pull/1090>
 
 ## 0.26.0
 

--- a/geo/src/algorithm/mod.rs
+++ b/geo/src/algorithm/mod.rs
@@ -283,3 +283,7 @@ pub use outlier_detection::OutlierDetection;
 /// Monotonic polygon subdivision
 pub mod monotone;
 pub use monotone::{monotone_subdivision, MonoPoly, MonotonicPolygons};
+
+/// Rhumb-line-related algorithms and utils
+pub mod rhumb;
+pub use rhumb::{RhumbBearing, RhumbDestination, RhumbDistance, RhumbIntermediate, RhumbLength};

--- a/geo/src/algorithm/rhumb/bearing.rs
+++ b/geo/src/algorithm/rhumb/bearing.rs
@@ -1,0 +1,91 @@
+use num_traits::FromPrimitive;
+
+use crate::{CoordFloat, Point};
+
+use super::RhumbCalculations;
+
+/// Returns the bearing to another Point in degrees.
+///
+/// Bullock, R.: Great Circle Distances and Bearings Between Two Locations, 2007.
+/// (<https://dtcenter.org/met/users/docs/write_ups/gc_simple.pdf>)
+
+pub trait RhumbBearing<T: CoordFloat + FromPrimitive> {
+    /// Returns the bearing to another Point in degrees along a [rhumb line], where North is 0° and East is 90°.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use approx::assert_relative_eq;
+    /// use geo::RhumbBearing;
+    /// use geo::Point;
+    ///
+    /// let p_1 = Point::new(9.177789688110352, 48.776781529534965);
+    /// let p_2 = Point::new(9.274348757829898, 48.84037308229984);
+    /// let bearing = p_1.rhumb_bearing(p_2);
+    /// assert_relative_eq!(bearing, 45., epsilon = 1.0e-6);
+    /// ```
+    /// [rhumb line]: https://en.wikipedia.org/wiki/Rhumb_line
+
+    fn rhumb_bearing(&self, point: Point<T>) -> T;
+}
+
+impl<T> RhumbBearing<T> for Point<T>
+where
+    T: CoordFloat + FromPrimitive,
+{
+    fn rhumb_bearing(&self, point: Point<T>) -> T {
+        let three_sixty = T::from(360.0f64).unwrap();
+
+        let calculations = RhumbCalculations::new(self, &point);
+        (calculations.theta().to_degrees() + three_sixty) % three_sixty
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::point;
+    use crate::RhumbBearing;
+    use crate::RhumbDestination;
+
+    #[test]
+    fn north_bearing() {
+        let p_1 = point!(x: 9., y: 47.);
+        let p_2 = point!(x: 9., y: 48.);
+        let bearing = p_1.rhumb_bearing(p_2);
+        assert_relative_eq!(bearing, 0.);
+    }
+
+    #[test]
+    fn equatorial_east_bearing() {
+        let p_1 = point!(x: 9., y: 0.);
+        let p_2 = point!(x: 10., y: 0.);
+        let bearing = p_1.rhumb_bearing(p_2);
+        assert_relative_eq!(bearing, 90.);
+    }
+
+    #[test]
+    fn east_bearing() {
+        let p_1 = point!(x: 9., y: 10.);
+        let p_2 = point!(x: 18.131938299366652, y: 10.);
+
+        let bearing = p_1.rhumb_bearing(p_2);
+        assert_relative_eq!(bearing, 90.);
+    }
+
+    #[test]
+    fn northeast_bearing() {
+        let p_1 = point!(x: 9.177789688110352f64, y: 48.776781529534965);
+        let p_2 = point!(x: 9.274348757829898, y: 48.84037308229984);
+        let bearing = p_1.rhumb_bearing(p_2);
+        assert_relative_eq!(bearing, 45., epsilon = 1.0e-6);
+    }
+
+    #[test]
+    fn consistent_with_destination() {
+        let p_1 = point!(x: 9.177789688110352f64, y: 48.776781529534965);
+        let p_2 = p_1.rhumb_destination(45., 10000.);
+
+        let b_1 = p_1.rhumb_bearing(p_2);
+        assert_relative_eq!(b_1, 45., epsilon = 1.0e-6);
+    }
+}

--- a/geo/src/algorithm/rhumb/destination.rs
+++ b/geo/src/algorithm/rhumb/destination.rs
@@ -1,0 +1,80 @@
+use crate::{CoordFloat, Point, MEAN_EARTH_RADIUS};
+use num_traits::FromPrimitive;
+
+use super::calculate_destination;
+
+/// Returns the destination Point having travelled the given distance along a [rhumb line]
+/// from the origin geometry with the given bearing
+///
+/// *Note*: this implementation uses a mean earth radius of 6371.088 km, based on the [recommendation of
+/// the IUGG](ftp://athena.fsv.cvut.cz/ZFG/grs80-Moritz.pdf)
+pub trait RhumbDestination<T: CoordFloat> {
+    /// Returns the destination Point having travelled the given distance along a [rhumb line]
+    /// from the origin Point with the given bearing
+    ///
+    /// # Units
+    ///
+    /// - `bearing`: degrees, zero degrees is north
+    /// - `distance`: meters
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use geo::RhumbDestination;
+    /// use geo::Point;
+    ///
+    /// let p_1 = Point::new(9.177789688110352, 48.776781529534965);
+    /// let p_2 = p_1.rhumb_destination(45., 10000.);
+    /// assert_eq!(p_2, Point::new(9.274348757829898, 48.84037308229984))
+    /// ```
+    /// [rhumb line]: https://en.wikipedia.org/wiki/Rhumb_line
+    fn rhumb_destination(&self, bearing: T, distance: T) -> Point<T>;
+}
+
+impl<T> RhumbDestination<T> for Point<T>
+where
+    T: CoordFloat + FromPrimitive,
+{
+    fn rhumb_destination(&self, bearing: T, distance: T) -> Point<T> {
+        let delta = distance / T::from(MEAN_EARTH_RADIUS).unwrap(); // angular distance in radians
+        let lambda1 = self.x().to_radians();
+        let phi1 = self.y().to_radians();
+        let theta = bearing.to_radians();
+
+        calculate_destination(delta, lambda1, phi1, theta)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::RhumbDistance;
+    use num_traits::pow;
+
+    #[test]
+    fn returns_a_new_point() {
+        let p_1 = Point::new(9.177789688110352, 48.776781529534965);
+        let p_2 = p_1.rhumb_destination(45., 10000.);
+        assert_eq!(p_2, Point::new(9.274348757829898, 48.84037308229984));
+        let distance = p_1.rhumb_distance(&p_2);
+        assert_relative_eq!(distance, 10000., epsilon = 1.0e-6)
+    }
+
+    #[test]
+    fn direct_and_indirect_destinations_are_close() {
+        let p_1 = Point::new(9.177789688110352, 48.776781529534965);
+        let p_2 = p_1.rhumb_destination(45., 10000.);
+        let square_edge = { pow(10000., 2) / 2f64 }.sqrt();
+        let p_3 = p_1.rhumb_destination(0., square_edge);
+        let p_4 = p_3.rhumb_destination(90., square_edge);
+        assert_relative_eq!(p_4, p_2, epsilon = 1.0e-3);
+    }
+
+    #[test]
+    fn bearing_zero_is_north() {
+        let p_1 = Point::new(9.177789688110352, 48.776781529534965);
+        let p_2 = p_1.rhumb_destination(0., 1000.);
+        assert_relative_eq!(p_1.x(), p_2.x(), epsilon = 1.0e-6);
+        assert!(p_2.y() > p_1.y())
+    }
+}

--- a/geo/src/algorithm/rhumb/distance.rs
+++ b/geo/src/algorithm/rhumb/distance.rs
@@ -1,0 +1,99 @@
+use crate::{CoordFloat, Point, MEAN_EARTH_RADIUS};
+use num_traits::FromPrimitive;
+
+use super::RhumbCalculations;
+
+/// Determine the distance between two geometries along a [rhumb line].
+///
+/// [rhumb line]: https://en.wikipedia.org/wiki/Rhumb_line
+///
+/// *Note*: this implementation uses a mean earth radius of 6371.088 km, based on the [recommendation of
+/// the IUGG](ftp://athena.fsv.cvut.cz/ZFG/grs80-Moritz.pdf)
+pub trait RhumbDistance<T, Rhs = Self> {
+    /// Determine the distance between along the [rhumb line] between two geometries.
+    ///
+    /// # Units
+    ///
+    /// - return value: meters
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use geo::prelude::*;
+    /// use geo::point;
+    ///
+    /// // New York City
+    /// let p1 = point!(x: -74.006f64, y: 40.7128f64);
+    ///
+    /// // London
+    /// let p2 = point!(x: -0.1278f64, y: 51.5074f64);
+    ///
+    /// let distance = p1.rhumb_distance(&p2);
+    ///
+    /// assert_eq!(
+    ///     5_794_129., // meters
+    ///     distance.round()
+    /// );
+    /// ```
+    ///
+    /// [rhumb line]: https://en.wikipedia.org/wiki/Rhumb_line
+    fn rhumb_distance(&self, rhs: &Rhs) -> T;
+}
+
+impl<T> RhumbDistance<T, Point<T>> for Point<T>
+where
+    T: CoordFloat + FromPrimitive,
+{
+    fn rhumb_distance(&self, rhs: &Point<T>) -> T {
+        let calculations = RhumbCalculations::new(self, rhs);
+        calculations.delta() * T::from(MEAN_EARTH_RADIUS).unwrap()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::Point;
+    use crate::RhumbDistance;
+
+    #[test]
+    fn distance1_test() {
+        let a = Point::new(0., 0.);
+        let b = Point::new(1., 0.);
+        assert_relative_eq!(
+            a.rhumb_distance(&b),
+            111195.0802335329_f64,
+            epsilon = 1.0e-6
+        );
+    }
+
+    #[test]
+    fn distance2_test() {
+        let a = Point::new(-72.1235, 42.3521);
+        let b = Point::new(72.1260, 70.612);
+        assert_relative_eq!(
+            a.rhumb_distance(&b),
+            8903668.508603323_f64,
+            epsilon = 1.0e-6
+        );
+    }
+
+    #[test]
+    fn distance3_test() {
+        // this input comes from issue #100
+        let a = Point::new(-77.036585, 38.897448);
+        let b = Point::new(-77.009080, 38.889825);
+        assert_relative_eq!(
+            a.rhumb_distance(&b),
+            2526.7031699343006_f64,
+            epsilon = 1.0e-6
+        );
+    }
+
+    #[test]
+    fn distance3_test_f32() {
+        // this input comes from issue #100
+        let a = Point::<f32>::new(-77.03658, 38.89745);
+        let b = Point::<f32>::new(-77.00908, 38.889825);
+        assert_relative_eq!(a.rhumb_distance(&b), 2526.7273_f32, epsilon = 1.0e-6);
+    }
+}

--- a/geo/src/algorithm/rhumb/intermediate.rs
+++ b/geo/src/algorithm/rhumb/intermediate.rs
@@ -1,0 +1,143 @@
+use crate::{CoordFloat, Point, MEAN_EARTH_RADIUS};
+use num_traits::FromPrimitive;
+
+use super::RhumbCalculations;
+
+/// Returns a new Point along a rhumb line between two existing points
+
+pub trait RhumbIntermediate<T: CoordFloat> {
+    /// Returns a new Point along a [rhumb line] between two existing points.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use approx::assert_relative_eq;
+    /// use geo::RhumbIntermediate;
+    /// use geo::Point;
+    ///
+    /// let p1 = Point::new(10.0, 20.0);
+    /// let p2 = Point::new(125.0, 25.0);
+    /// let i20 = p1.rhumb_intermediate(&p2, 0.2);
+    /// let i50 = p1.rhumb_intermediate(&p2, 0.5);
+    /// let i80 = p1.rhumb_intermediate(&p2, 0.8);
+    /// let i20_should = Point::new(32.7, 21.0);
+    /// let i50_should = Point::new(67.0, 22.5);
+    /// let i80_should = Point::new(101.7, 24.0);
+    /// assert_relative_eq!(i20.x(), i20_should.x(), epsilon = 0.2);
+    /// assert_relative_eq!(i20.y(), i20_should.y(), epsilon = 0.2);
+    /// assert_relative_eq!(i50.x(), i50_should.x(), epsilon = 0.2);
+    /// assert_relative_eq!(i50.y(), i50_should.y(), epsilon = 0.2);
+    /// assert_relative_eq!(i80.x(), i80_should.x(), epsilon = 0.2);
+    /// assert_relative_eq!(i80.y(), i80_should.y(), epsilon = 0.2);
+    /// ```
+    /// [rhumb line]: https://en.wikipedia.org/wiki/Rhumb_line
+
+    fn rhumb_intermediate(&self, other: &Point<T>, f: T) -> Point<T>;
+    fn rhumb_intermediate_fill(
+        &self,
+        other: &Point<T>,
+        max_dist: T,
+        include_ends: bool,
+    ) -> Vec<Point<T>>;
+}
+
+impl<T> RhumbIntermediate<T> for Point<T>
+where
+    T: CoordFloat + FromPrimitive,
+{
+    fn rhumb_intermediate(&self, other: &Point<T>, f: T) -> Point<T> {
+        let calculations = RhumbCalculations::new(self, other);
+        calculations.intermediate(f)
+    }
+
+    fn rhumb_intermediate_fill(
+        &self,
+        other: &Point<T>,
+        max_dist: T,
+        include_ends: bool,
+    ) -> Vec<Point<T>> {
+        let max_delta = max_dist / T::from(MEAN_EARTH_RADIUS).unwrap();
+        let calculations = RhumbCalculations::new(self, other);
+        calculations.intermediate_fill(max_delta, include_ends)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::RhumbIntermediate;
+
+    #[test]
+    fn f_is_zero_or_one_test() {
+        let p1 = Point::new(10.0, 20.0);
+        let p2 = Point::new(15.0, 25.0);
+        let i0 = p1.rhumb_intermediate(&p2, 0.0);
+        let i100 = p1.rhumb_intermediate(&p2, 1.0);
+        assert_relative_eq!(i0.x(), p1.x(), epsilon = 1.0e-6);
+        assert_relative_eq!(i0.y(), p1.y(), epsilon = 1.0e-6);
+        assert_relative_eq!(i100.x(), p2.x(), epsilon = 1.0e-6);
+        assert_relative_eq!(i100.y(), p2.y(), epsilon = 1.0e-6);
+    }
+
+    #[test]
+    fn various_f_values_test() {
+        let p1 = Point::new(10.0, 20.0);
+        let p2 = Point::new(125.0, 25.0);
+        let i20 = p1.rhumb_intermediate(&p2, 0.2);
+        let i50 = p1.rhumb_intermediate(&p2, 0.5);
+        let i80 = p1.rhumb_intermediate(&p2, 0.8);
+        let i20_should = Point::new(32.6766, 21.0);
+        let i50_should = Point::new(66.9801, 22.5);
+        let i80_should = Point::new(101.6577, 24.0);
+        assert_relative_eq!(i20.x(), i20_should.x(), epsilon = 0.2);
+        assert_relative_eq!(i20.y(), i20_should.y(), epsilon = 0.2);
+        assert_relative_eq!(i50.x(), i50_should.x(), epsilon = 0.2);
+        assert_relative_eq!(i50.y(), i50_should.y(), epsilon = 0.2);
+        assert_relative_eq!(i80.x(), i80_should.x(), epsilon = 0.2);
+        assert_relative_eq!(i80.y(), i80_should.y(), epsilon = 0.2);
+    }
+
+    #[test]
+    fn should_be_straight_across_test() {
+        let p1 = Point::new(0.0, 10.0);
+        let p2 = Point::new(180.0, 10.0);
+        let i50 = p1.rhumb_intermediate(&p2, 0.5);
+        let i50_should = Point::new(90.0, 10.0);
+        assert_relative_eq!(i50.x(), i50_should.x(), epsilon = 1.0e-6);
+        assert_relative_eq!(i50.y(), i50_should.y(), epsilon = 1.0e-6);
+    }
+
+    #[test]
+    fn should_be_start_end_test() {
+        let p1 = Point::new(30.0, 40.0);
+        let p2 = Point::new(40.0, 50.0);
+        let max_dist = 1500000.0; // meters
+        let include_ends = true;
+        let route = p1.rhumb_intermediate_fill(&p2, max_dist, include_ends);
+        assert_eq!(route, vec![p1, p2]);
+    }
+
+    #[test]
+    fn should_add_i50_test() {
+        let p1 = Point::new(30.0, 40.0);
+        let p2 = Point::new(40.0, 50.0);
+        let max_dist = 1000000.0; // meters
+        let include_ends = true;
+        let i50 = p1.clone().rhumb_intermediate(&p2, 0.5);
+        let route = p1.rhumb_intermediate_fill(&p2, max_dist, include_ends);
+        assert_eq!(route, vec![p1, i50, p2]);
+    }
+
+    #[test]
+    fn should_add_i25_i50_i75_test() {
+        let p1 = Point::new(30.0, 40.0);
+        let p2 = Point::new(40.0, 50.0);
+        let max_dist = 400000.0; // meters
+        let include_ends = true;
+        let i25 = p1.clone().rhumb_intermediate(&p2, 0.25);
+        let i50 = p1.clone().rhumb_intermediate(&p2, 0.5);
+        let i75 = p1.clone().rhumb_intermediate(&p2, 0.75);
+        let route = p1.rhumb_intermediate_fill(&p2, max_dist, include_ends);
+        assert_eq!(route, vec![p1, i25, i50, i75, p2]);
+    }
+}

--- a/geo/src/algorithm/rhumb/length.rs
+++ b/geo/src/algorithm/rhumb/length.rs
@@ -1,0 +1,74 @@
+use num_traits::FromPrimitive;
+
+use crate::RhumbDistance;
+use crate::{CoordFloat, Line, LineString, MultiLineString};
+
+/// Determine the length of a geometry assuming each segment is a [rhumb line].
+///
+/// [rhumb line]: https://en.wikipedia.org/wiki/Rhumb_line
+///
+/// *Note*: this implementation uses a mean earth radius of 6371.088 km, based on the [recommendation of
+/// the IUGG](ftp://athena.fsv.cvut.cz/ZFG/grs80-Moritz.pdf)
+pub trait RhumbLength<T, RHS = Self> {
+    /// Determine the length of a geometry assuming each segment is a [rhumb line].
+    ///
+    /// # Units
+    ///
+    /// - return value: meters
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use geo::prelude::*;
+    /// use geo::LineString;
+    ///
+    /// let linestring = LineString::<f64>::from(vec![
+    ///     // New York City
+    ///     (-74.006, 40.7128),
+    ///     // London
+    ///     (-0.1278, 51.5074),
+    /// ]);
+    ///
+    /// let length = linestring.rhumb_length();
+    ///
+    /// assert_eq!(
+    ///     5_794_129., // meters
+    ///     length.round()
+    /// );
+    /// ```
+    ///
+    /// [rhumb line]: https://en.wikipedia.org/wiki/Rhumb_line
+    fn rhumb_length(&self) -> T;
+}
+
+impl<T> RhumbLength<T> for Line<T>
+where
+    T: CoordFloat + FromPrimitive,
+{
+    fn rhumb_length(&self) -> T {
+        let (start, end) = self.points();
+        start.rhumb_distance(&end)
+    }
+}
+
+impl<T> RhumbLength<T> for LineString<T>
+where
+    T: CoordFloat + FromPrimitive,
+{
+    fn rhumb_length(&self) -> T {
+        self.lines().fold(T::zero(), |total_length, line| {
+            total_length + line.rhumb_length()
+        })
+    }
+}
+
+impl<T> RhumbLength<T> for MultiLineString<T>
+where
+    T: CoordFloat + FromPrimitive,
+{
+    fn rhumb_length(&self) -> T {
+        self.0
+            .iter()
+            .fold(T::zero(), |total, line| total + line.rhumb_length())
+    }
+}

--- a/geo/src/algorithm/rhumb/mod.rs
+++ b/geo/src/algorithm/rhumb/mod.rs
@@ -1,3 +1,11 @@
+//! This module provides rhumb-line (a.k.a. loxodrome) geometry operations.
+//! The distance, destination, and bearing implementations are adapted in part
+//! from their equivalents in [Turf.js](https://turfjs.org/), which in turn are
+//! adapted from the Movable Type
+//! [spherical geodesy tools](https://www.movable-type.co.uk/scripts/latlong.html).
+//! Turf.js is copyright its authors and the geodesy tools are copyright Chris
+//! Veness; both are available under an MIT license.
+
 use crate::{point, utils::normalize_longitude, CoordFloat, Point};
 use num_traits::FromPrimitive;
 

--- a/geo/src/algorithm/rhumb/mod.rs
+++ b/geo/src/algorithm/rhumb/mod.rs
@@ -1,0 +1,157 @@
+use crate::{point, utils::normalize_longitude, CoordFloat, Point};
+use num_traits::FromPrimitive;
+
+mod distance;
+pub use distance::RhumbDistance;
+
+mod bearing;
+pub use bearing::RhumbBearing;
+
+mod destination;
+pub use destination::RhumbDestination;
+
+mod intermediate;
+pub use intermediate::RhumbIntermediate;
+
+mod length;
+pub use length::RhumbLength;
+
+struct RhumbCalculations<T: CoordFloat + FromPrimitive> {
+    from: Point<T>,
+    to: Point<T>,
+    phi1: T,
+    delta_lambda: T,
+    delta_phi: T,
+    delta_psi: T,
+}
+
+impl<T: CoordFloat + FromPrimitive> RhumbCalculations<T> {
+    fn new(from: &Point<T>, to: &Point<T>) -> Self {
+        let pi = T::from(std::f64::consts::PI).unwrap();
+        let two = T::one() + T::one();
+        let four = two + two;
+
+        let phi1 = from.y().to_radians();
+        let phi2 = to.y().to_radians();
+        let mut delta_lambda = (to.x() - from.x()).to_radians();
+        // if delta_lambda is over 180° take shorter rhumb line across the anti-meridian:
+        if delta_lambda > pi {
+            delta_lambda = delta_lambda - (two * pi);
+        }
+        if delta_lambda < -pi {
+            delta_lambda = delta_lambda + (two * pi);
+        }
+
+        let delta_psi = ((phi2 / two + pi / four).tan() / (phi1 / two + pi / four).tan()).ln();
+        let delta_phi = phi2 - phi1;
+
+        RhumbCalculations {
+            from: *from,
+            to: *to,
+            phi1,
+            delta_lambda,
+            delta_phi,
+            delta_psi,
+        }
+    }
+
+    fn theta(&self) -> T {
+        self.delta_lambda.atan2(self.delta_psi)
+    }
+
+    fn delta(&self) -> T {
+        let threshold = T::from(10.0e-12).unwrap();
+        let q = if self.delta_psi > threshold {
+            self.delta_phi / self.delta_psi
+        } else {
+            self.phi1.cos()
+        };
+
+        (self.delta_phi * self.delta_phi + q * q * self.delta_lambda * self.delta_lambda).sqrt()
+    }
+
+    fn intermediate(&self, fraction: T) -> Point<T> {
+        let delta = fraction * self.delta();
+        let theta = self.theta();
+        let lambda1 = self.from.x().to_radians();
+        calculate_destination(delta, lambda1, self.phi1, theta)
+    }
+
+    fn intermediate_fill(&self, max_delta: T, include_ends: bool) -> Vec<Point<T>> {
+        let theta = self.theta();
+        let lambda1 = self.from.x().to_radians();
+
+        let total_delta = self.delta();
+
+        if total_delta <= max_delta {
+            return if include_ends {
+                vec![self.from, self.to]
+            } else {
+                vec![]
+            };
+        }
+
+        let number_of_points = (total_delta / max_delta).ceil();
+        let interval = T::one() / number_of_points;
+
+        let mut current_step = interval;
+        let mut points = if include_ends {
+            vec![self.from]
+        } else {
+            vec![]
+        };
+
+        while current_step < T::one() {
+            let delta = total_delta * current_step;
+            let point = calculate_destination(delta, lambda1, self.phi1, theta);
+            points.push(point);
+            current_step = current_step + interval;
+        }
+
+        if include_ends {
+            points.push(self.to);
+        }
+
+        points
+    }
+}
+
+fn calculate_destination<T: CoordFloat + FromPrimitive>(
+    delta: T,
+    lambda1: T,
+    phi1: T,
+    theta: T,
+) -> Point<T> {
+    let pi = T::from(std::f64::consts::PI).unwrap();
+    let two = T::one() + T::one();
+    let four = two + two;
+    let threshold = T::from(10.0e-12).unwrap();
+
+    let delta_phi = delta * theta.cos();
+    let mut phi2 = phi1 + delta_phi;
+
+    // check for some daft bugger going past the pole, normalise latitude if so
+    if phi2.abs() > pi / two {
+        phi2 = if phi2 > T::zero() {
+            pi - phi2
+        } else {
+            -pi - phi2
+        };
+    }
+
+    let delta_psi = ((phi2 / two + pi / four).tan() / (phi1 / two + pi / four).tan()).ln();
+    // E-W course becomes ill-conditioned with 0/0
+    let q = if delta_psi.abs() > threshold {
+        delta_phi / delta_psi
+    } else {
+        phi1.cos()
+    };
+
+    let delta_lambda = (delta * theta.sin()) / q;
+    let lambda2 = lambda1 + delta_lambda;
+
+    point! {
+        x: normalize_longitude(lambda2.to_degrees()),
+        y: phi2.to_degrees(),
+    }
+}

--- a/geo/src/lib.rs
+++ b/geo/src/lib.rs
@@ -47,6 +47,7 @@
 //! - **[`GeodesicDistance`](GeodesicDistance)**: Calculate the minimum geodesic distance between geometries using the algorithm presented in _Algorithms for geodesics_ by Charles Karney (2013)
 //! - **[`HausdorffDistance`](HausdorffDistance)**: Calculate "the maximum of the distances from a point in any of the sets to the nearest point in the other set." (Rote, 1991)
 //! - **[`HaversineDistance`](HaversineDistance)**: Calculate the minimum geodesic distance between geometries using the haversine formula
+//! - **[`RhumbDistance`](RhumbDistance)**: Calculate the length of a rhumb line connecting the two geometries
 //! - **[`VincentyDistance`](VincentyDistance)**: Calculate the minimum geodesic distance between geometries using Vincenty’s formula
 //!
 //! ## Length
@@ -54,6 +55,7 @@
 //! - **[`EuclideanLength`](EuclideanLength)**: Calculate the euclidean length of a geometry
 //! - **[`GeodesicLength`](GeodesicLength)**: Calculate the geodesic length of a geometry using the algorithm presented in _Algorithms for geodesics_ by Charles Karney (2013)
 //! - **[`HaversineLength`](HaversineLength)**: Calculate the geodesic length of a geometry using the haversine formula
+//! - **[`RhumbLength`](RhumbLength)**: Calculate the length of a geometry assuming it's composed of rhumb lines
 //! - **[`VincentyLength`](VincentyLength)**: Calculate the geodesic length of a geometry using Vincenty’s formula
 //!
 //! ## Outlier Detection
@@ -72,6 +74,7 @@
 //!
 //! - **[`HaversineBearing`]**: Calculate the bearing between points using great circle calculations.
 //! - **[`GeodesicBearing`](GeodesicBearing)**: Calculate the bearing between points on a [geodesic](https://en.wikipedia.org/wiki/Geodesics_on_an_ellipsoid)
+//! - **[`RhumbBearing`]**: Calculate the angle from north of the rhumb line connecting two points.
 //! - **[`ClosestPoint`](ClosestPoint)**: Find the point on a geometry
 //!   closest to a given point
 //! - **[`HaversineClosestPoint`](HaversineClosestPoint)**: Find the point on a geometry
@@ -157,8 +160,10 @@
 //! - **[`DensifyHaversine`](DensifyHaversine)**: Densify spherical geometry by interpolating points on a sphere
 //! - **[`GeodesicDestination`](GeodesicDestination)**: Given a start point, bearing, and distance, calculate the destination point on a [geodesic](https://en.wikipedia.org/wiki/Geodesics_on_an_ellipsoid)
 //! - **[`GeodesicIntermediate`](GeodesicIntermediate)**: Calculate intermediate points on a [geodesic](https://en.wikipedia.org/wiki/Geodesics_on_an_ellipsoid)
-//! - **[`HaversineDestination`]**: Given a start point, bearing, and distance, calculate the destination point on a sphere
-//! - **[`HaversineIntermediate`](HaversineIntermediate)**: Calculate intermediate points on a sphere
+//! - **[`HaversineDestination`]**: Given a start point, bearing, and distance, calculate the destination point on a sphere assuming travel on a great circle
+//! - **[`HaversineIntermediate`](HaversineIntermediate)**: Calculate intermediate points on a sphere along a great-circle line
+//! - **[`RhumbDestination`]**: Given a start point, bearing, and distance, calculate the destination point on a sphere assuming travel along a rhumb line
+//! - **[`RhumbIntermediate`](HaversineIntermediate)**: Calculate intermediate points on a sphere along a rhumb line
 //! - **[`proj`](proj)**: Project geometries with the `proj` crate (requires the `use-proj` feature)
 //! - **[`LineStringSegmentize`](LineStringSegmentize)**: Segment a LineString into `n` segments.
 //! - **[`Transform`](Transform)**: Transform a geometry using Proj.

--- a/geo/src/lib.rs
+++ b/geo/src/lib.rs
@@ -163,7 +163,7 @@
 //! - **[`HaversineDestination`]**: Given a start point, bearing, and distance, calculate the destination point on a sphere assuming travel on a great circle
 //! - **[`HaversineIntermediate`](HaversineIntermediate)**: Calculate intermediate points on a sphere along a great-circle line
 //! - **[`RhumbDestination`]**: Given a start point, bearing, and distance, calculate the destination point on a sphere assuming travel along a rhumb line
-//! - **[`RhumbIntermediate`](HaversineIntermediate)**: Calculate intermediate points on a sphere along a rhumb line
+//! - **[`RhumbIntermediate`](RhumbIntermediate)**: Calculate intermediate points on a sphere along a rhumb line
 //! - **[`proj`](proj)**: Project geometries with the `proj` crate (requires the `use-proj` feature)
 //! - **[`LineStringSegmentize`](LineStringSegmentize)**: Segment a LineString into `n` segments.
 //! - **[`Transform`](Transform)**: Transform a geometry using Proj.

--- a/geo/src/utils.rs
+++ b/geo/src/utils.rs
@@ -1,6 +1,7 @@
 //! Internal utility functions, types, and data structures.
 
-use geo_types::{Coord, CoordNum};
+use geo_types::{Coord, CoordFloat, CoordNum};
+use num_traits::FromPrimitive;
 
 /// Partition a mutable slice in-place so that it contains all elements for
 /// which `predicate(e)` is `true`, followed by all elements for which
@@ -153,6 +154,15 @@ pub fn least_and_greatest_index<T: CoordNum>(pts: &[Coord<T>]) -> (usize, usize)
             )
         });
     (min.unwrap().0, max.unwrap().0)
+}
+
+/// Normalize a longitude to coordinate to ensure it's within [-180,180]
+pub fn normalize_longitude<T: CoordFloat + FromPrimitive>(coord: T) -> T {
+    let one_eighty = T::from(180.0f64).unwrap();
+    let three_sixty = T::from(360.0f64).unwrap();
+    let five_forty = T::from(540.0f64).unwrap();
+
+    ((coord + five_forty) % three_sixty) - one_eighty
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
This PR adds a bunch of operations that are roughly equivalent to most of the current Haversine operations in `geo`, but using [rhumb line](https://en.wikipedia.org/wiki/Rhumb_line) (a.k.a. "loxodrome") geometry instead of great-circle geometry. In particular, this PR adds `RhumbBearing`, `RhumbDestination`, `RhumbDistance`, `RhumbIntermediate`, and `RhumbLength` traits.

The code layout is a little different from the haversine ones (everything is in a new `rhumb` module), mainly because I wanted to share code between several of these since there's a lot of overlap. In particular, all of the operations that work on two points (so, bearing, distance, and intermediate) use a common calculations struct that does a bunch of the up-front shared setup. Obviously this is all rearrange-able though if there's a different preferred layout.

The `RhumbBearing`, `RhumbDestination`, and `RhumbDistance` implementations are heavily inspired by their Turf.js equivalents ([bearing](https://github.com/Turfjs/turf/blob/master/packages/turf-rhumb-bearing/index.ts), [destination](https://github.com/Turfjs/turf/blob/master/packages/turf-rhumb-destination/index.ts), and [distance](https://github.com/Turfjs/turf/blob/master/packages/turf-rhumb-distance/index.ts), respectively), which seem in turn to largely be inspired by the [Movable Type](https://www.movable-type.co.uk/scripts/latlong.html) rhumb line formula descriptions.

Turf doesn't have an `intermediate` operation for rhumb lines, so what's I've done here is "find the rhumb distance and rhumb bearing, calculate a fraction along that distance, and then calculate a rhumb destination," with (hopefully) most of the redundant trig factored out, as there's a fair bit of overlap between those operations. There might well be a more-direct trigonometric solution to this problem, though? Movable Type has a "rhumb midpoint" formula, but it doesn't seem to generalize to fractions other than 0.5; [pygeodesy](https://github.com/mrJean1/PyGeodesy/blob/82c42efa4c36335ec48c31d379c13663cd96d971/pygeodesy/sphericalBase.py#L494) _does_ seem to implement this concept, and special-cases 0.5 with the formula from Movable Type but also has a more general one, but honestly I found the code to be very difficult to understand. Hopefully what I've got is good enough for a first pass.

Tests are mostly appropriated from the equivalent Haversine traits and then adjusted so the values look right. I also separately confirmed that at least for the functions where Turf has equivalents, these implementations produce (approximately, allowing for float differences, etc.) the same values.

A couple of other odds and ends:
- **Naming and methodology:** all of the methods here use spherical geometry. Iterative methods for calculating these values on an oblate spheroid also exist (see, e.g., the ones in [`GeographicLib`](https://geographiclib.sourceforge.io/cgi-bin/RhumbSolve)), so there may be some future in which it might make sense to include those as well, as with `HaversineX` vs `GeodesicX`; if so, it may make sense to do something more qualified than `RhumbX` to make it clear what kind of rhumb/loxodrome operations these are? I'm not sure what that would be though.
- **Attribution:** as these are ports and refactors of existing code, I'm not sure if I should put references in comments in these files to where they came from and what their licenses originally were. It doesn't look like existing code that's of similar provenance does so now for the most part, but if that would be a good thing to do, let me know where it's preferred that it go, and I can add it.