### PR TITLE
Add `DensifyGeodesic` trait

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -18,6 +18,8 @@
   * <https://github.com/georust/geo/pull/1201>
 * Add `StitchTriangles` trait which implements a new kind of combining algorithm for `Triangle`s
   * <https://github.com/georust/geo/pull/1087>
+* Add `DensifyGeodesic` trait which implements densification by interpolating points on a spheroid
+  * <https://github.com/georust/geo/pull/1208>
 
 ## 0.28.0
 

--- a/geo/src/algorithm/densify_geodesic.rs
+++ b/geo/src/algorithm/densify_geodesic.rs
@@ -255,4 +255,14 @@ mod tests {
         let dense = linestring.densify_geodesic(10.0);
         assert_eq!(0, dense.coords_count());
     }
+
+    #[test]
+    fn test_no_op_densify() {
+        let linestring: LineString = vec![[0.0, 0.0], [1.0, 0.0], [2.0, 0.0], [3.0, 0.0]].into();
+        let output: LineString = vec![[0.0, 0.0], [1.0, 0.0], [2.0, 0.0], [3.0, 0.0]].into();
+        // Use a very large max_meters to ensure no points are added.
+        let dense = linestring.densify_geodesic(1000000.0);
+        // Check that the densified linestring is identical to the original.
+        assert_relative_eq!(dense, output, epsilon = 1.0e-6);
+    }
 }

--- a/geo/src/algorithm/densify_geodesic.rs
+++ b/geo/src/algorithm/densify_geodesic.rs
@@ -1,6 +1,6 @@
 use num_traits::ToPrimitive;
 
-use crate::{CoordFloat, Line, Point};
+use crate::{CoordFloat, CoordsIter, Line, LineString, MultiLineString, MultiPolygon, Point, Polygon, Rect, Triangle};
 
 use crate::{GeodesicIntermediate, GeodesicLength};
 
@@ -39,5 +39,107 @@ fn densify_line(
         let ratio = frac * segment_idx as f64;
         let interpolated_point = Point::from(start).geodesic_intermediate(&Point::from(end), ratio);
         container.push(interpolated_point);
+    }
+}
+
+impl DensifyGeodesic<f64> for MultiPolygon<f64>
+where
+    Line<f64>: GeodesicLength<f64>,
+    LineString<f64>: GeodesicLength<f64>,
+{
+    type Output = MultiPolygon<f64>;
+
+    fn densify_geodesic(&self, max_distance: f64) -> Self::Output {
+        MultiPolygon::new(
+            self.iter().map(|polygon| polygon.densify_geodesic(max_distance)).collect(),
+        )
+    }
+}
+
+impl DensifyGeodesic<f64> for Polygon<f64>
+where
+    Line<f64>: GeodesicLength<f64>,
+    LineString<f64>: GeodesicLength<f64>,
+{
+    type Output = Polygon<f64>;
+
+    fn densify_geodesic(&self, max_distance: f64) -> Self::Output {
+        let densified_exterior = self.exterior().densify_geodesic(max_distance);
+        let densified_interiors = self.interiors().iter().map(|ring| ring.densify_geodesic(max_distance)).collect();
+        Polygon::new(densified_exterior, densified_interiors)
+    }
+}
+
+impl DensifyGeodesic<f64> for MultiLineString<f64>
+where
+    Line<f64>: GeodesicLength<f64>,
+    LineString<f64>: GeodesicLength<f64>,
+{
+    type Output = MultiLineString<f64>;
+
+    fn densify_geodesic(&self, max_distance: f64) -> Self::Output {
+        MultiLineString::new(
+            self.iter().map(|linestring| linestring.densify_geodesic(max_distance)).collect(),
+        )
+    }
+}
+
+impl DensifyGeodesic<f64> for LineString<f64>
+where
+    Line<f64>: GeodesicLength<f64>,
+    LineString<f64>: GeodesicLength<f64>,
+{
+    type Output = LineString<f64>;
+
+    fn densify_geodesic(&self, max_distance: f64) -> Self::Output {
+        if self.coords_count() == 0 {
+            return LineString::new(vec![]);
+        }
+
+        let mut new_line = vec![];
+        self.lines().for_each(|line| densify_line(line, &mut new_line, max_distance));
+        // we're done, push the last coordinate on to finish
+        new_line.push(self.points().last().unwrap());
+        LineString::from(new_line)
+    }
+}
+
+impl DensifyGeodesic<f64> for Line<f64>
+where
+    Line<f64>: GeodesicLength<f64>,
+    LineString<f64>: GeodesicLength<f64>,
+{
+    type Output = LineString<f64>;
+
+    fn densify_geodesic(&self, max_distance: f64) -> Self::Output {
+        let mut new_line = vec![];
+        densify_line(*self, &mut new_line, max_distance);
+        // we're done, push the last coordinate on to finish
+        new_line.push(self.end_point());
+        LineString::from(new_line)
+    }
+}
+
+impl DensifyGeodesic<f64> for Triangle<f64>
+where
+    Line<f64>: GeodesicLength<f64>,
+    LineString<f64>: GeodesicLength<f64>,
+{
+    type Output = Polygon<f64>;
+
+    fn densify_geodesic(&self, max_distance: f64) -> Self::Output {
+        self.to_polygon().densify_geodesic(max_distance)
+    }
+}
+
+impl DensifyGeodesic<f64> for Rect<f64>
+where
+    Line<f64>: GeodesicLength<f64>,
+    LineString<f64>: GeodesicLength<f64>,
+{
+    type Output = Polygon<f64>;
+
+    fn densify_geodesic(&self, max_distance: f64) -> Self::Output {
+        self.to_polygon().densify_geodesic(max_distance)
     }
 }

