### PR TITLE
Linear implementation of Frechet distance

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -10,6 +10,8 @@
   * <https://github.com/georust/geo/pull/1192>
 * Fix `AffineTransform::compose` ordering to be conventional - such that the argument is applied *after* self.
   * <https://github.com/georust/geo/pull/1196>
+* Implement Frechet distance using linear algorithm to avoid `fatal runtime error: stack overflow` and improve overall performances.
+  * <https://github.com/georust/geo/pull/1199>
 
 ## 0.28.0
 


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

This PR is due to the fact that when using the `frechet_distance` methods on our tools with long routes (200km+) we were not able to run it due to `fatal runtime error: stack overflow`.

This patch includes a new linear implementation (inspired from [here](https://github.com/joaofig/discrete-frechet/tree/master)) that removes recursion and allows to avoid the stack overflow fatal errors, while improving overall performances (~70% faster when testing 1000 10km-long routes).
