### PR TITLE
Polygon in Rect performance improvements

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -6,6 +6,8 @@
   * <https://github.com/georust/geo/pull/1159>
 * Fix issue in Debug impl for AffineTransform where yoff is shown instead of xoff
   * <https://github.com/georust/geo/pull/1191>
+* `Polygon` in `Rect` performance improvements.
+  * <https://github.com/georust/geo/pull/1192>
 
 ## 0.28.0
 

--- a/geo/benches/contains.rs
+++ b/geo/benches/contains.rs
@@ -1,6 +1,6 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use geo::contains::Contains;
-use geo::{point, polygon, Line, Point, Polygon, Triangle};
+use geo::{coord, point, polygon, Line, Point, Polygon, Rect, Triangle};
 
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("point in simple polygon", |bencher| {
@@ -126,6 +126,23 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         bencher.iter(|| {
             assert!(!criterion::black_box(&triangle).contains(criterion::black_box(&point)));
+        });
+    });
+
+    c.bench_function("Rect contains polygon", |bencher| {
+        let polygon = polygon![
+            (x: 150., y: 350.),
+            (x: 100., y: 350.),
+            (x: 210., y: 160.),
+            (x: 290., y: 350.),
+            (x: 250., y: 350.),
+            (x: 200., y: 250.),
+            (x: 150., y: 350.),
+        ];
+        let rect = Rect::new(coord! { x: 90., y: 150. }, coord! { x: 300., y: 360. });
+
+        bencher.iter(|| {
+            assert!(criterion::black_box(&rect).contains(criterion::black_box(&polygon)));
         });
     });
 }

--- a/geo/src/algorithm/contains/mod.rs
+++ b/geo/src/algorithm/contains/mod.rs
@@ -664,6 +664,44 @@ mod test {
             rect.contains(&poly_two_borders),
             rect.relate(&poly_two_borders).is_contains()
         );
+
+        let poly_two_borders_triangle = Polygon::new(
+            line_string![
+                (x: 90., y: 150.),
+                (x: 300., y: 150.),
+                (x: 90., y: 360.),
+                (x: 90., y: 150.),
+            ],
+            vec![],
+        );
+        assert_eq!(
+            rect.contains(&poly_two_borders_triangle),
+            rect.relate(&poly_two_borders_triangle).is_contains()
+        );
+    }
+
+    #[test]
+    fn rect_contains_polygon_in_boundary_with_hole() {
+        let rect = Rect::new(coord! { x: 90. , y: 150. }, coord! { x: 300., y: 360. });
+        let poly_two_borders_triangle_with_hole = Polygon::new(
+            line_string![
+                (x: 90., y: 150.),
+                (x: 300., y: 150.),
+                (x: 90., y: 360.),
+                (x: 90., y: 150.),
+            ],
+            vec![line_string![
+                (x: 90., y: 150.),
+                (x: 300., y: 150.),
+                (x: 90., y: 360.),
+                (x: 90., y: 150.),
+            ]],
+        );
+        assert_eq!(
+            rect.contains(&poly_two_borders_triangle_with_hole),
+            rect.relate(&poly_two_borders_triangle_with_hole)
+                .is_contains()
+        );
     }
 
     #[test]

--- a/geo/src/algorithm/contains/mod.rs
+++ b/geo/src/algorithm/contains/mod.rs
@@ -633,7 +633,7 @@ mod test {
     #[test]
     fn rect_contains_rect_polygon() {
         let rect = Rect::new(coord! { x: 90., y: 150. }, coord! { x: 300., y: 360. });
-        let rect_poly = rect.clone().to_polygon();
+        let rect_poly = rect.to_polygon();
         assert_eq!(
             rect.contains(&rect_poly),
             rect.relate(&rect_poly).is_contains()
@@ -721,7 +721,7 @@ mod test {
         );
         assert_eq!(rect.contains(&poly), rect.relate(&poly).is_contains());
 
-        let rect_poly = rect.clone().to_polygon();
+        let rect_poly = rect.to_polygon();
         assert_eq!(
             rect.contains(&rect_poly),
             rect.relate(&rect_poly).is_contains()

--- a/geo/src/algorithm/contains/rect.rs
+++ b/geo/src/algorithm/contains/rect.rs
@@ -1,7 +1,7 @@
 use geo_types::CoordFloat;
 
 use super::{impl_contains_from_relate, impl_contains_geometry_for, Contains};
-use crate::{geometry::*, Area, CoordsIter, HasDimensions};
+use crate::{geometry::*, Area, CoordsIter, HasDimensions, Intersects};
 use crate::{CoordNum, GeoFloat};
 
 // ┌──────────────────────────┐
@@ -56,12 +56,10 @@ where
         // none of the polygon's points may lie outside the rectangle
         let mut points_inside = 0;
         for c in rhs.exterior_coords_iter() {
-            if c.x < self.min().x || c.x > self.max().x || c.y < self.min().y || c.y > self.max().y
-            {
+            if !self.intersects(&c) {
                 return false;
             }
-            if c.x > self.min().x && c.x < self.max().x && c.y > self.min().y && c.y < self.max().y
-            {
+            if self.contains(&c) {
                 points_inside += 1;
             }
         }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [X] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
This PR improves the performance of the `Polygon` in `Rect` check:

**Before:**

```
Rect contains polygon   time:   [2.3345 µs 2.3514 µs 2.3662 µs]
                        change: [-1.3280% -0.6558% -0.0257%] (p = 0.05 < 0.05)
                        Change within noise threshold.
```

**After:**

```
Rect contains polygon   time:   [3.7123 ns 3.7174 ns 3.7237 ns]
                        change: [-99.841% -99.840% -99.839%] (p = 0.00 < 0.05)
                        Performance has improved.
```

I have an application where I need to perform this check millions of times and this small improvement shaves off several seconds for me.

I think the same can be done for the other geometry types (`LineString` in `Rect`, `MultiPolygon` in `Rect`, etc.), but I wanted to get your feedback on this one first.