### PR TITLE
Fix doc indents to appease clippy

### DIFF
--- a/geo-types/src/geometry/multi_polygon.rs
+++ b/geo-types/src/geometry/multi_polygon.rs
@@ -20,8 +20,7 @@ use core::iter::FromIterator;
 ///
 /// - The interiors of no two constituent polygons may intersect.
 ///
-/// - The boundaries of two (distinct) constituent polygons
-/// may only intersect at finitely many points.
+/// - The boundaries of two (distinct) constituent polygons may only intersect at finitely many points.
 ///
 /// Refer to section 6.1.14 of the OGC-SFA for a formal
 /// definition of validity. Note that the validity is not

--- a/geo-types/src/geometry/polygon.rs
+++ b/geo-types/src/geometry/polygon.rs
@@ -28,23 +28,23 @@ use approx::{AbsDiffEq, RelativeEq};
 /// # Validity
 ///
 /// - The exterior and interior rings must be valid
-/// `LinearRing`s (see [`LineString`]).
+///   `LinearRing`s (see [`LineString`]).
 ///
 /// - No two rings in the boundary may cross, and may
-/// intersect at a `Point` only as a tangent. In other
-/// words, the rings must be distinct, and for every pair of
-/// common points in two of the rings, there must be a
-/// neighborhood (a topological open set) around one that
-/// does not contain the other point.
+///   intersect at a `Point` only as a tangent. In other
+///   words, the rings must be distinct, and for every pair of
+///   common points in two of the rings, there must be a
+///   neighborhood (a topological open set) around one that
+///   does not contain the other point.
 ///
 /// - The closure of the interior of the `Polygon` must
-/// equal the `Polygon` itself. For instance, the exterior
-/// may not contain a spike.
+///   equal the `Polygon` itself. For instance, the exterior
+///   may not contain a spike.
 ///
 /// - The interior of the polygon must be a connected
-/// point-set. That is, any two distinct points in the
-/// interior must admit a curve between these two that lies
-/// in the interior.
+///   point-set. That is, any two distinct points in the
+///   interior must admit a curve between these two that lies
+///   in the interior.
 ///
 /// Refer to section 6.1.11.1 of the OGC-SFA for a formal
 /// definition of validity. Besides the closed `LineString`

--- a/geo/src/algorithm/is_convex.rs
+++ b/geo/src/algorithm/is_convex.rs
@@ -11,29 +11,29 @@ use crate::{Coord, GeoNum, LineString};
 /// # Remarks
 ///
 /// - Collinearity does not require that the `LineString`
-/// be closed, but the rest of the predicates do.
+///   be closed, but the rest of the predicates do.
 ///
 /// - This definition is closely related to the notion
-/// of [convexity of polygons][convex set]. In particular, a
-/// [`Polygon`](crate::Polygon) is convex, if and only if its `exterior` is
-/// convex, and `interiors` is empty.
+///   of [convexity of polygons][convex set]. In particular, a
+///   [`Polygon`](crate::Polygon) is convex, if and only if its `exterior` is
+///   convex, and `interiors` is empty.
 ///
 /// - The [`ConvexHull`] algorithm always returns a strictly
-/// convex `LineString` unless the input is empty or
-/// collinear. The [`graham_hull`] algorithm provides an
-/// option to include collinear points, producing a
-/// (possibly non-strict) convex `LineString`.
+///   convex `LineString` unless the input is empty or
+///   collinear. The [`graham_hull`] algorithm provides an
+///   option to include collinear points, producing a
+///   (possibly non-strict) convex `LineString`.
 ///
 /// # Edge Cases
 ///
 /// - the convexity, and collinearity of an empty
-/// `LineString` is _unspecified_ and must not be relied
-/// upon.
+///   `LineString` is _unspecified_ and must not be relied
+///   upon.
 ///
 /// - A closed `LineString` with at most three coordinates
-/// (including the possibly repeated first coordinate) is
-/// both convex and collinear. However, the strict convexity
-/// is _unspecified_ and must not be relied upon.
+///   (including the possibly repeated first coordinate) is
+///   both convex and collinear. However, the strict convexity
+///   is _unspecified_ and must not be relied upon.
 ///
 /// [convex combination]: //en.wikipedia.org/wiki/Convex_combination
 /// [convex set]: //en.wikipedia.org/wiki/Convex_set

--- a/geo/src/algorithm/monotone/sweep.rs
+++ b/geo/src/algorithm/monotone/sweep.rs
@@ -15,8 +15,8 @@ use super::{RcSegment, Segment};
 /// - iterate over all end-points of the input line or points in lex. order
 ///
 /// - query the set of active segments at the current iteration point: these are
-/// the segments currently intersecting the sweep line, and are ordered by their
-/// position on the line
+///   the segments currently intersecting the sweep line, and are ordered by their
+///    position on the line
 ///
 /// # Note
 ///

--- a/geo/src/algorithm/simplify_vw.rs
+++ b/geo/src/algorithm/simplify_vw.rs
@@ -548,9 +548,9 @@ pub trait SimplifyVwPreserve<T, Epsilon = T> {
     /// - It is possible for the simplification algorithm to displace a Polygon's interior ring outside its shell.
     /// - The algorithm does **not** guarantee a valid output geometry, especially on smaller geometries.
     /// - If removal of a point causes a self-intersection, but the geometry only has `n + 1`
-    /// points remaining (3 for a `LineString`, 5 for a `Polygon`), the point is retained and the
-    /// simplification process ends. This is because there is no guarantee that removal of two points will remove
-    /// the intersection, but removal of further points would leave too few points to form a valid geometry.
+    ///   points remaining (3 for a `LineString`, 5 for a `Polygon`), the point is retained and the
+    ///   simplification process ends. This is because there is no guarantee that removal of two points will remove
+    ///   the intersection, but removal of further points would leave too few points to form a valid geometry.
     /// - The tolerance used to remove a point is `epsilon`, in keeping with GEOS. JTS uses `epsilon ^ 2`
     ///
     /// # Examples

--- a/geo/src/algorithm/sweep/line_or_point.rs
+++ b/geo/src/algorithm/sweep/line_or_point.rs
@@ -146,10 +146,10 @@ impl<T: GeoNum> PartialEq for LineOrPoint<T> {
 /// Requires the following conditions:
 ///
 /// 1. If comparing two lines, both the left ends must be strictly
-/// smaller than both right ends.
+///    smaller than both right ends.
 ///
 /// 2. A point is treated as a infinitesimal small vertical segment
-/// centered at its coordinates.
+///    centered at its coordinates.
 impl<T: GeoNum> PartialOrd for LineOrPoint<T> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         match (self, other) {

--- a/geo/src/algorithm/triangulate_spade.rs
+++ b/geo/src/algorithm/triangulate_spade.rs
@@ -460,7 +460,7 @@ fn remove_lines_by_index<T: SpadeTriangulationFloat>(
 /// split lines based on intersection kind:
 ///
 /// - intersection point: create 4 new lines from the existing line's endpoints to the intersection
-/// point
+///   point
 /// - collinear: create 3 new lines (before overlap, overlap, after overlap)
 fn split_lines<T: SpadeTriangulationFloat>(
     [l0, l1]: [Line<T>; 2],


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Clippy complains about these as of 1.80
