### PR TITLE
Fix wrapping of longitudes in HaversineDestination

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -18,6 +18,8 @@
   * <https://github.com/georust/geo/pull/908>
 * Add `ToDegrees` and `ToRadians` traits.
   * <https://github.com/georust/geo/pull/1070>
+* Fix coordinate wrapping in `HaversineDestination`
+  * <https://github.com/georust/geo/pull/1091>
 
 ## 0.26.0
 

--- a/geo/src/algorithm/haversine_closest_point.rs
+++ b/geo/src/algorithm/haversine_closest_point.rs
@@ -25,10 +25,14 @@ use num_traits::FromPrimitive;
 /// ```
 /// # use geo::HaversineClosestPoint;
 /// # use geo::{Point, Line, Closest};
+/// use approx::assert_relative_eq;
 /// let line = Line::new(Point::new(-85.93942, 32.11055), Point::new(-84.74905, 32.61454));
 /// let p_from = Point::new(-84.75625, 31.81056);
-/// assert_eq!(line.haversine_closest_point(&p_from),
-///         Closest::SinglePoint(Point::new(-85.13337428852164, 32.45365659858937)));
+/// if let Closest::SinglePoint(pt) = line.haversine_closest_point(&p_from) {
+///     assert_relative_eq!(pt, Point::new(-85.13337428852164, 32.45365659858937), epsilon = 1e-6);
+/// } else {
+///     panic!("Closest::SinglePoint expected");
+/// }
 /// ```
 pub trait HaversineClosestPoint<T>
 where
@@ -458,7 +462,11 @@ mod test {
         let p_from = Point::new(8.15172, 77.40041);
 
         if let Closest::SinglePoint(pt) = line.haversine_closest_point(&p_from) {
-            assert_relative_eq!(pt, Point::new(5.481_094_923_165_54, 82.998_280_987_615_33));
+            assert_relative_eq!(
+                pt,
+                Point::new(5.481_094_923_165_54, 82.998_280_987_615_33),
+                epsilon = 1.0e-6
+            );
         } else {
             panic!("Did not get Closest::SinglePoint!");
         }
@@ -480,7 +488,11 @@ mod test {
         let p_from = Point::new(17.02374, 10.57037);
 
         if let Closest::SinglePoint(pt) = linestring.haversine_closest_point(&p_from) {
-            assert_relative_eq!(pt, Point::new(15.611386947136054, 10.006831648991811));
+            assert_relative_eq!(
+                pt,
+                Point::new(15.611386947136054, 10.006831648991811),
+                epsilon = 1.0e-6
+            );
         } else {
             panic!("Did not get Closest::SinglePoint!");
         }
@@ -516,7 +528,11 @@ mod test {
         let p_from = Point::new(-8.95108, 12.82790);
 
         if let Closest::SinglePoint(pt) = poly.haversine_closest_point(&p_from) {
-            assert_relative_eq!(pt, Point::new(-8.732575801021413, 12.518536164563992));
+            assert_relative_eq!(
+                pt,
+                Point::new(-8.732575801021413, 12.518536164563992),
+                epsilon = 1.0e-6
+            );
         } else {
             panic!("Did not get Closest::SinglePoint!");
         }
@@ -543,7 +559,11 @@ mod test {
         let p_from = Point::new(-8.38752, 12.29866);
 
         if let Closest::SinglePoint(pt) = poly.haversine_closest_point(&p_from) {
-            assert_relative_eq!(pt, Point::new(-8.310007197809414, 12.226641293789331));
+            assert_relative_eq!(
+                pt,
+                Point::new(-8.310007197809414, 12.226641293789331),
+                epsilon = 1.0e-6
+            );
         } else {
             panic!("Did not get Closest::SinglePoint!");
         }
@@ -605,7 +625,11 @@ mod test {
         let p_from = Point::new(-8.95108, 12.82790);
 
         if let Closest::SinglePoint(pt) = poly.haversine_closest_point(&p_from) {
-            assert_relative_eq!(pt, Point::new(-8.922208260289914, 12.806949983368323));
+            assert_relative_eq!(
+                pt,
+                Point::new(-8.922208260289914, 12.806949983368323),
+                epsilon = 1.0e-6
+            );
         } else {
             panic!("Did not get Closest::SinglePoint!");
         }

--- a/geo/src/utils.rs
+++ b/geo/src/utils.rs
@@ -1,6 +1,7 @@
 //! Internal utility functions, types, and data structures.
 
-use geo_types::{Coord, CoordNum};
+use geo_types::{Coord, CoordFloat, CoordNum};
+use num_traits::FromPrimitive;
 
 /// Partition a mutable slice in-place so that it contains all elements for
 /// which `predicate(e)` is `true`, followed by all elements for which
@@ -153,6 +154,15 @@ pub fn least_and_greatest_index<T: CoordNum>(pts: &[Coord<T>]) -> (usize, usize)
             )
         });
     (min.unwrap().0, max.unwrap().0)
+}
+
+/// Normalize a longitude to coordinate to ensure it's within [-180,180]
+pub fn normalize_longitude<T: CoordFloat + FromPrimitive>(coord: T) -> T {
+    let one_eighty = T::from(180.0f64).unwrap();
+    let three_sixty = T::from(360.0f64).unwrap();
+    let five_forty = T::from(540.0f64).unwrap();
+
+    ((coord + five_forty) % three_sixty) - one_eighty
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
Currently `HaversineDestination` sometimes produces output points with longitudes that aren't within [-180,180]. This PR adds logic to ensure that they're correctly wrapped.

**Note:** the wrapping logic is branchless so it's nice and speedy, but a drawback is that it slightly twiddles some floating-point results out like 10 places after the decimal, even for longitudes that don't need wrapping, which required adding some `epsilon = whatever` to some existing tests. If a branch-y version that only touches out of bounds longitudes is preferred, let me know, and I can make the swap (probably in this branch and also in #1090 , which uses the same new function).

fixes #1074 