--- a/geo/src/algorithm/densify_geodesic.rs
+++ b/geo/src/algorithm/densify_geodesic.rs
@@ -12,6 +12,22 @@ use crate::{GeodesicIntermediate, GeodesicLength};
 /// ## Units
 ///
 /// `max_distance`: meters
+///
+/// # Examples
+/// ```
+/// use approx::assert_relative_eq;
+///
+/// use geo::{coord, GeodesicLength, Line, LineString};
+/// use geo::DensifyGeodesic;
+///
+/// let line = Line::new(coord! {x: 10.0, y: 20.0}, coord! { x: 125.0, y: 25.00 });
+/// // known output
+/// let output: LineString = vec![[10.0, 20.0], [65.879360, 37.722253], [125.0, 25.00]].into();
+/// // densify
+/// let dense = line.densify_geodesic(5703861.471800622);
+///
+/// assert_relative_eq!(dense, output, epsilon = 1.0e-6);
+///```
 pub trait DensifyGeodesic<F: CoordFloat> {
     type Output;
 

--- a/geo/src/algorithm/densify_geodesic.rs
+++ b/geo/src/algorithm/densify_geodesic.rs
@@ -1,4 +1,8 @@
-use crate::CoordFloat;
+use num_traits::ToPrimitive;
+
+use crate::{CoordFloat, Line, Point};
+
+use crate::{GeodesicIntermediate, GeodesicLength};
 
 /// Returns a new geometry on a spheroid containing both existing and new interpolated coordinates with
 /// a maximum distance of `max_distance` between them.
@@ -12,4 +16,28 @@ pub trait DensifyGeodesic<F: CoordFloat> {
     type Output;
 
     fn densify_geodesic(&self, max_distance: F) -> Self::Output;
+}
+
+// Helper for densification trait
+fn densify_line(
+    line: Line<f64>,
+    container: &mut Vec<Point<f64>>,
+    max_distance: f64,
+) {
+    assert!(max_distance > 0.0);
+
+    container.push(line.start_point());
+
+    let num_segments = (line.geodesic_length() / max_distance).ceil().to_u64().unwrap();
+    // distance "unit" for this line segment
+    let frac = 1.0 / num_segments as f64;
+
+    let start = line.start;
+    let end = line.end;
+
+    for segment_idx in 1..num_segments {
+        let ratio = frac * segment_idx as f64;
+        let interpolated_point = Point::from(start).geodesic_intermediate(&Point::from(end), ratio);
+        container.push(interpolated_point);
+    }
 }

--- a/geo/src/algorithm/densify_geodesic.rs
+++ b/geo/src/algorithm/densify_geodesic.rs
@@ -1,0 +1,15 @@
+use crate::CoordFloat;
+
+/// Returns a new geometry on a spheroid containing both existing and new interpolated coordinates with
+/// a maximum distance of `max_distance` between them.
+///
+/// Note: `max_distance` must be greater than 0.
+///
+/// ## Units
+///
+/// `max_distance`: meters
+pub trait DensifyGeodesic<F: CoordFloat> {
+    type Output;
+
+    fn densify_geodesic(&self, max_distance: F) -> Self::Output;
+}

--- a/geo/src/algorithm/densify_geodesic.rs
+++ b/geo/src/algorithm/densify_geodesic.rs
@@ -1,6 +1,9 @@
-use num_traits::{FromPrimitive, ToPrimitive};
+use num_traits::ToPrimitive;
 
-use crate::{CoordFloat, CoordsIter, Line, LineString, MultiLineString, MultiPolygon, Point, Polygon, Rect, Triangle};
+use crate::{
+    CoordFloat, CoordsIter, Line, LineString, MultiLineString, MultiPolygon, Point, Polygon, Rect,
+    Triangle,
+};
 
 use crate::{GeodesicIntermediate, GeodesicLength};
 

--- a/geo/src/algorithm/mod.rs
+++ b/geo/src/algorithm/mod.rs
@@ -7,8 +7,10 @@ pub mod area;
 pub use area::Area;
 
 /// Calculate the bearing to another `Point`, in degrees.
-#[deprecated(since = "0.24.1",
-    note = "renamed to `haversine_bearing::HaversineBearing`")]
+#[deprecated(
+    since = "0.24.1",
+    note = "renamed to `haversine_bearing::HaversineBearing`"
+)]
 pub mod bearing;
 #[allow(deprecated)]
 #[deprecated(since = "0.24.1", note = "renamed to `HaversineBearing`")]

