### PR TITLE
deprecate EuclideanDistance

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -22,20 +22,22 @@
 * Unify various line measurements under new `line_measures::{Bearing, Distance, Destination, InterpolatePoint}` traits
   Before:
   ```
-  use geo::{GeodesicBearing, HaversineBearing, GeodesicDistance, HaversineDistance};
-  GeodesicBearing::geodesic_bearing(p1, p2)
-  HaversineBearing::haversine_bearing(p1, p2)
-  GeodesicDistance::geodesic_distance(p1, p2)
-  HaversineDistance::haversine_distance(p1, p2)
+  use geo::{GeodesicBearing, HaversineBearing, GeodesicDistance, HaversineDistance, EuclideanDistance};
+  p1.geodesic_bearing(p2)
+  p1.haversine_bearing(p2)
+  p1.geodesic_distance(p2)
+  p1.haversine_distance(p2)
+  p1.euclidean_distance(p2)
   ```
 
   After:
   ```
-  use geo::{Geodesic, Haversine, Bearing, Distance};
+  use geo::{Geodesic, Haversine, Euclidean, Bearing, Distance};
   Geodesic::bearing(p1, p2)
   Haversine::bearing(p1, p2)
   Geodesic::distance(p1, p2)
   Haversine::distance(p1, p2)
+  Euclidean::distance(p1, p2)
   ```
   * <https://github.com/georust/geo/pull/1216>
 * Deprecated legacy line measure traits in favor of those added in the previous changelog entry:

--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -42,7 +42,9 @@
   * `GeodesicBearing`, `GeodesicDistance`, `GeodesicDestination`, `GeodesicIntermediate`
   * `RhumbBearing`, `RhumbDistance`, `RhumbDestination`, `RhumbIntermediate`
   * `HaversineBearing`, `HaversineDistance`, `HaversineDestination`, `HaversineIntermediate`
+  * `EuclideanDistance`
   * <https://github.com/georust/geo/pull/1222>
