### PR TITLE
Add `PreparedGeometry` to speed up repeated `Relate` operations.

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -10,6 +10,8 @@
   * <https://github.com/georust/geo/pull/1192>
 * Fix `AffineTransform::compose` ordering to be conventional - such that the argument is applied *after* self.
   * <https://github.com/georust/geo/pull/1196>
+* Add `PreparedGeometry` to speed up repeated `Relate` operations.
+  * <https://github.com/georust/geo/pull/1197>
 
 ## 0.28.0
 

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -84,6 +84,10 @@ name = "euclidean_distance"
 harness = false
 
 [[bench]]
+name = "prepared_geometry"
+harness = false
+
+[[bench]]
 name = "rotate"
 harness = false
 

--- a/geo/benches/prepared_geometry.rs
+++ b/geo/benches/prepared_geometry.rs
@@ -1,0 +1,31 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use geo::algorithm::Relate;
+use geo::geometry::MultiPolygon;
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("relate unprepared polygons", |bencher| {
+        let plot_polygons: MultiPolygon = geo_test_fixtures::nl_plots();
+        let zone_polygons: MultiPolygon = geo_test_fixtures::nl_zones();
+
+        bencher.iter(|| {
+            let mut intersects = 0;
+            let mut non_intersects = 0;
+
+            for a in &plot_polygons {
+                for b in &zone_polygons {
+                    if criterion::black_box(a.relate(b).is_intersects()) {
+                        intersects += 1;
+                    } else {
+                        non_intersects += 1;
+                    }
+                }
+            }
+
+            assert_eq!(intersects, 974);
+            assert_eq!(non_intersects, 27782);
+        });
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/geo/benches/prepared_geometry.rs
+++ b/geo/benches/prepared_geometry.rs
@@ -1,11 +1,45 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use geo::algorithm::Relate;
-use geo::geometry::MultiPolygon;
+use geo::PreparedGeometry;
+use geo_types::MultiPolygon;
 
 fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("relate prepared polygons", |bencher| {
+        let plot_polygons: MultiPolygon = geo_test_fixtures::nl_plots();
+        let zone_polygons = geo_test_fixtures::nl_zones();
+
+        bencher.iter(|| {
+            let mut intersects = 0;
+            let mut non_intersects = 0;
+
+            let plot_polygons = plot_polygons
+                .iter()
+                .map(PreparedGeometry::from)
+                .collect::<Vec<_>>();
+
+            let zone_polygons = zone_polygons
+                .iter()
+                .map(PreparedGeometry::from)
+                .collect::<Vec<_>>();
+
+            for a in &plot_polygons {
+                for b in &zone_polygons {
+                    if criterion::black_box(a.relate(b).is_intersects()) {
+                        intersects += 1;
+                    } else {
+                        non_intersects += 1;
+                    }
+                }
+            }
+
+            assert_eq!(intersects, 974);
+            assert_eq!(non_intersects, 27782);
+        });
+    });
+
     c.bench_function("relate unprepared polygons", |bencher| {
         let plot_polygons: MultiPolygon = geo_test_fixtures::nl_plots();
-        let zone_polygons: MultiPolygon = geo_test_fixtures::nl_zones();
+        let zone_polygons = geo_test_fixtures::nl_zones();
 
         bencher.iter(|| {
             let mut intersects = 0;

--- a/geo/src/algorithm/relate/geomgraph/edge.rs
+++ b/geo/src/algorithm/relate/geomgraph/edge.rs
@@ -7,7 +7,7 @@ use std::collections::BTreeSet;
 /// An `Edge` represents a one dimensional line in a geometry.
 ///
 /// This is based on [JTS's `Edge` as of 1.18.1](https://github.com/locationtech/jts/blob/jts-1.18.1/modules/core/src/main/java/org/locationtech/jts/geomgraph/Edge.java)
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone)]
 pub(crate) struct Edge<F: GeoFloat> {
     /// `coordinates` of the line geometry
     coords: Vec<Coord<F>>,
@@ -48,6 +48,13 @@ impl<F: GeoFloat> Edge<F> {
         &mut self.label
     }
 
+    /// When comparing two prepared geometries, we cache each geometry's topology graph. Depending
+    /// on the order of the operation - `a.relate(b)` vs `b.relate(a)` - we may need to swap the
+    /// label.
+    pub fn swap_label_args(&mut self) {
+        self.label.swap_args()
+    }
+
     pub fn coords(&self) -> &[Coord<F>] {
         &self.coords
     }
@@ -55,6 +62,7 @@ impl<F: GeoFloat> Edge<F> {
     pub fn is_isolated(&self) -> bool {
         self.is_isolated
     }
+
     pub fn mark_as_unisolated(&mut self) {
         self.is_isolated = false;
     }

--- a/geo/src/algorithm/relate/geomgraph/edge_intersection.rs
+++ b/geo/src/algorithm/relate/geomgraph/edge_intersection.rs
@@ -6,7 +6,7 @@ use crate::{Coord, GeoFloat};
 /// the start of the line segment) The intersection point must be precise.
 ///
 /// This is based on [JTS's EdgeIntersection as of 1.18.1](https://github.com/locationtech/jts/blob/jts-1.18.1/modules/core/src/main/java/org/locationtech/jts/geomgraph/EdgeIntersection.java)
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct EdgeIntersection<F: GeoFloat> {
     coord: Coord<F>,
     segment_index: usize,

--- a/geo/src/algorithm/relate/geomgraph/index/edge_set_intersector.rs
+++ b/geo/src/algorithm/relate/geomgraph/index/edge_set_intersector.rs
@@ -1,4 +1,4 @@
-use super::super::Edge;
+use super::super::{Edge, GeometryGraph};
 use super::SegmentIntersector;
 use crate::{Coord, GeoFloat};
 
@@ -13,18 +13,18 @@ pub(crate) trait EdgeSetIntersector<F: GeoFloat> {
     /// `check_for_self_intersecting_edges`: if false, an edge is not checked for intersections with itself.
     /// `segment_intersector`: the SegmentIntersector to use
     fn compute_intersections_within_set(
-        &mut self,
-        edges: &[Rc<RefCell<Edge<F>>>],
+        &self,
+        graph: &GeometryGraph<F>,
         check_for_self_intersecting_edges: bool,
         segment_intersector: &mut SegmentIntersector<F>,
     );
 
     /// Compute all intersections between two sets of edges, recording those intersections on
     /// the intersecting edges.
-    fn compute_intersections_between_sets(
-        &mut self,
-        edges0: &[Rc<RefCell<Edge<F>>>],
-        edges1: &[Rc<RefCell<Edge<F>>>],
+    fn compute_intersections_between_sets<'a>(
+        &self,
+        graph_0: &GeometryGraph<'a, F>,
+        graph_1: &GeometryGraph<'a, F>,
         segment_intersector: &mut SegmentIntersector<F>,
     );
 }

--- a/geo/src/algorithm/relate/geomgraph/index/mod.rs
+++ b/geo/src/algorithm/relate/geomgraph/index/mod.rs
@@ -1,9 +1,13 @@
 mod edge_set_intersector;
+mod prepared_geometry;
 mod rstar_edge_set_intersector;
+mod segment;
 mod segment_intersector;
 mod simple_edge_set_intersector;
 
 pub(crate) use edge_set_intersector::EdgeSetIntersector;
-pub(crate) use rstar_edge_set_intersector::RstarEdgeSetIntersector;
+pub use prepared_geometry::PreparedGeometry;
+pub(crate) use rstar_edge_set_intersector::RStarEdgeSetIntersector;
+pub(crate) use segment::Segment;
 pub(crate) use segment_intersector::SegmentIntersector;
 pub(crate) use simple_edge_set_intersector::SimpleEdgeSetIntersector;

--- a/geo/src/algorithm/relate/geomgraph/index/prepared_geometry.rs
+++ b/geo/src/algorithm/relate/geomgraph/index/prepared_geometry.rs
@@ -1,0 +1,227 @@
+use super::Segment;
+use crate::geometry::*;
+use crate::relate::geomgraph::{GeometryGraph, RobustLineIntersector};
+use crate::GeometryCow;
+use crate::{GeoFloat, Relate};
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use rstar::{RTree, RTreeNum};
+
+/// A `PreparedGeometry` can be more efficient than a plain Geometry when performing
+/// multiple topological comparisons against the `PreparedGeometry`.
+///
+/// ```
+/// use geo::{Relate, PreparedGeometry, wkt};
+///
+/// let polygon = wkt! { POLYGON((2.0 2.0,2.0 6.0,4.0 6.0)) };
+/// let touching_line = wkt! { LINESTRING(0.0 0.0,2.0 2.0) };
+/// let intersecting_line = wkt! { LINESTRING(0.0 0.0,3.0 3.0) };
+/// let contained_line = wkt! { LINESTRING(2.0 2.0,3.0 5.0) };
+///
+/// let prepared_polygon = PreparedGeometry::from(polygon);
+/// assert!(prepared_polygon.relate(&touching_line).is_touches());
+/// assert!(prepared_polygon.relate(&intersecting_line).is_intersects());
+/// assert!(prepared_polygon.relate(&contained_line).is_contains());
+///
+/// ```
+pub struct PreparedGeometry<'a, F: GeoFloat + RTreeNum = f64> {
+    geometry_graph: GeometryGraph<'a, F>,
+}
+
+mod conversions {
+    use crate::geometry_cow::GeometryCow;
+    use crate::relate::geomgraph::{GeometryGraph, RobustLineIntersector};
+    use crate::{GeoFloat, PreparedGeometry};
+    use geo_types::{
+        Geometry, GeometryCollection, Line, LineString, MultiLineString, MultiPoint, MultiPolygon,
+        Point, Polygon, Rect, Triangle,
+    };
+    use std::rc::Rc;
+
+    impl<'a, F: GeoFloat> From<Point<F>> for PreparedGeometry<'a, F> {
+        fn from(point: Point<F>) -> Self {
+            PreparedGeometry::from(GeometryCow::from(point))
+        }
+    }
+    impl<'a, F: GeoFloat> From<Line<F>> for PreparedGeometry<'a, F> {
+        fn from(line: Line<F>) -> Self {
+            PreparedGeometry::from(GeometryCow::from(line))
+        }
+    }
+    impl<'a, F: GeoFloat> From<LineString<F>> for PreparedGeometry<'a, F> {
+        fn from(line_string: LineString<F>) -> Self {
+            PreparedGeometry::from(GeometryCow::from(line_string))
+        }
+    }
+    impl<'a, F: GeoFloat> From<Polygon<F>> for PreparedGeometry<'a, F> {
+        fn from(polygon: Polygon<F>) -> Self {
+            PreparedGeometry::from(GeometryCow::from(polygon))
+        }
+    }
+    impl<'a, F: GeoFloat> From<MultiPoint<F>> for PreparedGeometry<'a, F> {
+        fn from(multi_point: MultiPoint<F>) -> Self {
+            PreparedGeometry::from(GeometryCow::from(multi_point))
+        }
+    }
+    impl<'a, F: GeoFloat> From<MultiLineString<F>> for PreparedGeometry<'a, F> {
+        fn from(multi_line_string: MultiLineString<F>) -> Self {
+            PreparedGeometry::from(GeometryCow::from(multi_line_string))
+        }
+    }
+    impl<'a, F: GeoFloat> From<MultiPolygon<F>> for PreparedGeometry<'a, F> {
+        fn from(multi_polygon: MultiPolygon<F>) -> Self {
+            PreparedGeometry::from(GeometryCow::from(multi_polygon))
+        }
+    }
+    impl<'a, F: GeoFloat> From<Rect<F>> for PreparedGeometry<'a, F> {
+        fn from(rect: Rect<F>) -> Self {
+            PreparedGeometry::from(GeometryCow::from(rect))
+        }
+    }
+    impl<'a, F: GeoFloat> From<Triangle<F>> for PreparedGeometry<'a, F> {
+        fn from(triangle: Triangle<F>) -> Self {
+            PreparedGeometry::from(GeometryCow::from(triangle))
+        }
+    }
+    impl<'a, F: GeoFloat> From<GeometryCollection<F>> for PreparedGeometry<'a, F> {
+        fn from(geometry_collection: GeometryCollection<F>) -> Self {
+            PreparedGeometry::from(GeometryCow::from(geometry_collection))
+        }
+    }
+    impl<'a, F: GeoFloat> From<Geometry<F>> for PreparedGeometry<'a, F> {
+        fn from(geometry: Geometry<F>) -> Self {
+            PreparedGeometry::from(GeometryCow::from(geometry))
+        }
+    }
+
+    impl<'a, F: GeoFloat> From<&'a Point<F>> for PreparedGeometry<'a, F> {
+        fn from(point: &'a Point<F>) -> Self {
+            PreparedGeometry::from(GeometryCow::from(point))
+        }
+    }
+    impl<'a, F: GeoFloat> From<&'a Line<F>> for PreparedGeometry<'a, F> {
+        fn from(line: &'a Line<F>) -> Self {
+            PreparedGeometry::from(GeometryCow::from(line))
+        }
+    }
+    impl<'a, F: GeoFloat> From<&'a LineString<F>> for PreparedGeometry<'a, F> {
+        fn from(line_string: &'a LineString<F>) -> Self {
+            PreparedGeometry::from(GeometryCow::from(line_string))
+        }
+    }
+    impl<'a, F: GeoFloat> From<&'a Polygon<F>> for PreparedGeometry<'a, F> {
+        fn from(polygon: &'a Polygon<F>) -> Self {
+            PreparedGeometry::from(GeometryCow::from(polygon))
+        }
+    }
+    impl<'a, F: GeoFloat> From<&'a MultiPoint<F>> for PreparedGeometry<'a, F> {
+        fn from(multi_point: &'a MultiPoint<F>) -> Self {
+            PreparedGeometry::from(GeometryCow::from(multi_point))
+        }
+    }
+    impl<'a, F: GeoFloat> From<&'a MultiLineString<F>> for PreparedGeometry<'a, F> {
+        fn from(multi_line_string: &'a MultiLineString<F>) -> Self {
+            PreparedGeometry::from(GeometryCow::from(multi_line_string))
+        }
+    }
+    impl<'a, F: GeoFloat> From<&'a MultiPolygon<F>> for PreparedGeometry<'a, F> {
+        fn from(multi_polygon: &'a MultiPolygon<F>) -> Self {
+            PreparedGeometry::from(GeometryCow::from(multi_polygon))
+        }
+    }
+    impl<'a, F: GeoFloat> From<&'a GeometryCollection<F>> for PreparedGeometry<'a, F> {
+        fn from(geometry_collection: &'a GeometryCollection<F>) -> Self {
+            PreparedGeometry::from(GeometryCow::from(geometry_collection))
+        }
+    }
+    impl<'a, F: GeoFloat> From<&'a Rect<F>> for PreparedGeometry<'a, F> {
+        fn from(rect: &'a Rect<F>) -> Self {
+            PreparedGeometry::from(GeometryCow::from(rect))
+        }
+    }
+    impl<'a, F: GeoFloat> From<&'a Triangle<F>> for PreparedGeometry<'a, F> {
+        fn from(triangle: &'a Triangle<F>) -> Self {
+            PreparedGeometry::from(GeometryCow::from(triangle))
+        }
+    }
+
+    impl<'a, F: GeoFloat> From<&'a Geometry<F>> for PreparedGeometry<'a, F> {
+        fn from(geometry: &'a Geometry<F>) -> Self {
+            PreparedGeometry::from(GeometryCow::from(geometry))
+        }
+    }
+
+    impl<'a, F: GeoFloat> From<GeometryCow<'a, F>> for PreparedGeometry<'a, F> {
+        fn from(geometry: GeometryCow<'a, F>) -> Self {
+            let mut geometry_graph = GeometryGraph::new(0, geometry);
+            geometry_graph.set_tree(Rc::new(geometry_graph.build_tree()));
+
+            // TODO: don't pass in line intersector here - in theory we'll want pluggable line intersectors
+            // and the type (Robust) shouldn't be hard coded here.
+            geometry_graph.compute_self_nodes(Box::new(RobustLineIntersector::new()));
+
+            Self { geometry_graph }
+        }
+    }
+}
+
+impl<'a, F> PreparedGeometry<'a, F>
+where
+    F: GeoFloat + RTreeNum,
+{
+    pub(crate) fn geometry(&self) -> &GeometryCow<F> {
+        self.geometry_graph.geometry()
+    }
+}
+
+impl<F: GeoFloat> Relate<F> for PreparedGeometry<'_, F> {
+    /// Efficiently builds a [`GeometryGraph`] which can then be used for topological
+    /// computations.
+    fn geometry_graph(&self, arg_index: usize) -> GeometryGraph<F> {
+        self.geometry_graph.clone_for_arg_index(arg_index)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::algorithm::Relate;
+    use crate::polygon;
+
+    #[test]
+    fn relate() {
+        let p1 = polygon![(x: 0.0, y: 0.0), (x: 2.0, y: 0.0), (x: 1.0, y: 1.0)];
+        let p2 = polygon![(x: 0.5, y: 0.0), (x: 2.0, y: 0.0), (x: 1.0, y: 1.0)];
+        let prepared_1 = PreparedGeometry::from(&p1);
+        let prepared_2 = PreparedGeometry::from(&p2);
+        assert!(prepared_1.relate(&prepared_2).is_contains());
+        assert!(prepared_2.relate(&prepared_1).is_within());
+    }
+
+    #[test]
+    fn prepared_with_unprepared() {
+        let p1 = polygon![(x: 0.0, y: 0.0), (x: 2.0, y: 0.0), (x: 1.0, y: 1.0)];
+        let p2 = polygon![(x: 0.5, y: 0.0), (x: 2.0, y: 0.0), (x: 1.0, y: 1.0)];
+        let prepared_1 = PreparedGeometry::from(&p1);
+        assert!(prepared_1.relate(&p2).is_contains());
+        assert!(p2.relate(&prepared_1).is_within());
+    }
+
+    #[test]
+    fn swap_arg_index() {
+        let poly = polygon![(x: 0.0, y: 0.0), (x: 2.0, y: 0.0), (x: 1.0, y: 1.0)];
+        let prepared_geom = PreparedGeometry::from(&poly);
+
+        let poly_cow = GeometryCow::from(&poly);
+
+        let cached_graph = prepared_geom.geometry_graph(0);
+        let fresh_graph = GeometryGraph::new(0, poly_cow.clone());
+        cached_graph.assert_eq_graph(&fresh_graph);
+
+        let cached_graph = prepared_geom.geometry_graph(1);
+        let fresh_graph = GeometryGraph::new(1, poly_cow);
+        cached_graph.assert_eq_graph(&fresh_graph);
+    }
+}

