### PR TITLE
Include is_equal_topo tests from jts test suite

### DIFF
--- a/jts-test-runner/resources/testxml/validate/TestRelatePL.xml
+++ b/jts-test-runner/resources/testxml/validate/TestRelatePL.xml
@@ -40,7 +40,7 @@
   <test><op name="covers"     arg1="A" arg2="B">true</op></test>
   <test><op name="crosses"    arg1="A" arg2="B">false</op></test>
   <test><op name="disjoint"   arg1="A" arg2="B">false</op></test>
-  <test><op name="equalsTopo" arg1="A" arg2="B">false</op></test>
+  <test><op name="equalsTopo" arg1="A" arg2="B">true</op></test>
   <test><op name="intersects" arg1="A" arg2="B">true</op></test>
   <test><op name="overlaps"   arg1="A" arg2="B">false</op></test>
   <test><op name="touches"    arg1="A" arg2="B">false</op></test>

--- a/jts-test-runner/src/lib.rs
+++ b/jts-test-runner/src/lib.rs
@@ -74,7 +74,7 @@ mod tests {
         //
         // We'll need to increase this number as more tests are added, but it should never be
         // decreased.
-        let expected_test_count: usize = 2213;
+        let expected_test_count: usize = 2697;
         let actual_test_count = runner.failures().len() + runner.successes().len();
         match actual_test_count.cmp(&expected_test_count) {
             Ordering::Less => {

--- a/jts-test-runner/src/runner.rs
+++ b/jts-test-runner/src/runner.rs
@@ -8,7 +8,7 @@ use wkt::ToWkt;
 use super::{input, Operation, Result};
 use geo::algorithm::{BooleanOps, Contains, HasDimensions, Intersects, Within};
 use geo::geometry::*;
-use geo::GeoNum;
+use geo::{GeoNum, Relate};
 
 const GENERAL_TEST_XML: Dir = include_dir!("$CARGO_MANIFEST_DIR/resources/testxml/general");
 const VALIDATE_TEST_XML: Dir = include_dir!("$CARGO_MANIFEST_DIR/resources/testxml/validate");
@@ -140,6 +140,22 @@ impl TestRunner {
                     } else {
                         debug!("Contains success: actual == expected");
                         self.successes.push(test_case);
+                    }
+                }
+                Operation::EqualsTopo { a, b, expected } => {
+                    let im = a.relate(b);
+                    let actual = im.is_equal_topo();
+                    if actual == *expected {
+                        debug!("Passed: EqualsTopo was {actual}");
+                        self.successes.push(test_case);
+                    } else {
+                        debug!("is_equal_topo was {actual}, but expected {expected}");
+                        let error_description =
+                            format!("is_equal_topo was {actual}, but expected {expected}");
+                        self.failures.push(TestFailure {
+                            test_case,
+                            error_description,
+                        });
                     }
                 }
                 Operation::Within {


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [n/a] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

No change in behavior here - I just realized there were some additional tests we can add to our test suite.