### PR TITLE
Enable geom for i128, which is always available.

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -51,6 +51,8 @@
 * Improve `HasDimensions::dimensions` to handle dimensionally collapsed and empty geometries more consistently.
   A collection (like MultiPolygon) will now have EmptyDimensions when all of its elements have EmptyDimensions.
   * <https://github.com/georust/geo/pull/1226>
+* Enable i128 geometry types
+  * <https://github.com/georust/geo/pull/1230>
 
 ## 0.28.0
 

--- a/geo/src/lib.rs
+++ b/geo/src/lib.rs
@@ -347,16 +347,14 @@ macro_rules! impl_geo_num_for_int {
     };
 }
 
-// This is the list of primitives that we support. It should match our set of implementations for HasKernel since GeoNum
-// depends on HasKernel.
+// This is the list of primitives that we support.
 impl_geo_num_for_float!(f32);
 impl_geo_num_for_float!(f64);
-impl_geo_num_for_int!(i64);
-impl_geo_num_for_int!(i32);
 impl_geo_num_for_int!(i16);
-impl_geo_num_for_int!(isize);
-#[cfg(has_i128)]
+impl_geo_num_for_int!(i32);
+impl_geo_num_for_int!(i64);
 impl_geo_num_for_int!(i128);
+impl_geo_num_for_int!(isize);
 
 #[cfg(test)]
 mod tests {
@@ -377,5 +375,16 @@ mod tests {
         assert_eq!(GeoNum::total_cmp(&3i32, &2i32), Ordering::Greater);
         assert_eq!(GeoNum::total_cmp(&2i32, &2i32), Ordering::Equal);
         assert_eq!(GeoNum::total_cmp(&1i32, &2i32), Ordering::Less);
+    }
+
+    #[test]
+    fn numeric_types() {
+        let _n_i16 = Point::new(1i16, 2i16);
+        let _n_i32 = Point::new(1i32, 2i32);
+        let _n_i64 = Point::new(1i64, 2i64);
+        let _n_i128 = Point::new(1i128, 2i128);
+        let _n_isize = Point::new(1isize, 2isize);
+        let _n_f32 = Point::new(1.0f32, 2.0f32);
+        let _n_f64 = Point::new(1.0f64, 2.0f64);
     }
 }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

I'm not sure why we had a check before - i128 is defined on all
platforms as part of core.

https://doc.rust-lang.org/rust-by-example/primitives.html
https://doc.rust-lang.org/core/primitive.i128.html
