### PR TITLE
Add documentation

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[registries]
+franklin-ai-geo = { index = "https://dl.cloudsmith.io/basic/franklin-ai/geo/cargo/index.git" }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,537 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'geo'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=geo"
+                ],
+                "filter": {
+                    "name": "geo",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug example 'concavehull-usage'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--example=concavehull-usage",
+                    "--package=geo"
+                ],
+                "filter": {
+                    "name": "concavehull-usage",
+                    "kind": "example"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in example 'concavehull-usage'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--example=concavehull-usage",
+                    "--package=geo"
+                ],
+                "filter": {
+                    "name": "concavehull-usage",
+                    "kind": "example"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug example 'algorithm'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--example=algorithm",
+                    "--package=geo"
+                ],
+                "filter": {
+                    "name": "algorithm",
+                    "kind": "example"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in example 'algorithm'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--example=algorithm",
+                    "--package=geo"
+                ],
+                "filter": {
+                    "name": "algorithm",
+                    "kind": "example"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug example 'types'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--example=types",
+                    "--package=geo"
+                ],
+                "filter": {
+                    "name": "types",
+                    "kind": "example"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in example 'types'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--example=types",
+                    "--package=geo"
+                ],
+                "filter": {
+                    "name": "types",
+                    "kind": "example"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug benchmark 'area'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--bench=area",
+                    "--package=geo"
+                ],
+                "filter": {
+                    "name": "area",
+                    "kind": "bench"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug benchmark 'contains'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--bench=contains",
+                    "--package=geo"
+                ],
+                "filter": {
+                    "name": "contains",
+                    "kind": "bench"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug benchmark 'convex_hull'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--bench=convex_hull",
+                    "--package=geo"
+                ],
+                "filter": {
+                    "name": "convex_hull",
+                    "kind": "bench"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug benchmark 'concave_hull'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--bench=concave_hull",
+                    "--package=geo"
+                ],
+                "filter": {
+                    "name": "concave_hull",
+                    "kind": "bench"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug benchmark 'intersection'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--bench=intersection",
+                    "--package=geo"
+                ],
+                "filter": {
+                    "name": "intersection",
+                    "kind": "bench"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug benchmark 'vincenty_distance'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--bench=vincenty_distance",
+                    "--package=geo"
+                ],
+                "filter": {
+                    "name": "vincenty_distance",
+                    "kind": "bench"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug benchmark 'geodesic_distance'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--bench=geodesic_distance",
+                    "--package=geo"
+                ],
+                "filter": {
+                    "name": "geodesic_distance",
+                    "kind": "bench"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug benchmark 'extremes'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--bench=extremes",
+                    "--package=geo"
+                ],
+                "filter": {
+                    "name": "extremes",
+                    "kind": "bench"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug benchmark 'euclidean_distance'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--bench=euclidean_distance",
+                    "--package=geo"
+                ],
+                "filter": {
+                    "name": "euclidean_distance",
+                    "kind": "bench"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug benchmark 'rotate'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--bench=rotate",
+                    "--package=geo"
+                ],
+                "filter": {
+                    "name": "rotate",
+                    "kind": "bench"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug benchmark 'relate'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--bench=relate",
+                    "--package=geo"
+                ],
+                "filter": {
+                    "name": "relate",
+                    "kind": "bench"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug benchmark 'simplify'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--bench=simplify",
+                    "--package=geo"
+                ],
+                "filter": {
+                    "name": "simplify",
+                    "kind": "bench"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug benchmark 'simplifyvw'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--bench=simplifyvw",
+                    "--package=geo"
+                ],
+                "filter": {
+                    "name": "simplifyvw",
+                    "kind": "bench"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug benchmark 'frechet_distance'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--bench=frechet_distance",
+                    "--package=geo"
+                ],
+                "filter": {
+                    "name": "frechet_distance",
+                    "kind": "bench"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug benchmark 'rand_line_crossings'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--bench=rand_line_crossings",
+                    "--package=geo"
+                ],
+                "filter": {
+                    "name": "rand_line_crossings",
+                    "kind": "bench"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug benchmark 'winding_order'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--bench=winding_order",
+                    "--package=geo"
+                ],
+                "filter": {
+                    "name": "winding_order",
+                    "kind": "bench"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug benchmark 'monotone_subdiv'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--bench=monotone_subdiv",
+                    "--package=geo"
+                ],
+                "filter": {
+                    "name": "monotone_subdiv",
+                    "kind": "bench"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'geo-test-fixtures'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=geo-test-fixtures"
+                ],
+                "filter": {
+                    "name": "geo-test-fixtures",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'jts-test-runner'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=jts-test-runner"
+                ],
+                "filter": {
+                    "name": "jts-test-runner",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'geo-types'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=geo-types"
+                ],
+                "filter": {
+                    "name": "geo-types",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'geo-postgis'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=geo-postgis"
+                ],
+                "filter": {
+                    "name": "geo-postgis",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        }
+    ]
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
   "geo-postgis",
   "geo-test-fixtures",
   "jts-test-runner",
-  "geo-bool-ops-benches",
+  # "geo-bool-ops-benches",
 ]
 
 [patch.crates-io]

--- a/geo-bool-ops-benches/Cargo.toml
+++ b/geo-bool-ops-benches/Cargo.toml
@@ -6,8 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-geo = { path = "../geo" }
-geo-types = { path = "../geo-types" }
+geo-types = { version = "0.7.12", features = ["approx", "use-rstar_0_11"] }
 log = "0.4.11"
 
 [dev-dependencies]

--- a/geo-test-fixtures/Cargo.toml
+++ b/geo-test-fixtures/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 publish = false
 
 [dependencies]
+geo-types = { version = "0.7.12", features = ["approx", "use-rstar_0_11"] }
 wkt = { version = "0.10.0", default-features = false }
-geo-types = { path = "../geo-types" }

--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -1,6 +1,6 @@
 # Changes
 
-## Unrealeased
+## 0.7.12
 
 * Add `Polygon::try_exterior_mut` and `Polygon::try_interiors_mut`.
   <https://github.com/georust/geo/pull/1071>

--- a/geo-types/Cargo.toml
+++ b/geo-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geo-types"
-version = "0.7.11"
+version = "0.7.12"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/georust/geo"
 documentation = "https://docs.rs/geo-types/"

