### PR TITLE
Remove `clone` in geometry trait implementation

### DIFF
--- a/geo-traits/src/geometry.rs
+++ b/geo-traits/src/geometry.rs
@@ -110,3 +110,41 @@ impl<'a, T: CoordNum + 'a> GeometryTrait for Geometry<T> {
         }
     }
 }
+
+impl<'a, T: CoordNum + 'a> GeometryTrait for &'a Geometry<T> {
+    type T = T;
+    type Point<'b> = Point<Self::T> where Self: 'b;
+    type LineString<'b> = LineString<Self::T> where Self: 'b;
+    type Polygon<'b> = Polygon<Self::T> where Self: 'b;
+    type MultiPoint<'b> = MultiPoint<Self::T> where Self: 'b;
+    type MultiLineString<'b> = MultiLineString<Self::T> where Self: 'b;
+    type MultiPolygon<'b> = MultiPolygon<Self::T> where Self: 'b;
+    type GeometryCollection<'b> = GeometryCollection<Self::T> where Self: 'b;
+    type Rect<'b> = Rect<Self::T> where Self: 'b;
+
+    fn as_type(
+        &self,
+    ) -> GeometryType<
+        '_,
+        Point<T>,
+        LineString<T>,
+        Polygon<T>,
+        MultiPoint<T>,
+        MultiLineString<T>,
+        MultiPolygon<T>,
+        GeometryCollection<T>,
+        Rect<T>,
+    > {
+        match self {
+            Geometry::Point(p) => GeometryType::Point(p),
+            Geometry::LineString(p) => GeometryType::LineString(p),
+            Geometry::Polygon(p) => GeometryType::Polygon(p),
+            Geometry::MultiPoint(p) => GeometryType::MultiPoint(p),
+            Geometry::MultiLineString(p) => GeometryType::MultiLineString(p),
+            Geometry::MultiPolygon(p) => GeometryType::MultiPolygon(p),
+            Geometry::GeometryCollection(p) => GeometryType::GeometryCollection(p),
+            Geometry::Rect(p) => GeometryType::Rect(p),
+            _ => todo!(),
+        }
+    }
+}

--- a/geo-traits/src/geometry_collection.rs
+++ b/geo-traits/src/geometry_collection.rs
@@ -1,6 +1,5 @@
 use super::GeometryTrait;
 use geo_types::{CoordNum, Geometry, GeometryCollection};
-use std::iter::Cloned;
 use std::slice::Iter;
 
 pub trait GeometryCollectionTrait {
@@ -25,14 +24,14 @@ pub trait GeometryCollectionTrait {
 
 impl<T: CoordNum> GeometryCollectionTrait for GeometryCollection<T> {
     type T = T;
-    type ItemType<'a> = Geometry<Self::T>
+    type ItemType<'a> = &'a Geometry<Self::T>
     where
         Self: 'a;
-    type Iter<'a> = Cloned<Iter<'a, Self::ItemType<'a>>>
+    type Iter<'a> = Iter<'a, Geometry<Self::T>>
     where T: 'a;
 
     fn geometries(&self) -> Self::Iter<'_> {
-        self.0.iter().cloned()
+        self.0.iter()
     }
 
     fn num_geometries(&self) -> usize {
@@ -40,19 +39,19 @@ impl<T: CoordNum> GeometryCollectionTrait for GeometryCollection<T> {
     }
 
     fn geometry(&self, i: usize) -> Option<Self::ItemType<'_>> {
-        self.0.get(i).cloned()
+        self.0.get(i)
     }
 }
 
 impl<'a, T: CoordNum> GeometryCollectionTrait for &'a GeometryCollection<T> {
     type T = T;
-    type ItemType<'b> = Geometry<Self::T>     where
+    type ItemType<'b> = &'a Geometry<Self::T> where
         Self: 'b;
-    type Iter<'b> = Cloned<Iter<'a, Self::ItemType<'a>>> where
+    type Iter<'b> = Iter<'a, Geometry<Self::T>> where
         Self: 'b;
 
     fn geometries(&self) -> Self::Iter<'_> {
-        self.0.iter().cloned()
+        self.0.iter()
     }
 
     fn num_geometries(&self) -> usize {
@@ -60,6 +59,6 @@ impl<'a, T: CoordNum> GeometryCollectionTrait for &'a GeometryCollection<T> {
     }
 
     fn geometry(&self, i: usize) -> Option<Self::ItemType<'_>> {
-        self.0.get(i).cloned()
+        self.0.get(i)
     }
 }

