### PR TITLE
unify `Length` trait (deprecate `EuclideanLength`, `HaversineLength`, etc.)

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -43,6 +43,16 @@
   * `RhumbBearing`, `RhumbDistance`, `RhumbDestination`, `RhumbIntermediate`
   * `HaversineBearing`, `HaversineDistance`, `HaversineDestination`, `HaversineIntermediate`
   * <https://github.com/georust/geo/pull/1222>
+* Deprecated `HaversineLength`, `EuclideanLength`, `RhumbLength`, `GeodesicLength` in favor of new generic `Length` trait.
+  ```
+  // Before
+  line_string.euclidean_length();
+  line_string.haversine_length();
+  // After
+  line_string.length::<Euclidean>();
+  line_string.length::<Haversine>();
+  ```
+  * <https://github.com/georust/geo/pull/1228>
 * Change IntersectionMatrix::is_equal_topo to now consider empty geometries as equal.
   * <https://github.com/georust/geo/pull/1223>
 * Fix `(LINESTRING EMPTY).contains(LINESTRING EMPTY)` and `(MULTIPOLYGON EMPTY).contains(MULTIPOINT EMPTY)` which previously
@@ -53,7 +63,6 @@
   * <https://github.com/georust/geo/pull/1226>
 * Enable i128 geometry types
   * <https://github.com/georust/geo/pull/1230>
-
 ## 0.28.0
 
 * BREAKING: The `HasKernel` trait was removed and it's functionality was merged

--- a/geo/src/algorithm/centroid.rs
+++ b/geo/src/algorithm/centroid.rs
@@ -3,7 +3,7 @@ use std::cmp::Ordering;
 use crate::area::{get_linestring_area, Area};
 use crate::dimensions::{Dimensions, Dimensions::*, HasDimensions};
 use crate::geometry::*;
-use crate::EuclideanLength;
+use crate::line_measures::{Euclidean, Length};
 use crate::GeoFloat;
 
 /// Calculation of the centroid.
