### PR TITLE
Relax constraints on `Coord` and associated structures

### DIFF
--- a/geo-types/src/geometry/coord.rs
+++ b/geo-types/src/geometry/coord.rs
@@ -25,7 +25,7 @@ use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 /// [vector space]: //en.wikipedia.org/wiki/Vector_space
 #[derive(Eq, PartialEq, Clone, Copy, Debug, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct Coord<T: CoordNum = f64> {
+pub struct Coord<T = f64> {
     pub x: T,
     pub y: T,
 }
@@ -33,7 +33,7 @@ pub struct Coord<T: CoordNum = f64> {
 #[deprecated(note = "Renamed to `geo_types::Coord` (or `geo::Coord`)")]
 pub type Coordinate<T = f64> = Coord<T>;
 
-impl<T: CoordNum> From<(T, T)> for Coord<T> {
+impl<T> From<(T, T)> for Coord<T> {
     #[inline]
     fn from(coords: (T, T)) -> Self {
         coord! {
@@ -43,7 +43,7 @@ impl<T: CoordNum> From<(T, T)> for Coord<T> {
     }
 }
 
-impl<T: CoordNum> From<[T; 2]> for Coord<T> {
+impl<T: Copy> From<[T; 2]> for Coord<T> {
     #[inline]
     fn from(coords: [T; 2]) -> Self {
         coord! {
@@ -53,7 +53,7 @@ impl<T: CoordNum> From<[T; 2]> for Coord<T> {
     }
 }
 
-impl<T: CoordNum> From<Point<T>> for Coord<T> {
+impl<T: Copy> From<Point<T>> for Coord<T> {
     #[inline]
     fn from(point: Point<T>) -> Self {
         coord! {
@@ -63,21 +63,21 @@ impl<T: CoordNum> From<Point<T>> for Coord<T> {
     }
 }
 
-impl<T: CoordNum> From<Coord<T>> for (T, T) {
+impl<T> From<Coord<T>> for (T, T) {
     #[inline]
     fn from(coord: Coord<T>) -> Self {
         (coord.x, coord.y)
     }
 }
 
-impl<T: CoordNum> From<Coord<T>> for [T; 2] {
+impl<T> From<Coord<T>> for [T; 2] {
     #[inline]
     fn from(coord: Coord<T>) -> Self {
         [coord.x, coord.y]
     }
 }
 
-impl<T: CoordNum> Coord<T> {
+impl<T: Copy> Coord<T> {
     /// Returns a tuple that contains the x/horizontal & y/vertical component of the coordinate.
     ///
     /// # Examples
@@ -117,7 +117,7 @@ use core::ops::{Add, Div, Mul, Neg, Sub};
 /// ```
 impl<T> Neg for Coord<T>
 where
-    T: CoordNum + Neg<Output = T>,
+    T: Neg<Output = T>,
 {
     type Output = Self;
 
@@ -144,7 +144,7 @@ where
 /// assert_eq!(sum.x, 2.75);
 /// assert_eq!(sum.y, 5.0);
 /// ```
-impl<T: CoordNum> Add for Coord<T> {
+impl<T: Add<Output = T>> Add for Coord<T> {
     type Output = Self;
 
     #[inline]
@@ -170,7 +170,7 @@ impl<T: CoordNum> Add for Coord<T> {
 /// assert_eq!(diff.x, 0.25);
 /// assert_eq!(diff.y, 0.);
 /// ```
-impl<T: CoordNum> Sub for Coord<T> {
+impl<T: Sub<Output = T>> Sub for Coord<T> {
     type Output = Self;
 
     #[inline]
@@ -195,7 +195,7 @@ impl<T: CoordNum> Sub for Coord<T> {
 /// assert_eq!(q.x, 5.0);
 /// assert_eq!(q.y, 10.0);
 /// ```
-impl<T: CoordNum> Mul<T> for Coord<T> {
+impl<T: Copy + Mul<Output = T>> Mul<T> for Coord<T> {
     type Output = Self;
 
     #[inline]
@@ -220,7 +220,7 @@ impl<T: CoordNum> Mul<T> for Coord<T> {
 /// assert_eq!(q.x, 1.25);
 /// assert_eq!(q.y, 2.5);
 /// ```
-impl<T: CoordNum> Div<T> for Coord<T> {
+impl<T: Copy + Div<Output = T>> Div<T> for Coord<T> {
     type Output = Self;
 
     #[inline]
@@ -246,7 +246,7 @@ use num_traits::Zero;
 /// assert_eq!(p.x, 0.);
 /// assert_eq!(p.y, 0.);
 /// ```
-impl<T: CoordNum> Coord<T> {
+impl<T: Zero> Coord<T> {
     #[inline]
     pub fn zero() -> Self {
         coord! {
@@ -256,7 +256,7 @@ impl<T: CoordNum> Coord<T> {
     }
 }
 
-impl<T: CoordNum> Zero for Coord<T> {
+impl<T: Zero> Zero for Coord<T> {
     #[inline]
     fn zero() -> Self {
         Self::zero()

--- a/geo-types/src/geometry/multi_line_string.rs
+++ b/geo-types/src/geometry/multi_line_string.rs
@@ -35,7 +35,7 @@ use core::iter::FromIterator;
 /// of a closed `MultiLineString` is always empty.
 #[derive(Eq, PartialEq, Clone, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct MultiLineString<T: CoordNum = f64>(pub Vec<LineString<T>>);
+pub struct MultiLineString<T = f64>(pub Vec<LineString<T>>);
 
 impl<T: CoordNum> MultiLineString<T> {
     /// Instantiate Self from the raw content value

--- a/geo-types/src/geometry/multi_polygon.rs
+++ b/geo-types/src/geometry/multi_polygon.rs
@@ -21,7 +21,7 @@ use core::iter::FromIterator;
 /// - The interiors of no two constituent polygons may intersect.
 ///
 /// - The boundaries of two (distinct) constituent polygons
-/// may only intersect at finitely many points.
+///     may only intersect at finitely many points.
 ///
 /// Refer to section 6.1.14 of the OGC-SFA for a formal
 /// definition of validity. Note that the validity is not

--- a/geo-types/src/geometry/point.rs
+++ b/geo-types/src/geometry/point.rs
@@ -28,39 +28,103 @@ use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAss
 /// ```
 #[derive(Eq, PartialEq, Clone, Copy, Debug, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct Point<T: CoordNum = f64>(pub Coord<T>);
+pub struct Point<T = f64>(pub Coord<T>);
 
-impl<T: CoordNum> From<Coord<T>> for Point<T> {
+impl<T> From<Coord<T>> for Point<T> {
     fn from(x: Coord<T>) -> Self {
         Point(x)
     }
 }
 
-impl<T: CoordNum> From<(T, T)> for Point<T> {
+impl<T> From<(T, T)> for Point<T> {
     fn from(coords: (T, T)) -> Self {
         Point::new(coords.0, coords.1)
     }
 }
 
-impl<T: CoordNum> From<[T; 2]> for Point<T> {
+impl<T: Copy> From<[T; 2]> for Point<T> {
     fn from(coords: [T; 2]) -> Self {
         Point::new(coords[0], coords[1])
     }
 }
 
-impl<T: CoordNum> From<Point<T>> for (T, T) {
+impl<T> From<Point<T>> for (T, T) {
     fn from(point: Point<T>) -> Self {
         point.0.into()
     }
 }
 
-impl<T: CoordNum> From<Point<T>> for [T; 2] {
+impl<T> From<Point<T>> for [T; 2] {
     fn from(point: Point<T>) -> Self {
         point.0.into()
     }
 }
 
-impl<T: CoordNum> Point<T> {
+impl<T: Copy> Point<T> {
+    /// Returns the x/horizontal component of the point.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use geo_types::Point;
+    ///
+    /// let p = Point::new(1.234, 2.345);
+    ///
+    /// assert_eq!(p.x(), 1.234);
+    /// ```
+    pub fn x(self) -> T {
+        self.0.x
+    }
+
+    /// Returns the y/vertical component of the point.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use geo_types::Point;
+    ///
+    /// let p = Point::new(1.234, 2.345);
+    ///
+    /// assert_eq!(p.y(), 2.345);
+    /// ```
+    pub fn y(self) -> T {
+        self.0.y
+    }
+
+    /// Returns the longitude/horizontal component of the point.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use geo_types::Point;
+    ///
+    /// let p = Point::new(1.234, 2.345);
+    ///
+    /// assert_eq!(p.x(), 1.234);
+    /// ```
+    #[deprecated = "use `Point::x` instead, it's less ambiguous"]
+    pub fn lng(self) -> T {
+        self.x()
+    }
+
+    /// Returns the latitude/vertical component of the point.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use geo_types::Point;
+    ///
+    /// let p = Point::new(1.234, 2.345);
+    ///
+    /// assert_eq!(p.y(), 2.345);
+    /// ```
+    #[deprecated = "use `Point::y` instead, it's less ambiguous"]
+    pub fn lat(self) -> T {
+        self.y()
+    }
+}
+
+impl<T> Point<T> {
     /// Creates a new point.
     ///
     /// # Examples
@@ -75,21 +139,6 @@ impl<T: CoordNum> Point<T> {
     /// ```
     pub fn new(x: T, y: T) -> Self {
         point! { x: x, y: y }
-    }
-
-    /// Returns the x/horizontal component of the point.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use geo_types::Point;
-    ///
-    /// let p = Point::new(1.234, 2.345);
-    ///
-    /// assert_eq!(p.x(), 1.234);
-    /// ```
-    pub fn x(self) -> T {
-        self.0.x
     }
 
     /// Sets the x/horizontal component of the point.
@@ -123,20 +172,6 @@ impl<T: CoordNum> Point<T> {
     /// ```
     pub fn x_mut(&mut self) -> &mut T {
         &mut self.0.x
-    }
-    /// Returns the y/vertical component of the point.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use geo_types::Point;
-    ///
-    /// let p = Point::new(1.234, 2.345);
-    ///
-    /// assert_eq!(p.y(), 2.345);
-    /// ```
-    pub fn y(self) -> T {
-        self.0.y
     }
 
     /// Sets the y/vertical component of the point.
@@ -188,21 +223,6 @@ impl<T: CoordNum> Point<T> {
     pub fn x_y(self) -> (T, T) {
         (self.0.x, self.0.y)
     }
-    /// Returns the longitude/horizontal component of the point.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use geo_types::Point;
-    ///
-    /// let p = Point::new(1.234, 2.345);
-    ///
-    /// assert_eq!(p.x(), 1.234);
-    /// ```
-    #[deprecated = "use `Point::x` instead, it's less ambiguous"]
-    pub fn lng(self) -> T {
-        self.x()
-    }
 
     /// Sets the longitude/horizontal component of the point.
     ///
@@ -222,21 +242,6 @@ impl<T: CoordNum> Point<T> {
         self.set_x(lng)
     }
 
-    /// Returns the latitude/vertical component of the point.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use geo_types::Point;
-    ///
-    /// let p = Point::new(1.234, 2.345);
-    ///
-    /// assert_eq!(p.y(), 2.345);
-    /// ```
-    #[deprecated = "use `Point::y` instead, it's less ambiguous"]
-    pub fn lat(self) -> T {
-        self.y()
-    }
     /// Sets the latitude/vertical component of the point.
     ///
     /// # Examples

--- a/geo-types/src/geometry/polygon.rs
+++ b/geo-types/src/geometry/polygon.rs
@@ -28,23 +28,23 @@ use approx::{AbsDiffEq, RelativeEq};
 /// # Validity
 ///
 /// - The exterior and interior rings must be valid
-/// `LinearRing`s (see [`LineString`]).
+///     `LinearRing`s (see [`LineString`]).
 ///
 /// - No two rings in the boundary may cross, and may
-/// intersect at a `Point` only as a tangent. In other
-/// words, the rings must be distinct, and for every pair of
-/// common points in two of the rings, there must be a
-/// neighborhood (a topological open set) around one that
-/// does not contain the other point.
+///     intersect at a `Point` only as a tangent. In other
+///     words, the rings must be distinct, and for every pair of
+///     common points in two of the rings, there must be a
+///     neighborhood (a topological open set) around one that
+///     does not contain the other point.
 ///
 /// - The closure of the interior of the `Polygon` must
-/// equal the `Polygon` itself. For instance, the exterior
-/// may not contain a spike.
+///     equal the `Polygon` itself. For instance, the exterior
+///     may not contain a spike.
 ///
 /// - The interior of the polygon must be a connected
-/// point-set. That is, any two distinct points in the
-/// interior must admit a curve between these two that lies
-/// in the interior.
+///     point-set. That is, any two distinct points in the
+///     interior must admit a curve between these two that lies
+///     in the interior.
 ///
 /// Refer to section 6.1.11.1 of the OGC-SFA for a formal
 /// definition of validity. Besides the closed `LineString`
@@ -68,12 +68,12 @@ use approx::{AbsDiffEq, RelativeEq};
 /// [`LineString`]: line_string/struct.LineString.html
 #[derive(Eq, PartialEq, Clone, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct Polygon<T: CoordNum = f64> {
+pub struct Polygon<T = f64> {
     exterior: LineString<T>,
     interiors: Vec<LineString<T>>,
 }
 
-impl<T: CoordNum> Polygon<T> {
+impl<T> Polygon<T> {
     /// Create a new `Polygon` with the provided exterior `LineString` ring and
     /// interior `LineString` rings.
     ///
@@ -124,7 +124,10 @@ impl<T: CoordNum> Polygon<T> {
     ///     &LineString::from(vec![(0., 0.), (1., 1.), (1., 0.), (0., 0.),])
     /// );
     /// ```
-    pub fn new(mut exterior: LineString<T>, mut interiors: Vec<LineString<T>>) -> Self {
+    pub fn new(mut exterior: LineString<T>, mut interiors: Vec<LineString<T>>) -> Self
+    where
+        T: Copy + PartialEq,
+    {
         exterior.close();
         for interior in &mut interiors {
             interior.close();
@@ -241,6 +244,7 @@ impl<T: CoordNum> Polygon<T> {
     pub fn exterior_mut<F>(&mut self, f: F)
     where
         F: FnOnce(&mut LineString<T>),
+        T: PartialEq + Copy,
     {
         f(&mut self.exterior);
         self.exterior.close();
@@ -250,6 +254,7 @@ impl<T: CoordNum> Polygon<T> {
     pub fn try_exterior_mut<F, E>(&mut self, f: F) -> Result<(), E>
     where
         F: FnOnce(&mut LineString<T>) -> Result<(), E>,
+        T: PartialEq + Copy,
     {
         f(&mut self.exterior)?;
         self.exterior.close();
@@ -353,6 +358,7 @@ impl<T: CoordNum> Polygon<T> {
     pub fn interiors_mut<F>(&mut self, f: F)
     where
         F: FnOnce(&mut [LineString<T>]),
+        T: PartialEq + Copy,
     {
         f(&mut self.interiors);
         for interior in &mut self.interiors {
@@ -364,6 +370,7 @@ impl<T: CoordNum> Polygon<T> {
     pub fn try_interiors_mut<F, E>(&mut self, f: F) -> Result<(), E>
     where
         F: FnOnce(&mut [LineString<T>]) -> Result<(), E>,
+        T: PartialEq + Copy,
     {
         f(&mut self.interiors)?;
         for interior in &mut self.interiors {
@@ -402,7 +409,10 @@ impl<T: CoordNum> Polygon<T> {
     /// ```
     ///
     /// [will be closed]: #linestring-closing-operation
-    pub fn interiors_push(&mut self, new_interior: impl Into<LineString<T>>) {
+    pub fn interiors_push(&mut self, new_interior: impl Into<LineString<T>>)
+    where
+        T: PartialEq + Copy,
+    {
         let mut new_interior = new_interior.into();
         new_interior.close();
         self.interiors.push(new_interior);

--- a/geo-types/src/geometry/rect.rs
+++ b/geo-types/src/geometry/rect.rs
@@ -39,7 +39,7 @@ use approx::{AbsDiffEq, RelativeEq};
 /// ```
 #[derive(Eq, PartialEq, Clone, Copy, Debug, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct Rect<T: CoordNum = f64> {
+pub struct Rect<T = f64> {
     min: Coord<T>,
     max: Coord<T>,
 }

--- a/geo-types/src/geometry/triangle.rs
+++ b/geo-types/src/geometry/triangle.rs
@@ -9,24 +9,25 @@ use approx::{AbsDiffEq, RelativeEq};
 /// vertices must not be collinear and they must be distinct.
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct Triangle<T: CoordNum = f64>(pub Coord<T>, pub Coord<T>, pub Coord<T>);
+pub struct Triangle<T = f64>(pub Coord<T>, pub Coord<T>, pub Coord<T>);
 
-impl<T: CoordNum> Triangle<T> {
-    /// Instantiate Self from the raw content value
-    pub fn new(v1: Coord<T>, v2: Coord<T>, v3: Coord<T>) -> Self {
-        Self(v1, v2, v3)
-    }
-
+impl<T: Copy> Triangle<T> {
     pub fn to_array(&self) -> [Coord<T>; 3] {
         [self.0, self.1, self.2]
     }
-
     pub fn to_lines(&self) -> [Line<T>; 3] {
         [
             Line::new(self.0, self.1),
             Line::new(self.1, self.2),
             Line::new(self.2, self.0),
         ]
+    }
+}
+
+impl<T> Triangle<T> {
+    /// Instantiate Self from the raw content value
+    pub fn new(v1: Coord<T>, v2: Coord<T>, v3: Coord<T>) -> Self {
+        Self(v1, v2, v3)
     }
 
     /// Create a `Polygon` from the `Triangle`.
@@ -52,7 +53,10 @@ impl<T: CoordNum> Triangle<T> {
     ///     ],
     /// );
     /// ```
-    pub fn to_polygon(self) -> Polygon<T> {
+    pub fn to_polygon(self) -> Polygon<T>
+    where
+        T: Copy + PartialEq,
+    {
         polygon![self.0, self.1, self.2, self.0]
     }
 }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
Hello! I am currently working on a rendering library for leptos, which uses geo. I would like to make interactive `svg`s in the dom, but that requires that some of the inner types of several `geo-types` structs should have their constraints relaxed.

This change does not affect current implementations in other crates, as these changes only allow types that are not `CoordNum` (but potentially implement `Add` or `PartialEq`, etc.) to access crate implementations.

The reasoning for keeping generics unconstrained on structs is identified in the [Rust API Guide](https://rust-lang.github.io/api-guidelines/future-proofing.html#c-struct-bounds). This change is part of a series of processes to relax bounds as the `geo` ecosystem is extended.

- `Coord` no longer has an impl constraint of `CoordNum` for its inner values
- `Rect<T>`, `LineString<T>`, `Line<T>`,`PointsIter<T>` generic constraints have been relaxed.
- Certain implementations have been relaxed for `T` across types to allow values to access identical functionality written by `geo`

Relates to  #1169 and #1157.
Relates to https://github.com/georust/geo-svg/issues/13
Thank you for your consideration!