--- a/geo-traits/src/line_string.rs
+++ b/geo-traits/src/line_string.rs
@@ -1,7 +1,6 @@
 use geo_types::{Coord, CoordNum, LineString};
 
 use super::CoordTrait;
-use std::iter::Cloned;
 use std::slice::Iter;
 
 pub trait LineStringTrait {
@@ -26,12 +25,11 @@ pub trait LineStringTrait {
 
 impl<T: CoordNum> LineStringTrait for LineString<T> {
     type T = T;
-    type ItemType<'a> = Coord<Self::T> where Self: 'a;
-    type Iter<'a> = Cloned<Iter<'a, Self::ItemType<'a>>> where T: 'a;
+    type ItemType<'a> = &'a Coord<Self::T> where Self: 'a;
+    type Iter<'a> = Iter<'a, Coord<Self::T>> where T: 'a;
 
     fn coords(&self) -> Self::Iter<'_> {
-        // TODO: remove cloned
-        self.0.iter().cloned()
+        self.0.iter()
     }
 
     fn num_coords(&self) -> usize {
@@ -39,17 +37,17 @@ impl<T: CoordNum> LineStringTrait for LineString<T> {
     }
 
     fn coord(&self, i: usize) -> Option<Self::ItemType<'_>> {
-        self.0.get(i).cloned()
+        self.0.get(i)
     }
 }
 
 impl<'a, T: CoordNum> LineStringTrait for &'a LineString<T> {
     type T = T;
-    type ItemType<'b> = Coord<Self::T> where Self: 'b;
-    type Iter<'b> = Cloned<Iter<'a, Self::ItemType<'a>>> where Self: 'b;
+    type ItemType<'b> = &'a Coord<Self::T> where Self: 'b;
+    type Iter<'b> = Iter<'a, Coord<Self::T>> where Self: 'b;
 
     fn coords(&self) -> Self::Iter<'_> {
-        self.0.iter().cloned()
+        self.0.iter()
     }
 
     fn num_coords(&self) -> usize {
@@ -57,6 +55,6 @@ impl<'a, T: CoordNum> LineStringTrait for &'a LineString<T> {
     }
 
     fn coord(&self, i: usize) -> Option<Self::ItemType<'_>> {
-        self.0.get(i).cloned()
+        self.0.get(i)
     }
 }

--- a/geo-traits/src/multi_line_string.rs
+++ b/geo-traits/src/multi_line_string.rs
@@ -1,6 +1,5 @@
 use super::line_string::LineStringTrait;
 use geo_types::{CoordNum, LineString, MultiLineString};
-use std::iter::Cloned;
 use std::slice::Iter;
 
 pub trait MultiLineStringTrait {
@@ -25,11 +24,11 @@ pub trait MultiLineStringTrait {
 
 impl<T: CoordNum> MultiLineStringTrait for MultiLineString<T> {
     type T = T;
-    type ItemType<'a> = LineString<Self::T> where Self: 'a;
-    type Iter<'a> = Cloned<Iter<'a, Self::ItemType<'a>>> where T: 'a;
+    type ItemType<'a> = &'a LineString<Self::T> where Self: 'a;
+    type Iter<'a> = Iter<'a, LineString<Self::T>> where T: 'a;
 
     fn lines(&self) -> Self::Iter<'_> {
-        self.0.iter().cloned()
+        self.0.iter()
     }
 
     fn num_lines(&self) -> usize {
@@ -37,17 +36,17 @@ impl<T: CoordNum> MultiLineStringTrait for MultiLineString<T> {
     }
 
     fn line(&self, i: usize) -> Option<Self::ItemType<'_>> {
-        self.0.get(i).cloned()
+        self.0.get(i)
     }
 }
 
 impl<'a, T: CoordNum> MultiLineStringTrait for &'a MultiLineString<T> {
     type T = T;
-    type ItemType<'b> = LineString<Self::T> where Self: 'b;
-    type Iter<'b> = Cloned<Iter<'a, Self::ItemType<'a>>> where Self: 'b;
+    type ItemType<'b> = &'a LineString<Self::T> where Self: 'b;
+    type Iter<'b> = Iter<'a, LineString<Self::T>> where Self: 'b;
 
     fn lines(&self) -> Self::Iter<'_> {
-        self.0.iter().cloned()
+        self.0.iter()
     }
 
     fn num_lines(&self) -> usize {
@@ -55,6 +54,6 @@ impl<'a, T: CoordNum> MultiLineStringTrait for &'a MultiLineString<T> {
     }
 
     fn line(&self, i: usize) -> Option<Self::ItemType<'_>> {
-        self.0.get(i).cloned()
+        self.0.get(i)
     }
 }

