### PR TITLE
Empty geoms have equal topo

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -38,6 +38,8 @@
   Haversine::distance(p1, p2)
   ```
   * <https://github.com/georust/geo/pull/1216>
+* Change IntersectionMatrix::is_equal_topo to now consider empty geometries as equal.
+  * <https://github.com/georust/geo/pull/1223>
 
 ## 0.28.0
 

--- a/geo/src/algorithm/relate/geomgraph/intersection_matrix.rs
+++ b/geo/src/algorithm/relate/geomgraph/intersection_matrix.rs
@@ -324,6 +324,11 @@ impl IntersectionMatrix {
     /// - Matches `[T*F**FFF*]`
     /// - This predicate is **reflexive, symmetric, and transitive**
     pub fn is_equal_topo(&self) -> bool {
+        if self == &Self::empty_disjoint() {
+            // Any two empty geometries are topologically equal
+            return true;
+        }
+
         self.0[CoordPos::Inside][CoordPos::Inside] != Dimensions::Empty
             && self.0[CoordPos::Inside][CoordPos::Outside] == Dimensions::Empty
             && self.0[CoordPos::Outside][CoordPos::Inside] == Dimensions::Empty
@@ -753,5 +758,12 @@ mod tests {
     #[test]
     fn matches_wildcard() {
         assert!(subject().matches("F0011122*").unwrap());
+    }
+
+    #[test]
+    fn empty_is_equal_topo() {
+        let empty_polygon = Polygon::<f64>::new(LineString::new(vec![]), vec![]);
+        let im = empty_polygon.relate(&empty_polygon);
+        assert!(im.is_equal_topo());
     }
 }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Note, this is a divergence from JTS.Geometry.isEqualTopo, but it seems
like the right thing to do.

Supportive discussion with Dr. JTS:
https://github.com/locationtech/jts/issues/1087#issuecomment-2403630534

It also aligns with the new Overlay semantics in GEOS (OverlayNG).
