### PR TITLE
fix: replace `partial_cmp` with `total_cmp` in sorting

### DIFF
--- a/geo/src/algorithm/interior_point.rs
+++ b/geo/src/algorithm/interior_point.rs
@@ -210,7 +210,7 @@ fn polygon_interior_point_with_segment_length<T: GeoFloat>(
         let midpoint = Point::new((start.x + end.x) / two, y_mid);
         segments.push((midpoint, length));
     }
-    segments.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(Ordering::Less));
+    segments.sort_by(|a, b| b.1.total_cmp(&a.1));
 
     for (midpoint, segment_length) in segments {
         // some pairs of consecutive points traveling east-west will bound segments inside the


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

FIXES #1213 