--- a/geo-traits/src/multi_point.rs
+++ b/geo-traits/src/multi_point.rs
@@ -1,6 +1,5 @@
 use super::point::PointTrait;
 use geo_types::{CoordNum, MultiPoint, Point};
-use std::iter::Cloned;
 use std::slice::Iter;
 
 pub trait MultiPointTrait {
@@ -25,11 +24,11 @@ pub trait MultiPointTrait {
 
 impl<T: CoordNum> MultiPointTrait for MultiPoint<T> {
     type T = T;
-    type ItemType<'a> = Point<Self::T> where Self: 'a;
-    type Iter<'a> = Cloned<Iter<'a, Self::ItemType<'a>>> where T: 'a;
+    type ItemType<'a> = &'a Point<Self::T> where Self: 'a;
+    type Iter<'a> = Iter<'a, Point<Self::T>> where T: 'a;
 
     fn points(&self) -> Self::Iter<'_> {
-        self.0.iter().cloned()
+        self.0.iter()
     }
 
     fn num_points(&self) -> usize {
@@ -37,17 +36,17 @@ impl<T: CoordNum> MultiPointTrait for MultiPoint<T> {
     }
 
     fn point(&self, i: usize) -> Option<Self::ItemType<'_>> {
-        self.0.get(i).cloned()
+        self.0.get(i)
     }
 }
 
 impl<'a, T: CoordNum> MultiPointTrait for &'a MultiPoint<T> {
     type T = T;
-    type ItemType<'b> = Point<Self::T> where Self: 'b;
-    type Iter<'b> = Cloned<Iter<'a, Self::ItemType<'a>>> where Self: 'b;
+    type ItemType<'b> = &'a Point<Self::T> where Self: 'b;
+    type Iter<'b> = Iter<'a, Point<Self::T>> where Self: 'b;
 
     fn points(&self) -> Self::Iter<'_> {
-        self.0.iter().cloned()
+        self.0.iter()
     }
 
     fn num_points(&self) -> usize {
@@ -55,6 +54,6 @@ impl<'a, T: CoordNum> MultiPointTrait for &'a MultiPoint<T> {
     }
 
     fn point(&self, i: usize) -> Option<Self::ItemType<'_>> {
-        self.0.get(i).cloned()
+        self.0.get(i)
     }
 }

--- a/geo-traits/src/multi_polygon.rs
+++ b/geo-traits/src/multi_polygon.rs
@@ -1,6 +1,5 @@
 use super::polygon::PolygonTrait;
 use geo_types::{CoordNum, MultiPolygon, Polygon};
-use std::iter::Cloned;
 use std::slice::Iter;
 
 pub trait MultiPolygonTrait {
@@ -25,11 +24,11 @@ pub trait MultiPolygonTrait {
 
 impl<T: CoordNum> MultiPolygonTrait for MultiPolygon<T> {
     type T = T;
-    type ItemType<'a> = Polygon<Self::T> where Self: 'a;
-    type Iter<'a> = Cloned<Iter<'a, Self::ItemType<'a>>> where T: 'a;
+    type ItemType<'a> = &'a Polygon<Self::T> where Self: 'a;
+    type Iter<'a> = Iter<'a, Polygon<Self::T>> where T: 'a;
 
     fn polygons(&self) -> Self::Iter<'_> {
-        self.0.iter().cloned()
+        self.0.iter()
     }
 
     fn num_polygons(&self) -> usize {
@@ -37,17 +36,17 @@ impl<T: CoordNum> MultiPolygonTrait for MultiPolygon<T> {
     }
 
     fn polygon(&self, i: usize) -> Option<Self::ItemType<'_>> {
-        self.0.get(i).cloned()
+        self.0.get(i)
     }
 }
 
 impl<'a, T: CoordNum> MultiPolygonTrait for &'a MultiPolygon<T> {
     type T = T;
-    type ItemType<'b> = Polygon<Self::T> where Self: 'b;
-    type Iter<'b> = Cloned<Iter<'a, Self::ItemType<'a>>> where Self: 'b;
+    type ItemType<'b> = &'a Polygon<Self::T> where Self: 'b;
+    type Iter<'b> = Iter<'a, Polygon<Self::T>> where Self: 'b;
 
     fn polygons(&self) -> Self::Iter<'_> {
-        self.0.iter().cloned()
+        self.0.iter()
     }
 
     fn num_polygons(&self) -> usize {
@@ -55,6 +54,6 @@ impl<'a, T: CoordNum> MultiPolygonTrait for &'a MultiPolygon<T> {
     }
 
     fn polygon(&self, i: usize) -> Option<Self::ItemType<'_>> {
-        self.0.get(i).cloned()
+        self.0.get(i)
     }
 }