--- a/geo/src/algorithm/relate/geomgraph/index/segment.rs
+++ b/geo/src/algorithm/relate/geomgraph/index/segment.rs
@@ -1,0 +1,33 @@
+use crate::Coord;
+use crate::GeoFloat;
+
+#[derive(Debug, Clone)]
+pub(crate) struct Segment<F: GeoFloat + rstar::RTreeNum> {
+    pub edge_idx: usize,
+    pub segment_idx: usize,
+    pub envelope: rstar::AABB<Coord<F>>,
+}
+
+impl<F> Segment<F>
+where
+    F: GeoFloat + rstar::RTreeNum,
+{
+    pub fn new(edge_idx: usize, segment_idx: usize, p1: Coord<F>, p2: Coord<F>) -> Self {
+        Self {
+            edge_idx,
+            segment_idx,
+            envelope: rstar::AABB::from_corners(p1, p2),
+        }
+    }
+}
+
+impl<F> rstar::RTreeObject for Segment<F>
+where
+    F: GeoFloat + rstar::RTreeNum,
+{
+    type Envelope = rstar::AABB<Coord<F>>;
+
+    fn envelope(&self) -> Self::Envelope {
+        self.envelope
+    }
+}

--- a/geo/src/algorithm/relate/geomgraph/index/simple_edge_set_intersector.rs
+++ b/geo/src/algorithm/relate/geomgraph/index/simple_edge_set_intersector.rs
@@ -1,4 +1,4 @@
-use super::super::Edge;
+use super::super::{Edge, GeometryGraph};
 use super::{EdgeSetIntersector, SegmentIntersector};
 use crate::GeoFloat;
 
