### PR TITLE
Allow an AffineTransform to be constructed from a borrowed array

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -28,6 +28,8 @@
   * <https://github.com/georust/geo/pull/1091>
 * Add `wkt!` macro to define geometries at compile time.
   <https://github.com/georust/geo/pull/1063>
+* Allow affine transforms to be constructed from borrowed arrays.
+  <https://github.com/georust/geo/pull/1105>
 
 ## 0.26.0
 

--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -42,7 +42,7 @@
 * Add `compose_many` method to `AffineOps`
   * <https://github.com/georust/geo/pull/1148>
 * Allow affine transforms to be constructed from borrowed arrays.
-  <https://github.com/georust/geo/pull/1105>
+  * <https://github.com/georust/geo/pull/1105>
 
 ## 0.27.0
 

--- a/geo/src/algorithm/affine_ops.rs
+++ b/geo/src/algorithm/affine_ops.rs
@@ -336,6 +336,12 @@ impl<T: CoordNum> From<[T; 6]> for AffineTransform<T> {
     }
 }
 
+impl<T: CoordNum> From<&[T; 6]> for AffineTransform<T> {
+    fn from(arr: &[T; 6]) -> Self {
+        Self::new(arr[0], arr[1], arr[2], arr[3], arr[4], arr[5])
+    }
+}
+
 impl<T: CoordNum> From<(T, T, T, T, T, T)> for AffineTransform<T> {
     fn from(tup: (T, T, T, T, T, T)) -> Self {
         Self::new(tup.0, tup.1, tup.2, tup.3, tup.4, tup.5)


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

"borrowed array" was formerly "slice", which was wrong! 