--- a/geo-traits/src/polygon.rs
+++ b/geo-traits/src/polygon.rs
@@ -1,6 +1,5 @@
 use super::line_string::LineStringTrait;
 use geo_types::{CoordNum, LineString, Polygon};
-use std::iter::Cloned;
 use std::slice::Iter;
 
 pub trait PolygonTrait {
@@ -28,16 +27,16 @@ pub trait PolygonTrait {
 
 impl<T: CoordNum> PolygonTrait for Polygon<T> {
     type T = T;
-    type ItemType<'a> = LineString<Self::T> where Self: 'a;
-    type Iter<'a> = Cloned<Iter<'a, Self::ItemType<'a>>> where T: 'a;
+    type ItemType<'a> = &'a LineString<Self::T> where Self: 'a;
+    type Iter<'a> = Iter<'a, LineString<Self::T>> where T: 'a;
 
     fn exterior(&self) -> Option<Self::ItemType<'_>> {
         // geo-types doesn't really have a way to describe an empty polygon
-        Some(Polygon::exterior(self).clone())
+        Some(Polygon::exterior(self))
     }
 
     fn interiors(&self) -> Self::Iter<'_> {
-        Polygon::interiors(self).iter().cloned()
+        Polygon::interiors(self).iter()
     }
 
     fn num_interiors(&self) -> usize {
@@ -45,23 +44,23 @@ impl<T: CoordNum> PolygonTrait for Polygon<T> {
     }
 
     fn interior(&self, i: usize) -> Option<Self::ItemType<'_>> {
-        Polygon::interiors(self).get(i).cloned()
+        Polygon::interiors(self).get(i)
     }
 }
 
 impl<'a, T: CoordNum> PolygonTrait for &'a Polygon<T> {
     type T = T;
-    type ItemType<'b> = LineString<Self::T> where
+    type ItemType<'b> = &'a LineString<Self::T> where
         Self: 'b;
-    type Iter<'b> = Cloned<Iter<'a, Self::ItemType<'a>>>  where
+    type Iter<'b> = Iter<'a, LineString<Self::T>>  where
         Self: 'b;
 
     fn exterior(&self) -> Option<Self::ItemType<'_>> {
-        Some(Polygon::exterior(self).clone())
+        Some(Polygon::exterior(self))
     }
 
     fn interiors(&self) -> Self::Iter<'_> {
-        Polygon::interiors(self).iter().cloned()
+        Polygon::interiors(self).iter()
     }
 
     fn num_interiors(&self) -> usize {
@@ -69,6 +68,6 @@ impl<'a, T: CoordNum> PolygonTrait for &'a Polygon<T> {
     }
 
     fn interior(&self, i: usize) -> Option<Self::ItemType<'_>> {
-        Polygon::interiors(self).get(i).cloned()
+        Polygon::interiors(self).get(i)
     }
 }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

I struggled with this initially because I thought I _had_ to implement `Iter` in terms of `Self::ItemType`, which resulted in a double `&&Self::ItemType`.

In geoarrow-rs this resulted in a massive speedup (see https://github.com/geoarrow/geoarrow-rs/pull/278#issuecomment-1829024334) for converting `geo` objects to `geoarrow` (which is entirely implemented on top of these traits):

```
convert Vec<geo::Polygon> to PolygonArray
                        time:   [31.564 µs 31.608 µs 31.661 µs]
                        change: [-52.414% -52.271% -52.131%] (p = 0.00 < 0.05)
                        Performance has improved.
```

In the short term, in geoarrow-rs this also means all algorithms that result in geometries will get faster (though this probably isn't a huge part of the overall time) because currently all algorithms are implemented by converting each geometry to `geo`, applying the operation, and converting the output vec back to geoarrow.