@@ -465,9 +465,11 @@ impl<T: GeoFloat> CentroidOperation<T> {
     fn add_line(&mut self, line: &Line<T>) {
         match line.dimensions() {
             ZeroDimensional => self.add_coord(line.start),
-            OneDimensional => {
-                self.add_centroid(OneDimensional, line.centroid().0, line.euclidean_length())
-            }
+            OneDimensional => self.add_centroid(
+                OneDimensional,
+                line.centroid().0,
+                line.length::<Euclidean>(),
+            ),
             _ => unreachable!("Line must be zero or one dimensional"),
         }
     }

--- a/geo/src/algorithm/closest_point.rs
+++ b/geo/src/algorithm/closest_point.rs
@@ -1,4 +1,4 @@
-use crate::algorithm::{EuclideanLength, Intersects};
+use crate::algorithm::{Euclidean, Intersects, Length};
 use crate::geometry::*;
 use crate::Closest;
 use crate::GeoFloat;
@@ -52,7 +52,7 @@ impl<F: GeoFloat> ClosestPoint<F> for Point<F> {
 #[allow(clippy::many_single_char_names)]
 impl<F: GeoFloat> ClosestPoint<F> for Line<F> {
     fn closest_point(&self, p: &Point<F>) -> Closest<F> {
-        let line_length = self.euclidean_length();
+        let line_length = self.length::<Euclidean>();
         if line_length == F::zero() {
             // if we've got a zero length line, technically the entire line
             // is the closest point...

--- a/geo/src/algorithm/concave_hull.rs
+++ b/geo/src/algorithm/concave_hull.rs
@@ -1,7 +1,7 @@
 use crate::convex_hull::qhull;
 use crate::utils::partial_min;
 use crate::{
-    coord, Centroid, Coord, CoordNum, EuclideanDistance, EuclideanLength, GeoFloat, Line,
+    coord, Centroid, Coord, CoordNum, Euclidean, EuclideanDistance, GeoFloat, Length, Line,
     LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon,
 };
 use rstar::{RTree, RTreeNum};
@@ -116,7 +116,7 @@ where
     T: GeoFloat + RTreeNum,
 {
     let h = max_dist + max_dist;
-    let w = line.euclidean_length() + h;
+    let w = line.length::<Euclidean>() + h;
     let two = T::add(T::one(), T::one());
     let search_dist = T::div(T::sqrt(T::powi(w, 2) + T::powi(h, 2)), two);
     let centroid = line.centroid();
@@ -217,7 +217,7 @@ where
         line_tree.insert(line);
     }
     while let Some(line) = line_queue.pop_front() {
-        let edge_length = line.euclidean_length();
+        let edge_length = line.length::<Euclidean>();
         let dist = edge_length / concavity;
         let possible_closest_point = find_point_closest_to_line(
             &interior_points_tree,

--- a/geo/src/algorithm/densify.rs
+++ b/geo/src/algorithm/densify.rs
@@ -1,7 +1,12 @@
 use crate::{
-    CoordFloat, EuclideanLength, Line, LineInterpolatePoint, LineString, MultiLineString,
-    MultiPolygon, Point, Polygon, Rect, Triangle,
+    CoordFloat, Line, LineInterpolatePoint, LineString, MultiLineString, MultiPolygon, Point,
+    Polygon, Rect, Triangle,
 };
+
+// This is still used in the trait constraints - but Densify too will soon be replaced with a
+// generic version, at which point this implementation detail can be removed.
+#[allow(deprecated)]
+use crate::EuclideanLength;
 
 /// Return a new linear geometry containing both existing and new interpolated coordinates with
 /// a maximum distance of `max_distance` between them.
@@ -26,6 +31,7 @@ pub trait Densify<F: CoordFloat> {
 }
 
 // Helper for densification trait
+#[allow(deprecated)]
 fn densify_line<T: CoordFloat>(line: Line<T>, container: &mut Vec<Point<T>>, max_distance: T) {
     assert!(max_distance > T::zero());
     container.push(line.start_point());
@@ -44,6 +50,7 @@ fn densify_line<T: CoordFloat>(line: Line<T>, container: &mut Vec<Point<T>>, max
     }
 }
 
+#[allow(deprecated)]
 impl<T> Densify<T> for MultiPolygon<T>
 where
     T: CoordFloat,
@@ -61,6 +68,7 @@ where
     }
 }
 
+#[allow(deprecated)]
 impl<T> Densify<T> for Polygon<T>
 where
     T: CoordFloat,
@@ -80,6 +88,7 @@ where
     }
 }
 
+#[allow(deprecated)]
 impl<T> Densify<T> for MultiLineString<T>
 where
     T: CoordFloat,
@@ -97,6 +106,7 @@ where
     }
 }
 
+#[allow(deprecated)]
 impl<T> Densify<T> for LineString<T>
 where
     T: CoordFloat,
@@ -120,6 +130,7 @@ where
     }
 }
 
+#[allow(deprecated)]
 impl<T> Densify<T> for Line<T>
 where
     T: CoordFloat,
@@ -137,6 +148,7 @@ where
     }
 }
 
+#[allow(deprecated)]
 impl<T> Densify<T> for Triangle<T>
 where
     T: CoordFloat,
@@ -150,6 +162,7 @@ where
     }
 }
 
+#[allow(deprecated)]
 impl<T> Densify<T> for Rect<T>
 where
     T: CoordFloat,

--- a/geo/src/algorithm/densify_haversine.rs
+++ b/geo/src/algorithm/densify_haversine.rs
@@ -1,6 +1,8 @@
 use num_traits::FromPrimitive;
 
-use crate::line_measures::{Haversine, InterpolatePoint};
+use crate::line_measures::{Haversine, InterpolatePoint, Length};
+// Densify will soon be deprecated too, so let's just allow deprecated for now
+#[allow(deprecated)]
 use crate::HaversineLength;
 use crate::{
     CoordFloat, CoordsIter, Line, LineString, MultiLineString, MultiPolygon, Point, Polygon, Rect,
@@ -42,7 +44,7 @@ fn densify_line<T: CoordFloat + FromPrimitive>(
 ) {
     assert!(max_distance > T::zero());
     container.push(line.start_point());
-    let num_segments = (line.haversine_length() / max_distance)
+    let num_segments = (line.length::<Haversine>() / max_distance)
         .ceil()
         .to_u64()
         .unwrap();
@@ -57,6 +59,7 @@ fn densify_line<T: CoordFloat + FromPrimitive>(
     }
 }
 
+#[allow(deprecated)]
 impl<T> DensifyHaversine<T> for MultiPolygon<T>
 where
     T: CoordFloat + FromPrimitive,
@@ -74,6 +77,7 @@ where
     }
 }
 