@@ -13,7 +13,7 @@ impl SimpleEdgeSetIntersector {
     }
 
     fn compute_intersects<F: GeoFloat>(
-        &mut self,
+        &self,
         edge0: &Rc<RefCell<Edge<F>>>,
         edge1: &Rc<RefCell<Edge<F>>>,
         segment_intersector: &mut SegmentIntersector<F>,
@@ -30,11 +30,12 @@ impl SimpleEdgeSetIntersector {
 
 impl<F: GeoFloat> EdgeSetIntersector<F> for SimpleEdgeSetIntersector {
     fn compute_intersections_within_set(
-        &mut self,
-        edges: &[Rc<RefCell<Edge<F>>>],
+        &self,
+        graph: &GeometryGraph<F>,
         check_for_self_intersecting_edges: bool,
         segment_intersector: &mut SegmentIntersector<F>,
     ) {
+        let edges = graph.edges();
         for edge0 in edges.iter() {
             for edge1 in edges.iter() {
                 if check_for_self_intersecting_edges || edge0.as_ptr() != edge1.as_ptr() {
@@ -44,14 +45,17 @@ impl<F: GeoFloat> EdgeSetIntersector<F> for SimpleEdgeSetIntersector {
         }
     }
 
-    fn compute_intersections_between_sets(
-        &mut self,
-        edges0: &[Rc<RefCell<Edge<F>>>],
-        edges1: &[Rc<RefCell<Edge<F>>>],
+    fn compute_intersections_between_sets<'a>(
+        &self,
+        graph_0: &GeometryGraph<'a, F>,
+        graph_1: &GeometryGraph<'a, F>,
         segment_intersector: &mut SegmentIntersector<F>,
     ) {
-        for edge0 in edges0 {
-            for edge1 in edges1 {
+        let edges_0 = graph_0.edges();
+        let edges_1 = graph_1.edges();
+
+        for edge0 in edges_0 {
+            for edge1 in edges_1 {
                 self.compute_intersects(edge0, edge1, segment_intersector);
             }
         }

--- a/geo/src/algorithm/relate/geomgraph/intersection_matrix.rs
+++ b/geo/src/algorithm/relate/geomgraph/intersection_matrix.rs
@@ -1,6 +1,7 @@
-use crate::{coordinate_position::CoordPos, dimensions::Dimensions};
+use crate::{coordinate_position::CoordPos, dimensions::Dimensions, GeoNum, GeometryCow};
 
 use crate::geometry_cow::GeometryCow::Point;
+use crate::relate::geomgraph::intersection_matrix::dimension_matcher::DimensionMatcher;
 use std::str::FromStr;
 
 /// Models a *Dimensionally Extended Nine-Intersection Model (DE-9IM)* matrix.
@@ -104,8 +105,55 @@ impl std::fmt::Debug for IntersectionMatrix {
 }
 
 impl IntersectionMatrix {
-    pub fn empty() -> Self {
+    pub const fn empty() -> Self {
         IntersectionMatrix(LocationArray([LocationArray([Dimensions::Empty; 3]); 3]))
+    }
+
+    pub(crate) const fn empty_disjoint() -> Self {
+        IntersectionMatrix(LocationArray([
+            LocationArray([Dimensions::Empty, Dimensions::Empty, Dimensions::Empty]),
+            LocationArray([Dimensions::Empty, Dimensions::Empty, Dimensions::Empty]),
+            // since Geometries are finite and embedded in a 2-D space,
+            // the `(Outside, Outside)` element must always be 2-D
+            LocationArray([
+                Dimensions::Empty,
+                Dimensions::Empty,
+                Dimensions::TwoDimensional,
+            ]),
+        ]))
+    }
+
+    /// If the Geometries are disjoint, we need to enter their dimension and boundary dimension in
+    /// the `Outside` rows in the IM
+    pub(crate) fn compute_disjoint<F: GeoNum>(
+        &mut self,
+        geometry_a: &GeometryCow<F>,
+        geometry_b: &GeometryCow<F>,
+    ) {
+        use crate::algorithm::dimensions::HasDimensions;
+        {
+            let dimensions = geometry_a.dimensions();
+            if dimensions != Dimensions::Empty {
+                self.set(CoordPos::Inside, CoordPos::Outside, dimensions);
+
+                let boundary_dimensions = geometry_a.boundary_dimensions();
+                if boundary_dimensions != Dimensions::Empty {
+                    self.set(CoordPos::OnBoundary, CoordPos::Outside, boundary_dimensions);
+                }
+            }
+        }
+
+        {
+            let dimensions = geometry_b.dimensions();
+            if dimensions != Dimensions::Empty {
+                self.set(CoordPos::Outside, CoordPos::Inside, dimensions);
+
+                let boundary_dimensions = geometry_b.boundary_dimensions();
+                if boundary_dimensions != Dimensions::Empty {
+                    self.set(CoordPos::Outside, CoordPos::OnBoundary, boundary_dimensions);
+                }
+            }
+        }
     }
 
     /// Set `dimensions` of the cell specified by the positions.

--- a/geo/src/algorithm/relate/geomgraph/label.rs
+++ b/geo/src/algorithm/relate/geomgraph/label.rs
@@ -13,7 +13,7 @@ use std::fmt;
 ///
 /// If the component has *no* incidence with one of the geometries, than the `Label`'s
 /// `TopologyPosition` for that geometry is called `empty`.
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub(crate) struct Label {
     geometry_topologies: [TopologyPosition; 2],
 }
@@ -29,6 +29,10 @@ impl fmt::Debug for Label {
 }
 
 impl Label {
+    pub fn swap_args(&mut self) {
+        self.geometry_topologies.swap(0, 1)
+    }
+
     /// Construct an empty `Label` for relating a 1-D line or 0-D point to both geometries.
     pub fn empty_line_or_point() -> Label {
         Label {

--- a/geo/src/algorithm/relate/geomgraph/mod.rs
+++ b/geo/src/algorithm/relate/geomgraph/mod.rs
@@ -8,7 +8,7 @@ pub(crate) use edge_end::{EdgeEnd, EdgeEndKey};
 pub(crate) use edge_end_bundle::{EdgeEndBundle, LabeledEdgeEndBundle};
 pub(crate) use edge_end_bundle_star::{EdgeEndBundleStar, LabeledEdgeEndBundleStar};
 pub(crate) use edge_intersection::EdgeIntersection;
-pub(crate) use geometry_graph::GeometryGraph;
+pub use geometry_graph::GeometryGraph;
 pub(crate) use intersection_matrix::IntersectionMatrix;
 pub(crate) use label::Label;
 pub(crate) use line_intersector::{LineIntersection, LineIntersector};

--- a/geo/src/algorithm/relate/geomgraph/node.rs
+++ b/geo/src/algorithm/relate/geomgraph/node.rs
@@ -1,7 +1,7 @@
 use super::{CoordPos, Dimensions, EdgeEnd, EdgeEndBundleStar, IntersectionMatrix, Label};
 use crate::{Coord, GeoFloat};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) struct CoordNode<F>
 where
     F: GeoFloat,
@@ -11,6 +11,10 @@ where
 }
 
 impl<F: GeoFloat> CoordNode<F> {
+    pub fn swap_label_args(&mut self) {
+        self.label.swap_args()
+    }
+
     pub(crate) fn label(&self) -> &Label {
         &self.label
     }

--- a/geo/src/algorithm/relate/geomgraph/node_map.rs
+++ b/geo/src/algorithm/relate/geomgraph/node_map.rs
@@ -6,6 +6,7 @@ use std::fmt;
 use std::marker::PhantomData;
 
 /// A map of nodes, indexed by the coordinate of the node
+#[derive(Clone, PartialEq)]
 pub(crate) struct NodeMap<F, NF>
 where
     F: GeoFloat,
@@ -16,7 +17,7 @@ where
 }
 
 /// Creates the node stored in `NodeMap`
-pub(crate) trait NodeFactory<F: GeoFloat> {
+pub(crate) trait NodeFactory<F: GeoFloat>: PartialEq {
     type Node;
     fn create_node(coordinate: Coord<F>) -> Self::Node;
 }

--- a/geo/src/algorithm/relate/geomgraph/planar_graph.rs
+++ b/geo/src/algorithm/relate/geomgraph/planar_graph.rs
@@ -7,6 +7,7 @@ use crate::{Coord, GeoFloat};
 use std::cell::RefCell;
 use std::rc::Rc;
 
+#[derive(Clone, PartialEq)]
 pub(crate) struct PlanarGraphNode;
 
 /// The basic node constructor does not allow for incident edges
@@ -20,12 +21,44 @@ where
     }
 }
 
+#[derive(Clone, PartialEq)]
 pub(crate) struct PlanarGraph<F: GeoFloat> {
     pub(crate) nodes: NodeMap<F, PlanarGraphNode>,
     edges: Vec<Rc<RefCell<Edge<F>>>>,
 }
 
 impl<F: GeoFloat> PlanarGraph<F> {
+    pub fn clone_for_arg_index(&self, from_arg_index: usize, to_arg_index: usize) -> Self {
+        let mut graph = Self {
+            nodes: self.nodes.clone(),
+            // deep copy edges
+            edges: self
+                .edges
+                .iter()
+                .map(|e| Rc::new(RefCell::new(e.borrow().clone())))
+                .collect(),
+        };
+        assert_eq!(from_arg_index, 0);
+        if from_arg_index != to_arg_index {
+            graph.swap_labels();
+        }
+        graph
+    }
+
+    fn swap_labels(&mut self) {
+        for node in self.nodes.iter_mut() {
+            node.swap_label_args();
+        }
+        for edge in &mut self.edges {
+            edge.borrow_mut().swap_label_args();
+        }
+    }
+
+    pub fn assert_eq_graph(&self, other: &Self) {
+        assert_eq!(self.nodes, other.nodes);
+        assert_eq!(self.edges, other.edges);
+    }
+
     pub fn edges(&self) -> &[Rc<RefCell<Edge<F>>>] {
         &self.edges
     }

--- a/geo/src/algorithm/relate/geomgraph/topology_position.rs
+++ b/geo/src/algorithm/relate/geomgraph/topology_position.rs
@@ -14,7 +14,7 @@ use std::fmt;
 /// topological relationship attribute for the [`On`](Direction::On) position.
 ///
 /// See [`CoordPos`] for the possible values.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub(crate) enum TopologyPosition {
     Area {
         on: Option<CoordPos>,

--- a/geo/src/geometry_cow.rs
+++ b/geo/src/geometry_cow.rs
@@ -10,7 +10,7 @@ use std::borrow::Cow;
 /// This is a way to "upgrade" an inner type to something like a `Geometry` without `moving` it.
 ///
 /// As an example, see the [`Relate`] trait which uses `GeometryCow`.
-#[derive(PartialEq, Debug, Hash)]
+#[derive(PartialEq, Debug, Hash, Clone)]
 pub(crate) enum GeometryCow<'a, T>
 where
     T: CoordNum,
@@ -101,5 +101,84 @@ impl<'a, T: CoordNum> From<&'a Rect<T>> for GeometryCow<'a, T> {
 impl<'a, T: CoordNum> From<&'a Triangle<T>> for GeometryCow<'a, T> {
     fn from(triangle: &'a Triangle<T>) -> Self {
         GeometryCow::Triangle(Cow::Borrowed(triangle))
+    }
+}
+
+impl<'a, T: CoordNum> From<Point<T>> for GeometryCow<'a, T> {
+    fn from(point: Point<T>) -> Self {
+        GeometryCow::Point(Cow::Owned(point))
+    }
+}
+
+impl<'a, T: CoordNum> From<LineString<T>> for GeometryCow<'a, T> {
+    fn from(line_string: LineString<T>) -> Self {
+        GeometryCow::LineString(Cow::Owned(line_string))
+    }
+}
+
+impl<'a, T: CoordNum> From<Line<T>> for GeometryCow<'a, T> {
+    fn from(line: Line<T>) -> Self {
+        GeometryCow::Line(Cow::Owned(line))
+    }
+}
+
+impl<'a, T: CoordNum> From<Polygon<T>> for GeometryCow<'a, T> {
+    fn from(polygon: Polygon<T>) -> Self {
+        GeometryCow::Polygon(Cow::Owned(polygon))
+    }
+}
+
+impl<'a, T: CoordNum> From<MultiPoint<T>> for GeometryCow<'a, T> {
+    fn from(multi_point: MultiPoint<T>) -> GeometryCow<'a, T> {
+        GeometryCow::MultiPoint(Cow::Owned(multi_point))
+    }
+}
+
+impl<'a, T: CoordNum> From<MultiLineString<T>> for GeometryCow<'a, T> {
+    fn from(multi_line_string: MultiLineString<T>) -> Self {
+        GeometryCow::MultiLineString(Cow::Owned(multi_line_string))
+    }
+}
+
+impl<'a, T: CoordNum> From<MultiPolygon<T>> for GeometryCow<'a, T> {
+    fn from(multi_polygon: MultiPolygon<T>) -> Self {
+        GeometryCow::MultiPolygon(Cow::Owned(multi_polygon))
+    }
+}
+
+impl<'a, T: CoordNum> From<GeometryCollection<T>> for GeometryCow<'a, T> {
+    fn from(geometry_collection: GeometryCollection<T>) -> Self {
+        GeometryCow::GeometryCollection(Cow::Owned(geometry_collection))
+    }
+}
+
+impl<'a, T: CoordNum> From<Rect<T>> for GeometryCow<'a, T> {
+    fn from(rect: Rect<T>) -> Self {
+        GeometryCow::Rect(Cow::Owned(rect))
+    }
+}
+
+impl<'a, T: CoordNum> From<Triangle<T>> for GeometryCow<'a, T> {
+    fn from(triangle: Triangle<T>) -> Self {
+        GeometryCow::Triangle(Cow::Owned(triangle))
+    }
+}
+
+impl<'a, T: CoordNum> From<Geometry<T>> for GeometryCow<'a, T> {
+    fn from(geometry: Geometry<T>) -> Self {
+        match geometry {
+            Geometry::Point(point) => GeometryCow::from(point),
+            Geometry::Line(line) => GeometryCow::from(line),
+            Geometry::LineString(line_string) => GeometryCow::from(line_string),
+            Geometry::Polygon(polygon) => GeometryCow::from(polygon),
+            Geometry::MultiPoint(multi_point) => GeometryCow::from(multi_point),
+            Geometry::MultiLineString(multi_line_string) => GeometryCow::from(multi_line_string),
+            Geometry::MultiPolygon(multi_polygon) => GeometryCow::from(multi_polygon),
+            Geometry::GeometryCollection(geometry_collection) => {
+                GeometryCow::from(geometry_collection)
+            }
+            Geometry::Rect(rect) => GeometryCow::from(rect),
+            Geometry::Triangle(triangle) => GeometryCow::from(triangle),
+        }
     }
 }

--- a/geo/src/lib.rs
+++ b/geo/src/lib.rs
@@ -222,6 +222,7 @@ pub use crate::algorithm::*;
 pub use crate::types::Closest;
 use std::cmp::Ordering;
 
+pub use crate::relate::PreparedGeometry;
 pub use geo_types::{coord, line_string, point, polygon, wkt, CoordFloat, CoordNum};
 
 pub mod geometry;


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Fixes #803 

Much of the cost of the `Relate` operation comes from finding all
intersections between all segments of the two geometries.

To speed this up, the edges of each geometry are put into an R-Tree.

We also have to "self node" each geometry, meaning we need to split any
segments at the point that they'd intersect with themselves.

None of that work is new to this commit, but what is new is that we now
cache the self-noding work and the geometry's r-tree.

    relate prepared polygons
                            time:   [49.036 ms 49.199 ms 49.373 ms]
    relate unprepared polygons
                            time:   [842.91 ms 844.32 ms 845.82 ms]