### PR TITLE
Fix bug where `geo_traits::TriangleTrait::{second,third}` return the first coordinate.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,5 +3,6 @@
 Each crate in this repository has its own changelog:
 
 - [geo/CHANGES.md](./geo/CHANGES.md)
+- [geo-traits/CHANGES.md](./geo-traits/CHANGES.md)
 - [geo-types/CHANGES.md](./geo-types/CHANGES.md)
 - [geo-postgis/CHANGES.md](./geo-postgis/CHANGES.md)

--- a/geo-traits/CHANGES.md
+++ b/geo-traits/CHANGES.md
@@ -1,0 +1,12 @@
+# Changes
+
+## Unreleased
+
+## 0.1.1
+
+- Fix `TriangleTrait::second` and `TriangleTrait::third` to return the second and third coordinates instead of the first.
+  - <https://github.com/georust/geo/pull/1236>
+
+## 0.1.0
+
+- Initial release

--- a/geo-traits/Cargo.toml
+++ b/geo-traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geo-traits"
-version = "0.1.0"
+version = "0.1.1"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/georust/geo"
 documentation = "https://docs.rs/geo-traits/"

--- a/geo-traits/src/triangle.rs
+++ b/geo-traits/src/triangle.rs
@@ -48,11 +48,11 @@ impl<T: CoordNum> TriangleTrait for Triangle<T> {
     }
 
     fn second(&self) -> Self::CoordType<'_> {
-        &self.0
+        &self.1
     }
 
     fn third(&self) -> Self::CoordType<'_> {
-        &self.0
+        &self.2
     }
 }
 


### PR DESCRIPTION

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