+#[allow(deprecated)]
 impl<T> DensifyHaversine<T> for Polygon<T>
 where
     T: CoordFloat + FromPrimitive,
@@ -93,6 +97,7 @@ where
     }
 }
 
+#[allow(deprecated)]
 impl<T> DensifyHaversine<T> for MultiLineString<T>
 where
     T: CoordFloat + FromPrimitive,
@@ -110,6 +115,7 @@ where
     }
 }
 
+#[allow(deprecated)]
 impl<T> DensifyHaversine<T> for LineString<T>
 where
     T: CoordFloat + FromPrimitive,
@@ -132,6 +138,7 @@ where
     }
 }
 
+#[allow(deprecated)]
 impl<T> DensifyHaversine<T> for Line<T>
 where
     T: CoordFloat + FromPrimitive,
@@ -149,6 +156,7 @@ where
     }
 }
 
+#[allow(deprecated)]
 impl<T> DensifyHaversine<T> for Triangle<T>
 where
     T: CoordFloat + FromPrimitive,
@@ -162,6 +170,7 @@ where
     }
 }
 
+#[allow(deprecated)]
 impl<T> DensifyHaversine<T> for Rect<T>
 where
     T: CoordFloat + FromPrimitive,

--- a/geo/src/algorithm/euclidean_distance.rs
+++ b/geo/src/algorithm/euclidean_distance.rs
@@ -1,10 +1,9 @@
 use crate::utils::{coord_pos_relative_to_ring, CoordPos};
-use crate::EuclideanLength;
-use crate::Intersects;
 use crate::{
     Coord, GeoFloat, GeoNum, Geometry, GeometryCollection, Line, LineString, MultiLineString,
     MultiPoint, MultiPolygon, Point, Polygon, Rect, Triangle,
 };
+use crate::{Distance, Euclidean, Intersects};
 use num_traits::{float::FloatConst, Bounded, Float, Signed};
 
 use rstar::primitives::CachedEnvelope;
@@ -104,7 +103,7 @@ where
 {
     /// Minimum distance between two `Coord`s
     fn euclidean_distance(&self, c: &Coord<T>) -> T {
-        Line::new(*self, *c).euclidean_length()
+        Euclidean::distance((*self).into(), (*c).into())
     }
 }
 

--- a/geo/src/algorithm/euclidean_length.rs
+++ b/geo/src/algorithm/euclidean_length.rs
@@ -1,6 +1,6 @@
 use std::iter::Sum;
 
-use crate::{CoordFloat, Line, LineString, MultiLineString};
+use crate::{CoordFloat, Euclidean, Length, Line, LineString, MultiLineString};
 
 /// Calculation of the length
 
@@ -30,51 +30,56 @@ pub trait EuclideanLength<T, RHS = Self> {
     fn euclidean_length(&self) -> T;
 }
 
+#[allow(deprecated)]
 impl<T> EuclideanLength<T> for Line<T>
 where
     T: CoordFloat,
 {
     fn euclidean_length(&self) -> T {
-        ::geo_types::private_utils::line_euclidean_length(*self)
+        self.length::<Euclidean>()
     }
 }
 
+#[allow(deprecated)]
 impl<T> EuclideanLength<T> for LineString<T>
 where
     T: CoordFloat + Sum,
 {
     fn euclidean_length(&self) -> T {
-        self.lines().map(|line| line.euclidean_length()).sum()
+        self.length::<Euclidean>()
     }
 }
 