+  * <https://github.com/georust/geo/pull/1232>
 * Deprecated `HaversineLength`, `EuclideanLength`, `RhumbLength`, `GeodesicLength` in favor of new generic `Length` trait.
   ```
   // Before
@@ -77,6 +79,8 @@
   * <https://github.com/georust/geo/pull/1226>
 * Enable i128 geometry types
   * <https://github.com/georust/geo/pull/1230>
+
+
 ## 0.28.0
 
 * BREAKING: The `HasKernel` trait was removed and it's functionality was merged

--- a/geo/benches/euclidean_distance.rs
+++ b/geo/benches/euclidean_distance.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main};
-use geo::algorithm::{ConvexHull, EuclideanDistance};
+use geo::algorithm::{ConvexHull, Distance, Euclidean};
 use geo::{polygon, Polygon};
 
 fn criterion_benchmark(c: &mut criterion::Criterion) {
@@ -37,9 +37,7 @@ fn criterion_benchmark(c: &mut criterion::Criterion) {
             (x: -6.064453, y: 68.49604),
         ];
         bencher.iter(|| {
-            criterion::black_box(
-                criterion::black_box(&poly1).euclidean_distance(criterion::black_box(&poly2)),
-            );
+            criterion::black_box(Euclidean::distance(&poly1, &poly2));
         });
     });
 
@@ -81,9 +79,7 @@ fn criterion_benchmark(c: &mut criterion::Criterion) {
             ]
             .convex_hull();
             bencher.iter(|| {
-                criterion::black_box(
-                    criterion::black_box(&poly1).euclidean_distance(criterion::black_box(&poly2)),
-                );
+                criterion::black_box(Euclidean::distance(&poly1, &poly2));
             });
         },
     );

--- a/geo/src/algorithm/concave_hull.rs
+++ b/geo/src/algorithm/concave_hull.rs
@@ -1,8 +1,8 @@
 use crate::convex_hull::qhull;
 use crate::utils::partial_min;
 use crate::{
-    coord, Centroid, Coord, CoordNum, Euclidean, EuclideanDistance, GeoFloat, Length, Line,
-    LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon,
+    coord, Centroid, Coord, CoordNum, Distance, Euclidean, GeoFloat, Length, Line, LineString,
+    MultiLineString, MultiPoint, MultiPolygon, Point, Polygon,
 };
 use rstar::{RTree, RTreeNum};
 use std::collections::VecDeque;
@@ -134,8 +134,8 @@ where
             let closest_point =
                 candidates.fold(Point::new(point.x, point.y), |acc_point, candidate| {
                     let candidate_point = Point::new(candidate.x, candidate.y);
-                    if line.euclidean_distance(&acc_point)
-                        > line.euclidean_distance(&candidate_point)
+                    if Euclidean::distance(&line, &acc_point)
+                        > Euclidean::distance(&line, &candidate_point)
                     {
                         candidate_point
                     } else {
@@ -154,8 +154,8 @@ where
             let closest_edge_option = match peeked_edge {
                 None => None,
                 Some(&edge) => Some(edges_nearby_point.fold(*edge, |acc, candidate| {
-                    if closest_point.euclidean_distance(&acc)
-                        > closest_point.euclidean_distance(candidate)
+                    if Euclidean::distance(&closest_point, &acc)
+                        > Euclidean::distance(&closest_point, candidate)
                     {
                         *candidate
                     } else {
@@ -164,8 +164,8 @@ where
                 })),
             };
             let decision_distance = partial_min(
-                closest_point.euclidean_distance(&line.start_point()),
-                closest_point.euclidean_distance(&line.end_point()),
+                Euclidean::distance(&closest_point, &line.start_point()),
+                Euclidean::distance(&closest_point, &line.end_point()),
             );
             if let Some(closest_edge) = closest_edge_option {
                 let far_enough = edge_length / decision_distance > concavity;

--- a/geo/src/algorithm/frechet_distance.rs
+++ b/geo/src/algorithm/frechet_distance.rs
@@ -1,6 +1,6 @@
 use crate::coords_iter::CoordsIter;
-use crate::euclidean_distance::EuclideanDistance;
-use crate::{GeoFloat, LineString, Point};
+use crate::line_measures::{Distance, Euclidean};
+use crate::{GeoFloat, LineString};
 use num_traits::FromPrimitive;
 
 /// Determine the similarity between two `LineStrings` using the [Frechet distance].
@@ -78,7 +78,7 @@ where
 
         for (i, &a) in self.ls_a.coords().enumerate() {
             for (j, &b) in self.ls_b.coords().enumerate() {
-                let dist = Point::from(a).euclidean_distance(&Point::from(b));
+                let dist = Euclidean::distance(a, b);
 
                 self.cache[i * columns_count + j] = match (i, j) {
                     (0, 0) => dist,
@@ -98,16 +98,14 @@ where
 
 #[cfg(test)]
 mod test {
-    use crate::euclidean_distance::EuclideanDistance;
-    use crate::FrechetDistance;
-    use crate::LineString;
+    use super::*;
 
     #[test]
     fn test_single_point_in_linestring() {
         let ls_a = LineString::from(vec![(1., 1.)]);
         let ls_b = LineString::from(vec![(0., 2.)]);
         assert_relative_eq!(
-            (ls_a.clone().into_points())[0].euclidean_distance(&(&ls_b.clone().into_points())[0]),
+            Euclidean::distance(ls_a.0[0], ls_b.0[0]),
             ls_a.frechet_distance(&ls_b)
         );
     }

--- a/geo/src/algorithm/hausdorff_distance.rs
+++ b/geo/src/algorithm/hausdorff_distance.rs
@@ -1,4 +1,4 @@
-use crate::algorithm::EuclideanDistance;
+use crate::algorithm::{Distance, Euclidean};
 use crate::CoordsIter;
 use crate::GeoFloat;
 use geo_types::{Coord, Point};
@@ -35,7 +35,7 @@ where
             .coords_iter()
             .map(|c| {
                 rhs.coords_iter()
-                    .map(|c2| c.euclidean_distance(&c2))
+                    .map(|c2| Euclidean::distance(c, c2))
                     .fold(<T as Bounded>::max_value(), |accum, val| accum.min(val))
             })
             .fold(<T as Bounded>::min_value(), |accum, val| accum.max(val));
@@ -45,7 +45,7 @@ where
             .coords_iter()
             .map(|c| {
                 self.coords_iter()
-                    .map(|c2| c.euclidean_distance(&c2))
+                    .map(|c2| Euclidean::distance(c, c2))
                     .fold(<T as Bounded>::max_value(), |accum, val| accum.min(val))
             })
             .fold(<T as Bounded>::min_value(), |accum, val| accum.max(val));

--- a/geo/src/algorithm/line_measures/metric_spaces/euclidean/distance.rs
+++ b/geo/src/algorithm/line_measures/metric_spaces/euclidean/distance.rs
@@ -67,9 +67,9 @@ impl<F: CoordFloat> Distance<F, Point<F>, Point<F>> for Euclidean {
     /// );
     /// ```
     ///
