### PR TITLE
small perf improvements to TriangulateSpade

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -9,6 +9,8 @@
   * <https://github.com/georust/geo/pull/1107>
 * Make `SpadeTriangulationConfig` actually configurable
   * <https://github.com/georust/geo/pull/1123>
+* PERF: small improvements to TriangulateSpade trait
+  * <https://github.com/georust/geo/pull/1122>
 
 ## 0.27.0
 

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -110,3 +110,7 @@ harness = false
 [[bench]]
 name = "monotone_subdiv"
 harness = false
+
+[[bench]]
+name = "triangulate"
+harness = false

--- a/geo/benches/triangulate.rs
+++ b/geo/benches/triangulate.rs
@@ -1,0 +1,81 @@
+use criterion::{criterion_group, criterion_main};
+use geo::algorithm::{TriangulateEarcut, TriangulateSpade};
+use geo::geometry::Polygon;
+use geo::triangulate_spade::SpadeTriangulationConfig;
+
+fn criterion_benchmark(c: &mut criterion::Criterion) {
+    c.bench_function(
+        "TriangulateSpade (unconstrained) - small polys",
+        |bencher| {
+            let multi_poly = geo_test_fixtures::nl_zones::<f64>();
+            bencher.iter(|| {
+                for poly in &multi_poly {
+                    let triangulation =
+                        TriangulateSpade::unconstrained_triangulation(poly).unwrap();
+                    assert!(triangulation.len() > 1);
+                    criterion::black_box(triangulation);
+                }
+            });
+        },
+    );
+
+    c.bench_function("TriangulateSpade (constrained) - small polys", |bencher| {
+        let multi_poly = geo_test_fixtures::nl_zones::<f64>();
+        bencher.iter(|| {
+            for poly in &multi_poly {
+                let triangulation = TriangulateSpade::constrained_triangulation(
+                    poly,
+                    SpadeTriangulationConfig { snap_radius: 1e-8 },
+                )
+                .unwrap();
+                assert!(triangulation.len() > 1);
+                criterion::black_box(triangulation);
+            }
+        });
+    });
+
+    c.bench_function("TriangulateEarcut - small polys", |bencher| {
+        let multi_poly = geo_test_fixtures::nl_zones::<f64>();
+        bencher.iter(|| {
+            for poly in &multi_poly {
+                let triangulation = TriangulateEarcut::earcut_triangles(poly);
+                assert!(triangulation.len() > 1);
+                criterion::black_box(triangulation);
+            }
+        });
+    });
+
+    c.bench_function("TriangulateSpade (unconstrained) - large_poly", |bencher| {
+        let poly = Polygon::new(geo_test_fixtures::norway_main::<f64>(), vec![]);
+        bencher.iter(|| {
+            let triangulation = TriangulateSpade::unconstrained_triangulation(&poly).unwrap();
+            assert!(triangulation.len() > 1);
+            criterion::black_box(triangulation);
+        });
+    });
+
+    c.bench_function("TriangulateSpade (constrained) - large_poly", |bencher| {
+        let poly = Polygon::new(geo_test_fixtures::norway_main::<f64>(), vec![]);
+        bencher.iter(|| {
+            let triangulation = TriangulateSpade::constrained_triangulation(
+                &poly,
+                SpadeTriangulationConfig { snap_radius: 1e-8 },
+            )
+            .unwrap();
+            assert!(triangulation.len() > 1);
+            criterion::black_box(triangulation);
+        });
+    });
+
+    c.bench_function("TriangulateEarcut - large_poly", |bencher| {
+        let poly = Polygon::new(geo_test_fixtures::norway_main::<f64>(), vec![]);
+        bencher.iter(|| {
+            let triangulation = TriangulateEarcut::earcut_triangles(&poly);
+            assert!(triangulation.len() > 1);
+            criterion::black_box(triangulation);
+        });
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Bench output:
```
TriangulateSpade (unconstrained)
                        time:   [8.8442 ms 8.8522 ms 8.8619 ms]
                        change: [-2.9583% -2.7775% -2.6122%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe

TriangulateSpade (constrained)
                        time:   [8.9126 ms 8.9274 ms 8.9444 ms]
                        change: [-2.4017% -2.1584% -1.9066%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high severe

TriangulateEarcut       time:   [6.9632 ms 6.9750 ms 6.9883 ms]
                        change: [-1.0174% -0.7692% -0.5114%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
```

Note this is an internal API, so we can safely break the API.