### PR TITLE
triangulate-spade: small optimization, potentially up to a factor of 1/2

### DIFF
--- a/geo/src/algorithm/triangulate_spade.rs
+++ b/geo/src/algorithm/triangulate_spade.rs
@@ -412,6 +412,7 @@ fn iter_line_pairs<T: SpadeTriangulationFloat>(
         lines
             .iter()
             .enumerate()
+            .skip(idx0 + 1)
             .filter(move |(idx1, line1)| *idx1 != idx0 && line0 != *line1)
             .map(move |(idx1, line1)| [(idx0, line0), (idx1, line1)])
     })


### PR DESCRIPTION
Just found this when randomly inspecting the code.

Benchmarking results after the optimization:

```
TriangulateSpade (unconstrained) - small polys
                        time:   [7.7546 ms 7.7579 ms 7.7615 ms]
                        change: [-0.1240% -0.0645% -0.0048%] (p = 0.04 < 0.05)
                        Change within noise threshold.
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) high mild
  4 (4.00%) high severe

Benchmarking TriangulateSpade (constrained) - small polys: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 51.6s, or reduce sample count to 10.
TriangulateSpade (constrained) - small polys
                        time:   [512.64 ms 513.03 ms 513.44 ms]
                        change: [-10.101% -10.023% -9.9359%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

TriangulateEarcut - small polys
                        time:   [4.2893 ms 4.2922 ms 4.2949 ms]
                        change: [+0.5207% +0.6343% +0.7477%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 16 outliers among 100 measurements (16.00%)
  6 (6.00%) low severe
  7 (7.00%) low mild
  1 (1.00%) high mild
  2 (2.00%) high severe

TriangulateSpade (unconstrained) - large_poly
                        time:   [3.4148 ms 3.4174 ms 3.4204 ms]
                        change: [+0.7127% +0.8072% +0.9017%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe

Benchmarking TriangulateSpade (constrained) - large_poly: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 91.7s, or reduce sample count to 10.
TriangulateSpade (constrained) - large_poly
                        time:   [916.72 ms 917.95 ms 919.33 ms]
                        change: [-10.563% -10.367% -10.184%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high severe

Benchmarking TriangulateEarcut - large_poly: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 7.3s, enable flat sampling, or reduce sample count to 50.
TriangulateEarcut - large_poly
                        time:   [1.4410 ms 1.4438 ms 1.4474 ms]
                        change: [-0.7569% -0.5342% -0.3114%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 12 outliers among 100 measurements (12.00%)
  7 (7.00%) high mild
  5 (5.00%) high severe
```

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] ~~I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.~~
---
