### PR TITLE
Minor: outlier_detection: no need to enumerate().

### DIFF
--- a/geo/src/algorithm/outlier_detection.rs
+++ b/geo/src/algorithm/outlier_detection.rs
@@ -241,8 +241,7 @@ where
     // to the point p, all divided by the number of items in p's kNN set, squared.
     knn_dists
         .iter()
-        .enumerate()
-        .map(|(_, neighbours)| {
+        .map(|neighbours| {
             // for each point's neighbour set, calculate kth distance
             let kth_dist = neighbours
                 .iter()


### PR DESCRIPTION
This is really minor

The index created by a call to .enumerate() is not used. 

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
---

