### PR TITLE
Minor: 'Cargo doc' fix trivial lint errors.

### DIFF
--- a/geo/src/algorithm/affine_ops.rs
+++ b/geo/src/algorithm/affine_ops.rs
@@ -63,8 +63,8 @@ impl<T: CoordNum, M: MapCoordsInPlace<T> + MapCoords<T, T, Output = Self>> Affin
 ///
 /// Note that affine ops are **already implemented** on most `geo-types` primitives, using this module.
 ///
-/// Affine transforms using the same numeric type (e.g. [`CoordFloat`](crate::CoordFloat)) can be **composed**,
-/// and the result can be applied to geometries using e.g. [`MapCoords`](crate::MapCoords). This allows the
+/// Affine transforms using the same numeric type (e.g. [`CoordFloat`]) can be **composed**,
+/// and the result can be applied to geometries using e.g. [`MapCoords`]. This allows the
 /// efficient application of transforms: an arbitrary number of operations can be chained.
 /// These are then composed, producing a final transformation matrix which is applied to the geometry coordinates.
 ///

--- a/geo/src/algorithm/haversine_closest_point.rs
+++ b/geo/src/algorithm/haversine_closest_point.rs
@@ -16,7 +16,7 @@ use num_traits::FromPrimitive;
 ///
 /// The implemetation is based on <https://edwilliams.org/avform147.htm#XTE>.
 ///
-/// See [Closest<F>] for a description of the return states.
+/// See [`Closest<F>`] for a description of the return states.
 ///
 /// Note: This may return `Closest::Intersection` even for non-intersecting geometies if they are
 /// very close to the input.

--- a/geo/src/algorithm/rotate.rs
+++ b/geo/src/algorithm/rotate.rs
@@ -9,9 +9,9 @@ use crate::CoordFloat;
 /// ## Performance
 ///
 /// If you will be performing multiple transformations, like [`Scale`](crate::Scale),
-/// [`Skew`](crate::Skew), [`Translate`](crate::Translate), or [`Rotate`](crate::Rotate), it is more
+/// [`Skew`](crate::Skew), [`Translate`], or [`Rotate`], it is more
 /// efficient to compose the transformations and apply them as a single operation using the
