### PR TITLE
FIX: MultiPolygon with only Empty Polygon should have Empty dimensions

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -48,6 +48,9 @@
 * Fix `(LINESTRING EMPTY).contains(LINESTRING EMPTY)` and `(MULTIPOLYGON EMPTY).contains(MULTIPOINT EMPTY)` which previously
   reported true
   * <https://github.com/georust/geo/pull/1227>
+* Improve `HasDimensions::dimensions` to handle dimensionally collapsed and empty geometries more consistently.
+  A collection (like MultiPolygon) will now have EmptyDimensions when all of its elements have EmptyDimensions.
+  * <https://github.com/georust/geo/pull/1226>
 
 ## 0.28.0
 


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

In pursuit of evaluating i_overlay, I found some bugs with how we compute dimensions for some empty / dimensionally collapsed geometries.

Most of the new tests were already passing, but these ones failed with the old code:
```
failures:

---- algorithm::dimensions::tests::dimensional_collapse::polygon_collapsed_to_line stdout ----
thread 'algorithm::dimensions::tests::dimensional_collapse::polygon_collapsed_to_line' panicked at geo/src/algorithm/dimensions.rs:577:13:
assertion `left == right` failed
  expected: OneDimensional
    actual: TwoDimensional

---- algorithm::dimensions::tests::dimensional_collapse::multi_polygon_with_polygon_collapsed_to_point stdout ----
thread 'algorithm::dimensions::tests::dimensional_collapse::multi_polygon_with_polygon_collapsed_to_point' panicked at geo/src/algorithm/dimensions.rs:601:13:
assertion `left == right` failed
  expected: ZeroDimensional
    actual: TwoDimensional

---- algorithm::dimensions::tests::dimensional_collapse::multi_polygon_with_polygon_collapsed_to_line stdout ----
thread 'algorithm::dimensions::tests::dimensional_collapse::multi_polygon_with_polygon_collapsed_to_line' panicked at geo/src/algorithm/dimensions.rs:613:13:
assertion `left == right` failed
  expected: OneDimensional
    actual: TwoDimensional
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- algorithm::dimensions::tests::empty::multi_polygon_with_empty_polygon stdout ----
thread 'algorithm::dimensions::tests::empty::multi_polygon_with_empty_polygon' panicked at geo/src/algorithm/dimensions.rs:536:13:
assertion `left == right` failed
  expected: Empty
    actual: TwoDimensional
```