### PR TITLE
Implement `CoordsIter` for arrays and slices

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -37,6 +37,8 @@
 * Add remaining Relate predicates
   * <https://github.com/georust/geo/pull/1136>
 * Update rstar to v0.12.0
+* Implement `CoordsIter` for arrays and slices. This is useful when you'd like to use traits
+  implemented for `CoordsIter` without re-allocating (e.g., creating a `MultiPoint`).
 
 ## 0.27.0
 

--- a/geo/src/algorithm/coords_iter.rs
+++ b/geo/src/algorithm/coords_iter.rs
@@ -447,6 +447,50 @@ impl<T: CoordNum> CoordsIter for Geometry<T> {
     }
 }
 
+// ┌──────────────────────────┐
+// │ Implementation for Array │
+// └──────────────────────────┘
+
+impl<const N: usize, T: CoordNum> CoordsIter for [Coord<T>; N] {
+    type Iter<'a> = iter::Copied<slice::Iter<'a, Coord<T>>> where T: 'a;
+    type ExteriorIter<'a> = Self::Iter<'a> where T: 'a;
+    type Scalar = T;
+
+    fn coords_iter(&self) -> Self::Iter<'_> {
+        self.iter().copied()
+    }
+
+    fn coords_count(&self) -> usize {
+        N
+    }
+
+    fn exterior_coords_iter(&self) -> Self::ExteriorIter<'_> {
+        self.coords_iter()
+    }
+}
+
+// ┌──────────────────────────┐
+// │ Implementation for Slice │
+// └──────────────────────────┘
+
+impl<'a, T: CoordNum> CoordsIter for &'a [Coord<T>] {
+    type Iter<'b> = iter::Copied<slice::Iter<'b, Coord<T>>> where T: 'b, 'a: 'b;
+    type ExteriorIter<'b> = Self::Iter<'b> where T: 'b, 'a: 'b;
+    type Scalar = T;
+
+    fn coords_iter(&self) -> Self::Iter<'_> {
+        self.iter().copied()
+    }
+
+    fn coords_count(&self) -> usize {
+        self.len()
+    }
+
+    fn exterior_coords_iter(&self) -> Self::ExteriorIter<'_> {
+        self.coords_iter()
+    }
+}
+
 // ┌───────────┐
 // │ Utilities │
 // └───────────┘
@@ -785,6 +829,32 @@ mod test {
         .collect::<Vec<_>>();
 
         assert_eq!(expected_coords, actual_coords);
+    }
+
+    #[test]
+    fn test_array() {
+        let coords = [
+            coord! { x: 1., y: 2. },
+            coord! { x: 3., y: 4. },
+            coord! { x: 5., y: 6. },
+        ];
+
+        let actual_coords = coords.coords_iter().collect::<Vec<_>>();
+
+        assert_eq!(coords.to_vec(), actual_coords);
+    }
+
+    #[test]
+    fn test_slice() {
+        let coords = &[
+            coord! { x: 1., y: 2. },
+            coord! { x: 3., y: 4. },
+            coord! { x: 5., y: 6. },
+        ];
+
+        let actual_coords = coords.coords_iter().collect::<Vec<_>>();
+
+        assert_eq!(coords.to_vec(), actual_coords);
     }
 
     fn create_point() -> (Point, Vec<Coord>) {


### PR DESCRIPTION
- [X] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [X] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

I found this useful so I could use `extremes` etc. on some kind of arbitrary coordinate list I'm already storing somewhere.

Many of the coordinate lists I'm using could technically form triangles but the points could be colinear or identical, so they don't follow the guarantees for `Triangle`. I also don't want to use `MultiPoint` for these because it would require creating another `Vec` (potentially thousands in my case).

I'm not sure if it makes sense to implement this for arrays and slices of `Coord`, `Point`, or both. For now it's only implemented at the `Coord` level.