-/// [`AffineOps`](crate::AffineOps) trait.
+/// [`AffineOps`] trait.
 pub trait Rotate<T: CoordFloat> {
     /// Rotate a geometry around its [centroid](Centroid) by an angle, in degrees
     ///

--- a/geo/src/algorithm/rotate.rs
+++ b/geo/src/algorithm/rotate.rs
@@ -9,7 +9,7 @@ use crate::CoordFloat;
 /// ## Performance
 ///
 /// If you will be performing multiple transformations, like [`Scale`](crate::Scale),
-/// [`Skew`](crate::Skew), [`Translate`], or [`Rotate`], it is more
+/// [`Skew`], [`Translate`], or [`Rotate`], it is more
 /// efficient to compose the transformations and apply them as a single operation using the
 /// [`AffineOps`] trait.
 pub trait Rotate<T: CoordFloat> {

--- a/geo/src/algorithm/scale.rs
+++ b/geo/src/algorithm/scale.rs
@@ -4,10 +4,10 @@ use crate::{AffineOps, AffineTransform, BoundingRect, Coord, CoordFloat, CoordNu
 ///
 /// ## Performance
 ///
-/// If you will be performing multiple transformations, like [`Scale`](crate::Scale),
+/// If you will be performing multiple transformations, like [`Scale`],
 /// [`Skew`](crate::Skew), [`Translate`](crate::Translate), or [`Rotate`](crate::Rotate), it is more
 /// efficient to compose the transformations and apply them as a single operation using the
-/// [`AffineOps`](crate::AffineOps) trait.
+/// [`AffineOps`] trait.
 pub trait Scale<T: CoordNum> {
     /// Scale a geometry from it's bounding box center.
     ///

--- a/geo/src/algorithm/skew.rs
+++ b/geo/src/algorithm/skew.rs
@@ -4,10 +4,10 @@ use crate::{AffineOps, AffineTransform, BoundingRect, Coord, CoordFloat, CoordNu
 ///
 /// ## Performance
 ///
-/// If you will be performing multiple transformations, like [`Scale`](crate::Scale),
-/// [`Skew`](crate::Skew), [`Translate`](crate::Translate), or [`Rotate`](crate::Rotate), it is more
+/// If you will be performing multiple transformations, like [`Scale`],
+/// [`Skew`], [`Translate`], or [`Rotate`], it is more
 /// efficient to compose the transformations and apply them as a single operation using the
-/// [`AffineOps`](crate::AffineOps) trait.
+/// [`AffineOps`] trait.
 ///
 pub trait Skew<T: CoordNum> {
     /// An affine transformation which skews a geometry, sheared by a uniform angle along the x and

--- a/geo/src/algorithm/translate.rs
+++ b/geo/src/algorithm/translate.rs
@@ -6,9 +6,9 @@ pub trait Translate<T: CoordNum> {
     /// ## Performance
     ///
     /// If you will be performing multiple transformations, like [`Scale`](crate::Scale),
-    /// [`Skew`](crate::Skew), [`Translate`](crate::Translate), or [`Rotate`](crate::Rotate), it is more
+    /// [`Skew`](crate::Skew), [`Translate`], or [`Rotate`](crate::Rotate), it is more
     /// efficient to compose the transformations and apply them as a single operation using the
-    /// [`AffineOps`](crate::AffineOps) trait.
+    /// [`AffineOps`] trait.
     ///
     /// # Examples
     ///

--- a/geo/src/algorithm/translate.rs
+++ b/geo/src/algorithm/translate.rs
@@ -6,7 +6,7 @@ pub trait Translate<T: CoordNum> {
     /// ## Performance
     ///
     /// If you will be performing multiple transformations, like [`Scale`](crate::Scale),
-    /// [`Skew`](crate::Skew), [`Translate`], or [`Rotate`](crate::Rotate), it is more
+    /// [`Skew`], [`Translate`], or [`Rotate`], it is more
     /// efficient to compose the transformations and apply them as a single operation using the
     /// [`AffineOps`] trait.
     ///

--- a/geo/src/lib.rs
+++ b/geo/src/lib.rs
@@ -166,7 +166,7 @@
 //! - **[`RhumbIntermediate`]**: Calculate intermediate points on a sphere along a rhumb line
 //! - **[`proj`]**: Project geometries with the `proj` crate (requires the `use-proj` feature)
 //! - **[`LineStringSegmentize`]**: Segment a LineString into `n` segments.
-//! - **[`Transform`](crate::Transform)**: Transform a geometry using Proj.
+//! - **[`Transform`]**: Transform a geometry using Proj.
 //! - **[`RemoveRepeatedPoints`]**: Remove repeated points from a geometry.
 //!
 //! # Features

--- a/geo/src/lib.rs
+++ b/geo/src/lib.rs
@@ -33,76 +33,76 @@
 //!
 //! ## Area
 //!
-//! - **[`Area`](Area)**: Calculate the planar area of a geometry
-//! - **[`ChamberlainDuquetteArea`](ChamberlainDuquetteArea)**: Calculate the geodesic area of a geometry on a sphere using the algorithm presented in _Some Algorithms for Polygons on a Sphere_ by Chamberlain and Duquette (2007)
-//! - **[`GeodesicArea`](GeodesicArea)**: Calculate the geodesic area and perimeter of a geometry on an ellipsoid using the algorithm presented in _Algorithms for geodesics_ by Charles Karney (2013)
+//! - **[`Area`]**: Calculate the planar area of a geometry
+//! - **[`ChamberlainDuquetteArea`]**: Calculate the geodesic area of a geometry on a sphere using the algorithm presented in _Some Algorithms for Polygons on a Sphere_ by Chamberlain and Duquette (2007)
+//! - **[`GeodesicArea`]**: Calculate the geodesic area and perimeter of a geometry on an ellipsoid using the algorithm presented in _Algorithms for geodesics_ by Charles Karney (2013)
 //!
 //! ## Boolean Operations
 //!
-//! - **[`BooleanOps`](BooleanOps)**: combine or split (Multi)Polygons using intersecton, union, xor, or difference operations
+//! - **[`BooleanOps`]**: combine or split (Multi)Polygons using intersecton, union, xor, or difference operations
 //!
 //! ## Distance
 //!
-//! - **[`EuclideanDistance`](EuclideanDistance)**: Calculate the minimum euclidean distance between geometries
-//! - **[`GeodesicDistance`](GeodesicDistance)**: Calculate the minimum geodesic distance between geometries using the algorithm presented in _Algorithms for geodesics_ by Charles Karney (2013)
-//! - **[`HausdorffDistance`](HausdorffDistance)**: Calculate "the maximum of the distances from a point in any of the sets to the nearest point in the other set." (Rote, 1991)
-//! - **[`HaversineDistance`](HaversineDistance)**: Calculate the minimum geodesic distance between geometries using the haversine formula
-//! - **[`RhumbDistance`](RhumbDistance)**: Calculate the length of a rhumb line connecting the two geometries
-//! - **[`VincentyDistance`](VincentyDistance)**: Calculate the minimum geodesic distance between geometries using Vincenty’s formula
+//! - **[`EuclideanDistance`]**: Calculate the minimum euclidean distance between geometries
+//! - **[`GeodesicDistance`]**: Calculate the minimum geodesic distance between geometries using the algorithm presented in _Algorithms for geodesics_ by Charles Karney (2013)
+//! - **[`HausdorffDistance`]**: Calculate "the maximum of the distances from a point in any of the sets to the nearest point in the other set." (Rote, 1991)
+//! - **[`HaversineDistance`]**: Calculate the minimum geodesic distance between geometries using the haversine formula
+//! - **[`RhumbDistance`]**: Calculate the length of a rhumb line connecting the two geometries
+//! - **[`VincentyDistance`]**: Calculate the minimum geodesic distance between geometries using Vincenty’s formula
 //!
 //! ## Length
 //!
-//! - **[`EuclideanLength`](EuclideanLength)**: Calculate the euclidean length of a geometry
-//! - **[`GeodesicLength`](GeodesicLength)**: Calculate the geodesic length of a geometry using the algorithm presented in _Algorithms for geodesics_ by Charles Karney (2013)
-//! - **[`HaversineLength`](HaversineLength)**: Calculate the geodesic length of a geometry using the haversine formula
-//! - **[`RhumbLength`](RhumbLength)**: Calculate the length of a geometry assuming it's composed of rhumb lines
-//! - **[`VincentyLength`](VincentyLength)**: Calculate the geodesic length of a geometry using Vincenty’s formula
+//! - **[`EuclideanLength`]**: Calculate the euclidean length of a geometry
+//! - **[`GeodesicLength`]**: Calculate the geodesic length of a geometry using the algorithm presented in _Algorithms for geodesics_ by Charles Karney (2013)
+//! - **[`HaversineLength`]**: Calculate the geodesic length of a geometry using the haversine formula
+//! - **[`RhumbLength`]**: Calculate the length of a geometry assuming it's composed of rhumb lines
+//! - **[`VincentyLength`]**: Calculate the geodesic length of a geometry using Vincenty’s formula
 //!
 //! ## Outlier Detection
 //!
-//! - **[`OutlierDetection`](OutlierDetection)**: Detect outliers in a group of points using [LOF](https://en.wikipedia.org/wiki/Local_outlier_factor)
+//! - **[`OutlierDetection`]**: Detect outliers in a group of points using [LOF](https://en.wikipedia.org/wiki/Local_outlier_factor)
 //!
 //! ## Simplification
 //!
-//! - **[`Simplify`](Simplify)**: Simplify a geometry using the Ramer–Douglas–Peucker algorithm
-//! - **[`SimplifyIdx`](SimplifyIdx)**: Calculate a simplified geometry using the Ramer–Douglas–Peucker algorithm, returning coordinate indices
-//! - **[`SimplifyVw`](SimplifyVw)**: Simplify a geometry using the Visvalingam-Whyatt algorithm
-//! - **[`SimplifyVwPreserve`](SimplifyVwPreserve)**: Simplify a geometry using a topology-preserving variant of the Visvalingam-Whyatt algorithm
-//! - **[`SimplifyVwIdx`](SimplifyVwIdx)**: Calculate a simplified geometry using the Visvalingam-Whyatt algorithm, returning coordinate indices
+//! - **[`Simplify`]**: Simplify a geometry using the Ramer–Douglas–Peucker algorithm
+//! - **[`SimplifyIdx`]**: Calculate a simplified geometry using the Ramer–Douglas–Peucker algorithm, returning coordinate indices
+//! - **[`SimplifyVw`]**: Simplify a geometry using the Visvalingam-Whyatt algorithm
+//! - **[`SimplifyVwPreserve`]**: Simplify a geometry using a topology-preserving variant of the Visvalingam-Whyatt algorithm
+//! - **[`SimplifyVwIdx`]**: Calculate a simplified geometry using the Visvalingam-Whyatt algorithm, returning coordinate indices
 //!
 //! ## Query
 //!
 //! - **[`HaversineBearing`]**: Calculate the bearing between points using great circle calculations.
-//! - **[`GeodesicBearing`](GeodesicBearing)**: Calculate the bearing between points on a [geodesic](https://en.wikipedia.org/wiki/Geodesics_on_an_ellipsoid)
+//! - **[`GeodesicBearing`]**: Calculate the bearing between points on a [geodesic](https://en.wikipedia.org/wiki/Geodesics_on_an_ellipsoid)
 //! - **[`RhumbBearing`]**: Calculate the angle from north of the rhumb line connecting two points.
-//! - **[`ClosestPoint`](ClosestPoint)**: Find the point on a geometry
+//! - **[`ClosestPoint`]**: Find the point on a geometry
 //!   closest to a given point
-//! - **[`HaversineClosestPoint`](HaversineClosestPoint)**: Find the point on a geometry
+//! - **[`HaversineClosestPoint`]**: Find the point on a geometry
 //!   closest to a given point on a sphere using spherical coordinates and lines being great arcs.
-//! - **[`IsConvex`](IsConvex)**: Calculate the convexity of a
+//! - **[`IsConvex`]**: Calculate the convexity of a
 //!   [`LineString`]
-//! - **[`LineInterpolatePoint`](LineInterpolatePoint)**:
+//! - **[`LineInterpolatePoint`]**:
 //!   Generates a point that lies a given fraction along the line
-//! - **[`LineLocatePoint`](LineLocatePoint)**: Calculate the
+//! - **[`LineLocatePoint`]**: Calculate the
 //!   fraction of a line’s total length representing the location of the closest point on the
 //!   line to the given point
 //!
 //! ## Similarity
 //!
-//! - **[`FrechetDistance`](FrechetDistance)**: Calculate the similarity between [`LineString`]s using the Fréchet distance
+//! - **[`FrechetDistance`]**: Calculate the similarity between [`LineString`]s using the Fréchet distance
 //!
 //! ## Topology
 //!
-//! - **[`Contains`](Contains)**: Calculate if a geometry contains another
+//! - **[`Contains`]**: Calculate if a geometry contains another
 //!   geometry
-//! - **[`CoordinatePosition`](CoordinatePosition)**: Calculate
+//! - **[`CoordinatePosition`]**: Calculate
 //!   the position of a coordinate relative to a geometry
-//! - **[`HasDimensions`](HasDimensions)**: Determine the dimensions of a geometry
-//! - **[`Intersects`](Intersects)**: Calculate if a geometry intersects
+//! - **[`HasDimensions`]**: Determine the dimensions of a geometry
+//! - **[`Intersects`]**: Calculate if a geometry intersects
 //!   another geometry
-//! - **[`line_intersection`](line_intersection::line_intersection)**: Calculates the
+//! - **[`line_intersection`]**: Calculates the
 //!   intersection, if any, between two lines.
-//! - **[`Relate`](Relate)**: Topologically relate two geometries based on
+//! - **[`Relate`]**: Topologically relate two geometries based on
 //!   [DE-9IM](https://en.wikipedia.org/wiki/DE-9IM) semantics.
 //! - **[`Within`]**: Calculate if a geometry lies completely within another geometry.
 //!
@@ -112,8 +112,8 @@
 //!
 //! ## Winding
 //!
-//! - **[`Orient`](Orient)**: Apply a specified winding [`Direction`](orient::Direction) to a [`Polygon`]’s interior and exterior rings
-//! - **[`Winding`](Winding)**: Calculate and manipulate the [`WindingOrder`](winding_order::WindingOrder) of a [`LineString`]
+//! - **[`Orient`]**: Apply a specified winding [`Direction`](orient::Direction) to a [`Polygon`]’s interior and exterior rings
+//! - **[`Winding`]**: Calculate and manipulate the [`WindingOrder`](winding_order::WindingOrder) of a [`LineString`]
 //!
 //! ## Iteration
 //!
@@ -126,24 +126,24 @@
 //!
 //! ## Boundary
 //!
-//! - **[`BoundingRect`](BoundingRect)**: Calculate the axis-aligned
+//! - **[`BoundingRect`]**: Calculate the axis-aligned
 //!   bounding rectangle of a geometry
-//! - **[`MinimumRotatedRect`](MinimumRotatedRect)**: Calculate the
+//! - **[`MinimumRotatedRect`]**: Calculate the
 //!   minimum bounding box of a geometry
-//! - **[`ConcaveHull`](ConcaveHull)**: Calculate the concave hull of a
+//! - **[`ConcaveHull`]**: Calculate the concave hull of a
 //!   geometry
-//! - **[`ConvexHull`](ConvexHull)**: Calculate the convex hull of a
+//! - **[`ConvexHull`]**: Calculate the convex hull of a
 //!   geometry
-//! - **[`Extremes`](Extremes)**: Calculate the extreme coordinates and
+//! - **[`Extremes`]**: Calculate the extreme coordinates and
 //!   indices of a geometry
 //!
 //! ## Affine transformations
 //!
-//! - **[`Rotate`](Rotate)**: Rotate a geometry around its centroid
-//! - **[`Scale`](Scale)**: Scale a geometry up or down by a factor
-//! - **[`Skew`](Skew)**: Skew a geometry by shearing angles along the `x` and `y` dimension
-//! - **[`Translate`](Translate)**: Translate a geometry along its axis
-//! - **[`AffineOps`](AffineOps)**: generalised composable affine operations
+//! - **[`Rotate`]**: Rotate a geometry around its centroid
+//! - **[`Scale`]**: Scale a geometry up or down by a factor
+//! - **[`Skew`]**: Skew a geometry by shearing angles along the `x` and `y` dimension
+//! - **[`Translate`]**: Translate a geometry along its axis
+//! - **[`AffineOps`]**: generalised composable affine operations
 //!
 //! ## Conversion
 //!
@@ -154,20 +154,20 @@
 //!
 //! ## Miscellaneous
 //!
-//! - **[`Centroid`](Centroid)**: Calculate the centroid of a geometry
-//! - **[`ChaikinSmoothing`](ChaikinSmoothing)**: Smoothen `LineString`, `Polygon`, `MultiLineString` and `MultiPolygon` using Chaikin's algorithm.
-//! - **[`Densify`](Densify)**: Densify linear geometry components by interpolating points
-//! - **[`DensifyHaversine`](DensifyHaversine)**: Densify spherical geometry by interpolating points on a sphere
-//! - **[`GeodesicDestination`](GeodesicDestination)**: Given a start point, bearing, and distance, calculate the destination point on a [geodesic](https://en.wikipedia.org/wiki/Geodesics_on_an_ellipsoid)
-//! - **[`GeodesicIntermediate`](GeodesicIntermediate)**: Calculate intermediate points on a [geodesic](https://en.wikipedia.org/wiki/Geodesics_on_an_ellipsoid)
+//! - **[`Centroid`]**: Calculate the centroid of a geometry
+//! - **[`ChaikinSmoothing`]**: Smoothen `LineString`, `Polygon`, `MultiLineString` and `MultiPolygon` using Chaikin's algorithm.
+//! - **[`Densify`]**: Densify linear geometry components by interpolating points
+//! - **[`DensifyHaversine`]**: Densify spherical geometry by interpolating points on a sphere
+//! - **[`GeodesicDestination`]**: Given a start point, bearing, and distance, calculate the destination point on a [geodesic](https://en.wikipedia.org/wiki/Geodesics_on_an_ellipsoid)
+//! - **[`GeodesicIntermediate`]**: Calculate intermediate points on a [geodesic](https://en.wikipedia.org/wiki/Geodesics_on_an_ellipsoid)
 //! - **[`HaversineDestination`]**: Given a start point, bearing, and distance, calculate the destination point on a sphere assuming travel on a great circle
-//! - **[`HaversineIntermediate`](HaversineIntermediate)**: Calculate intermediate points on a sphere along a great-circle line
+//! - **[`HaversineIntermediate`]**: Calculate intermediate points on a sphere along a great-circle line
 //! - **[`RhumbDestination`]**: Given a start point, bearing, and distance, calculate the destination point on a sphere assuming travel along a rhumb line
-//! - **[`RhumbIntermediate`](RhumbIntermediate)**: Calculate intermediate points on a sphere along a rhumb line
-//! - **[`proj`](proj)**: Project geometries with the `proj` crate (requires the `use-proj` feature)
-//! - **[`LineStringSegmentize`](LineStringSegmentize)**: Segment a LineString into `n` segments.
-//! - **[`Transform`](Transform)**: Transform a geometry using Proj.
-//! - **[`RemoveRepeatedPoints`](RemoveRepeatedPoints)**: Remove repeated points from a geometry.
+//! - **[`RhumbIntermediate`]**: Calculate intermediate points on a sphere along a rhumb line
+//! - **[`proj`]**: Project geometries with the `proj` crate (requires the `use-proj` feature)
+//! - **[`LineStringSegmentize`]**: Segment a LineString into `n` segments.
+//! - **[`Transform`](crate::Transform)**: Transform a geometry using Proj.
+//! - **[`RemoveRepeatedPoints`]**: Remove repeated points from a geometry.
 //!
 //! # Features
 //!


### PR DESCRIPTION

There are some stale references in the docs.
When running cargo doc these are hidden as
the user is inundated by a repeating trivial
warning :-

```
warning: redundant explicit link target
  --> geo/src/algorithm/translate.rs:11:23
   |
11 |     /// [`AffineOps`](crate::AffineOps) trait.
   |          -----------  ^^^^^^^^^^^^^^^^ explicit target is redundant
```

As a first step I just want to clear these.

- [ x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).