--- a/geo-types/src/geometry/multi_point.rs
+++ b/geo-types/src/geometry/multi_point.rs
@@ -35,16 +35,16 @@ use core::iter::FromIterator;
 pub struct MultiPoint<T: CoordNum = f64>(pub Vec<Point<T>>);
 
 impl<T: CoordNum, IP: Into<Point<T>>> From<IP> for MultiPoint<T> {
-    /// Convert a single `Point` (or something which can be converted to a `Point`) into a
-    /// one-member `MultiPoint`
+    /// Convert a single `Point` (or something which can be converted to a
+    /// `Point`) into a one-member `MultiPoint`
     fn from(x: IP) -> Self {
         Self(vec![x.into()])
     }
 }
 
 impl<T: CoordNum, IP: Into<Point<T>>> From<Vec<IP>> for MultiPoint<T> {
-    /// Convert a `Vec` of `Points` (or `Vec` of things which can be converted to a `Point`) into a
-    /// `MultiPoint`.
+    /// Convert a `Vec` of `Points` (or `Vec` of things which can be converted
+    /// to a `Point`) into a `MultiPoint`.
     fn from(v: Vec<IP>) -> Self {
         Self(v.into_iter().map(|p| p.into()).collect())
     }
@@ -88,6 +88,14 @@ impl<'a, T: CoordNum> IntoIterator for &'a mut MultiPoint<T> {
 impl<T: CoordNum> MultiPoint<T> {
     pub fn new(value: Vec<Point<T>>) -> Self {
         Self(value)
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
     }
 
     pub fn iter(&self) -> impl Iterator<Item = &Point<T>> {

--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -32,9 +32,6 @@
   * <https://github.com/georust/geo/pull/1083>
 * Add `len()` and `is_empty()` to `MultiPoint`
   * <https://github.com/georust/geo/pull/1109>
-  <https://github.com/georust/geo/pull/1063>
-* Add `TriangulateSpade` trait which provides (un)constrained Delaunay Triangulations for all `geo_types` via the `spade` crate
-  * <https://github.com/georust/geo/pull/1083>
 * Add `TriangulateDelaunay` and `VoronoiDiagram` traits.
   * <https://github.com/franklin-ai/geo/pull/2>
 

--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -1,6 +1,6 @@
 # Changes
 
-## Unreleased
+## 0.27.0
 
 * Use `CachedEnvelope` in R-Trees when computing euclidean distance between polygons
   * <https://github.com/georust/geo/pull/1093>
@@ -27,6 +27,11 @@
 * Fix coordinate wrapping in `HaversineDestination`
   * <https://github.com/georust/geo/pull/1091>
 * Add `wkt!` macro to define geometries at compile time.
+  * <https://github.com/georust/geo/pull/1063>
+* Add `TriangulateSpade` trait which provides (un)constrained Delaunay Triangulations for all `geo_types` via the `spade` crate
+  * <https://github.com/georust/geo/pull/1083>
+* Add `len()` and `is_empty()` to `MultiPoint`
+  * <https://github.com/georust/geo/pull/1109>
   <https://github.com/georust/geo/pull/1063>
 * Add `TriangulateSpade` trait which provides (un)constrained Delaunay Triangulations for all `geo_types` via the `spade` crate
   * <https://github.com/georust/geo/pull/1083>

--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -28,6 +28,8 @@
   * <https://github.com/georust/geo/pull/1091>
 * Add `wkt!` macro to define geometries at compile time.
   <https://github.com/georust/geo/pull/1063>
+* Add `TriangulateDelaunay` and `VoronoiDiagram` traits.
+  * <https://github.com/franklin-ai/geo/pull/2>
 
 ## 0.26.0
 

--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -28,6 +28,8 @@
   * <https://github.com/georust/geo/pull/1091>
 * Add `wkt!` macro to define geometries at compile time.
   <https://github.com/georust/geo/pull/1063>
+* Add `TriangulateSpade` trait which provides (un)constrained Delaunay Triangulations for all `geo_types` via the `spade` crate
+  * <https://github.com/georust/geo/pull/1083>
 * Add `TriangulateDelaunay` and `VoronoiDiagram` traits.
   * <https://github.com/franklin-ai/geo/pull/2>
 

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "geo"
 description = "Geospatial primitives and algorithms"
-version = "0.28.0-alpha3"
+version = "0.28.0-alpha4"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/georust/geo"
 documentation = "https://docs.rs/geo/"

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "geo"
 description = "Geospatial primitives and algorithms"
-version = "0.28.0-alpha1"
+version = "0.28.0-alpha2"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/georust/geo"
 documentation = "https://docs.rs/geo/"
@@ -13,7 +13,7 @@ rust-version = "1.65"
 categories = ["science::geo"]
 
 [features]
-default = ["earcutr", "spade"]
+default = ["earcutr", "spade", "voronoi"]
 proj-network = ["use-proj", "proj/network"]
 use-proj = ["proj"]
 use-serde = ["serde", "geo-types/serde"]

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "geo"
 description = "Geospatial primitives and algorithms"
-version = "0.26.0"
+version = "0.27.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/georust/geo"
 documentation = "https://docs.rs/geo/"
@@ -13,18 +13,18 @@ rust-version = "1.65"
 categories = ["science::geo"]
 
 [features]
-default = ["earcutr", "spade", "delaunay", "voronoi"]
-delaunay = []
+default = ["earcutr", "spade", "voronoi"]
 proj-network = ["use-proj", "proj/network"]
 use-proj = ["proj"]
 use-serde = ["serde", "geo-types/serde"]
+delaunay = []
 voronoi = ["delaunay"]
 
 [dependencies]
 earcutr = { version = "0.4.2", optional = true }
 spade = { version = "2.2.0", optional = true }
 float_next_after = "1.0.0"
-geo-types = { version = "0.7.9", features = ["approx", "use-rstar_0_11"] }
+geo-types = { version = "0.7.12", features = ["approx", "use-rstar_0_11"] }
 geographiclib-rs = { version = "0.2.3", default-features = false }
 log = "0.4.11"
 num-traits = "0.2"

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "geo"
 description = "Geospatial primitives and algorithms"
-version = "0.28.0-alpha2"
+version = "0.28.0-alpha3"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/georust/geo"
 documentation = "https://docs.rs/geo/"

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.65"
 categories = ["science::geo"]
 
 [features]
-default = ["earcutr", "delaunay", "voronoi"]
+default = ["earcutr", "spade", "delaunay", "voronoi"]
 delaunay = []
 proj-network = ["use-proj", "proj/network"]
 use-proj = ["proj"]
@@ -22,6 +22,7 @@ voronoi = ["delaunay"]
 
 [dependencies]
 earcutr = { version = "0.4.2", optional = true }
+spade = { version = "2.2.0", optional = true }
 float_next_after = "1.0.0"
 geo-types = { version = "0.7.9", features = ["approx", "use-rstar_0_11"] }
 geographiclib-rs = { version = "0.2.3", default-features = false }

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -13,10 +13,12 @@ rust-version = "1.65"
 categories = ["science::geo"]
 
 [features]
-default = ["earcutr"]
-use-proj = ["proj"]
+default = ["earcutr", "delaunay", "voronoi"]
+delaunay = []
 proj-network = ["use-proj", "proj/network"]
+use-proj = ["proj"]
 use-serde = ["serde", "geo-types/serde"]
+voronoi = ["delaunay"]
 
 [dependencies]
 earcutr = { version = "0.4.2", optional = true }

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -112,3 +112,7 @@ harness = false
 [[bench]]
 name = "monotone_subdiv"
 harness = false
+
+[[bench]]
+name = "delaunay_diagram"
+harness = false

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "geo"
 description = "Geospatial primitives and algorithms"
-version = "0.27.0"
+version = "0.28.0-alpha1"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/georust/geo"
 documentation = "https://docs.rs/geo/"
@@ -13,7 +13,7 @@ rust-version = "1.65"
 categories = ["science::geo"]
 
 [features]
-default = ["earcutr", "spade", "voronoi"]
+default = ["earcutr", "spade"]
 proj-network = ["use-proj", "proj/network"]
 use-proj = ["proj"]
 use-serde = ["serde", "geo-types/serde"]

--- a/geo/benches/delaunay_diagram.rs
+++ b/geo/benches/delaunay_diagram.rs
@@ -1,0 +1,48 @@
+use criterion::{criterion_group, criterion_main};
+use geo::coord;
+use geo::{polygon, Polygon, TriangulateDelaunay, TriangulateSpade};
+
+fn get_polygon() -> Polygon {
+    polygon![
+        coord! { x: 10., y: 10.},
+        coord! { x: 10., y: 20.},
+        coord! { x: 20., y: 20.},
+        coord! { x: 20., y: 10.},
+        coord! { x: 10., y: 0.},
+        coord! { x: 10., y: 0.},
+        coord! { x: 0., y: 10.},
+        coord! { x: 0., y: 20.},
+    ]
+}
+
+fn criterion_benchmark(c: &mut criterion::Criterion) {
+    c.bench_function("Delaunay Triangulation", |bencher| {
+        let poly = get_polygon();
+        bencher.iter(|| poly.delaunay_triangulation().unwrap())
+    });
+
+    c.bench_function("Spade Unconstrained Triangulation", |bencher| {
+        let poly = get_polygon();
+        bencher.iter(|| {
+            poly.unconstrained_triangulation().unwrap();
+        })
+    });
+
+    c.bench_function("Constrained Outer Triangulation", |bencher| {
+        let poly = get_polygon();
+        bencher.iter(|| {
+            poly.constrained_outer_triangulation(Default::default())
+                .unwrap();
+        })
+    });
+
+    c.bench_function("Constrain Triangulation", |bencher| {
+        let poly = get_polygon();
+        bencher.iter(|| {
+            poly.constrained_triangulation(Default::default()).unwrap();
+        })
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/geo/src/algorithm/mod.rs
+++ b/geo/src/algorithm/mod.rs
@@ -265,6 +265,8 @@ pub use triangulate_delaunay::TriangulateDelaunay;
 
 #[cfg(feature = "voronoi")]
 pub mod voronoi_diagram;
+#[cfg(feature = "voronoi")]
+pub use voronoi_diagram::VoronoiDiagram;
 
 /// Vector Operations for 2D coordinates
 mod vector_ops;

--- a/geo/src/algorithm/mod.rs
+++ b/geo/src/algorithm/mod.rs
@@ -252,6 +252,14 @@ pub mod triangulate_earcut;
 #[cfg(feature = "earcutr")]
 pub use triangulate_earcut::TriangulateEarcut;
 
+#[cfg(feature = "delaunay")]
+pub mod triangulate_delaunay;
+#[cfg(feature = "delaunay")]
+pub use triangulate_delaunay::TriangulateDelaunay;
+
+#[cfg(feature = "voronoi")]
+pub mod voronoi_diagram;
+
 /// Vector Operations for 2D coordinates
 mod vector_ops;
 pub use vector_ops::Vector2DOps;

--- a/geo/src/algorithm/mod.rs
+++ b/geo/src/algorithm/mod.rs
@@ -252,6 +252,12 @@ pub mod triangulate_earcut;
 #[cfg(feature = "earcutr")]
 pub use triangulate_earcut::TriangulateEarcut;
 
+/// Triangulate polygons using an (un)constrained [Delaunay Triangulation](https://en.wikipedia.org/wiki/Delaunay_triangulation) algorithm.
+#[cfg(feature = "spade")]
+pub mod triangulate_spade;
+#[cfg(feature = "spade")]
+pub use triangulate_spade::TriangulateSpade;
+
 #[cfg(feature = "delaunay")]
 pub mod triangulate_delaunay;
 #[cfg(feature = "delaunay")]

--- a/geo/src/algorithm/triangulate_delaunay.rs
+++ b/geo/src/algorithm/triangulate_delaunay.rs
@@ -11,9 +11,9 @@ type Result<T> = std::result::Result<T, DelaunayTriangulationError>;
 /// [Bowyer](https://doi.org/10.1093%2Fcomjnl%2F24.2.162)-[Watson](https://doi.org/10.1093%2Fcomjnl%2F24.2.167)
 /// algorithm
 pub trait TriangulateDelaunay<T: GeoFloat> {
-    /// # Examples
+    /// # Example
     ///
-    /// ```
+    /// ```rust
     /// use geo::{coord, polygon, Triangle, TriangulateDelaunay};
     ///
     /// let points = polygon![
@@ -320,7 +320,8 @@ pub enum DelaunayTriangulationError {
     /// This error occurs when the `Polygon` describing the points to
     /// triangulate does not return a bounding rectangle.
     FailedToConstructSuperTriangle,
-    FailedToConvertSuperTriangleFactor,
+    /// Failed to convert value into generic type T.
+    /// This error occurs when the value 2.0 cannot be converted into T.
     GeoTypeConversionError,
 }
 
@@ -338,9 +339,6 @@ impl fmt::Display for DelaunayTriangulationError {
             }
             DelaunayTriangulationError::GeoTypeConversionError => {
                 write!(f, "Failed to convert from Geo type T")
-            }
-            DelaunayTriangulationError::FailedToConvertSuperTriangleFactor => {
-                write!(f, "Failed to convert super triangle expansion factor")
             }
         }
     }

--- a/geo/src/algorithm/triangulate_delaunay.rs
+++ b/geo/src/algorithm/triangulate_delaunay.rs
@@ -671,4 +671,10 @@ mod test {
             assert!(expected_triangles.contains(tri));
         }
     }
+
+    #[test]
+    fn test_neg_0() {
+        let zero: f64 = num_traits::Zero::zero();
+        assert!(zero.is_finite());
+    }
 }

--- a/geo/src/algorithm/triangulate_delaunay.rs
+++ b/geo/src/algorithm/triangulate_delaunay.rs
@@ -1,0 +1,632 @@
+use std::{fmt, fmt::Debug};
+
+use crate::coord;
+use crate::{BoundingRect, Coord, GeoFloat, Line, MultiPoint, Polygon, Triangle};
+
+pub const DEFAULT_SUPER_TRIANGLE_EXPANSION: f64 = 20.;
+
+type Result<T> = std::result::Result<T, DelaunayTriangulationError>;
+
+/// Delaunay Triangulation for a given set of points using the
+/// [Bowyer](https://doi.org/10.1093%2Fcomjnl%2F24.2.162)-[Watson](https://doi.org/10.1093%2Fcomjnl%2F24.2.167)
+/// algorithm
+pub trait TriangulateDelaunay<T: GeoFloat> {
+    /// # Examples
+    ///
+    /// ```
+    /// use geo::{coord, polygon, Triangle, TriangulateDelaunay};
+    ///
+    /// let points = polygon![
+    ///     (x: 0., y: 0.),
+    ///     (x: 1., y: 2.),
+    ///     (x: 2., y: 4.),
+    ///     (x: 2., y: 0.),
+    ///     (x: 3., y: 2.),
+    ///     (x: 4., y: 0.),
+    /// ];
+    ///
+    /// let tri_force = points.delaunay_triangulation().unwrap();
+    ///
+    /// assert_eq!(vec![
+    ///     Triangle(
+    ///         coord! {x: 1., y: 2.},
+    ///         coord! {x: 0., y: 0.},
+    ///         coord! {x: 2., y: 0.},
+    ///     ),
+    ///     Triangle(
+    ///         coord! {x: 2., y: 4.},
+    ///         coord! {x: 1., y: 2.},
+    ///         coord! {x: 3., y: 2.},
+    ///     ),
+    ///     Triangle(
+    ///         coord! {x: 1., y: 2.},
+    ///         coord! {x: 2., y: 0.},
+    ///         coord! {x: 3., y: 2.},
+    ///     ),
+    ///     Triangle(
+    ///         coord! {x: 3., y: 2.},
+    ///         coord! {x: 2., y: 0.},
+    ///         coord! {x: 4., y: 0.},
+    ///     )],
+    ///     tri_force
+    /// );
+    ///
+    /// ```
+    ///
+    fn delaunay_triangulation(&self) -> Result<Vec<Triangle<T>>>;
+}
+
+impl<T: GeoFloat> TriangulateDelaunay<T> for Polygon<T>
+where
+    f64: From<T>,
+{
+    fn delaunay_triangulation(&self) -> Result<Vec<Triangle<T>>> {
+        let super_triangle = DelaunayTriangle(create_super_triangle(self)?);
+
+        let mut triangles: Vec<DelaunayTriangle<T>> = vec![super_triangle.clone()];
+        for pt in self.exterior().coords() {
+            add_coordinate(&mut triangles, pt);
+        }
+        let triangles = remove_super_triangle(&triangles, &super_triangle);
+        Ok(triangles.iter().map(|x| x.0).collect())
+    }
+}
+
+impl<T: GeoFloat> TriangulateDelaunay<T> for MultiPoint<T>
+where
+    f64: From<T>,
+{
+    fn delaunay_triangulation(&self) -> Result<Vec<Triangle<T>>> {
+        let poly = Polygon::new(self.into_iter().cloned().collect(), vec![]);
+        poly.delaunay_triangulation()
+    }
+}
+
+fn create_super_triangle<T: GeoFloat>(geometry: &Polygon<T>) -> Result<Triangle<T>>
+where
+    f64: From<T>,
+{
+    let expand_factor = T::from(DEFAULT_SUPER_TRIANGLE_EXPANSION)
+        .ok_or(DelaunayTriangulationError::FailedToConstructSuperTriangle)?;
+    let bounds = geometry
+        .bounding_rect()
+        .ok_or(DelaunayTriangulationError::FailedToConstructSuperTriangle)?;
+    let width = bounds.width() * expand_factor;
+    let height = bounds.height() * expand_factor;
+    let bounds_min = bounds.min();
+    let bounds_max = bounds.max();
+
+    Ok(Triangle(
+        coord! {x: bounds_min.x - width, y: bounds_min.y},
+        coord! {x: bounds_max.x + width, y: bounds_min.y - height},
+        coord! {x: bounds_max.x + width, y: bounds_max.y + height},
+    ))
+}
+
+fn find_line<T: GeoFloat>(line: &Line<T>, lines: &[Line<T>]) -> Option<usize> {
+    for (idx, sample_line) in lines.iter().enumerate() {
+        if line == sample_line {
+            return Some(idx);
+        }
+    }
+    None
+}
+
+fn add_coordinate<T: GeoFloat>(triangles: &mut Vec<DelaunayTriangle<T>>, c: &Coord<T>)
+where
+    f64: From<T>,
+{
+    let mut bad_triangles: Vec<&DelaunayTriangle<T>> = Vec::new();
+
+    // Check for the triangles where the point is present within the
+    // corresponding circumcircle.
+    for tri in triangles.iter() {
+        if tri.is_in_circumcircle(c) {
+            bad_triangles.push(tri);
+        }
+    }
+
+    let mut bad_triangle_edges: Vec<Line<T>> = Vec::new();
+    let mut bad_triangle_edge_count: Vec<u128> = Vec::new();
+    for x in &bad_triangles {
+        for y in x.0.to_lines() {
+            let flipped_y = Line::new(y.end, y.start);
+            let idx =
+                find_line(&y, &bad_triangle_edges).or(find_line(&flipped_y, &bad_triangle_edges));
+            if let Some(idx) = idx {
+                // The unwrap is acceptable due to the push lines below.
+                let count = bad_triangle_edge_count.get_mut(idx).unwrap();
+                *count += 1;
+            } else {
+                // These two vectors must be updated at the same time
+                bad_triangle_edges.push(y);
+                bad_triangle_edge_count.push(1);
+            }
+        }
+    }
+
+    // Shared edges are those with a count of > 1
+    let polygon: Vec<Line<T>> = bad_triangle_edge_count
+        .iter()
+        .enumerate()
+        .filter(|(_, count)| **count < 2)
+        .map(|(idx, _)| bad_triangle_edges[idx])
+        .collect();
+
+    // Remove the bad triangles
+    let mut new_triangles: Vec<DelaunayTriangle<T>> = triangles
+        .iter()
+        .filter(|x| !bad_triangles.contains(x))
+        .cloned()
+        .collect();
+
+    polygon
+        .iter()
+        .for_each(|x| new_triangles.push(DelaunayTriangle(Triangle(x.start, x.end, *c))));
+
+    // Replace the triangles
+    triangles.clear();
+    new_triangles.iter().for_each(|x| triangles.push(x.clone()));
+}
+
+fn remove_super_triangle<T: GeoFloat>(
+    triangles: &[DelaunayTriangle<T>],
+    super_triangle: &DelaunayTriangle<T>,
+) -> Vec<DelaunayTriangle<T>> {
+    let mut new_triangles: Vec<DelaunayTriangle<T>> = Vec::new();
+    let super_tri_vertices = super_triangle.0.to_array();
+
+    for tri in triangles.iter() {
+        let mut add_to_update = true;
+        for pt in tri.0.to_array().iter() {
+            if super_tri_vertices.contains(pt) {
+                add_to_update = false;
+            }
+        }
+        if add_to_update {
+            new_triangles.push(tri.clone())
+        }
+    }
+    new_triangles
+}
+
+/// A triangle structure used during Delaunay Triangulation.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DelaunayTriangle<T: GeoFloat>(Triangle<T>);
+
+impl<T: GeoFloat> From<Triangle<T>> for DelaunayTriangle<T> {
+    fn from(value: Triangle<T>) -> Self {
+        DelaunayTriangle(value)
+    }
+}
+
+impl<T: GeoFloat> From<DelaunayTriangle<T>> for Triangle<T> {
+    fn from(value: DelaunayTriangle<T>) -> Self {
+        value.0
+    }
+}
+
+fn is_line_shared<T: GeoFloat>(a: &Line<T>, b: &Line<T>) -> bool {
+    (a.start == b.start && a.end == b.end) || (a.start == b.end && a.end == b.start)
+}
+
+/// Methods required for delaunay triangulation
+impl<T: GeoFloat> DelaunayTriangle<T>
+where
+    f64: From<T>,
+{
+    #[cfg(feature = "voronoi")]
+    /// Check if a `DelaunayTriangle` shares at least one vertex.
+    pub fn shares_vertex(&self, other: &DelaunayTriangle<T>) -> bool {
+        let other_vertices = other.0.to_array();
+        for vertex in self.0.to_array().iter() {
+            if other_vertices.contains(vertex) {
+                return true;
+            }
+        }
+        false
+    }
+
+    #[cfg(feature = "voronoi")]
+    /// Check if a `DelaunayTriangle` is a neighbour i.e.
+    /// shares an edge.
+    /// If the triangles are neighbours the shared edge is returned.
+    pub fn shares_edge(&self, other: &DelaunayTriangle<T>) -> Option<Line<T>> {
+        let other_lines = other.0.to_lines();
+        for line in self.0.to_lines().iter() {
+            for other_line in other_lines.iter() {
+                if is_line_shared(line, other_line) {
+                    return Some(*line);
+                }
+            }
+        }
+        None
+    }
+
+    /// Check if a `Coord` is in the [Circumcircle](https://en.wikipedia.org/wiki/Circumcircle)
+    /// for the Delaunay triangle.
+    /// This method uses the determinant of the vertices of the triangle and the
+    /// new point as described by [Guibas & Stolfi](https://doi.org/10.1145%2F282918.282923)
+    /// and on [Wikipedia](https://en.wikipedia.org/wiki/Delaunay_triangulation#Algorithms).
+    pub fn is_in_circumcircle(&self, c: &Coord<T>) -> bool {
+        let a_d_x: f64 = (self.0 .0.x - c.x).into();
+        let a_d_y: f64 = (self.0 .0.y - c.y).into();
+        let b_d_x: f64 = (self.0 .1.x - c.x).into();
+        let b_d_y: f64 = (self.0 .1.y - c.y).into();
+        let c_d_x: f64 = (self.0 .2.x - c.x).into();
+        let c_d_y: f64 = (self.0 .2.y - c.y).into();
+        let a_d_x_d_y = a_d_x.powi(2) + a_d_y.powi(2);
+        let b_d_x_d_y = b_d_x.powi(2) + b_d_y.powi(2);
+        let c_d_x_d_y = c_d_x.powi(2) + c_d_y.powi(2);
+
+        // Compute the determinant of the following matrix
+        // [
+        //     [a_d_x, a_d_y, a_d_x_d_y],
+        //     [b_d_x, b_d_y, b_d_x_d_y],
+        //     [c_d_x, c_d_y, c_d_x_d_y],
+        // ]
+        //
+        let determinant = a_d_x * ((b_d_y * c_d_x_d_y) - (b_d_x_d_y * c_d_y))
+            - a_d_y * ((b_d_x * c_d_x_d_y) - (b_d_x_d_y * c_d_x))
+            + a_d_x_d_y * (b_d_x * c_d_y - b_d_y * c_d_x);
+
+        determinant > 0.0
+    }
+
+    #[cfg(feature = "voronoi")]
+    /// Get the center of the [Circumcircle](https://en.wikipedia.org/wiki/Circumcircle)
+    /// for the Delaunay triangle.
+    pub fn get_circumcircle_center(&self) -> Result<Coord<T>> {
+        // Pin the triangle to the origin to simplify the calculation
+        let b = self.0 .1 - self.0 .0;
+        let c = self.0 .2 - self.0 .0;
+
+        let a_x = self.0 .0.x;
+        let a_y = self.0 .0.y;
+        let b_x = b.x;
+        let b_y = b.y;
+        let c_x = c.x;
+        let c_y = c.y;
+
+        let d = T::from(2.0).ok_or(DelaunayTriangulationError::GeoTypeConversionError)?
+            * (b_x * c_y - b_y * c_x);
+
+        if d.is_zero() {
+            return Err(DelaunayTriangulationError::FailedToComputeCircumcircle);
+        }
+
+        let u_x = (c_y * (b_x.powi(2) + b_y.powi(2)) - b_y * (c_x.powi(2) + c_y.powi(2))) / d;
+        let u_y = (b_x * (c_x.powi(2) + c_y.powi(2)) - c_x * (b_x.powi(2) + b_y.powi(2))) / d;
+
+        Ok(coord! {x: a_x + u_x, y: a_y + u_y})
+    }
+}
+
+/// Delaunay Triangulation Errors
+#[derive(Debug, PartialEq, Eq)]
+pub enum DelaunayTriangulationError {
+    /// Failed to compute the circumcircle for a given triangle.
+    /// This can occur if the points are collinear.
+    FailedToComputeCircumcircle,
+    /// Failed to check if a point is in a circumcircle.
+    FailedToCheckPointInCircumcircle,
+    /// Failed to construct the super triangle.
+    /// This error occurs when the `Polygon` describing the points to
+    /// triangulate does not return a bounding rectangle.
+    FailedToConstructSuperTriangle,
+    FailedToConvertSuperTriangleFactor,
+    GeoTypeConversionError,
+}
+
+impl fmt::Display for DelaunayTriangulationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            DelaunayTriangulationError::FailedToComputeCircumcircle => {
+                write!(f, "Cannot compute circumcircle.")
+            }
+            DelaunayTriangulationError::FailedToCheckPointInCircumcircle => {
+                write!(f, "Cannot determine if the point is in the circumcircle.")
+            }
+            DelaunayTriangulationError::FailedToConstructSuperTriangle => {
+                write!(f, "Failed to construct the super triangle.")
+            }
+            DelaunayTriangulationError::GeoTypeConversionError => {
+                write!(f, "Failed to convert from Geo type T")
+            }
+            DelaunayTriangulationError::FailedToConvertSuperTriangleFactor => {
+                write!(f, "Failed to convert super triangle expansion factor")
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::Contains;
+    use geo_types::{LineString, MultiPoint, Point};
+
+    #[test]
+    fn test_triangle_shares_vertex() {
+        let triangle = DelaunayTriangle(Triangle::new(
+            coord! {x: 0., y: 0.},
+            coord! {x: 10., y: 20.},
+            coord! {x: -12., y: -2.},
+        ));
+        let other = DelaunayTriangle(Triangle::new(
+            coord! {x: 0., y: 0.},
+            coord! {x: 30., y: 40.},
+            coord! {x: 40., y: 30.},
+        ));
+
+        assert!(triangle.shares_vertex(&other));
+
+        let other = DelaunayTriangle(Triangle::new(
+            coord! {x: 30., y: 40.},
+            coord! {x: 40., y: 30.},
+            coord! {x: 50., y: 20.},
+        ));
+
+        assert!(!triangle.shares_vertex(&other));
+    }
+
+    #[test]
+    fn test_triangle_is_neighbour() {
+        let triangle = DelaunayTriangle(Triangle::new(
+            coord! {x: 0., y: 0.},
+            coord! {x: 10., y: 20.},
+            coord! {x: -12., y: -2.},
+        ));
+        let other = DelaunayTriangle(Triangle::new(
+            coord! {x: 0., y: 0.},
+            coord! {x: 10., y: 20.},
+            coord! {x: 30., y: 40.},
+        ));
+
+        assert_eq!(
+            triangle.shares_edge(&other).unwrap(),
+            Line::new(coord! {x: 0., y:0.}, coord! { x: 10., y: 20.})
+        );
+
+        let other = DelaunayTriangle(Triangle::new(
+            coord! {x: 0., y: 0.},
+            coord! {x: 30., y: 40.},
+            coord! {x: 40., y: 50.},
+        ));
+
+        assert!(triangle.shares_edge(&other).is_none());
+    }
+
+    #[test]
+    fn test_point_in_circumcircle() {
+        let triangle = DelaunayTriangle(Triangle::new(
+            coord! {x: 10., y: 10.},
+            coord! {x: 30., y: 10.},
+            coord! {x: 20., y: 20.},
+        ));
+
+        assert!(triangle.is_in_circumcircle(&coord! {x: 20., y: 10.}));
+        assert!(!triangle.is_in_circumcircle(&coord! {x: 10., y: 30.}));
+    }
+
+    #[test]
+    fn test_get_circumcircle() {
+        let triangle = DelaunayTriangle(Triangle::new(
+            coord! {x: 10., y: 10.},
+            coord! {x: 20., y: 20.},
+            coord! {x: 30., y: 10.},
+        ));
+
+        let circle_center = triangle.get_circumcircle_center().unwrap();
+        approx::assert_relative_eq!(circle_center, coord! {x: 20., y: 10.});
+    }
+
+    #[test]
+    fn test_get_circumcircle_collinear_points() {
+        let triangle = DelaunayTriangle(Triangle::new(
+            coord! {x: 10., y: 10.},
+            coord! {x: 20., y: 20.},
+            coord! {x: 30., y: 30.},
+        ));
+
+        // The circumcircle for collinear points cannot be
+        // determined as the radius would be infinite
+        triangle
+            .get_circumcircle_center()
+            .expect_err("Cannot compute circumcircle");
+    }
+
+    #[test]
+    fn test_get_super_triangle() {
+        let points: Polygon = Polygon::new(
+            LineString::from(vec![(0., 0.), (1., 0.), (1., 1.), (0., 1.)]),
+            vec![],
+        );
+
+        let super_tri = create_super_triangle(&points).unwrap();
+        assert!(super_tri.contains(&points));
+    }
+
+    #[test]
+    fn test_add_point() {
+        // Create a super triangle
+        let mut triangles = vec![DelaunayTriangle(Triangle::new(
+            coord! {x: -20., y: 0.},
+            coord! {x: 21., y: -20.},
+            coord! {x: 21., y: 21.},
+        ))];
+
+        let expected_result = vec![
+            DelaunayTriangle(Triangle::new(
+                coord! {x: -20., y: 0.},
+                coord! {x: 21., y: -20.},
+                coord! {x: 0., y: 0.},
+            )),
+            DelaunayTriangle(Triangle::new(
+                coord! {x: 21., y: -20.},
+                coord! {x: 21., y: 21.},
+                coord! {x: 0., y: 0.},
+            )),
+            DelaunayTriangle(Triangle::new(
+                coord! {x: 21., y: 21.},
+                coord! {x: -20., y: 0.},
+                coord! {x: 0., y: 0.},
+            )),
+        ];
+
+        add_coordinate(&mut triangles, &coord! {x: 0., y: 0.});
+
+        assert_eq!(expected_result, triangles);
+    }
+
+    // Execute the geos tests
+
+    // https://github.com/libgeos/geos/blob/d51982c6da5b7adb63ca0933ae7b53828cc8d72e/tests/unit/triangulate/DelaunayTest.cpp#L113
+    #[test]
+    fn test_triangle() {
+        let points = MultiPoint::new(vec![
+            Point::new(10., 10.),
+            Point::new(10., 20.),
+            Point::new(20., 20.),
+        ]);
+
+        let expected_triangle = vec![Triangle::new(
+            coord! {x: 10.0, y: 20.},
+            coord! {x: 10.0, y: 10.},
+            coord! {x: 20.0, y: 20.},
+        )];
+
+        assert_eq!(points.delaunay_triangulation().unwrap(), expected_triangle);
+    }
+
+    // https://github.com/libgeos/geos/blob/d51982c6da5b7adb63ca0933ae7b53828cc8d72e/tests/unit/triangulate/DelaunayTest.cpp#L127
+    #[test]
+    fn test_random() {
+        let points = MultiPoint::new(vec![
+            Point::new(50., 40.),
+            Point::new(140., 70.),
+            Point::new(80., 100.),
+            Point::new(130., 140.),
+            Point::new(30., 150.),
+            Point::new(70., 180.),
+            Point::new(190., 110.),
+            Point::new(120., 20.),
+        ]);
+
+        let expected_triangles = vec![
+            Triangle::new(
+                coord! {x: 50.0, y: 40.},
+                coord! {x: 80.0, y: 100.},
+                coord! {x: 30.0, y: 150.},
+            ),
+            Triangle::new(
+                coord! {x: 30.0, y: 150.},
+                coord! {x: 80.0, y: 100.},
+                coord! {x: 70.0, y: 180.},
+            ),
+            Triangle::new(
+                coord! {x: 80.0, y: 100.},
+                coord! {x: 130.0, y: 140.},
+                coord! {x: 70.0, y: 180.},
+            ),
+            Triangle::new(
+                coord! {x: 70.0, y: 180.},
+                coord! {x: 130.0, y: 140.},
+                coord! {x: 190.0, y: 110.},
+            ),
+            Triangle::new(
+                coord! {x: 130.0, y: 140.},
+                coord! {x: 140.0, y: 70.},
+                coord! {x: 190.0, y: 110.},
+            ),
+            Triangle::new(
+                coord! {x: 190.0, y: 110.},
+                coord! {x: 140.0, y: 70.},
+                coord! {x: 120.0, y: 20.},
+            ),
+            Triangle::new(
+                coord! {x: 140.0, y: 70.},
+                coord! {x: 80.0, y: 100.},
+                coord! {x: 120.0, y: 20.},
+            ),
+            Triangle::new(
+                coord! {x: 80.0, y: 100.},
+                coord! {x: 50.0, y: 40.},
+                coord! {x: 120.0, y: 20.},
+            ),
+            Triangle::new(
+                coord! {x: 80.0, y: 100.},
+                coord! {x: 140.0, y: 70.},
+                coord! {x: 130.0, y: 140.},
+            ),
+        ];
+
+        let delaunay_triangles = points.delaunay_triangulation().unwrap();
+
+        assert_eq!(delaunay_triangles.len(), expected_triangles.len());
+        for tri in delaunay_triangles.iter() {
+            assert!(expected_triangles.contains(tri));
+        }
+    }
+
+    // Test grid
+    // https://github.com/libgeos/geos/blob/d51982c6da5b7adb63ca0933ae7b53828cc8d72e/tests/unit/triangulate/DelaunayTest.cpp#L143
+    #[test]
+    fn test_grid() {
+        let points = MultiPoint::new(vec![
+            Point::new(10., 10.),
+            Point::new(10., 20.),
+            Point::new(20., 20.),
+            Point::new(20., 10.),
+            Point::new(10., 0.),
+            Point::new(0., 0.),
+            Point::new(0., 10.),
+            Point::new(0., 20.),
+        ]);
+
+        let expected_triangles = vec![
+            Triangle::new(
+                coord! {x: 0.0, y: 0.},
+                coord! {x: 10.0, y: 10.},
+                coord! {x: 0.0, y: 10.},
+            ),
+            Triangle::new(
+                coord! {x: 10.0, y: 0.},
+                coord! {x: 10.0, y: 10.},
+                coord! {x: 0.0, y: 0.},
+            ),
+            Triangle::new(
+                coord! {x: 0.0, y: 10.},
+                coord! {x: 10.0, y: 20.},
+                coord! {x: 0.0, y: 20.},
+            ),
+            Triangle::new(
+                coord! {x: 10.0, y: 10.},
+                coord! {x: 10.0, y: 20.},
+                coord! {x: 0.0, y: 10.},
+            ),
+            Triangle::new(
+                coord! {x: 10.0, y: 20.},
+                coord! {x: 10.0, y: 10.},
+                coord! {x: 20.0, y: 20.},
+            ),
+            Triangle::new(
+                coord! {x: 20.0, y: 20.},
+                coord! {x: 10.0, y: 10.},
+                coord! {x: 20.0, y: 10.},
+            ),
+            Triangle::new(
+                coord! {x: 20.0, y: 10.},
+                coord! {x: 10.0, y: 10.},
+                coord! {x: 10.0, y: 0.},
+            ),
+        ];
+
+        let delaunay_triangles = points.delaunay_triangulation().unwrap();
+
+        assert_eq!(delaunay_triangles.len(), expected_triangles.len());
+        for tri in delaunay_triangles.iter() {
+            assert!(expected_triangles.contains(tri));
+        }
+    }
+}

--- a/geo/src/algorithm/triangulate_spade.rs
+++ b/geo/src/algorithm/triangulate_spade.rs
@@ -1,0 +1,782 @@
+use geo_types::{Coord, Line, Point, Triangle};
+use spade::{
+    ConstrainedDelaunayTriangulation, DelaunayTriangulation, Point2, SpadeNum, Triangulation,
+};
+
+use crate::{
+    line_intersection::line_intersection, CoordsIter, EuclideanDistance, GeoFloat,
+    LineIntersection, LinesIter,
+};
+use crate::{Centroid, Contains};
+
+// ======== Config ============
+
+/// Collection of parameters that influence the precision of the algorithm in some sense (see
+/// explanations on fields of this struct)
+///
+/// This implements the `Default` trait and you can just use it most of the time
+#[derive(Debug, Clone)]
+pub struct SpadeTriangulationConfig<T: SpadeTriangulationFloat> {
+    /// Coordinates within this radius are snapped to the same position. For any two `Coords` there's
+    /// no real way to influence the decision when choosing the snapper and the snappee
+    snap_radius: T,
+}
+
+impl<T> Default for SpadeTriangulationConfig<T>
+where
+    T: SpadeTriangulationFloat,
+{
+    fn default() -> Self {
+        Self {
+            snap_radius: <T as std::convert::From<f32>>::from(0.000_1),
+        }
+    }
+}
+
+// ====== Error ========
+
+#[derive(Debug)]
+pub enum TriangulationError {
+    SpadeError(spade::InsertionError),
+    LoopTrap,
+    ConstraintFailure,
+}
+
+impl std::fmt::Display for TriangulationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl std::error::Error for TriangulationError {}
+
+pub type TriangulationResult<T> = Result<T, TriangulationError>;
+
+// ======= Float trait ========
+
+pub trait SpadeTriangulationFloat: GeoFloat + SpadeNum {}
+impl<T: GeoFloat + SpadeNum> SpadeTriangulationFloat for T {}
+
+// ======= Triangulation trait =========
+
+pub type Triangles<T> = Vec<Triangle<T>>;
+
+// seal the trait that needs to be implemented for TriangulateSpade to be implemented. This is done
+// so that we don't leak these weird methods on the public interface.
+mod private {
+    use super::*;
+    pub trait TriangulationRequirementTrait<'a, T>
+    where
+        T: SpadeTriangulationFloat,
+    {
+        /// collect all the lines that are relevant for triangulations from the geometric object that
+        /// should be triangulated.
+        ///
+        /// intersecting lines are allowed
+        fn lines(&'a self) -> Vec<Line<T>>;
+        /// collect all the coords that are relevant for triangulations from the geometric object that
+        /// should be triangulated
+        fn coords(&'a self) -> Vec<Coord<T>>;
+        /// define a predicate that decides if a point is inside of the object (used for constrained triangulation)
+        fn contains_point(&'a self, p: Point<T>) -> bool;
+
+        // processing of the lines that prepare the lines for triangulation.
+        //
+        // `spade` has the general limitation that constraint lines cannot intersect or else it
+        // will panic. This is why we need to manually split up the lines into smaller parts at the
+        // intersection point
+        //
+        // there's also a preprocessing step which tries to minimize the risk of failure of the algo
+        // through edge cases (thin/flat triangles are prevented as much as possible & lines are deduped, ...)
+        fn cleanup_lines(lines: Vec<Line<T>>, snap_radius: T) -> TriangulationResult<Vec<Line<T>>> {
+            let (known_coords, lines) = preprocess_lines(lines, snap_radius);
+            prepare_intersection_contraint(lines, known_coords, snap_radius)
+        }
+    }
+}
+
+/// Triangulate polygons using a [Delaunay
+/// Triangulation](https://en.wikipedia.org/wiki/Delaunay_triangulation)
+///
+/// This trait contains both constrained and unconstrained triangulation methods. To read more
+/// about the differences of these methods also consult [this
+/// page](https://en.wikipedia.org/wiki/Constrained_Delaunay_triangulation)
+pub trait TriangulateSpade<'a, T>: private::TriangulationRequirementTrait<'a, T>
+where
+    T: SpadeTriangulationFloat,
+{
+    /// returns a triangulation that's solely based on the points of the geometric object
+    ///
+    /// The triangulation is guaranteed to be Delaunay
+    ///
+    /// Note that the lines of the triangulation don't necessarily follow the lines of the input
+    /// geometry. If you wish to achieve that take a look at the `constrained_triangulation` and the
+    /// `constrained_outer_triangulation` functions.
+    ///
+    /// ```rust
+    /// use geo::TriangulateSpade;
+    /// use geo::{Polygon, LineString, Coord};
+    /// let u_shape = Polygon::new(
+    ///     LineString::new(vec![
+    ///         Coord { x: 0.0, y: 0.0 },
+    ///         Coord { x: 1.0, y: 0.0 },
+    ///         Coord { x: 1.0, y: 1.0 },
+    ///         Coord { x: 2.0, y: 1.0 },
+    ///         Coord { x: 2.0, y: 0.0 },
+    ///         Coord { x: 3.0, y: 0.0 },
+    ///         Coord { x: 3.0, y: 3.0 },
+    ///         Coord { x: 0.0, y: 3.0 },
+    ///     ]),
+    ///     vec![],
+    /// );
+    /// let unconstrained_triangulation = u_shape.unconstrained_triangulation().unwrap();
+    /// let num_triangles = unconstrained_triangulation.len();
+    /// assert_eq!(num_triangles, 8);
+    /// ```
+    ///
+    fn unconstrained_triangulation(&'a self) -> TriangulationResult<Triangles<T>> {
+        let points = self.coords();
+        points
+            .into_iter()
+            .map(to_spade_point)
+            .try_fold(DelaunayTriangulation::<Point2<T>>::new(), |mut tris, p| {
+                tris.insert(p).map_err(TriangulationError::SpadeError)?;
+                Ok(tris)
+            })
+            .map(triangulation_to_triangles)
+    }
+
+    /// returns triangulation that's based on the points of the geometric object and also
+    /// incorporates the lines of the input geometry
+    ///
+    /// The triangulation is not guaranteed to be Delaunay because of the constraint lines
+    ///
+    /// This outer triangulation also contains triangles that are not included in the input
+    /// geometry if it wasn't convex. Here's an example:
+    ///
+    /// ```text
+    /// ┌──────────────────┐
+    /// │\              __/│
+    /// │ \          __/ / │
+    /// │  \      __/   /  │
+    /// │   \  __/     /   │
+    /// │    \/       /    │
+    /// │     ┌──────┐     │
+    /// │    /│\:::::│\    │
+    /// │   / │:\::::│ \   │
+    /// │  /  │::\:::│  \  │
+    /// │ /   │:::\::│   \ │
+    /// │/    │::::\:│    \│
+    /// └─────┘______└─────┘
+    /// ```
+    ///
+    /// ```rust
+    /// use geo::TriangulateSpade;
+    /// use geo::{Polygon, LineString, Coord};
+    /// let u_shape = Polygon::new(
+    ///     LineString::new(vec![
+    ///         Coord { x: 0.0, y: 0.0 },
+    ///         Coord { x: 1.0, y: 0.0 },
+    ///         Coord { x: 1.0, y: 1.0 },
+    ///         Coord { x: 2.0, y: 1.0 },
+    ///         Coord { x: 2.0, y: 0.0 },
+    ///         Coord { x: 3.0, y: 0.0 },
+    ///         Coord { x: 3.0, y: 3.0 },
+    ///         Coord { x: 0.0, y: 3.0 },
+    ///     ]),
+    ///     vec![],
+    /// );
+    /// // we use the default [`SpadeTriangulationConfig`] here
+    /// let constrained_outer_triangulation =
+    /// u_shape.constrained_outer_triangulation(Default::default()).unwrap();
+    /// let num_triangles = constrained_outer_triangulation.len();
+    /// assert_eq!(num_triangles, 8);
+    /// ```
+    ///
+    /// The outer triangulation of the top down U-shape contains extra triangles marked
+    /// with ":". If you want to exclude those, take a look at `constrained_triangulation`
+    fn constrained_outer_triangulation(
+        &'a self,
+        config: SpadeTriangulationConfig<T>,
+    ) -> TriangulationResult<Triangles<T>> {
+        let lines = self.lines();
+        let lines = Self::cleanup_lines(lines, config.snap_radius)?;
+        lines
+            .into_iter()
+            .map(to_spade_line)
+            .try_fold(
+                ConstrainedDelaunayTriangulation::<Point2<T>>::new(),
+                |mut cdt, [start, end]| {
+                    let start = cdt.insert(start).map_err(TriangulationError::SpadeError)?;
+                    let end = cdt.insert(end).map_err(TriangulationError::SpadeError)?;
+                    // safety check (to prevent panic) whether we can add the line
+                    if !cdt.can_add_constraint(start, end) {
+                        return Err(TriangulationError::ConstraintFailure);
+                    }
+                    cdt.add_constraint(start, end);
+                    Ok(cdt)
+                },
+            )
+            .map(triangulation_to_triangles)
+    }
+
+    /// returns triangulation that's based on the points of the geometric object and also
+    /// incorporates the lines of the input geometry
+    ///
+    /// The triangulation is not guaranteed to be Delaunay because of the constraint lines
+    ///
+    /// This triangulation only contains triangles that are included in the input geometry.
+    /// Here's an example:
+    ///
+    /// ```text
+    /// ┌──────────────────┐
+    /// │\              __/│
+    /// │ \          __/ / │
+    /// │  \      __/   /  │
+    /// │   \  __/     /   │
+    /// │    \/       /    │
+    /// │     ┌──────┐     │
+    /// │    /│      │\    │
+    /// │   / │      │ \   │
+    /// │  /  │      │  \  │
+    /// │ /   │      │   \ │
+    /// │/    │      │    \│
+    /// └─────┘      └─────┘
+    /// ```
+    ///
+    /// ```rust
+    /// use geo::TriangulateSpade;
+    /// use geo::{Polygon, LineString, Coord};
+    /// let u_shape = Polygon::new(
+    ///     LineString::new(vec![
+    ///         Coord { x: 0.0, y: 0.0 },
+    ///         Coord { x: 1.0, y: 0.0 },
+    ///         Coord { x: 1.0, y: 1.0 },
+    ///         Coord { x: 2.0, y: 1.0 },
+    ///         Coord { x: 2.0, y: 0.0 },
+    ///         Coord { x: 3.0, y: 0.0 },
+    ///         Coord { x: 3.0, y: 3.0 },
+    ///         Coord { x: 0.0, y: 3.0 },
+    ///     ]),
+    ///     vec![],
+    /// );
+    /// // we use the default [`SpadeTriangulationConfig`] here
+    /// let constrained_triangulation = u_shape.constrained_triangulation(Default::default()).unwrap();
+    /// let num_triangles = constrained_triangulation.len();
+    /// assert_eq!(num_triangles, 6);
+    /// ```
+    ///
+    /// Compared to the `constrained_outer_triangulation` it only includes the triangles
+    /// inside of the input geometry
+    fn constrained_triangulation(
+        &'a self,
+        config: SpadeTriangulationConfig<T>,
+    ) -> TriangulationResult<Triangles<T>> {
+        self.constrained_outer_triangulation(config)
+            .map(|triangles| {
+                triangles
+                    .into_iter()
+                    .filter(|triangle| {
+                        let center = triangle.centroid();
+                        self.contains_point(center)
+                    })
+                    .collect::<Vec<_>>()
+            })
+    }
+}
+
+/// conversion from spade triangulation back to geo triangles
+fn triangulation_to_triangles<T, F>(triangulation: T) -> Triangles<F>
+where
+    T: Triangulation<Vertex = Point2<F>>,
+    F: SpadeTriangulationFloat,
+{
+    triangulation
+        .inner_faces()
+        .map(|face| face.positions())
+        .map(|points| points.map(|p| Coord::<F> { x: p.x, y: p.y }))
+        .map(Triangle::from)
+        .collect::<Vec<_>>()
+}
+
+// ========== Triangulation trait impls ============
+
+// everything that satisfies the requirement methods automatically implements the triangulation
+impl<'a, T, G> TriangulateSpade<'a, T> for G
+where
+    T: SpadeTriangulationFloat,
+    G: private::TriangulationRequirementTrait<'a, T>,
+{
+}
+
+impl<'a, 'l, T, G> private::TriangulationRequirementTrait<'a, T> for G
+where
+    'a: 'l,
+    T: SpadeTriangulationFloat,
+    G: LinesIter<'l, Scalar = T> + CoordsIter<Scalar = T> + Contains<Point<T>>,
+{
+    fn coords(&'a self) -> Vec<Coord<T>> {
+        self.coords_iter().collect::<Vec<_>>()
+    }
+
+    fn lines(&'a self) -> Vec<Line<T>> {
+        self.lines_iter().collect()
+    }
+
+    fn contains_point(&'a self, p: Point<T>) -> bool {
+        self.contains(&p)
+    }
+}
+
+// it would be cool to impl the trait for GS: AsRef<[G]> but I wasn't able to get this to compile
+// (yet)
+
+impl<'a, T, G> private::TriangulationRequirementTrait<'a, T> for Vec<G>
+where
+    T: SpadeTriangulationFloat,
+    G: TriangulateSpade<'a, T>,
+{
+    fn coords(&'a self) -> Vec<Coord<T>> {
+        self.iter().flat_map(|g| g.coords()).collect::<Vec<_>>()
+    }
+
+    fn lines(&'a self) -> Vec<Line<T>> {
+        self.iter().flat_map(|g| g.lines()).collect::<Vec<_>>()
+    }
+
+    fn contains_point(&'a self, p: Point<T>) -> bool {
+        self.iter().any(|g| g.contains_point(p))
+    }
+}
+
+impl<'a, T, G> private::TriangulationRequirementTrait<'a, T> for &[G]
+where
+    T: SpadeTriangulationFloat,
+    G: TriangulateSpade<'a, T>,
+{
+    fn coords(&'a self) -> Vec<Coord<T>> {
+        self.iter().flat_map(|g| g.coords()).collect::<Vec<_>>()
+    }
+
+    fn lines(&'a self) -> Vec<Line<T>> {
+        self.iter().flat_map(|g| g.lines()).collect::<Vec<_>>()
+    }
+
+    fn contains_point(&'a self, p: Point<T>) -> bool {
+        self.iter().any(|g| g.contains_point(p))
+    }
+}
+
+// ========== Triangulation trait impl helpers ============
+
+fn prepare_intersection_contraint<T: SpadeTriangulationFloat>(
+    mut lines: Vec<Line<T>>,
+    mut known_points: Vec<Coord<T>>,
+    snap_radius: T,
+) -> Result<Vec<Line<T>>, TriangulationError> {
+    // Rule 2 of "Power of 10" rules (NASA)
+    // safety net. We can't prove that the `while let` loop isn't going to run infinitely, so
+    // we abort after a fixed amount of iterations. In case that the iteration seems to loop
+    // indefinitely this check will return an Error indicating the infinite loop.
+    let mut loop_count = 1000;
+    let mut loop_check = || {
+        loop_count -= 1;
+        (loop_count != 0)
+            .then_some(())
+            .ok_or(TriangulationError::LoopTrap)
+    };
+
+    while let Some((indices, intersection)) = {
+        let mut iter = iter_line_pairs(&lines);
+        iter.find_map(find_intersecting_lines_fn)
+    } {
+        loop_check()?;
+        let [l0, l1] = remove_lines_by_index(indices, &mut lines);
+        let new_lines = split_lines([l0, l1], intersection);
+        let new_lines = cleanup_filter_lines(new_lines, &lines, &mut known_points, snap_radius);
+
+        lines.extend(new_lines);
+    }
+
+    Ok(lines)
+}
+
+/// iterates over all combinations (a,b) of lines in a vector where a != b
+fn iter_line_pairs<T: SpadeTriangulationFloat>(
+    lines: &[Line<T>],
+) -> impl Iterator<Item = [(usize, &Line<T>); 2]> {
+    lines.iter().enumerate().flat_map(|(idx0, line0)| {
+        lines
+            .iter()
+            .enumerate()
+            .filter(move |(idx1, line1)| *idx1 != idx0 && line0 != *line1)
+            .map(move |(idx1, line1)| [(idx0, line0), (idx1, line1)])
+    })
+}
+
+/// checks whether two lines are intersecting and if so, checks the intersection to not be ill
+/// formed
+///
+/// returns
+/// - [usize;2] : sorted indexes of lines, smaller one comes first
+/// - intersection : type of intersection
+fn find_intersecting_lines_fn<T: SpadeTriangulationFloat>(
+    [(idx0, line0), (idx1, line1)]: [(usize, &Line<T>); 2],
+) -> Option<([usize; 2], LineIntersection<T>)> {
+    line_intersection(*line0, *line1)
+        .filter(|intersection| {
+            match intersection {
+                // intersection is not located in both lines
+                LineIntersection::SinglePoint { is_proper, .. } if !is_proper => false,
+                // collinear intersection is length zero line
+                LineIntersection::Collinear { intersection }
+                    if intersection.start == intersection.end =>
+                {
+                    false
+                }
+                _ => true,
+            }
+        })
+        .map(|intersection| ([idx0, idx1], intersection))
+}
+
+/// removes two lines by index in a safe way since the second index can be invalidated after
+/// the first line was removed (remember `.remove(idx)` returns the element and shifts the tail
+/// of the vector in direction of its start to close the gap)
+fn remove_lines_by_index<T: SpadeTriangulationFloat>(
+    mut indices: [usize; 2],
+    lines: &mut Vec<Line<T>>,
+) -> [Line<T>; 2] {
+    indices.sort();
+    let [idx0, idx1] = indices;
+    let l1 = lines.remove(idx1);
+    let l0 = lines.remove(idx0);
+    [l0, l1]
+}
+
+/// split lines based on intersection kind:
+///
+/// - intersection point: create 4 new lines from the existing line's endpoints to the intersection
+/// point
+/// - collinear: create 3 new lines (before overlap, overlap, after overlap)
+fn split_lines<T: SpadeTriangulationFloat>(
+    [l0, l1]: [Line<T>; 2],
+    intersection: LineIntersection<T>,
+) -> Vec<Line<T>> {
+    match intersection {
+        LineIntersection::SinglePoint { intersection, .. } => [
+            (l0.start, intersection),
+            (l0.end, intersection),
+            (l1.start, intersection),
+            (l1.end, intersection),
+        ]
+        .map(|(a, b)| Line::new(a, b))
+        .to_vec(),
+        LineIntersection::Collinear { .. } => {
+            let mut points = [l0.start, l0.end, l1.start, l1.end];
+            // sort points by their coordinate values to resolve ambiguities
+            points.sort_by(|a, b| {
+                a.x.partial_cmp(&b.x)
+                    .expect("sorting points by coordinate x failed")
+                    .then_with(|| {
+                        a.y.partial_cmp(&b.y)
+                            .expect("sorting points by coordinate y failed")
+                    })
+            });
+            // since all points are on one line we can just create new lines from consecutive
+            // points after sorting
+            points
+                .windows(2)
+                .map(|win| Line::new(win[0], win[1]))
+                .collect::<Vec<_>>()
+        }
+    }
+}
+
+/// new lines from the `split_lines` function may contain a variety of ill formed lines, this
+/// function cleans all of these cases up
+fn cleanup_filter_lines<T: SpadeTriangulationFloat>(
+    lines_need_check: Vec<Line<T>>,
+    existing_lines: &[Line<T>],
+    known_points: &mut Vec<Coord<T>>,
+    snap_radius: T,
+) -> Vec<Line<T>> {
+    lines_need_check
+        .into_iter()
+        .map(|mut line| {
+            line.start = snap_or_register_point(line.start, known_points, snap_radius);
+            line.end = snap_or_register_point(line.end, known_points, snap_radius);
+            line
+        })
+        .filter(|l| l.start != l.end)
+        .filter(|l| !existing_lines.contains(l))
+        .filter(|l| !existing_lines.contains(&Line::new(l.end, l.start)))
+        .collect::<Vec<_>>()
+}
+
+/// snap point to the nearest existing point if it's close enough
+///
+/// snap_radius can be configured via the third parameter of this function
+fn snap_or_register_point<T: SpadeTriangulationFloat>(
+    point: Coord<T>,
+    known_points: &mut Vec<Coord<T>>,
+    snap_radius: T,
+) -> Coord<T> {
+    known_points
+        .iter()
+        // find closest
+        .min_by(|a, b| {
+            a.euclidean_distance(&point)
+                .partial_cmp(&b.euclidean_distance(&point))
+                .expect("Couldn't compare coordinate distances")
+        })
+        // only snap if closest is within epsilone range
+        .filter(|nearest_point| nearest_point.euclidean_distance(&point) < snap_radius)
+        .cloned()
+        // otherwise register and use input point
+        .unwrap_or_else(|| {
+            known_points.push(point);
+            point
+        })
+}
+
+/// preprocesses lines so that we're less likely to hit issues when using the spade triangulation
+fn preprocess_lines<T: SpadeTriangulationFloat>(
+    lines: Vec<Line<T>>,
+    snap_radius: T,
+) -> (Vec<Coord<T>>, Vec<Line<T>>) {
+    let mut known_coords: Vec<Coord<T>> = vec![];
+    let capacity = lines.len();
+    let lines = lines
+        .into_iter()
+        .fold(Vec::with_capacity(capacity), |mut lines, mut line| {
+            // deduplicating:
+
+            // 1. snap coords of lines to existing coords
+            line.start = snap_or_register_point(line.start, &mut known_coords, snap_radius);
+            line.end = snap_or_register_point(line.end, &mut known_coords, snap_radius);
+            if
+            // 2. make sure line isn't degenerate (no length when start == end)
+            line.start != line.end
+                // 3. make sure line or flipped line wasn't already added
+                && !lines.contains(&line)
+                && !lines.contains(&Line::new(line.end, line.start))
+            {
+                lines.push(line)
+            }
+
+            lines
+        });
+    (known_coords, lines)
+}
+
+/// converts Line to something somewhat similar in the spade world
+fn to_spade_line<T: SpadeTriangulationFloat>(line: Line<T>) -> [Point2<T>; 2] {
+    [to_spade_point(line.start), to_spade_point(line.end)]
+}
+
+/// converts Coord to something somewhat similar in the spade world
+fn to_spade_point<T: SpadeTriangulationFloat>(coord: Coord<T>) -> Point2<T> {
+    Point2::new(coord.x, coord.y)
+}
+
+#[cfg(test)]
+mod spade_triangulation {
+    use super::*;
+    use geo_types::*;
+
+    fn assert_num_triangles<T: SpadeTriangulationFloat>(
+        triangulation: &TriangulationResult<Triangles<T>>,
+        num: usize,
+    ) {
+        assert_eq!(
+            triangulation
+                .as_ref()
+                .map(|tris| tris.len())
+                .expect("triangulation success"),
+            num
+        )
+    }
+
+    #[test]
+    fn basic_triangle_triangulates() {
+        let triangulation = Triangle::new(
+            Coord { x: 0.0, y: 0.0 },
+            Coord { x: 1.0, y: 0.0 },
+            Coord { x: 0.0, y: 1.0 },
+        )
+        .unconstrained_triangulation();
+
+        assert_num_triangles(&triangulation, 1);
+    }
+
+    #[test]
+    fn basic_rectangle_triangulates() {
+        let triangulation = Rect::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 1.0, y: 1.0 })
+            .unconstrained_triangulation();
+
+        assert_num_triangles(&triangulation, 2);
+    }
+
+    #[test]
+    fn basic_polygon_triangulates() {
+        let triangulation = Polygon::new(
+            LineString::new(vec![
+                Coord { x: 0.0, y: 1.0 },
+                Coord { x: -1.0, y: 0.0 },
+                Coord { x: -0.5, y: -1.0 },
+                Coord { x: 0.5, y: -1.0 },
+                Coord { x: 1.0, y: 0.0 },
+            ]),
+            vec![],
+        )
+        .unconstrained_triangulation();
+
+        assert_num_triangles(&triangulation, 3);
+    }
+
+    #[test]
+    fn overlapping_triangles_triangulate_unconstrained() {
+        let triangles = vec![
+            Triangle::new(
+                Coord { x: 0.0, y: 0.0 },
+                Coord { x: 2.0, y: 0.0 },
+                Coord { x: 0.0, y: 2.0 },
+            ),
+            Triangle::new(
+                Coord { x: 1.0, y: 1.0 },
+                Coord { x: -1.0, y: 1.0 },
+                Coord { x: 1.0, y: -1.0 },
+            ),
+        ];
+
+        let unconstrained_triangulation = triangles.unconstrained_triangulation();
+        assert_num_triangles(&unconstrained_triangulation, 4);
+    }
+
+    #[test]
+    fn overlapping_triangles_triangulate_constrained_outer() {
+        let triangles = vec![
+            Triangle::new(
+                Coord { x: 0.0, y: 0.0 },
+                Coord { x: 2.0, y: 0.0 },
+                Coord { x: 0.0, y: 2.0 },
+            ),
+            Triangle::new(
+                Coord { x: 1.0, y: 1.0 },
+                Coord { x: -1.0, y: 1.0 },
+                Coord { x: 1.0, y: -1.0 },
+            ),
+        ];
+
+        let constrained_outer_triangulation =
+            triangles.constrained_outer_triangulation(Default::default());
+        assert_num_triangles(&constrained_outer_triangulation, 8);
+    }
+
+    #[test]
+    fn overlapping_triangles_triangulate_constrained() {
+        let triangles = vec![
+            Triangle::new(
+                Coord { x: 0.0, y: 0.0 },
+                Coord { x: 2.0, y: 0.0 },
+                Coord { x: 0.0, y: 2.0 },
+            ),
+            Triangle::new(
+                Coord { x: 1.0, y: 1.0 },
+                Coord { x: -1.0, y: 1.0 },
+                Coord { x: 1.0, y: -1.0 },
+            ),
+        ];
+
+        let constrained_outer_triangulation =
+            triangles.constrained_triangulation(Default::default());
+        assert_num_triangles(&constrained_outer_triangulation, 6);
+    }
+
+    #[test]
+    fn u_shaped_polygon_triangulates_unconstrained() {
+        let u_shape = Polygon::new(
+            LineString::new(vec![
+                Coord { x: 0.0, y: 0.0 },
+                Coord { x: 1.0, y: 0.0 },
+                Coord { x: 1.0, y: 1.0 },
+                Coord { x: 2.0, y: 1.0 },
+                Coord { x: 2.0, y: 0.0 },
+                Coord { x: 3.0, y: 0.0 },
+                Coord { x: 3.0, y: 3.0 },
+                Coord { x: 0.0, y: 3.0 },
+            ]),
+            vec![],
+        );
+
+        let unconstrained_triangulation = u_shape.unconstrained_triangulation();
+        assert_num_triangles(&unconstrained_triangulation, 8);
+    }
+
+    #[test]
+    fn u_shaped_polygon_triangulates_constrained_outer() {
+        let u_shape = Polygon::new(
+            LineString::new(vec![
+                Coord { x: 0.0, y: 0.0 },
+                Coord { x: 1.0, y: 0.0 },
+                Coord { x: 1.0, y: 1.0 },
+                Coord { x: 2.0, y: 1.0 },
+                Coord { x: 2.0, y: 0.0 },
+                Coord { x: 3.0, y: 0.0 },
+                Coord { x: 3.0, y: 3.0 },
+                Coord { x: 0.0, y: 3.0 },
+            ]),
+            vec![],
+        );
+
+        let constrained_outer_triangulation =
+            u_shape.constrained_outer_triangulation(Default::default());
+        assert_num_triangles(&constrained_outer_triangulation, 8);
+    }
+
+    #[test]
+    fn u_shaped_polygon_triangulates_constrained_inner() {
+        let u_shape = Polygon::new(
+            LineString::new(vec![
+                Coord { x: 0.0, y: 0.0 },
+                Coord { x: 1.0, y: 0.0 },
+                Coord { x: 1.0, y: 1.0 },
+                Coord { x: 2.0, y: 1.0 },
+                Coord { x: 2.0, y: 0.0 },
+                Coord { x: 3.0, y: 0.0 },
+                Coord { x: 3.0, y: 3.0 },
+                Coord { x: 0.0, y: 3.0 },
+            ]),
+            vec![],
+        );
+
+        let constrained_triangulation = u_shape.constrained_triangulation(Default::default());
+        assert_num_triangles(&constrained_triangulation, 6);
+    }
+
+    #[test]
+    fn various_snap_radius_works() {
+        let u_shape = Polygon::new(
+            LineString::new(vec![
+                Coord { x: 0.0, y: 0.0 },
+                Coord { x: 1.0, y: 0.0 },
+                Coord { x: 1.0, y: 1.0 },
+                Coord { x: 2.0, y: 1.0 },
+                Coord { x: 2.0, y: 0.0 },
+                Coord { x: 3.0, y: 0.0 },
+                Coord { x: 3.0, y: 3.0 },
+                Coord { x: 0.0, y: 3.0 },
+            ]),
+            vec![],
+        );
+
+        for snap_with in (1..6).map(|pow| 0.1_f64.powi(pow)) {
+            let constrained_triangulation =
+                u_shape.constrained_triangulation(SpadeTriangulationConfig {
+                    snap_radius: snap_with,
+                });
+            assert_num_triangles(&constrained_triangulation, 6);
+        }
+    }
+}

--- a/geo/src/algorithm/voronoi_diagram.rs
+++ b/geo/src/algorithm/voronoi_diagram.rs
@@ -1,0 +1,989 @@
+use std::{fmt, result};
+
+use crate::{coord, Coord, GeoFloat, Line, MultiPoint, Point, Polygon, Rect, Triangle};
+
+use crate::triangulate_delaunay::{
+    DelaunayTriangle, DelaunayTriangulationError, DEFAULT_SUPER_TRIANGLE_EXPANSION,
+};
+use crate::{BoundingRect, TriangulateDelaunay};
+
+type Result<T> = result::Result<T, VoronoiDiagramError>;
+
+#[derive(Debug, Clone)]
+pub struct VoronoiComponents<T: GeoFloat> {
+    pub delaunay_triangles: Vec<Triangle<T>>,
+    pub vertices: Vec<Coord<T>>,
+    pub lines: Vec<Line<T>>,
+    pub neighbours: Vec<(Option<usize>, Option<usize>)>,
+}
+
+pub type ClippingMask<T> = Polygon<T>;
+
+pub trait VoronoiDiagram<T: GeoFloat>
+where
+    f64: From<T>,
+{
+    fn compute_voronoi_components(
+        &self,
+        clipping_mask: Option<&ClippingMask<T>>,
+    ) -> Result<VoronoiComponents<T>>;
+    fn compute_voronoi_diagram(
+        &self,
+        clipping_mask: Option<&ClippingMask<T>>,
+    ) -> Result<Vec<Polygon>>;
+}
+
+impl<T: GeoFloat> VoronoiDiagram<T> for Polygon<T>
+where
+    f64: From<T>,
+{
+    fn compute_voronoi_components(
+        &self,
+        clipping_mask: Option<&ClippingMask<T>>,
+    ) -> Result<VoronoiComponents<T>> {
+        compute_voronoi_components(self, clipping_mask)
+    }
+
+    fn compute_voronoi_diagram(
+        &self,
+        _clipping_mask: Option<&ClippingMask<T>>,
+    ) -> Result<Vec<Polygon>> {
+        todo!("Need to map the components to voronoi cells");
+    }
+}
+impl<T: GeoFloat> VoronoiDiagram<T> for MultiPoint<T>
+where
+    f64: From<T>,
+{
+    fn compute_voronoi_components(
+        &self,
+        clipping_mask: Option<&ClippingMask<T>>,
+    ) -> Result<VoronoiComponents<T>> {
+        compute_voronoi_components(self, clipping_mask)
+    }
+
+    fn compute_voronoi_diagram(
+        &self,
+        _clipping_mask: Option<&ClippingMask<T>>,
+    ) -> Result<Vec<Polygon>> {
+        todo!("Need to map the components to voronoi cells");
+    }
+}
+
+fn compute_voronoi_components<T: GeoFloat, U: TriangulateDelaunay<T>>(
+    polygon: &U,
+    clipping_mask: Option<&ClippingMask<T>>,
+) -> Result<VoronoiComponents<T>>
+where
+    f64: From<T>,
+{
+    let triangles = polygon
+        .delaunay_triangulation()
+        .map_err(VoronoiDiagramError::DelaunayError)?;
+
+    if triangles.is_empty() {
+        return Ok(VoronoiComponents {
+            delaunay_triangles: vec![],
+            vertices: vec![],
+            lines: vec![],
+            neighbours: vec![],
+        });
+    }
+
+    compute_voronoi_components_from_delaunay(&triangles, clipping_mask)
+}
+
+/// Compute the Voronoi Diagram from Delaunay Triangles.
+/// The Voronoi Diagram is a [dual graph](https://en.wikipedia.org/wiki/Dual_graph)
+/// of the [Delaunay Triangulation](https://en.wikipedia.org/wiki/Delaunay_triangulation)
+/// and thus the Voronoi Diagram can be created from the Delaunay Triangulation.
+pub fn compute_voronoi_components_from_delaunay<T: GeoFloat>(
+    triangles: &[Triangle<T>],
+    clipping_mask: Option<&Polygon<T>>,
+) -> Result<VoronoiComponents<T>>
+where
+    f64: From<T>,
+{
+    if triangles.is_empty() {
+        return Ok(VoronoiComponents {
+            delaunay_triangles: vec![],
+            vertices: vec![],
+            lines: vec![],
+            neighbours: vec![],
+        });
+    }
+
+    let clipping_mask = match clipping_mask {
+        Some(mask) => mask.to_owned(),
+        None => create_clipping_mask(triangles)?,
+    };
+
+    let delaunay_triangles: Vec<DelaunayTriangle<T>> =
+        triangles.iter().map(|x| (*x).into()).collect();
+
+    // The centres of the delaunay circumcircles form the vertices of the
+    // voronoi diagram
+    let mut vertices: Vec<Coord<T>> = Vec::new();
+    for tri in &delaunay_triangles {
+        vertices.push(
+            tri.get_circumcircle_center()
+                .map_err(VoronoiDiagramError::DelaunayError)?,
+        );
+    }
+
+    // Find the shared edges
+    let mut shared = find_shared_edges(&delaunay_triangles);
+
+    // Create the lines joining the vertices
+    let mut voronoi_lines: Vec<Line<T>> = Vec::new();
+    for neighbour in &shared.neighbours {
+        if let (Some(first_vertex), Some(second_vertex)) = (neighbour.0, neighbour.1) {
+            voronoi_lines.push(Line::new(vertices[first_vertex], vertices[second_vertex]));
+        }
+    }
+
+    voronoi_lines.extend(construct_edges_to_inf(
+        &delaunay_triangles,
+        &vertices,
+        &mut shared.shared_edges,
+        &shared.neighbours,
+        &clipping_mask,
+    )?);
+
+    Ok(VoronoiComponents {
+        delaunay_triangles: triangles.to_vec(),
+        vertices,
+        lines: voronoi_lines,
+        neighbours: shared.neighbours,
+    })
+}
+
+fn create_clipping_mask<T: GeoFloat>(triangles: &[Triangle<T>]) -> Result<Polygon<T>>
+where
+    f64: From<T>,
+{
+    let mut pts: Vec<Point<T>> = Vec::new();
+    for tri in triangles {
+        pts.extend(tri.to_array().iter().map(|x| Point::from(*x)));
+    }
+    let bounds = MultiPoint::new(pts)
+        .bounding_rect()
+        .ok_or(VoronoiDiagramError::CannotDetermineBoundsFromClipppingMask)?;
+
+    let expand_factor = T::from(DEFAULT_SUPER_TRIANGLE_EXPANSION)
+        .ok_or(VoronoiDiagramError::CannotConvertBetweenGeoGenerics)?;
+
+    let width = bounds.width() * expand_factor;
+    let height = bounds.height() * expand_factor;
+    let bounds_min = bounds.min();
+
+    Ok(Polygon::from(Rect::new(
+        coord! { x: bounds_min.x - width, y: bounds_min.y - height},
+        coord! { x: bounds_min.x + width, y: bounds_min.y + height},
+    )))
+}
+
+type Neighbor = (Option<usize>, Option<usize>);
+type Neighbors = Vec<Neighbor>;
+
+#[derive(Debug, Clone)]
+struct SharedEdgesData<T: GeoFloat> {
+    neighbours: Neighbors,
+    shared_edges: Vec<Line<T>>,
+}
+
+fn find_shared_edges<T: GeoFloat>(triangles: &[DelaunayTriangle<T>]) -> SharedEdgesData<T>
+where
+    f64: From<T>,
+{
+    let mut neighbours: Vec<(Option<usize>, Option<usize>)> = Vec::new();
+    let mut shared_edges: Vec<Line<T>> = Vec::new();
+
+    // Search the delaunay triangles for neighbour triangles and shared edges
+    for (tri_idx, tri) in triangles.iter().enumerate() {
+        for (other_idx, other_tri) in triangles.iter().enumerate() {
+            if tri_idx == other_idx {
+                continue;
+            }
+
+            if let Some(shared_edge) = tri.shares_edge(other_tri) {
+                if !neighbours.contains(&(Some(tri_idx), Some(other_idx)))
+                    && !neighbours.contains(&(Some(other_idx), Some(tri_idx)))
+                {
+                    neighbours.push((Some(tri_idx), Some(other_idx)));
+                }
+
+                let flipped_edge = Line::new(shared_edge.end, shared_edge.start);
+
+                if !shared_edges.contains(&shared_edge) && !shared_edges.contains(&flipped_edge) {
+                    shared_edges.push(shared_edge);
+                }
+            }
+        }
+    }
+
+    // For Voronoi diagrams, the triangles / circumcenters that are on the edge of the
+    // diagram require connections to infinity to ensure separation of points between
+    // voronoi cells. Voronoi cells on the borders can have 2 connections to infinity.
+    // These connections to infinity will be bounded later, for now add the connections from infinity.
+    let mut num_neighbours: Vec<usize> = triangles.iter().map(|_| 0).collect();
+    for x in &neighbours {
+        // unwrap here is safe as neighbours do not contain None values yet
+        for n in [x.0.unwrap(), x.1.unwrap()] {
+            num_neighbours[n] += 1;
+        }
+    }
+
+    num_neighbours.iter().enumerate().for_each(|(idx, val)| {
+        for _ in 0..3 - val {
+            neighbours.push((None, Some(idx)));
+        }
+    });
+
+    SharedEdgesData {
+        neighbours,
+        shared_edges,
+    }
+}
+
+fn get_perpendicular_line<T: GeoFloat>(line: &Line<T>) -> Result<Line<T>>
+where
+    f64: From<T>,
+{
+    let slope = f64::from(line.slope());
+
+    // Vertical line
+    if slope.is_infinite() {
+        Ok(Line::new(
+            coord! {x: line.start.x, y: line.start.y},
+            coord! {x: line.start.x - line.dy(), y: line.start.y},
+        ))
+    } else if slope == 0. {
+        Ok(Line::new(
+            coord! {x: line.start.x, y: line.start.y},
+            coord! {x: line.start.x, y: line.start.y + line.dx()},
+        ))
+    } else {
+        let midpoint = coord! {
+            x: f64::from(line.start.x) + f64::from(line.dx()) / 2.,
+            y: f64::from(line.start.y) + f64::from(line.dy()) / 2.,
+        };
+        // y = mx + b
+        let m = -1. / slope;
+        let b = m.mul_add(-midpoint.x, midpoint.y);
+        let x = midpoint.x + f64::from(line.dx());
+        let y = m.mul_add(x, b);
+
+        let end_x = T::from(x).ok_or(VoronoiDiagramError::CannotConvertBetweenGeoGenerics)?;
+        let end_y = T::from(y).ok_or(VoronoiDiagramError::CannotConvertBetweenGeoGenerics)?;
+        let start_x =
+            T::from(midpoint.x).ok_or(VoronoiDiagramError::CannotConvertBetweenGeoGenerics)?;
+        let start_y =
+            T::from(midpoint.y).ok_or(VoronoiDiagramError::CannotConvertBetweenGeoGenerics)?;
+        Ok(Line::new(
+            coord! {x: start_x, y: start_y},
+            coord! {x: end_x, y: end_y},
+        ))
+    }
+}
+
+#[derive(Debug, Clone)]
+enum GuidingDirection {
+    Left,
+    Right,
+    Up,
+    Down,
+}
+
+impl GuidingDirection {
+    // The common point is the end co-ordinate of both lines
+    fn from_midpoints<T: GeoFloat>(line_a: &Line<T>, line_b: &Line<T>) -> Self {
+        let dx_a = line_a.dx().is_sign_positive();
+        let dy_a = line_a.dy().is_sign_positive();
+        let dx_b = line_b.dx().is_sign_positive();
+        let dy_b = line_b.dy().is_sign_positive();
+
+        // In a triangle a midpoint must either be
+        // to the left or right of the other midpoints, or
+        // above of below the other midpoints
+        if (dx_a == dx_b) && dx_a {
+            Self::Right
+        } else if (dx_a == dx_b) && !dx_a {
+            Self::Left
+        } else if (dy_a == dy_b) && dy_a {
+            Self::Up
+        } else {
+            Self::Down
+        }
+    }
+}
+
+fn define_edge_to_infinity<T: GeoFloat>(
+    triangle: &DelaunayTriangle<T>,
+    circumcenter: &Coord<T>,
+    shared_edges: &mut Vec<Line<T>>,
+    clipping_mask: &Rect<T>,
+) -> Result<Option<Line<T>>>
+where
+    f64: From<T>,
+{
+    let two = T::from(2.).ok_or(VoronoiDiagramError::CannotConvertBetweenGeoGenerics)?;
+
+    let tri: Triangle<T> = triangle.clone().into();
+    let midpoints: Vec<_> = tri
+        .to_lines()
+        .iter()
+        .map(|edge| edge.start + coord! {x: edge.dx() / two, y: edge.dy() / two})
+        .collect();
+    for (edge, midpoint) in tri.to_lines().iter().zip(&midpoints) {
+        let flipped_edge = Line::new(edge.end, edge.start);
+        if shared_edges.contains(edge) || shared_edges.contains(&flipped_edge) {
+            continue;
+        }
+
+        // Get the line that passes from the circumcenter and is perpendicular to
+        // the edge without a 3rd vertex
+        let line: Line<T> = get_perpendicular_line(edge)?;
+        let slope = line.slope();
+
+        // Get the width and height of the clipping mask to ensure intersection with
+        // the lines of infinity. 2 x the width or height should be sufficient.
+        // Add the values to each other to prevent the need for another trait
+        let width_factor = clipping_mask.width() + clipping_mask.width();
+        let height_factor = clipping_mask.height() + clipping_mask.height();
+
+        // We want to move away from the other two edges of the triangle towards infinity.
+        // We will compare the three midpoints of the triangle to determine the correct direction.
+        let rel_to_midpoint: Vec<_> = midpoints
+            .iter()
+            .filter(|x| *x != midpoint)
+            .map(|x| Line::new(*x, *midpoint))
+            .collect();
+        let guiding_direction =
+            GuidingDirection::from_midpoints(&rel_to_midpoint[0], &rel_to_midpoint[1]);
+
+        // It is a vertical line so we need to ensure it moves up or down correctly
+        let end = if slope.is_infinite() {
+            match guiding_direction {
+                GuidingDirection::Up => {
+                    coord! {x: circumcenter.x, y: circumcenter.y + line.dy().abs() * height_factor}
+                }
+                GuidingDirection::Down => {
+                    coord! {x: circumcenter.x, y: circumcenter.y - line.dy().abs() * height_factor}
+                }
+                _ => return Err(VoronoiDiagramError::UnexpectedDirectionForInfinityVertex),
+            }
+        } else {
+            let intercept = circumcenter.y - line.slope() * circumcenter.x;
+            let end_x_neg = circumcenter.x - line.dx().abs() * width_factor;
+            let end_y_neg = line.slope() * end_x_neg + intercept;
+            let end_x_pos = circumcenter.x + line.dx().abs() * width_factor;
+            let end_y_pos = line.slope() * end_x_pos + intercept;
+
+            match guiding_direction {
+                GuidingDirection::Left => {
+                    coord! {x: end_x_neg, y: end_y_neg}
+                }
+                GuidingDirection::Right => {
+                    coord! {x: end_x_pos, y: end_y_pos}
+                }
+                GuidingDirection::Up => {
+                    if end_y_neg.is_positive() {
+                        coord! {x: end_x_neg, y: end_y_neg}
+                    } else {
+                        coord! {x: end_x_pos, y: end_y_pos}
+                    }
+                }
+                GuidingDirection::Down => {
+                    if end_y_neg.is_negative() {
+                        coord! {x: end_x_neg, y: end_y_neg}
+                    } else {
+                        coord! {x: end_x_pos, y: end_y_pos}
+                    }
+                }
+            }
+        };
+
+        shared_edges.push(*edge);
+
+        return Ok(Some(Line::new(*circumcenter, end)));
+    }
+    Ok(None)
+}
+
+fn trim_line_to_intersection<T: GeoFloat>(
+    inf_line: &Line<T>,
+    bounding_line: &Line<T>,
+) -> Option<Line<T>>
+where
+    f64: From<T>,
+{
+    let (x1, y1) = inf_line.start.x_y();
+    let (x2, y2) = inf_line.end.x_y();
+    let (x3, y3) = bounding_line.start.x_y();
+    let (x4, y4) = bounding_line.end.x_y();
+
+    let denom = (x1 - x2) * (y3 - y4) - (y1 - y2) * (x3 - x4);
+    if denom.is_zero() {
+        return None;
+    }
+
+    let p_x = (x1 * y2 - y1 * x2) * (x3 - x4) - (x1 - x2) * (x3 * y4 - y3 * x4);
+    let p_y = (x1 * y2 - y1 * x2) * (y3 - y4) - (y1 - y2) * (x3 * y4 - y3 * x4);
+
+    let p_x = p_x / denom;
+    let p_y = p_y / denom;
+
+    // Trim the inf_line at the intersection location
+    Some(Line::new(inf_line.start, coord! { x: p_x, y: p_y}))
+}
+
+fn construct_edges_to_inf<T: GeoFloat>(
+    triangles: &[DelaunayTriangle<T>],
+    vertices: &[Coord<T>],
+    edges: &mut Vec<Line<T>>,
+    neighbours: &[(Option<usize>, Option<usize>)],
+    clipping_mask: &Polygon<T>,
+) -> Result<Vec<Line<T>>>
+where
+    f64: From<T>,
+{
+    // Find the mean vertex to determine the direction
+    // of edges going to infinity.
+    let clipping_bounds = clipping_mask
+        .bounding_rect()
+        .ok_or(VoronoiDiagramError::CannotDetermineBoundsFromClipppingMask)?;
+    let clipping_min = clipping_bounds.min();
+    let clipping_max = clipping_bounds.max();
+
+    // Get the vertices with connections to infinity
+    let mut inf_lines: Vec<Line<T>> = Vec::new();
+    for neighbour in neighbours {
+        if let (None, Some(tri_idx)) = (neighbour.0, neighbour.1) {
+            let inf_edge = define_edge_to_infinity(
+                &triangles[tri_idx],
+                &vertices[tri_idx],
+                edges,
+                &clipping_bounds,
+            )?
+            .ok_or(VoronoiDiagramError::CannotComputeExpectedInfinityVertex)?;
+            let inf_edge_dx_sign = inf_edge.dx().is_sign_positive();
+            let inf_edge_dy_sign = inf_edge.dy().is_sign_positive();
+
+            // Get the clipping mask line where the inf_vertex intersects
+            let intersection_lines: Vec<Line<T>> = clipping_mask
+                .exterior()
+                .lines()
+                .map(|x| trim_line_to_intersection(&inf_edge, &x))
+                .filter(|x| x.is_some())
+                .flatten()
+                // A line can intersect and be outside of the bounding box
+                // filter those out
+                .filter(|x| {
+                    x.end.x >= clipping_min.x
+                        && x.end.x <= clipping_max.x
+                        && x.end.y >= clipping_min.y
+                        && x.end.y <= clipping_max.y
+                })
+                // Get the lines going in the same direction as the inf_edge
+                .filter(|x| {
+                    x.dx().is_sign_positive() == inf_edge_dx_sign
+                        && x.dy().is_sign_positive() == inf_edge_dy_sign
+                })
+                .collect();
+
+            if intersection_lines.len() > 1 {
+                eprintln!("Warning: multiple intersection lines with clipping mask found. Using the first intersection");
+            }
+
+            let intersection_line = intersection_lines
+                .get(0)
+                .ok_or(VoronoiDiagramError::InvalidClippingMaskNoIntersections)?;
+
+            inf_lines.push(*intersection_line);
+        }
+    }
+    Ok(inf_lines)
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum VoronoiDiagramError {
+    DelaunayError(DelaunayTriangulationError),
+    CannotConvertBetweenGeoGenerics,
+    CannotDetermineBoundsFromClipppingMask,
+    CannotComputeExpectedInfinityVertex,
+    InvalidClippingMaskMultipleIntersections,
+    InvalidClippingMaskNoIntersections,
+    UnexpectedDirectionForInfinityVertex,
+}
+
+impl fmt::Display for VoronoiDiagramError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            VoronoiDiagramError::DelaunayError(e) => {
+                write!(f, "Delaunay Triangulation error: {}", e)
+            }
+            VoronoiDiagramError::CannotConvertBetweenGeoGenerics => {
+                write!(f, "Cannot convert between Geo generic types")
+            }
+            VoronoiDiagramError::CannotDetermineBoundsFromClipppingMask => {
+                write!(f, "Cannot determine the bounds from the clipping mask")
+            }
+            VoronoiDiagramError::CannotComputeExpectedInfinityVertex => {
+                write!(f, "Cannot compute expected boundary to infinity")
+            }
+            VoronoiDiagramError::InvalidClippingMaskMultipleIntersections => {
+                write!(
+                    f,
+                    "An edge to infinity intersects with multiple lines in the clipping mask"
+                )
+            }
+            VoronoiDiagramError::InvalidClippingMaskNoIntersections => {
+                write!(
+                    f,
+                    "An edge to infinity does not intersect with the clipping mask"
+                )
+            }
+            VoronoiDiagramError::UnexpectedDirectionForInfinityVertex => {
+                write!(f, "The direction of the infinity vertex is unexpected")
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use geo_types::polygon;
+
+    #[test]
+    fn test_find_shared_edge() {
+        let triangles: Vec<DelaunayTriangle<f64>> = vec![
+            Triangle::new(
+                coord! {x: 0., y: 0.},
+                coord! {x: 1., y: 1.},
+                coord! {x: 2., y: 0.},
+            )
+            .into(),
+            Triangle::new(
+                coord! {x: 1., y: 1.},
+                coord! {x: 2., y: 0.},
+                coord! {x: 3., y: 1.},
+            )
+            .into(),
+        ];
+
+        let shared = find_shared_edges(&triangles);
+
+        assert_eq!(
+            shared.neighbours,
+            vec![
+                (Some(0), Some(1)),
+                (None, Some(0)),
+                (None, Some(0)),
+                (None, Some(1)),
+                (None, Some(1))
+            ]
+        );
+
+        assert_eq!(
+            shared.shared_edges,
+            vec![Line::new(coord! { x: 1.0, y: 1.0}, coord! {x: 2.0, y: 0.}),]
+        );
+
+        let triangles: Vec<DelaunayTriangle<f64>> = vec![
+            Triangle::new(
+                coord! {x: 0., y: 0.},
+                coord! {x: 0., y: 1.},
+                coord! {x: 1., y: 1.},
+            )
+            .into(),
+            Triangle::new(
+                coord! {x: 0., y: 1.},
+                coord! {x: 1., y: 1.},
+                coord! {x: -1., y: 2.},
+            )
+            .into(),
+            Triangle::new(
+                coord! {x: 0., y: 0.},
+                coord! {x: 0., y: 1.},
+                coord! {x: -1., y: 2.},
+            )
+            .into(),
+        ];
+
+        let shared = find_shared_edges(&triangles);
+
+        assert_eq!(
+            shared.neighbours,
+            vec![
+                (Some(0), Some(1)),
+                (Some(0), Some(2)),
+                (Some(1), Some(2)),
+                (None, Some(0)),
+                (None, Some(1)),
+                (None, Some(2))
+            ]
+        );
+
+        assert_eq!(
+            shared.shared_edges,
+            vec![
+                Line::new(coord! { x: 0.0, y: 1.0}, coord! {x: 1.0, y: 1.}),
+                Line::new(coord! { x: 0.0, y: 0.0}, coord! {x: 0.0, y: 1.}),
+                Line::new(coord! { x: -1.0, y: 2.0}, coord! {x: 0.0, y: 1.}),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_get_perpendicular_line() {
+        // Vertical line
+        let line = Line::new(coord! {x: 0., y: 0.}, coord! {x: 0., y: 1.});
+        assert_eq!(
+            get_perpendicular_line(&line).unwrap(),
+            Line::new(coord! {x: 0., y: 0.}, coord! {x: -1.0, y: 0.})
+        );
+        // Horizontal line
+        let line = Line::new(coord! {x: 0., y: 0.}, coord! {x: 1., y: 0.});
+        assert_eq!(
+            get_perpendicular_line(&line).unwrap(),
+            Line::new(coord! {x: 0., y: 0.}, coord! {x: 0., y: 1.})
+        );
+
+        // Check a diagonal line with a new starting point
+        let line = Line::new(coord! {x: 0., y: 0.}, coord! {x: 2., y: 2.});
+        assert_eq!(
+            get_perpendicular_line(&line).unwrap(),
+            Line::new(coord! {x: 1., y: 1.}, coord! {x: 3., y: -1.})
+        );
+
+        let line = Line::new(coord! {x: 0., y: 0.}, coord! {x: 2., y: -1.});
+        assert_eq!(
+            get_perpendicular_line(&line).unwrap(),
+            Line::new(coord! {x: 1., y: -0.5}, coord! {x: 3., y: 3.5})
+        );
+    }
+
+    #[test]
+    fn test_define_edge_to_infinity() {
+        let tri: DelaunayTriangle<_> = Triangle::new(
+            coord! {x: 0., y: 0.},
+            coord! {x: 0., y: 1.},
+            coord! {x: 1., y: 1.},
+        )
+        .into();
+        let tri2: DelaunayTriangle<_> = Triangle::new(
+            coord! {x: 0., y: 0.},
+            coord! {x: 0., y: 1.},
+            coord! {x: -1., y: 2.},
+        )
+        .into();
+        let tri3: DelaunayTriangle<_> = Triangle::new(
+            coord! {x: 0., y: 1.},
+            coord! {x: -1., y: 2.},
+            coord! {x: 1., y: 1.},
+        )
+        .into();
+
+        let bounds = Rect::new(coord! {x: -2., y: -2.}, coord! {x: 2., y: 2.});
+
+        let circumcenter = tri.get_circumcircle_center().unwrap();
+        let mut shared_edges = vec![
+            Line::new(coord! {x: 0., y: 0.}, coord! {x: 0., y: 1. }),
+            Line::new(coord! {x: 0., y: 1.}, coord! {x: 1., y: 1. }),
+            Line::new(coord! {x: 0., y: 1.}, coord! {x: -1., y: 2. }),
+        ];
+        let perpendicular_line =
+            define_edge_to_infinity(&tri, &circumcenter, &mut shared_edges, &bounds).unwrap();
+        assert_eq!(
+            perpendicular_line.unwrap(),
+            Line::new(coord! {x: 0.5, y: 0.5}, coord! {x: 8.5, y: -7.5},)
+        );
+
+        let circumcenter = tri2.get_circumcircle_center().unwrap();
+        let perpendicular_line =
+            define_edge_to_infinity(&tri2, &circumcenter, &mut shared_edges, &bounds).unwrap();
+        assert_eq!(
+            perpendicular_line.unwrap(),
+            Line::new(coord! {x: -1.5, y: 0.5}, coord! {x: -9.5, y: -3.5},)
+        );
+
+        let circumcenter = tri3.get_circumcircle_center().unwrap();
+        let perpendicular_line =
+            define_edge_to_infinity(&tri3, &circumcenter, &mut shared_edges, &bounds).unwrap();
+        assert_eq!(
+            perpendicular_line.unwrap(),
+            Line::new(coord! {x: 0.5, y: 2.5}, coord! {x: 16.5, y: 34.5},)
+        );
+    }
+
+    #[test]
+    fn test_trim_lines_to_intersection() {
+        let inf_line = Line::new(coord! { x: 0., y: 0.}, coord! { x: 100., y: 100.});
+        let bounding_line = Line::new(coord! { x: 100., y: 0.}, coord! {x: 0., y: 100.});
+        let trimmed_inf = trim_line_to_intersection(&inf_line, &bounding_line).unwrap();
+
+        assert_eq!(
+            trimmed_inf,
+            Line::new(coord! {x: 0., y: 0.}, coord! {x: 50., y: 50.})
+        );
+
+        let inf_line = Line::new(coord! { x: -12., y: 9.}, coord! { x: 3., y: -21.});
+        let bounding_line = Line::new(coord! { x: -10., y: -25.}, coord! {x: 10., y: 55.});
+        let trimmed_inf = trim_line_to_intersection(&inf_line, &bounding_line).unwrap();
+
+        assert_eq!(
+            trimmed_inf,
+            Line::new(coord! { x: -12., y: 9.}, coord! { x: -5., y: -5.})
+        );
+
+        // Parallel lines do not intersect and thus should return None
+        let inf_line = Line::new(coord! { x: 0., y: 0.}, coord! { x: 100., y: 100.});
+        let bounding_line = Line::new(coord! { x: 100., y: 100.}, coord! {x: 200., y: 200.});
+        let trimmed_inf = trim_line_to_intersection(&inf_line, &bounding_line);
+
+        assert!(trimmed_inf.is_none());
+    }
+
+    fn compare_voronoi(voronoi_vertices: Vec<Coord>, voronoi_lines: Vec<Line>) {
+        let expected_lines = vec![
+            Line::new(coord! {x: 0.5, y: 0.5}, coord! {x: -1.5, y: 0.5}),
+            Line::new(coord! {x: 0.5, y: 0.5}, coord! {x: 0.5, y: 2.5}),
+            Line::new(coord! {x: -1.5, y: 0.5}, coord! {x: 0.5, y: 2.5}),
+            Line::new(coord! {x: 0.5, y: 0.5}, coord! {x: 39., y: -38.}),
+            Line::new(coord! {x: -1.5, y: 0.5}, coord! {x: -41., y: -19.25}),
+            Line::new(coord! {x: 0.5, y: 2.5}, coord! {x: 19.25, y: 40.}),
+        ];
+
+        let expected_vertices = vec![
+            coord! { x: 0.5, y: 0.5},
+            coord! {x: -1.5, y: 0.5},
+            coord! {x: 0.5, y: 2.5},
+        ];
+
+        assert_eq!(expected_vertices.len(), voronoi_vertices.len());
+        assert_eq!(expected_lines.len(), voronoi_lines.len());
+
+        for vertex in expected_vertices.iter() {
+            assert!(expected_vertices.contains(vertex));
+        }
+
+        for line in expected_lines.iter() {
+            assert!(voronoi_lines.contains(line));
+        }
+    }
+
+    #[test]
+    fn test_compute_voronoi_from_delaunay() {
+        let triangles: Vec<Triangle<_>> = vec![
+            Triangle::new(
+                coord! {x: 0., y: 0.},
+                coord! {x: 0., y: 1.},
+                coord! {x: 1., y: 1.},
+            ),
+            Triangle::new(
+                coord! {x: 0., y: 0.},
+                coord! {x: 0., y: 1.},
+                coord! {x: -1., y: 2.},
+            ),
+            Triangle::new(
+                coord! {x: 0., y: 1.},
+                coord! {x: -1., y: 2.},
+                coord! {x: 1., y: 1.},
+            ),
+        ];
+
+        let voronoi = compute_voronoi_components_from_delaunay(&triangles, None).unwrap();
+
+        compare_voronoi(voronoi.vertices, voronoi.lines);
+    }
+
+    #[test]
+    fn test_compute_voronoi_twin_inf_edges() {
+        let triangles: Vec<Triangle<_>> = vec![
+            Triangle::new(
+                coord! {x: 0., y: 0.},
+                coord! {x: 1., y: 1.},
+                coord! {x: 2., y: 0.},
+            ),
+            Triangle::new(
+                coord! {x: 1., y: 1.},
+                coord! {x: 2., y: 0.},
+                coord! {x: 3., y: 1.},
+            ),
+            Triangle::new(
+                coord! {x: 2., y: 0.},
+                coord! {x: 3., y: 1.},
+                coord! {x: 3., y: 0.},
+            ),
+        ];
+
+        let voronoi = compute_voronoi_components_from_delaunay(&triangles, None).unwrap();
+
+        assert_eq!(
+            voronoi.vertices,
+            vec![
+                coord! {x: 1.0, y: 0.0},
+                coord! {x: 2.0, y: 1.0},
+                coord! {x: 2.5, y: 0.5}
+            ]
+        );
+        assert_eq!(
+            voronoi.lines,
+            vec![
+                Line::new(coord! {x: 1.0, y: 0.0}, coord! {x: 2.0, y: 1.0}),
+                Line::new(coord! {x: 2.0, y: 1.0}, coord! {x: 2.5, y: 0.5}),
+                Line::new(coord! {x: 1.0, y: 0.0}, coord! {x: -19., y: 20.0}),
+                Line::new(coord! {x: 1.0, y: 0.0}, coord! {x: 1., y: -20.0}),
+                Line::new(coord! {x: 2.0, y: 1.0}, coord! {x: 2., y: 20.0}),
+                Line::new(coord! {x: 2.5, y: 0.5}, coord! {x: 60., y: 0.5}),
+                Line::new(coord! {x: 2.5, y: 0.5}, coord! {x: 2.5, y: -20.}),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_voronoi_from_polygon() {
+        let poly = polygon![(x: 0., y: 0.), (x: 0., y: 1.), (x: 1., y: 1.), (x: -1., y: 2.)];
+
+        let voronoi = poly.compute_voronoi_components(None).unwrap();
+        compare_voronoi(voronoi.vertices, voronoi.lines);
+    }
+
+    // https://github.com/libgeos/geos/blob/d51982c6da5b7adb63ca0933ae7b53828cc8d72e/tests/unit/triangulate/VoronoiTest.cpp#L154
+    #[test]
+    fn test_single_point() {
+        let poly = polygon![(x: 150., y: 200.)];
+        let voronoi = poly.compute_voronoi_components(None).unwrap();
+
+        assert!(voronoi.vertices.is_empty());
+        assert!(voronoi.lines.is_empty());
+    }
+
+    // https://github.com/libgeos/geos/blob/d51982c6da5b7adb63ca0933ae7b53828cc8d72e/tests/unit/triangulate/VoronoiTest.cpp#L164
+    #[test]
+    fn test_simple() {
+        let points = polygon![(x: 150., y: 200.), (x: 180., y: 270.), (x: 275., y: 163.)];
+
+        let voronoi = points.compute_voronoi_components(None).unwrap();
+
+        let expected_vertex = coord! {x: 211.205, y: 210.911};
+
+        approx::assert_relative_eq!(
+            voronoi.vertices[0],
+            expected_vertex,
+            max_relative = 0.3 // epsilon = 1e-3
+        );
+
+        let expected_lines = vec![
+            Line::new(expected_vertex, coord! {x: -2350.0, y: 1312.857}),
+            Line::new(expected_vertex, coord! {x: -426.416, y: -1977.0}),
+            Line::new(expected_vertex, coord! {x: 2577.558, y: 2303.0}),
+        ];
+
+        for (line, expected) in voronoi.lines.iter().zip(expected_lines) {
+            approx::assert_relative_eq!(*line, expected, max_relative = 0.3);
+        }
+    }
+
+    // https://github.com/libgeos/geos/blob/d51982c6da5b7adb63ca0933ae7b53828cc8d72e/tests/unit/triangulate/VoronoiTest.cpp#L174
+    #[test]
+    fn test_four_points() {
+        let points: MultiPoint<_> =
+            vec![(280., 300.), (420., 330.), (380., 230.), (320., 160.)].into();
+
+        let voronoi = points.compute_voronoi_components(None).unwrap();
+
+        let expected_vertices = [
+            coord! {x: 353.516, y: 298.594},
+            coord! {x: 306.875, y: 231.964},
+        ];
+
+        for (vertex, expected) in voronoi.vertices.iter().zip(expected_vertices) {
+            approx::assert_relative_eq!(
+                *vertex,
+                expected,
+                max_relative = 0.3 // epsilon = 1e-3
+            );
+        }
+
+        let expected_lines = [
+            Line::new(
+                coord! {x: 353.516, y: 298.594},
+                coord! {x: 306.875, y: 231.964},
+            ),
+            Line::new(
+                coord! {x: 353.516, y: 298.594},
+                coord! {x: -345.571, y: 3556.0},
+            ),
+            Line::new(coord! {x: 353.516, y: 298.594}, coord! {x: 3080., y: -792.}),
+            Line::new(
+                coord! {x: 306.875, y: 231.964},
+                coord! {x: -2520., y: -575.714},
+            ),
+            Line::new(
+                coord! {x: 306.875, y: 231.964},
+                coord! {x: 3080., y: -2145.},
+            ),
+        ];
+
+        for (line, expected) in voronoi.lines.iter().zip(expected_lines) {
+            approx::assert_relative_eq!(
+                *line,
+                expected,
+                max_relative = 0.3 // epsilon = 1e-3
+            );
+        }
+    }
+
+    //https://github.com/libgeos/geos/blob/d51982c6da5b7adb63ca0933ae7b53828cc8d72e/tests/unit/triangulate/VoronoiTest.cpp#L174
+    #[test]
+    fn test_five_points() {
+        let points: MultiPoint<_> =
+            vec![(280., 300.), (420., 330.), (380., 230.), (320., 160.)].into();
+
+        let voronoi = points.compute_voronoi_components(None).unwrap();
+
+        let expected_vertices = [
+            coord! {x: 353.516, y: 298.594},
+            coord! {x: 306.875, y: 231.964},
+        ];
+
+        for (vertex, expected) in voronoi.vertices.iter().zip(expected_vertices) {
+            approx::assert_relative_eq!(
+                *vertex,
+                expected,
+                max_relative = 0.3 // epsilon = 1e-3
+            );
+        }
+
+        let expected_lines = [
+            Line::new(
+                coord! {x: 353.516, y: 298.594},
+                coord! {x: 306.875, y: 231.964},
+            ),
+            Line::new(
+                coord! {x: 353.516, y: 298.594},
+                coord! {x: -345.571, y: 3556.0},
+            ),
+            Line::new(coord! {x: 353.516, y: 298.594}, coord! {x: 3080., y: -792.}),
+            Line::new(
+                coord! {x: 306.875, y: 231.964},
+                coord! {x: -2520., y: -575.714},
+            ),
+            Line::new(
+                coord! {x: 306.875, y: 231.964},
+                coord! {x: 3080., y: -2145.},
+            ),
+        ];
+
+        for (line, expected) in voronoi.lines.iter().zip(expected_lines) {
+            approx::assert_relative_eq!(
+                *line,
+                expected,
+                max_relative = 0.3 // epsilon = 1e-3
+            );
+        }
+    }
+}


### PR DESCRIPTION
* Remove unimplemented function from `VoronoiDiagram` trait
* Add documentation for `voronoi_diagram` file
* Add benchmark tests for alternate delaunay triangulation methods.

The results of the bench mark when executed on my machine are:

```
Delaunay Triangulation  time:   [2.2839 µs 2.3687 µs 2.4780 µs]
                        change: [-21.682% -14.728% -7.0971%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

Spade Unconstrained Triangulation
                        time:   [1.4216 µs 1.4831 µs 1.5582 µs]
                        change: [+39.411% +46.250% +53.808%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe

Constrained Outer Triangulation
                        time:   [3.5185 µs 3.7830 µs 4.1260 µs]

Constrain Triangulation time:   [3.5962 µs 3.7355 µs 3.8970 µs]
Found 15 outliers among 100 measurements (15.00%)
  2 (2.00%) low mild
  4 (4.00%) high mild
  9 (9.00%) high severe
```
