### PR TITLE
Implement getter methods on AffineTransform to access internal elements

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Implement getter methods on `AffineTransform` to access internal elements.
+  * <https://github.com/georust/geo/pull/1159>
+
 ## 0.28.0
 
 * BREAKING: The `HasKernel` trait was removed and it's functionality was merged

--- a/geo/src/algorithm/affine_ops.rs
+++ b/geo/src/algorithm/affine_ops.rs
@@ -323,27 +323,27 @@ impl<T: CoordNum> AffineTransform<T> {
         Self([[a, b, xoff], [d, e, yoff], [T::zero(), T::zero(), T::one()]])
     }
 
-    /// Get the x-resolution value.
+    /// See [AffineTransform::new] for this value's role in the affine transformation.
     pub fn a(&self) -> T {
         self.0[0][0]
     }
-    /// Get the x-rotation value.
+    /// See [AffineTransform::new] for this value's role in the affine transformation.
     pub fn b(&self) -> T {
         self.0[0][1]
     }
-    /// Get the x-offset value.
+    /// See [AffineTransform::new] for this value's role in the affine transformation.
     pub fn xoff(&self) -> T {
         self.0[0][2]
     }
-    /// Get the y-rotation value.
+    /// See [AffineTransform::new] for this value's role in the affine transformation.
     pub fn d(&self) -> T {
         self.0[1][0]
     }
-    /// Get the y-resolution value.
+    /// See [AffineTransform::new] for this value's role in the affine transformation.
     pub fn e(&self) -> T {
         self.0[1][1]
     }
-    /// Get the y-offset value.
+    /// See [AffineTransform::new] for this value's role in the affine transformation.
     pub fn yoff(&self) -> T {
         self.0[1][2]
     }

--- a/geo/src/algorithm/affine_ops.rs
+++ b/geo/src/algorithm/affine_ops.rs
@@ -624,13 +624,13 @@ mod tests {
         assert_eq!(expected, poly);
     }
     #[test]
-    fn test_affine_transform_indexing() {
+    fn test_affine_transform_getters() {
         let transform = AffineTransform::new(10.0, 0.0, 400_000.0, 0.0, -10.0, 500_000.0);
         assert_eq!(transform.a(), &10.0);
         assert_eq!(transform.b(), &0.0);
         assert_eq!(transform.xoff(), &400_000.0);
         assert_eq!(transform.d(), &0.0);
-        assert_eq!(transform.e(), -&10.0);
+        assert_eq!(transform.e(), &-10.0);
         assert_eq!(transform.yoff(), &500_000.0);
     }
 }

--- a/geo/src/algorithm/affine_ops.rs
+++ b/geo/src/algorithm/affine_ops.rs
@@ -321,28 +321,28 @@ impl<T: CoordNum> AffineTransform<T> {
     }
 
     /// Get the x-resolution value.
-    pub fn a(&self) -> &T {
-        &self.0[0][0]
+    pub fn a(&self) -> T {
+        self.0[0][0]
     }
     /// Get the x-rotation value.
-    pub fn b(&self) -> &T {
-        &self.0[0][1]
+    pub fn b(&self) -> T {
+        self.0[0][1]
     }
     /// Get the x-offset value.
-    pub fn xoff(&self) -> &T {
-        &self.0[0][2]
+    pub fn xoff(&self) -> T {
+        self.0[0][2]
     }
     /// Get the y-rotation value.
-    pub fn d(&self) -> &T {
-        &self.0[1][0]
+    pub fn d(&self) -> T {
+        self.0[1][0]
     }
     /// Get the y-resolution value.
-    pub fn e(&self) -> &T {
-        &self.0[1][1]
+    pub fn e(&self) -> T {
+        self.0[1][1]
     }
     /// Get the y-offset value.
-    pub fn yoff(&self) -> &T {
-        &self.0[1][2]
+    pub fn yoff(&self) -> T {
+        self.0[1][2]
     }
 }
 
@@ -626,11 +626,11 @@ mod tests {
     #[test]
     fn test_affine_transform_getters() {
         let transform = AffineTransform::new(10.0, 0.0, 400_000.0, 0.0, -10.0, 500_000.0);
-        assert_eq!(transform.a(), &10.0);
-        assert_eq!(transform.b(), &0.0);
-        assert_eq!(transform.xoff(), &400_000.0);
-        assert_eq!(transform.d(), &0.0);
-        assert_eq!(transform.e(), &-10.0);
-        assert_eq!(transform.yoff(), &500_000.0);
+        assert_eq!(transform.a(), 10.0);
+        assert_eq!(transform.b(), 0.0);
+        assert_eq!(transform.xoff(), 400_000.0);
+        assert_eq!(transform.d(), 0.0);
+        assert_eq!(transform.e(), -10.0);
+        assert_eq!(transform.yoff(), 500_000.0);
     }
 }

--- a/geo/src/algorithm/affine_ops.rs
+++ b/geo/src/algorithm/affine_ops.rs
@@ -124,11 +124,11 @@ impl<T: CoordNum, M: MapCoordsInPlace<T> + MapCoords<T, T, Output = Self>> Affin
 ///
 /// let a: f64 = transform.a();
 /// let b: f64 = transform.b();
-/// let c: f64 = transform.xoff();
+/// let xoff: f64 = transform.xoff();
 /// let d: f64 = transform.d();
 /// let e: f64 = transform.e();
-/// let f: f64 = transform.yoff();
-/// assert_eq!(transform, AffineTransform::new(a, b, c, d, e, f))
+/// let yoff: f64 = transform.yoff();
+/// assert_eq!(transform, AffineTransform::new(a, b, xoff, d, e, yoff))
 /// ```
 
 #[derive(Copy, Clone, PartialEq, Eq)]

--- a/geo/src/algorithm/affine_ops.rs
+++ b/geo/src/algorithm/affine_ops.rs
@@ -118,6 +118,8 @@ impl<T: CoordNum, M: MapCoordsInPlace<T> + MapCoords<T, T, Output = Self>> Affin
 ///
 /// ## Create affine transform manually, and access elements using getter methods
 /// ```
+/// use geo::AffineTransform;
+///
 /// let transform = AffineTransform::new(10.0, 0.0, 400_000.0, 0.0, -10.0, 500_000.0);
 ///
 /// let a: f64 = transform.a();
@@ -126,6 +128,7 @@ impl<T: CoordNum, M: MapCoordsInPlace<T> + MapCoords<T, T, Output = Self>> Affin
 /// let d: f64 = transform.d();
 /// let e: f64 = transform.e();
 /// let f: f64 = transform.yoff();
+/// assert_eq!(transform, AffineTransform::new(a, b, c, d, e, f))
 /// ```
 
 #[derive(Copy, Clone, PartialEq, Eq)]


### PR DESCRIPTION
Enable internal elements of the affine transform matrix to be retrieved using getter methods. Included some short documentation and a unit test.

Example usage:

```rust
use geo::AffineTransform;

let transform = AffineTransform::new(10.0, 0.0, 400_000.0, 0.0, -10.0, 500_000.0);

let a: f64 = transform.a();
let b: f64 = transform.b();
let xoff: f64 = transform.xoff();
let d: f64 = transform.d();
let e: f64 = transform.e();
let yoff: f64 = transform.yoff();

assert_eq!(transform, AffineTransform::new(a, b, xoff, d, e, yoff))

```


- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Fixes #1158