### PR TITLE
Add docs to clarify writing Intersection Matrix functions

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -32,6 +32,8 @@
   * <https://github.com/georust/geo/pull/1134>
 * Add topological equality comparison method:
   * <https://github.com/georust/geo/pull/1133>
+* Add docs to Relate trait
+  * <https://github.com/georust/geo/pull/1135>
 
 ## 0.27.0
 

--- a/geo/src/algorithm/relate/geomgraph/intersection_matrix.rs
+++ b/geo/src/algorithm/relate/geomgraph/intersection_matrix.rs
@@ -192,7 +192,7 @@ impl IntersectionMatrix {
     // See https://en.wikipedia.org/wiki/DE-9IM#Spatial_predicates for a mapping between predicates and matrices
     // The number of constraints in your relation function MUST match the number of NON-MASK (T or F) matrix entries
 
-    // CoordPos relations map onto the matrix positions as follows:
+    // Indexes of the IntersectionMatrix map to indexes of a DE-9IM specification string as follows:
     // ==================================================================
     // self.0[CoordPos::Inside][CoordPos::Inside]: 0
     // self.0[CoordPos::Inside][CoordPos::OnBoundary]: 1

--- a/geo/src/algorithm/relate/geomgraph/intersection_matrix.rs
+++ b/geo/src/algorithm/relate/geomgraph/intersection_matrix.rs
@@ -188,6 +188,40 @@ impl IntersectionMatrix {
         Ok(())
     }
 
+    // NOTE for implementers
+    // See https://en.wikipedia.org/wiki/DE-9IM#Spatial_predicates for a mapping between predicates and matrices
+    // The number of constraints in your relation function MUST match the number of NON-MASK (T or F) matrix entries
+
+    // CoordPos relations map onto the matrix positions as follows:
+    // ==================================================================
+    // self.0[CoordPos::Inside][CoordPos::Inside]: 0
+    // self.0[CoordPos::Inside][CoordPos::OnBoundary]: 1
+    // self.0[CoordPos::Inside][CoordPos::Outside]: 2
+
+    // self.0[CoordPos::OnBoundary][CoordPos::Inside]: 3
+    // self.0[CoordPos::OnBoundary][CoordPos::OnBoundary]: 4
+    // self.0[CoordPos::OnBoundary][CoordPos::Outside]: 5
+
+    // self.0[CoordPos::Outside][CoordPos::Inside]: 6
+    // self.0[CoordPos::Outside][CoordPos::OnBoundary]: 7
+    // self.0[CoordPos::Outside][CoordPos::Outside]: 8
+    // ==================================================================
+
+    // Relationship between matrix entry and Dimensions
+    // ==================================================================
+    // A `T` entry translates to `!= Dimensions::Empty`
+    // An `F` entry translates to `== Dimensions::Empty`
+    // A `*` (mask) entry is OMITTED
+    // ==================================================================
+
+    // Examples
+    // ==================================================================
+    // `[T********]` -> `self.0[CoordPos::Inside][CoordPos::Inside] != Dimensions::Empty`
+    // `[********F]` -> `self.0[CoordPos::Outside][CoordPos::Outside] == Dimensions::Empty`
+    // `[**T****F*]` -> `self.0[CoordPos::Inside][CoordPos::Outside] != Dimensions::Empty
+    //     && self.0[CoordPos::Outside][CoordPos::OnBoundary] == Dimensions::Empty`
+    // ==================================================================
+
     /// Tests if this matrix matches `[FF*FF****]`.
     ///
     /// returns `true` if the two geometries related by this matrix are disjoint


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Following on from discussion in https://github.com/georust/geo/pull/1133/files/c1a57d18ccc4d03a00d71fb1c0bd079be1cdb806..f8aab2d44143c2cd96023876c0399b94465680a5 this PR adds documentation and examples with the aim of making writing and/or modifying spatial predicate functions easier for our future selves / new contributors.

This PR should be rebased once #1133 merges