### PR TITLE
Fix broken links in docs and fail CI unless docs build cleanly

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -173,3 +173,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - run: cargo bench --no-run
+
+  docs:
+    name: build documentation
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    container:
+      image: georust/geo-ci:proj-9.2.1-rust-1.72
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - run: RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps
+

--- a/geo/src/algorithm/haversine_closest_point.rs
+++ b/geo/src/algorithm/haversine_closest_point.rs
@@ -10,7 +10,7 @@ use num_traits::FromPrimitive;
 
 /// Calculates the closest `Point` on a geometry from a given `Point` in sperical coordinates.
 ///
-/// Similar to [`ClosestPoint`] but for spherical coordinates:
+/// Similar to [`ClosestPoint`](crate::ClosestPoint) but for spherical coordinates:
 /// * Longitude (x) in the [-180; 180] degrees range.
 /// * Latitude (y) in the [-90; 90] degrees range.
 ///

--- a/geo/src/algorithm/rotate.rs
+++ b/geo/src/algorithm/rotate.rs
@@ -9,7 +9,7 @@ use crate::CoordFloat;
 /// ## Performance
 ///
 /// If you will be performing multiple transformations, like [`Scale`](crate::Scale),
-/// [`Skew`], [`Translate`], or [`Rotate`], it is more
+/// [`Skew`](crate::Skew), [`Translate`](crate::Translate) or [`Rotate`], it is more
 /// efficient to compose the transformations and apply them as a single operation using the
 /// [`AffineOps`] trait.
 pub trait Rotate<T: CoordFloat> {

--- a/geo/src/algorithm/skew.rs
+++ b/geo/src/algorithm/skew.rs
@@ -4,8 +4,8 @@ use crate::{AffineOps, AffineTransform, BoundingRect, Coord, CoordFloat, CoordNu
 ///
 /// ## Performance
 ///
-/// If you will be performing multiple transformations, like [`Scale`],
-/// [`Skew`], [`Translate`], or [`Rotate`], it is more
+/// If you will be performing multiple transformations, like [`Scale`](crate::Scale),
+/// [`Skew`], [`Translate`](crate::Translate), or [`Rotate`](crate::Rotate), it is more
 /// efficient to compose the transformations and apply them as a single operation using the
 /// [`AffineOps`] trait.
 ///

--- a/geo/src/algorithm/translate.rs
+++ b/geo/src/algorithm/translate.rs
@@ -6,7 +6,7 @@ pub trait Translate<T: CoordNum> {
     /// ## Performance
     ///
     /// If you will be performing multiple transformations, like [`Scale`](crate::Scale),
-    /// [`Skew`], [`Translate`], or [`Rotate`], it is more
+    /// [`Skew`](crate::Skew), [`Translate`], or [`Rotate`](crate::Rotate), it is more
     /// efficient to compose the transformations and apply them as a single operation using the
     /// [`AffineOps`] trait.
     ///


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [-] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Two changes: 

The first fails CI unless docs build cleanly. This should help us avoid broken links etc. in our docs.

The second commit (forthcoming) fixes the CI failure. I pushed up the first commit separately so you can see what it looks like when CI fails for this reason.
