### PR TITLE
Add all remaining predicates: covered by, covers, crosses, overlaps, and touches

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ The `geo` crate provides geospatial primitive types such as `Point`, `LineString
 - Simplification and convex hull operations
 - Euclidean and Haversine distance measurement
 - Intersection checks
-- Affine transforms such as rotation and translation.
+- Affine transforms such as rotation and translation
+- All DE-9IM spatial predicates such as contains, crosses, and touches.
 
 Please refer to [the documentation](https://docs.rs/geo) for a complete list.
 

--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -34,6 +34,8 @@
   * <https://github.com/georust/geo/pull/1133>
 * Add docs to Relate trait
   * <https://github.com/georust/geo/pull/1135>
+* Add remaining Relate predicates
+  * <https://github.com/georust/geo/pull/1136>
 
 ## 0.27.0
 

--- a/geo/src/algorithm/relate/mod.rs
+++ b/geo/src/algorithm/relate/mod.rs
@@ -10,7 +10,7 @@ mod relate_operation;
 
 /// Topologically relate two geometries based on [DE-9IM](https://en.wikipedia.org/wiki/DE-9IM) semantics.
 ///
-/// See [`IntersectionMatrix`] for details.
+/// See [`IntersectionMatrix`] for details. All predicates are available on the calculated matrix.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

<s>I want to do a little more checking with regard to the logic we use to determine whether the input dimensions differ (which is a requirement of the `Crosses` predicate), and conversely checking whether they're the same (a requirement of the `Overlaps` predicate). I'm currently doing this by interrogating the IM for the following two relations: `a-interior / b-exterior` and `a-exterior / b-interior`. I assert that if they're **not** equal the input geometry dimensions differ, and vice versa, but I'm not yet 100 % certain that this is true for all valid input geometries.</s>

<s>Addressed in https://github.com/georust/geo/pull/1136/commits/af8a50cf1da7ba014b3778751e16c95b1995bfae for all non multi-geometries.</s>