### PR TITLE
Improve documentation of `clip`

### DIFF
--- a/geo/src/algorithm/bool_ops/mod.rs
+++ b/geo/src/algorithm/bool_ops/mod.rs
@@ -41,8 +41,8 @@ pub trait BooleanOps: Sized {
 
     /// Clip a 1-D geometry with self.
     ///
-    /// Returns the set-theoeretic intersection of `self` and `ls` if `invert`
-    /// is false, and the difference (`ls - self`) otherwise.
+    /// Returns the portion of `ls` that lies within `self` (known as the set-theoeretic
+    /// intersection) if `invert` is false, and the difference (`ls - self`) otherwise.
     fn clip(
         &self,
         ls: &MultiLineString<Self::Scalar>,


### PR DESCRIPTION
Expand on the technical definition for users not familiar with the term "set-theoretic intersection".

- [X] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [X] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
