### PR TITLE
fix: error in earth radius

### DIFF
--- a/geo/src/algorithm/haversine_length.rs
+++ b/geo/src/algorithm/haversine_length.rs
@@ -7,7 +7,7 @@ use crate::{CoordFloat, Line, LineString, MultiLineString};
 ///
 /// [haversine formula]: https://en.wikipedia.org/wiki/Haversine_formula
 ///
-/// *Note*: this implementation uses a mean earth radius of 6371.088 km, based on the [recommendation of
+/// *Note*: this implementation uses a mean earth radius of 6371.0088 km, based on the [recommendation of
 /// the IUGG](ftp://athena.fsv.cvut.cz/ZFG/grs80-Moritz.pdf)
 pub trait HaversineLength<T, RHS = Self> {
     /// Determine the length of a geometry using the [haversine formula].


### PR DESCRIPTION
Just a typo in the documentation, const is ok (according to IUGG R1 radius https://en.wikipedia.org/wiki/Earth_radius)

See const here : https://github.com/georust/geo/blob/main/geo/src/lib.rs#L245

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
