### PR TITLE
Minor: (clippy)  List constraint on T in only one place.

### DIFF
--- a/geo/src/algorithm/k_nearest_concave_hull.rs
+++ b/geo/src/algorithm/k_nearest_concave_hull.rs
@@ -88,9 +88,9 @@ where
     }
 }
 
-fn concave_hull<'a, T: 'a>(coords: impl Iterator<Item = &'a Coord<T>>, k: u32) -> Polygon<T>
+fn concave_hull<'a, T>(coords: impl Iterator<Item = &'a Coord<T>>, k: u32) -> Polygon<T>
 where
-    T: GeoFloat + RTreeNum,
+    T: 'a + GeoFloat + RTreeNum,
 {
     let dataset = prepare_dataset(coords);
     concave_hull_inner(dataset, k)
@@ -99,9 +99,9 @@ where
 const DELTA: f32 = 0.000000001;
 
 /// Removes duplicate coords from the dataset.
-fn prepare_dataset<'a, T: 'a>(coords: impl Iterator<Item = &'a Coord<T>>) -> rstar::RTree<Coord<T>>
+fn prepare_dataset<'a, T>(coords: impl Iterator<Item = &'a Coord<T>>) -> rstar::RTree<Coord<T>>
 where
-    T: GeoFloat + RTreeNum,
+    T: 'a + GeoFloat + RTreeNum,
 {
     let mut dataset: rstar::RTree<Coord<T>> = rstar::RTree::new();
     for coord in coords {


### PR DESCRIPTION
I love this project it is really useful.

I saw this minor blemish while reading the code.

Constraints on T are detailed in two places, once before the function arguments and **THEN**  they are augmented in a WHERE clause. 

This for me is a readability issues... I think all constraints should be in one place.

```rustlang
-fn prepare_dataset<'a, T: 'a>(coords: impl Iterator<Item = &'a Coord<T>>) -> rstar::RTree<Coord<T>>
+fn prepare_dataset<'a, T>(coords: impl Iterator<Item = &'a Coord<T>>) -> rstar::RTree<Coord<T>>
 where
-    T: GeoFloat + RTreeNum,
+    T: 'a + GeoFloat + RTreeNum,
```

Also after checking .. I cleared an addional warning about this form the clippy warning logs.

- [ x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
---