### PR TITLE
Add `len()` and `is_empty()` to MultiPoint.

### DIFF
--- a/geo-types/src/geometry/multi_point.rs
+++ b/geo-types/src/geometry/multi_point.rs
@@ -35,16 +35,16 @@ use core::iter::FromIterator;
 pub struct MultiPoint<T: CoordNum = f64>(pub Vec<Point<T>>);
 
 impl<T: CoordNum, IP: Into<Point<T>>> From<IP> for MultiPoint<T> {
-    /// Convert a single `Point` (or something which can be converted to a `Point`) into a
-    /// one-member `MultiPoint`
+    /// Convert a single `Point` (or something which can be converted to a
+    /// `Point`) into a one-member `MultiPoint`
     fn from(x: IP) -> Self {
         Self(vec![x.into()])
     }
 }
 
 impl<T: CoordNum, IP: Into<Point<T>>> From<Vec<IP>> for MultiPoint<T> {
-    /// Convert a `Vec` of `Points` (or `Vec` of things which can be converted to a `Point`) into a
-    /// `MultiPoint`.
+    /// Convert a `Vec` of `Points` (or `Vec` of things which can be converted
+    /// to a `Point`) into a `MultiPoint`.
     fn from(v: Vec<IP>) -> Self {
         Self(v.into_iter().map(|p| p.into()).collect())
     }
@@ -88,6 +88,10 @@ impl<'a, T: CoordNum> IntoIterator for &'a mut MultiPoint<T> {
 impl<T: CoordNum> MultiPoint<T> {
     pub fn new(value: Vec<Point<T>>) -> Self {
         Self(value)
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
     }
 
     pub fn iter(&self) -> impl Iterator<Item = &Point<T>> {

--- a/geo-types/src/geometry/multi_point.rs
+++ b/geo-types/src/geometry/multi_point.rs
@@ -94,6 +94,10 @@ impl<T: CoordNum> MultiPoint<T> {
         self.0.len()
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
     pub fn iter(&self) -> impl Iterator<Item = &Point<T>> {
         self.0.iter()
     }

--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -27,9 +27,11 @@
 * Fix coordinate wrapping in `HaversineDestination`
   * <https://github.com/georust/geo/pull/1091>
 * Add `wkt!` macro to define geometries at compile time.
-  <https://github.com/georust/geo/pull/1063>
+  * <https://github.com/georust/geo/pull/1063>
 * Add `TriangulateSpade` trait which provides (un)constrained Delaunay Triangulations for all `geo_types` via the `spade` crate
   * <https://github.com/georust/geo/pull/1083>
+* Add `len()` and `is_empty()` to `MultiPoint`
+  * <https://github.com/georust/geo/pull/1109>
 
 ## 0.26.0
 


### PR DESCRIPTION
- [X] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [X] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
Adds `len()` and `is_empty()` to `MultiPoint`.

Fixes #1099.