-    /// [`Haversine`]: super::Haversine
-    /// [`Geodesic`]: super::Geodesic
-    /// [metric spaces]: super
+    /// [`Haversine`]: crate::line_measures::metric_spaces::Haversine
+    /// [`Geodesic`]: crate::line_measures::metric_spaces::Geodesic
+    /// [metric spaces]: crate::line_measures::metric_spaces
     fn distance(origin: Point<F>, destination: Point<F>) -> F {
         Self::distance(origin.0, destination.0)
     }

--- a/geo/src/algorithm/line_measures/metric_spaces/euclidean/mod.rs
+++ b/geo/src/algorithm/line_measures/metric_spaces/euclidean/mod.rs
@@ -1,3 +1,5 @@
+mod distance;
+
 use super::super::{Distance, InterpolatePoint};
 use crate::line_measures::densify::densify_between;
 use crate::{CoordFloat, Point};
@@ -19,41 +21,6 @@ use num_traits::FromPrimitive;
 /// [`Geodesic`]: super::Geodesic
 /// [metric spaces]: super
 pub struct Euclidean;
-
-/// Calculate the Euclidean distance (a.k.a. pythagorean distance) between two Points
-impl<F: CoordFloat> Distance<F, Point<F>, Point<F>> for Euclidean {
-    /// Calculate the Euclidean distance (a.k.a. pythagorean distance) between two Points
-    ///
-    /// # Units
-    /// - `origin`, `destination`: Point where the units of x/y represent non-angular units
-    ///    — e.g. meters or miles, not lon/lat. For lon/lat points, use the
-    ///    [`Haversine`] or [`Geodesic`] [metric spaces].
-    /// - returns: distance in the same units as the `origin` and `destination` points
-    ///
-    /// # Example
-    /// ```
-    /// use geo::{Euclidean, Distance};
-    /// use geo::Point;
-    /// // web mercator
-    /// let new_york_city = Point::new(-8238310.24, 4942194.78);
-    /// // web mercator
-    /// let london = Point::new(-14226.63, 6678077.70);
-    /// let distance: f64 = Euclidean::distance(new_york_city, london);
-    ///
-    /// assert_eq!(
-    ///     8_405_286., // meters in web mercator
-    ///     distance.round()
-    /// );
-    /// ```
-    ///
-    /// [`Haversine`]: super::Haversine
-    /// [`Geodesic`]: super::Geodesic
-    /// [metric spaces]: super
-    fn distance(origin: Point<F>, destination: Point<F>) -> F {
-        let delta = origin - destination;
-        delta.x().hypot(delta.y())
-    }
-}
 
 impl<F: CoordFloat + FromPrimitive> InterpolatePoint<F> for Euclidean {
     fn point_at_ratio_between(start: Point<F>, end: Point<F>, ratio_from_start: F) -> Point<F> {

--- a/geo/src/algorithm/mod.rs
+++ b/geo/src/algorithm/mod.rs
@@ -77,6 +77,7 @@ pub use dimensions::HasDimensions;
 
 /// Calculate the minimum Euclidean distance between two `Geometries`.
 pub mod euclidean_distance;
+#[allow(deprecated)]
 pub use euclidean_distance::EuclideanDistance;
 
 /// Calculate the length of a planar line between two `Geometries`.

--- a/geo/src/algorithm/relate/geomgraph/mod.rs
+++ b/geo/src/algorithm/relate/geomgraph/mod.rs
@@ -18,8 +18,8 @@ pub(crate) use quadrant::Quadrant;
 pub(crate) use robust_line_intersector::RobustLineIntersector;
 use topology_position::TopologyPosition;
 
+pub use crate::coordinate_position::CoordPos;
 use crate::dimensions::Dimensions;
-pub use crate::utils::CoordPos;
 
 mod edge;
 mod edge_end;

--- a/geo/src/algorithm/simplify.rs
+++ b/geo/src/algorithm/simplify.rs
@@ -1,5 +1,6 @@
-use crate::{Coord, GeoFloat, Line, LineString, MultiLineString, MultiPolygon, Polygon};
-use crate::{CoordsIter, EuclideanDistance};
+use crate::algorithm::{CoordsIter, Distance, Euclidean};
+use crate::geometry::{Coord, Line, LineString, MultiLineString, MultiPolygon, Polygon};
+use crate::GeoFloat;
 
 const LINE_STRING_INITIAL_MIN: usize = 2;
 const POLYGON_INITIAL_MIN: usize = 4;
@@ -96,7 +97,12 @@ where
         .enumerate()
         .take(rdp_indices.len() - 1) // Don't include the last index
         .skip(1) // Don't include the first index
-        .map(|(index, rdp_index)| (index, rdp_index.coord.euclidean_distance(&first_last_line)))
+        .map(|(index, rdp_index)| {
+            (
+                index,
+                Euclidean::distance(rdp_index.coord, &first_last_line),
+            )
+        })
         .fold(
             (0usize, T::zero()),
             |(farthest_index, farthest_distance), (index, distance)| {

--- a/geo/src/algorithm/triangulate_spade.rs
+++ b/geo/src/algorithm/triangulate_spade.rs
@@ -4,7 +4,7 @@ use spade::{
 };
 
 use crate::{
-    line_intersection::line_intersection, CoordsIter, EuclideanDistance, GeoFloat,
+    line_intersection::line_intersection, CoordsIter, Distance, Euclidean, GeoFloat,
     LineIntersection, LinesIter,
 };
 use crate::{Centroid, Contains};
@@ -530,12 +530,12 @@ fn snap_or_register_point<T: SpadeTriangulationFloat>(
         .iter()
         // find closest
         .min_by(|a, b| {
-            a.euclidean_distance(&point)
-                .partial_cmp(&b.euclidean_distance(&point))
+            Euclidean::distance(**a, point)
+                .partial_cmp(&Euclidean::distance(**b, point))
                 .expect("Couldn't compare coordinate distances")
         })
-        // only snap if closest is within epsilone range
-        .filter(|nearest_point| nearest_point.euclidean_distance(&point) < snap_radius)
+        // only snap if closest is within epsilon range
+        .filter(|nearest_point| Euclidean::distance(**nearest_point, point) < snap_radius)
         .cloned()
         // otherwise register and use input point
         .unwrap_or_else(|| {

--- a/geo/src/types.rs
+++ b/geo/src/types.rs
@@ -16,7 +16,7 @@ impl<F: GeoFloat> Closest<F> {
     /// Compare two `Closest`s relative to `p` and return a copy of the best
     /// one.
     pub fn best_of_two(&self, other: &Self, p: Point<F>) -> Self {
-        use crate::EuclideanDistance;
+        use crate::{Distance, Euclidean};
 
         let left = match *self {
             Closest::Indeterminate => return *other,
@@ -29,7 +29,7 @@ impl<F: GeoFloat> Closest<F> {
             Closest::SinglePoint(r) => r,
         };
 
-        if left.euclidean_distance(&p) <= right.euclidean_distance(&p) {
+        if Euclidean::distance(left, p) <= Euclidean::distance(right, p) {
             *self
         } else {
             *other

--- a/geo/src/utils.rs
+++ b/geo/src/utils.rs
@@ -93,9 +93,6 @@ pub fn partial_min<T: PartialOrd>(a: T, b: T) -> T {
     }
 }
 
-// Moved to their own module, but we re-export to avoid breaking the API.
-pub use crate::coordinate_position::{coord_pos_relative_to_ring, CoordPos};
-
 use std::cmp::Ordering;
 
 /// Compare two coordinates lexicographically: first by the


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Part of #1181

In #1222, I moved only the `Point x Point` distance calculations. EuclideanDistance is implemented for all other geometry types too. This PR moves the rest of those calculations to the new `Euclidean` line measure struct for consistency.

It's a lot of code movement, but no change in behavior (unless I messed up 😬).
