### PR TITLE
change the boolops trait to return result

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -1,7 +1,8 @@
 # Changes
 
 ## Unreleased
-
+* Change BooleanOps trait to return an ErrorType instead of crashing when given bad input
+  * <https://github.com/georust/geo/pull/1233>
 * Implement getter methods on `AffineTransform` to access internal elements.
   * <https://github.com/georust/geo/pull/1159>
 * Fix issue in Debug impl for AffineTransform where yoff is shown instead of xoff

--- a/geo/src/algorithm/bool_ops/tests.rs
+++ b/geo/src/algorithm/bool_ops/tests.rs
@@ -179,7 +179,7 @@ fn test_clip_adhoc() -> Result<()> {
     let mls = MultiLineString::try_from_wkt_str(wkt2)
         .or_else(|_| LineString::<f64>::try_from_wkt_str(wkt2).map(MultiLineString::from))
         .unwrap();
-    let output = poly1.clip(&mls, true);
+    let output = poly1.clip(&mls, true)?;
     eprintln!("{wkt}", wkt = output.to_wkt());
     Ok(())
 }
@@ -209,16 +209,17 @@ fn test_issue_885_big_simplified() -> Result<()> {
 }
 
 #[test]
-fn test_issue_894() {
+fn test_issue_894() -> Result<()> {
     use geo_test_fixtures::multi_polygon;
     let a: MultiPolygon<f64> = multi_polygon("issue-894/inpa.wkt");
     let b = multi_polygon("issue-894/inpb.wkt");
     let c = multi_polygon("issue-894/inpc.wkt");
 
-    let aib = a.intersection(&b); // works
-    b.intersection(&c); // works
-    let intersection = aib.intersection(&c);
+    let aib = a.intersection(&b)?; // works
+    b.intersection(&c)?; // works
+    let intersection = aib.intersection(&c)?;
     println!("{}", intersection.to_wkt());
+    Ok(())
 }
 
 #[test]

--- a/jts-test-runner/src/runner.rs
+++ b/jts-test-runner/src/runner.rs
@@ -324,9 +324,9 @@ impl TestRunner {
                     };
 
                     let actual = match (a, b) {
-                        (Geometry::Polygon(a), Geometry::Polygon(b)) => a.boolean_op(b, *op),
+                        (Geometry::Polygon(a), Geometry::Polygon(b)) => a.boolean_op(b, *op)?,
                         (Geometry::MultiPolygon(a), Geometry::MultiPolygon(b)) => {
-                            a.boolean_op(b, *op)
+                            a.boolean_op(b, *op)?
                         }
                         _ => {
                             info!("skipping unsupported Union combination: {:?}, {:?}", a, b);


### PR DESCRIPTION
This would enable us to start working on removing the crashes due to ".unwrap" and instead let a user handle them gracefully in the code

I intentionally did not solve any actual crashes as of now, more checking if this is a direction that is likely to be implemented

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
