### PR TITLE
Ring counts

### DIFF
--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -5,6 +5,7 @@
 * POSSIBLY BREAKING: Minimum supported version of Rust (MSRV) is now 1.70
   * <https://github.com/georust/geo/pull/1134>
 * Add feature for rstar v0.12.0
+* Add num_rings and num_interior_rings methods to polygons.
 
 ## 0.7.12
 

--- a/geo-types/src/geometry/polygon.rs
+++ b/geo-types/src/geometry/polygon.rs
@@ -415,6 +415,56 @@ impl<T: CoordNum> Polygon<T> {
     {
         (current_vertex + (self.exterior.0.len() - 1) - 1) % (self.exterior.0.len() - 1)
     }
+
+    /// Count the number of rings in the polygon
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use geo_types::{coord, LineString, Polygon};
+    ///
+    /// let polygon = Polygon::new(
+    ///     LineString::from(vec![(0., 0.), (1., 1.), (1., 0.), (0., 0.)]),
+    ///     vec![],
+    /// );
+    ///
+    /// assert_eq!(polygon.num_rings(), 1);
+    ///
+    /// let polygon = Polygon::new(
+    ///     LineString::from(vec![(0., 0.), (1., 1.), (1., 0.), (0., 0.)]),
+    ///     vec![LineString::from(vec![(0.1, 0.1), (0.9, 0.9), (0.9, 0.1)])],
+    /// );
+    ///
+    /// assert_eq!(polygon.num_rings(), 2);
+    /// ```
+    pub fn num_rings(&self) -> usize {
+        self.interiors.len() + 1
+    }
+
+    /// Count the number of interior rings in the polygon
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use geo_types::{coord, LineString, Polygon};
+    ///
+    /// let polygon = Polygon::new(
+    ///     LineString::from(vec![(0., 0.), (1., 1.), (1., 0.), (0., 0.)]),
+    ///     vec![],
+    /// );
+    ///
+    /// assert_eq!(polygon.num_interior_rings(), 0);
+    ///
+    /// let polygon = Polygon::new(
+    ///     LineString::from(vec![(0., 0.), (1., 1.), (1., 0.), (0., 0.)]),
+    ///     vec![LineString::from(vec![(0.1, 0.1), (0.9, 0.9), (0.9, 0.1)])],
+    /// );
+    ///
+    /// assert_eq!(polygon.num_interior_rings(), 1);
+    /// ```
+    pub fn num_interior_rings(&self) -> usize {
+        self.interiors.len()
+    }
 }
 
 // used to check the sign of a vec of floats

--- a/geo-types/src/geometry/polygon.rs
+++ b/geo-types/src/geometry/polygon.rs
@@ -416,7 +416,7 @@ impl<T: CoordNum> Polygon<T> {
         (current_vertex + (self.exterior.0.len() - 1) - 1) % (self.exterior.0.len() - 1)
     }
 
-    /// Count the number of rings in the polygon
+    /// Count the total number of rings (interior and exterior) in the polygon
     ///
     /// # Examples
     ///

--- a/geo-types/src/geometry/polygon.rs
+++ b/geo-types/src/geometry/polygon.rs
@@ -438,7 +438,7 @@ impl<T: CoordNum> Polygon<T> {
     /// assert_eq!(polygon.num_rings(), 2);
     /// ```
     pub fn num_rings(&self) -> usize {
-        self.interiors.len() + 1
+        self.num_interior_rings() + 1
     }
 
     /// Count the number of interior rings in the polygon


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
This implements 2 methods for polygons: num_rings as total of rings in a polygon, and num_interior_rings as the count of internal rings. This hopefully fulfils issue [706](https://github.com/georust/geo/issues/706)