+#[allow(deprecated)]
 impl<T> EuclideanLength<T> for MultiLineString<T>
 where
     T: CoordFloat + Sum,
 {
     fn euclidean_length(&self) -> T {
-        self.0
-            .iter()
-            .fold(T::zero(), |total, line| total + line.euclidean_length())
+        self.length::<Euclidean>()
     }
 }
 
 #[cfg(test)]
 mod test {
     use crate::line_string;
+    #[allow(deprecated)]
     use crate::EuclideanLength;
     use crate::{coord, Line, MultiLineString};
 
+    #[allow(deprecated)]
     #[test]
     fn empty_linestring_test() {
         let linestring = line_string![];
         assert_relative_eq!(0.0_f64, linestring.euclidean_length());
     }
+    #[allow(deprecated)]
     #[test]
     fn linestring_one_point_test() {
         let linestring = line_string![(x: 0., y: 0.)];
         assert_relative_eq!(0.0_f64, linestring.euclidean_length());
     }
+    #[allow(deprecated)]
     #[test]
     fn linestring_test() {
         let linestring = line_string![
@@ -87,6 +92,7 @@ mod test {
         ];
         assert_relative_eq!(10.0_f64, linestring.euclidean_length());
     }
+    #[allow(deprecated)]
     #[test]
     fn multilinestring_test() {
         let mline = MultiLineString::new(vec![
@@ -105,6 +111,7 @@ mod test {
         ]);
         assert_relative_eq!(15.0_f64, mline.euclidean_length());
     }
+    #[allow(deprecated)]
     #[test]
     fn line_test() {
         let line0 = Line::new(coord! { x: 0., y: 0. }, coord! { x: 0., y: 1. });

--- a/geo/src/algorithm/euclidean_length.rs
+++ b/geo/src/algorithm/euclidean_length.rs
@@ -4,6 +4,10 @@ use crate::{CoordFloat, Line, LineString, MultiLineString};
 
 /// Calculation of the length
 
+#[deprecated(
+    since = "0.29.0",
+    note = "Please use the `line.length::<Euclidean>()` via the `Length` trait instead."
+)]
 pub trait EuclideanLength<T, RHS = Self> {
     /// Calculation of the length of a Line
     ///

--- a/geo/src/algorithm/geodesic_area.rs
+++ b/geo/src/algorithm/geodesic_area.rs
@@ -350,7 +350,7 @@ impl GeodesicArea<f64> for Geometry<f64> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::algorithm::geodesic_length::GeodesicLength;
+    use crate::algorithm::line_measures::{Geodesic, Length};
     use crate::polygon;
 
     #[test]
@@ -380,7 +380,7 @@ mod test {
 
         // Confirm that the exterior ring geodesic_length is the same as the perimeter
         assert_relative_eq!(
-            polygon.exterior().geodesic_length(),
+            polygon.exterior().length::<Geodesic>(),
             polygon.geodesic_perimeter()
         );
     }
@@ -410,7 +410,7 @@ mod test {
 
         // Confirm that the exterior ring geodesic_length is the same as the perimeter
         assert_relative_eq!(
-            polygon.exterior().geodesic_length(),
+            polygon.exterior().length::<Geodesic>(),
             polygon.geodesic_perimeter()
         );
     }
@@ -440,7 +440,7 @@ mod test {
 
         // Confirm that the exterior ring geodesic_length is the same as the perimeter
         assert_relative_eq!(
-            polygon.exterior().geodesic_length(),
+            polygon.exterior().length::<Geodesic>(),
             polygon.geodesic_perimeter()
         );
     }

--- a/geo/src/algorithm/geodesic_length.rs
+++ b/geo/src/algorithm/geodesic_length.rs
@@ -1,5 +1,9 @@
 use crate::{Distance, Geodesic, Line, LineString, MultiLineString};
 
+#[deprecated(
+    since = "0.29.0",
+    note = "Please use the `line.length::<Geodesic>()` via the `Length` trait instead."
+)]
 /// Determine the length of a geometry on an ellipsoidal model of the earth.
 ///
 /// This uses the geodesic measurement methods given by [Karney (2013)]. As opposed to older methods

--- a/geo/src/algorithm/geodesic_length.rs
+++ b/geo/src/algorithm/geodesic_length.rs
@@ -1,4 +1,4 @@
-use crate::{Distance, Geodesic, Line, LineString, MultiLineString};
+use crate::{Geodesic, Length, Line, LineString, MultiLineString};
 
 #[deprecated(
     since = "0.29.0",
@@ -48,30 +48,24 @@ pub trait GeodesicLength<T, RHS = Self> {
     fn geodesic_length(&self) -> T;
 }
 
+#[allow(deprecated)]
 impl GeodesicLength<f64> for Line {
     /// The units of the returned value is meters.
     fn geodesic_length(&self) -> f64 {
-        let (start, end) = self.points();
-        Geodesic::distance(start, end)
+        self.length::<Geodesic>()
     }
 }
 
+#[allow(deprecated)]
 impl GeodesicLength<f64> for LineString {
     fn geodesic_length(&self) -> f64 {
-        let mut length = 0.0;
-        for line in self.lines() {
-            length += line.geodesic_length();
-        }
-        length
+        self.length::<Geodesic>()
     }
 }
 
+#[allow(deprecated)]
 impl GeodesicLength<f64> for MultiLineString {
     fn geodesic_length(&self) -> f64 {
-        let mut length = 0.0;
-        for line_string in &self.0 {
-            length += line_string.geodesic_length();
-        }
-        length
+        self.length::<Geodesic>()
     }
 }

--- a/geo/src/algorithm/haversine_length.rs
+++ b/geo/src/algorithm/haversine_length.rs
@@ -3,6 +3,10 @@ use num_traits::FromPrimitive;
 use crate::{CoordFloat, Line, LineString, MultiLineString};
 use crate::{Distance, Haversine};
 
+#[deprecated(
+    since = "0.29.0",
+    note = "Please use the `line.length::<Haversine>()` via the `Length` trait instead."
+)]
 /// Determine the length of a geometry using the [haversine formula].
 ///
 /// [haversine formula]: https://en.wikipedia.org/wiki/Haversine_formula