--- a/geo/src/algorithm/mod.rs
+++ b/geo/src/algorithm/mod.rs
@@ -7,10 +7,8 @@ pub mod area;
 pub use area::Area;
 
 /// Calculate the bearing to another `Point`, in degrees.
-#[deprecated(
-    since = "0.24.1",
-    note = "renamed to `haversine_bearing::HaversineBearing`"
-)]
+#[deprecated(since = "0.24.1",
+    note = "renamed to `haversine_bearing::HaversineBearing`")]
 pub mod bearing;
 #[allow(deprecated)]
 #[deprecated(since = "0.24.1", note = "renamed to `HaversineBearing`")]
@@ -83,6 +81,10 @@ pub use densify::Densify;
 /// Densify spherical geometry components
 pub mod densify_haversine;
 pub use densify_haversine::DensifyHaversine;
+
+/// Densify geometry components on a spheroid;
+pub mod densify_geodesic;
+pub use densify_geodesic::DensifyGeodesic;
 
 /// Dimensionality of a geometry and its boundary, based on OGC-SFA.
 pub mod dimensions;

--- a/geo/src/algorithm/mod.rs
+++ b/geo/src/algorithm/mod.rs
@@ -82,7 +82,7 @@ pub use densify::Densify;
 pub mod densify_haversine;
 pub use densify_haversine::DensifyHaversine;
 
-/// Densify geometry components on a spheroid;
+/// Densify geometry components on a geodesic.
 pub mod densify_geodesic;
 pub use densify_geodesic::DensifyGeodesic;
 

--- a/geo/src/lib.rs
+++ b/geo/src/lib.rs
@@ -158,6 +158,7 @@
 //! - **[`ChaikinSmoothing`]**: Smoothen `LineString`, `Polygon`, `MultiLineString` and `MultiPolygon` using Chaikin's algorithm.
 //! - **[`Densify`]**: Densify linear geometry components by interpolating points
 //! - **[`DensifyHaversine`]**: Densify spherical geometry by interpolating points on a sphere
+//! - **[`DensifyGeodesic`]**: Densify geometry by interpolating points on a spheroid
 //! - **[`GeodesicDestination`]**: Given a start point, bearing, and distance, calculate the destination point on a [geodesic](https://en.wikipedia.org/wiki/Geodesics_on_an_ellipsoid)
 //! - **[`GeodesicIntermediate`]**: Calculate intermediate points on a [geodesic](https://en.wikipedia.org/wiki/Geodesics_on_an_ellipsoid)
 //! - **[`HaversineDestination`]**: Given a start point, bearing, and distance, calculate the destination point on a sphere assuming travel on a great circle


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

This PR adds `DensifyGeodesic` trait that follows logic similar to `DensifyHaversine`. However, the trait is only implemented for `T = f64` as underlying Geodesic traits are implemented only for this type. 