--- a/geo/src/algorithm/haversine_length.rs
+++ b/geo/src/algorithm/haversine_length.rs
@@ -1,7 +1,7 @@
 use num_traits::FromPrimitive;
 
 use crate::{CoordFloat, Line, LineString, MultiLineString};
-use crate::{Distance, Haversine};
+use crate::{Haversine, Length};
 
 #[deprecated(
     since = "0.29.0",
@@ -45,34 +45,32 @@ pub trait HaversineLength<T, RHS = Self> {
     fn haversine_length(&self) -> T;
 }
 
+#[allow(deprecated)]
 impl<T> HaversineLength<T> for Line<T>
 where
     T: CoordFloat + FromPrimitive,
 {
     fn haversine_length(&self) -> T {
-        let (start, end) = self.points();
-        Haversine::distance(start, end)
+        self.length::<Haversine>()
     }
 }
 
+#[allow(deprecated)]
 impl<T> HaversineLength<T> for LineString<T>
 where
     T: CoordFloat + FromPrimitive,
 {
     fn haversine_length(&self) -> T {
-        self.lines().fold(T::zero(), |total_length, line| {
-            total_length + line.haversine_length()
-        })
+        self.length::<Haversine>()
     }
 }
 
+#[allow(deprecated)]
 impl<T> HaversineLength<T> for MultiLineString<T>
 where
     T: CoordFloat + FromPrimitive,
 {
     fn haversine_length(&self) -> T {
-        self.0
-            .iter()
-            .fold(T::zero(), |total, line| total + line.haversine_length())
+        self.length::<Haversine>()
     }
 }

--- a/geo/src/algorithm/line_interpolate_point.rs
+++ b/geo/src/algorithm/line_interpolate_point.rs
@@ -1,4 +1,8 @@
 use crate::coords_iter::CoordsIter;
+// This algorithm will be deprecated in the future, replaced by a unified implementation
+// rather than being Euclidean specific. Until the alternative is available, lets allow deprecations
+// so as not to change the method signature for existing users.
+#[allow(deprecated)]
 use crate::{CoordFloat, EuclideanLength, Line, LineString, Point};
 use std::ops::AddAssign;
 
@@ -66,6 +70,7 @@ where
     }
 }
 
+#[allow(deprecated)]
 impl<T> LineInterpolatePoint<T> for LineString<T>
 where
     T: CoordFloat + AddAssign + std::fmt::Debug,

--- a/geo/src/algorithm/line_locate_point.rs
+++ b/geo/src/algorithm/line_locate_point.rs
@@ -1,3 +1,7 @@
+// This algorithm will be deprecated in the future, replaced by a unified implementation
+// rather than being Euclidean specific. Until the alternative is available, lets allow deprecations
+// so as not to change the method signature for existing users.
+#[allow(deprecated)]
 use crate::{
     CoordFloat, Line, LineString, Point,
     {euclidean_distance::EuclideanDistance, euclidean_length::EuclideanLength},
@@ -75,6 +79,7 @@ where
     }
 }
 
+#[allow(deprecated)]
 impl<T> LineLocatePoint<T, Point<T>> for LineString<T>
 where
     T: CoordFloat + AddAssign,

--- a/geo/src/algorithm/line_measures/length.rs
+++ b/geo/src/algorithm/line_measures/length.rs
@@ -1,0 +1,130 @@
+use super::Distance;
+use crate::{CoordFloat, Line, LineString, MultiLineString, Point};
+
+/// Calculate the length of a `Line`, `LineString`, or `MultiLineString` in a given [metric space](crate::algorithm::line_measures::metric_spaces).
+///
+/// # Examples
+/// ```
+/// use geo::algorithm::line_measures::{Length, Euclidean, Haversine};
+///
+/// let line_string = geo::wkt!(LINESTRING(
+///     0.0 0.0,
+///     3.0 4.0,
+///     3.0 5.0
+/// ));
+/// assert_eq!(line_string.length::<Euclidean>(), 6.);
+///
+/// let line_string_lon_lat = geo::wkt!(LINESTRING (
+///     -47.9292 -15.7801f64,
+///     -58.4173 -34.6118,
+///     -70.6483 -33.4489
+/// ));
+/// assert_eq!(line_string_lon_lat.length::<Haversine>().round(), 3_474_956.0);
+/// ```
+pub trait Length<F: CoordFloat> {
+    fn length<MetricSpace: Distance<F, Point<F>, Point<F>>>(&self) -> F;
+}
+
+impl<F: CoordFloat> Length<F> for Line<F> {
+    fn length<MetricSpace: Distance<F, Point<F>, Point<F>>>(&self) -> F {
+        MetricSpace::distance(self.start_point(), self.end_point())
+    }
+}
+
+impl<F: CoordFloat> Length<F> for LineString<F> {
+    fn length<MetricSpace: Distance<F, Point<F>, Point<F>>>(&self) -> F {
+        let mut length = F::zero();
+        for line in self.lines() {
+            length = length + line.length::<MetricSpace>();
+        }
+        length
+    }
+}
+
+impl<F: CoordFloat> Length<F> for MultiLineString<F> {
+    fn length<MetricSpace: Distance<F, Point<F>, Point<F>>>(&self) -> F {
+        let mut length = F::zero();
+        for line in self {
+            length = length + line.length::<MetricSpace>();
+        }
+        length
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{coord, Euclidean, Geodesic, Haversine, Rhumb};
+
+    #[test]
+    fn lines() {
+        // london to paris
+        let line = Line::new(
+            coord!(x: -0.1278f64, y: 51.5074),
+            coord!(x: 2.3522, y: 48.8566),
+        );
+
+        assert_eq!(
+            343_923., // meters
+            line.length::<Geodesic>().round()
+        );
+        assert_eq!(
+            341_088., // meters
+            line.length::<Rhumb>().round()
+        );
+        assert_eq!(
+            343_557., // meters
+            line.length::<Haversine>().round()
+        );
+
+        // computing Euclidean length of an unprojected (lng/lat) line gives a nonsense answer
+        assert_eq!(
+            4., // nonsense!
+            line.length::<Euclidean>().round()
+        );
+        // london to paris in EPSG:3035
+        let projected_line = Line::new(
+            coord!(x: 3620451.74f64, y: 3203901.44),
+            coord!(x: 3760771.86, y: 2889484.80),
+        );
+        assert_eq!(344_307., projected_line.length::<Euclidean>().round());
+    }
+
+    #[test]
+    fn line_strings() {
+        let line_string = LineString::new(vec![
+            coord!(x: -58.3816f64, y: -34.6037), // Buenos Aires, Argentina
+            coord!(x: -77.0428, y: -12.0464),    // Lima, Peru
+            coord!(x: -47.9292, y: -15.7801),    // Brasília, Brazil
+        ]);
+
+        assert_eq!(
+            6_302_220., // meters
+            line_string.length::<Geodesic>().round()
+        );
+        assert_eq!(
+            6_332_790., // meters
+            line_string.length::<Rhumb>().round()
+        );
+        assert_eq!(
+            6_304_387., // meters
+            line_string.length::<Haversine>().round()
+        );
+
+        // computing Euclidean length of an unprojected (lng/lat) gives a nonsense answer
+        assert_eq!(
+            59., // nonsense!
+            line_string.length::<Euclidean>().round()
+        );
+        // EPSG:102033
+        let projected_line_string = LineString::from(vec![
+            coord!(x: 143042.46f64, y: -1932485.45), // Buenos Aires, Argentina
+            coord!(x: -1797084.08, y: 583528.84),    // Lima, Peru
+            coord!(x: 1240052.27, y: 207169.12),     // Brasília, Brazil
+        ]);
+        assert_eq!(
+            6_237_538.,
+            projected_line_string.length::<Euclidean>().round()
+        );
+    }
+}

--- a/geo/src/algorithm/line_measures/metric_spaces/euclidean.rs
+++ b/geo/src/algorithm/line_measures/metric_spaces/euclidean.rs
@@ -1,5 +1,5 @@
 use super::super::Distance;
-use crate::{GeoFloat, Point};
+use crate::{CoordFloat, Point};
 
 /// Operations on the [Euclidean plane] measure distance with the pythagorean formula -
 /// what you'd measure with a ruler.
@@ -19,7 +19,7 @@ use crate::{GeoFloat, Point};
 pub struct Euclidean;
 
 /// Calculate the Euclidean distance (a.k.a. pythagorean distance) between two Points
-impl<F: GeoFloat> Distance<F, Point<F>, Point<F>> for Euclidean {
+impl<F: CoordFloat> Distance<F, Point<F>, Point<F>> for Euclidean {
     /// Calculate the Euclidean distance (a.k.a. pythagorean distance) between two Points
     ///
     /// # Units
@@ -48,7 +48,8 @@ impl<F: GeoFloat> Distance<F, Point<F>, Point<F>> for Euclidean {
     /// [`Geodesic`]: super::Geodesic
     /// [metric spaces]: super
     fn distance(origin: Point<F>, destination: Point<F>) -> F {
-        crate::EuclideanDistance::euclidean_distance(&origin, &destination)
+        let delta = origin - destination;
+        delta.x().hypot(delta.y())
     }
 }
 

--- a/geo/src/algorithm/line_measures/metric_spaces/haversine.rs
+++ b/geo/src/algorithm/line_measures/metric_spaces/haversine.rs
@@ -23,7 +23,7 @@ impl<F: CoordFloat + FromPrimitive> Bearing<F> for Haversine {
     /// # Units
     ///
     /// - `origin`, `destination`: Points where x/y are lon/lat degree coordinates
-    /// returns: degrees, where: North: 0°, East: 90°, South: 180°, West: 270°
+    /// - returns: degrees, where: North: 0°, East: 90°, South: 180°, West: 270°
     ///
     /// # Examples
     ///

--- a/geo/src/algorithm/line_measures/mod.rs
+++ b/geo/src/algorithm/line_measures/mod.rs
@@ -12,5 +12,8 @@ pub use distance::Distance;
 mod interpolate_point;
 pub use interpolate_point::InterpolatePoint;
 
+mod length;
+pub use length::Length;
+
 pub mod metric_spaces;
 pub use metric_spaces::{Euclidean, Geodesic, Haversine, Rhumb};

--- a/geo/src/algorithm/mod.rs
+++ b/geo/src/algorithm/mod.rs
@@ -84,6 +84,7 @@ pub use euclidean_distance::EuclideanDistance;
 
 /// Calculate the length of a planar line between two `Geometries`.
 pub mod euclidean_length;
+#[allow(deprecated)]
 pub use euclidean_length::EuclideanLength;
 
 /// Calculate the extreme coordinates and indices of a geometry.
@@ -119,6 +120,7 @@ pub use geodesic_intermediate::GeodesicIntermediate;
 
 /// Calculate the Geodesic length of a line.
 pub mod geodesic_length;
+#[allow(deprecated)]
 pub use geodesic_length::GeodesicLength;
 
 /// Calculate the Hausdorff distance between two geometries.
@@ -147,6 +149,7 @@ pub use haversine_intermediate::HaversineIntermediate;
 
 /// Calculate the Haversine length of a Line.
 pub mod haversine_length;
+#[allow(deprecated)]
 pub use haversine_length::HaversineLength;
 
 /// Calculate the closest point on a Great Circle arc geometry to a given point.
@@ -187,7 +190,7 @@ pub use lines_iter::LinesIter;
 
 pub mod line_measures;
 pub use line_measures::metric_spaces::{Euclidean, Geodesic, Haversine, Rhumb};
-pub use line_measures::{Bearing, Destination, Distance, InterpolatePoint};
+pub use line_measures::{Bearing, Destination, Distance, InterpolatePoint, Length};
 
 /// Split a LineString into n segments
 pub mod linestring_segment;
@@ -298,6 +301,5 @@ pub use monotone::{monotone_subdivision, MonoPoly, MonotonicPolygons};
 
 /// Rhumb-line-related algorithms and utils
 pub mod rhumb;
-pub use rhumb::RhumbLength;
 #[allow(deprecated)]
-pub use rhumb::{RhumbBearing, RhumbDestination, RhumbDistance, RhumbIntermediate};
+pub use rhumb::{RhumbBearing, RhumbDestination, RhumbDistance, RhumbIntermediate, RhumbLength};

--- a/geo/src/algorithm/rhumb/length.rs
+++ b/geo/src/algorithm/rhumb/length.rs
@@ -2,6 +2,10 @@ use num_traits::FromPrimitive;
 
 use crate::{CoordFloat, Distance, Line, LineString, MultiLineString, Rhumb};
 
+#[deprecated(
+    since = "0.29.0",
+    note = "Please use the `line.length::<Rhumb>()` via the `Length` trait instead."
+)]
 /// Determine the length of a geometry assuming each segment is a [rhumb line].
 ///
 /// [rhumb line]: https://en.wikipedia.org/wiki/Rhumb_line

--- a/geo/src/algorithm/rhumb/length.rs
+++ b/geo/src/algorithm/rhumb/length.rs
@@ -1,6 +1,6 @@
 use num_traits::FromPrimitive;
 
-use crate::{CoordFloat, Distance, Line, LineString, MultiLineString, Rhumb};
+use crate::{CoordFloat, Length, Line, LineString, MultiLineString, Rhumb};
 
 #[deprecated(
     since = "0.29.0",
@@ -44,34 +44,32 @@ pub trait RhumbLength<T, RHS = Self> {
     fn rhumb_length(&self) -> T;
 }
 
+#[allow(deprecated)]
 impl<T> RhumbLength<T> for Line<T>
 where
     T: CoordFloat + FromPrimitive,
 {
     fn rhumb_length(&self) -> T {
-        let (start, end) = self.points();
-        Rhumb::distance(start, end)
+        self.length::<Rhumb>()
     }
 }
 
+#[allow(deprecated)]
 impl<T> RhumbLength<T> for LineString<T>
 where
     T: CoordFloat + FromPrimitive,
 {
     fn rhumb_length(&self) -> T {
-        self.lines().fold(T::zero(), |total_length, line| {
-            total_length + line.rhumb_length()
-        })
+        self.length::<Rhumb>()
     }
 }
 
+#[allow(deprecated)]
 impl<T> RhumbLength<T> for MultiLineString<T>
 where
     T: CoordFloat + FromPrimitive,
 {
     fn rhumb_length(&self) -> T {
-        self.0
-            .iter()
-            .fold(T::zero(), |total, line| total + line.rhumb_length())
+        self.length::<Rhumb>()
     }
 }

--- a/geo/src/algorithm/rhumb/mod.rs
+++ b/geo/src/algorithm/rhumb/mod.rs
@@ -26,6 +26,7 @@ mod intermediate;
 pub use intermediate::RhumbIntermediate;
 
 mod length;
+#[allow(deprecated)]
 pub use length::RhumbLength;
 
 pub(crate) struct RhumbCalculations<T: CoordFloat + FromPrimitive> {


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
Part of https://github.com/georust/geo/issues/1181
Fixes #256 

- **Unified Length trait, generic over MetricSpace**
- **Deprecate legacy `length` usage**
