### PR TITLE
geo-traits: Make `geo-types` dependency optional

### DIFF
--- a/geo-traits/Cargo.toml
+++ b/geo-traits/Cargo.toml
@@ -10,7 +10,10 @@ description = "Geospatial traits"
 rust-version = "1.65"
 edition = "2021"
 
+[features]
+default = ["geo-types"]
+
 [dependencies]
-geo-types = "0.7"
+geo-types = { version = "0.7", optional = true }
 
 [dev-dependencies]

--- a/geo-traits/src/coord.rs
+++ b/geo-traits/src/coord.rs
@@ -1,5 +1,8 @@
 use std::marker::PhantomData;
 
+#[cfg(feature = "geo-types")]
+use geo_types::{Coord, CoordNum};
+
 use crate::Dimensions;
 
 /// A trait for accessing data from a generic Coord.
@@ -41,7 +44,7 @@ pub trait CoordTrait {
 }
 
 #[cfg(feature = "geo-types")]
-impl<T: geo_types::CoordNum> CoordTrait for geo_types::Coord<T> {
+impl<T: CoordNum> CoordTrait for Coord<T> {
     type T = T;
 
     fn nth_unchecked(&self, n: usize) -> Self::T {
@@ -66,7 +69,7 @@ impl<T: geo_types::CoordNum> CoordTrait for geo_types::Coord<T> {
 }
 
 #[cfg(feature = "geo-types")]
-impl<T: geo_types::CoordNum> CoordTrait for &geo_types::Coord<T> {
+impl<T: CoordNum> CoordTrait for &Coord<T> {
     type T = T;
 
     fn nth_unchecked(&self, n: usize) -> Self::T {

--- a/geo-traits/src/coord.rs
+++ b/geo-traits/src/coord.rs
@@ -1,7 +1,5 @@
 use std::marker::PhantomData;
 
-use geo_types::{Coord, CoordNum};
-
 use crate::Dimensions;
 
 /// A trait for accessing data from a generic Coord.
@@ -9,7 +7,7 @@ use crate::Dimensions;
 /// Refer to [geo_types::Coord] for information about semantics and validity.
 pub trait CoordTrait {
     /// The coordinate type of this geometry
-    type T: CoordNum;
+    type T;
 
     /// Dimensions of the coordinate tuple
     fn dim(&self) -> Dimensions;
@@ -42,7 +40,8 @@ pub trait CoordTrait {
     fn nth_unchecked(&self, n: usize) -> Self::T;
 }
 
-impl<T: CoordNum> CoordTrait for Coord<T> {
+#[cfg(feature = "geo-types")]
+impl<T: geo_types::CoordNum> CoordTrait for geo_types::Coord<T> {
     type T = T;
 
     fn nth_unchecked(&self, n: usize) -> Self::T {
@@ -66,7 +65,8 @@ impl<T: CoordNum> CoordTrait for Coord<T> {
     }
 }
 
-impl<T: CoordNum> CoordTrait for &Coord<T> {
+#[cfg(feature = "geo-types")]
+impl<T: geo_types::CoordNum> CoordTrait for &geo_types::Coord<T> {
     type T = T;
 
     fn nth_unchecked(&self, n: usize) -> Self::T {
@@ -90,7 +90,7 @@ impl<T: CoordNum> CoordTrait for &Coord<T> {
     }
 }
 
-impl<T: CoordNum> CoordTrait for (T, T) {
+impl<T: Copy> CoordTrait for (T, T) {
     type T = T;
 
     fn nth_unchecked(&self, n: usize) -> Self::T {
@@ -118,9 +118,9 @@ impl<T: CoordNum> CoordTrait for (T, T) {
 ///
 /// This can be used as the `CoordType` of the `GeometryTrait` by implementations that don't have a
 /// Coord concept
-pub struct UnimplementedCoord<T: CoordNum>(PhantomData<T>);
+pub struct UnimplementedCoord<T>(PhantomData<T>);
 
-impl<T: CoordNum> CoordTrait for UnimplementedCoord<T> {
+impl<T> CoordTrait for UnimplementedCoord<T> {
     type T = T;
 
     fn dim(&self) -> Dimensions {

--- a/geo-traits/src/geometry.rs
+++ b/geo-traits/src/geometry.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "geo-types")]
 use geo_types::{
     CoordNum, Geometry, GeometryCollection, Line, LineString, MultiLineString, MultiPoint,
     MultiPolygon, Point, Polygon, Rect, Triangle,
@@ -12,7 +13,7 @@ use crate::{
 #[allow(clippy::type_complexity)]
 pub trait GeometryTrait {
     /// The coordinate type of this geometry
-    type T: CoordNum;
+    type T;
 
     /// The type of each underlying Point, which implements [PointTrait]
     type PointType<'a>: 'a + PointTrait<T = Self::T>
@@ -124,6 +125,7 @@ where
     Line(&'a L),
 }
 
+#[cfg(feature = "geo-types")]
 impl<'a, T: CoordNum + 'a> GeometryTrait for Geometry<T> {
     type T = T;
     type PointType<'b> = Point<Self::T> where Self: 'b;
@@ -171,6 +173,7 @@ impl<'a, T: CoordNum + 'a> GeometryTrait for Geometry<T> {
     }
 }
 
+#[cfg(feature = "geo-types")]
 impl<'a, T: CoordNum + 'a> GeometryTrait for &'a Geometry<T> {
     type T = T;
     type PointType<'b> = Point<Self::T> where Self: 'b;
@@ -222,6 +225,7 @@ impl<'a, T: CoordNum + 'a> GeometryTrait for &'a Geometry<T> {
 
 macro_rules! impl_specialization {
     ($geometry_type:ident) => {
+        #[cfg(feature = "geo-types")]
         impl<T: CoordNum> GeometryTrait for $geometry_type<T> {
             type T = T;
             type PointType<'b> = Point<Self::T> where Self: 'b;
@@ -258,6 +262,7 @@ macro_rules! impl_specialization {
             }
         }
 
+        #[cfg(feature = "geo-types")]
         impl<'a, T: CoordNum + 'a> GeometryTrait for &'a $geometry_type<T> {
             type T = T;
             type PointType<'b> = Point<Self::T> where Self: 'b;

--- a/geo-traits/src/geometry_collection.rs
+++ b/geo-traits/src/geometry_collection.rs
@@ -1,5 +1,6 @@
 use crate::iterator::GeometryCollectionIterator;
 use crate::{Dimensions, GeometryTrait};
+#[cfg(feature = "geo-types")]
 use geo_types::{CoordNum, Geometry, GeometryCollection};
 
 /// A trait for accessing data from a generic GeometryCollection.
@@ -7,7 +8,7 @@ use geo_types::{CoordNum, Geometry, GeometryCollection};
 /// A GeometryCollection is a collection of [Geometry][GeometryTrait] types.
 pub trait GeometryCollectionTrait: Sized {
     /// The coordinate type of this geometry
-    type T: CoordNum;
+    type T;
 
     /// The type of each underlying geometry, which implements [GeometryTrait]
     type GeometryType<'a>: 'a + GeometryTrait<T = Self::T>
@@ -45,6 +46,7 @@ pub trait GeometryCollectionTrait: Sized {
     unsafe fn geometry_unchecked(&self, i: usize) -> Self::GeometryType<'_>;
 }
 
+#[cfg(feature = "geo-types")]
 impl<T: CoordNum> GeometryCollectionTrait for GeometryCollection<T> {
     type T = T;
     type GeometryType<'a> = &'a Geometry<Self::T>
@@ -64,6 +66,7 @@ impl<T: CoordNum> GeometryCollectionTrait for GeometryCollection<T> {
     }
 }
 
+#[cfg(feature = "geo-types")]
 impl<'a, T: CoordNum> GeometryCollectionTrait for &'a GeometryCollection<T> {
     type T = T;
     type GeometryType<'b> = &'a Geometry<Self::T> where

--- a/geo-traits/src/iterator.rs
+++ b/geo-traits/src/iterator.rs
@@ -1,17 +1,14 @@
-use crate::CoordTrait;
-
 use super::{
-    GeometryCollectionTrait, GeometryTrait, LineStringTrait, MultiLineStringTrait, MultiPointTrait,
-    MultiPolygonTrait, PointTrait, PolygonTrait,
+    CoordTrait, GeometryCollectionTrait, GeometryTrait, LineStringTrait, MultiLineStringTrait,
+    MultiPointTrait, MultiPolygonTrait, PointTrait, PolygonTrait,
 };
-use geo_types::CoordNum;
 
 macro_rules! impl_iterator {
     ($struct_name:ident, $self_trait:ident, $item_trait:ident, $access_method:ident, $item_type:ident) => {
         /// An iterator over the parts of this geometry.
         pub(crate) struct $struct_name<
             'a,
-            T: CoordNum,
+            T,
             $item_type: 'a + $item_trait<T = T>,
             G: $self_trait<T = T, $item_type<'a> = $item_type>,
         > {
@@ -22,7 +19,7 @@ macro_rules! impl_iterator {
 
         impl<
                 'a,
-                T: CoordNum,
+                T,
                 $item_type: 'a + $item_trait<T = T>,
                 G: $self_trait<T = T, $item_type<'a> = $item_type>,
             > $struct_name<'a, T, $item_type, G>
@@ -35,7 +32,7 @@ macro_rules! impl_iterator {
 
         impl<
                 'a,
-                T: CoordNum,
+                T,
                 $item_type: 'a + $item_trait<T = T>,
                 G: $self_trait<T = T, $item_type<'a> = $item_type>,
             > Iterator for $struct_name<'a, T, $item_type, G>
@@ -60,7 +57,7 @@ macro_rules! impl_iterator {
 
         impl<
                 'a,
-                T: CoordNum,
+                T,
                 $item_type: 'a + $item_trait<T = T>,
                 G: $self_trait<T = T, $item_type<'a> = $item_type>,
             > ExactSizeIterator for $struct_name<'a, T, $item_type, G>
@@ -69,7 +66,7 @@ macro_rules! impl_iterator {
 
         impl<
                 'a,
-                T: CoordNum,
+                T,
                 $item_type: 'a + $item_trait<T = T>,
                 G: $self_trait<T = T, $item_type<'a> = $item_type>,
             > DoubleEndedIterator for $struct_name<'a, T, $item_type, G>

--- a/geo-traits/src/line.rs
+++ b/geo-traits/src/line.rs
@@ -1,6 +1,7 @@
 use std::marker::PhantomData;
 
 use crate::{CoordTrait, Dimensions, UnimplementedCoord};
+#[cfg(feature = "geo-types")]
 use geo_types::{Coord, CoordNum, Line};
 
 /// A trait for accessing data from a generic Line.
@@ -10,7 +11,7 @@ use geo_types::{Coord, CoordNum, Line};
 /// Refer to [geo_types::Line] for information about semantics and validity.
 pub trait LineTrait: Sized {
     /// The coordinate type of this geometry
-    type T: CoordNum;
+    type T;
 
     /// The type of each underlying coordinate, which implements [CoordTrait]
     type CoordType<'a>: 'a + CoordTrait<T = Self::T>
@@ -32,6 +33,7 @@ pub trait LineTrait: Sized {
     }
 }
 
+#[cfg(feature = "geo-types")]
 impl<T: CoordNum> LineTrait for Line<T> {
     type T = T;
     type CoordType<'a> = &'a Coord<Self::T> where Self: 'a;
@@ -49,6 +51,7 @@ impl<T: CoordNum> LineTrait for Line<T> {
     }
 }
 
+#[cfg(feature = "geo-types")]
 impl<'a, T: CoordNum> LineTrait for &'a Line<T> {
     type T = T;
     type CoordType<'b> = &'a Coord<Self::T> where Self: 'b;
@@ -70,9 +73,9 @@ impl<'a, T: CoordNum> LineTrait for &'a Line<T> {
 ///
 /// This can be used as the `LineType` of the `GeometryTrait` by implementations that don't
 /// have a Line concept
-pub struct UnimplementedLine<T: CoordNum>(PhantomData<T>);
+pub struct UnimplementedLine<T>(PhantomData<T>);
 
-impl<T: CoordNum> LineTrait for UnimplementedLine<T> {
+impl<T> LineTrait for UnimplementedLine<T> {
     type T = T;
     type CoordType<'a> = UnimplementedCoord<Self::T> where Self: 'a;
 

--- a/geo-traits/src/line_string.rs
+++ b/geo-traits/src/line_string.rs
@@ -2,6 +2,7 @@ use std::marker::PhantomData;
 
 use crate::iterator::LineStringIterator;
 use crate::{CoordTrait, Dimensions, UnimplementedCoord};
+#[cfg(feature = "geo-types")]
 use geo_types::{Coord, CoordNum, LineString};
 
 /// A trait for accessing data from a generic LineString.
@@ -12,7 +13,7 @@ use geo_types::{Coord, CoordNum, LineString};
 /// Refer to [geo_types::LineString] for information about semantics and validity.
 pub trait LineStringTrait: Sized {
     /// The coordinate type of this geometry
-    type T: CoordNum;
+    type T;
 
     /// The type of each underlying coordinate, which implements [CoordTrait]
     type CoordType<'a>: 'a + CoordTrait<T = Self::T>
@@ -49,6 +50,7 @@ pub trait LineStringTrait: Sized {
     unsafe fn coord_unchecked(&self, i: usize) -> Self::CoordType<'_>;
 }
 
+#[cfg(feature = "geo-types")]
 impl<T: CoordNum> LineStringTrait for LineString<T> {
     type T = T;
     type CoordType<'a> = &'a Coord<Self::T> where Self: 'a;
@@ -66,6 +68,7 @@ impl<T: CoordNum> LineStringTrait for LineString<T> {
     }
 }
 
+#[cfg(feature = "geo-types")]
 impl<'a, T: CoordNum> LineStringTrait for &'a LineString<T> {
     type T = T;
     type CoordType<'b> = &'a Coord<Self::T> where Self: 'b;
@@ -87,9 +90,9 @@ impl<'a, T: CoordNum> LineStringTrait for &'a LineString<T> {
 ///
 /// This can be used as the `LineStringType` of the `GeometryTrait` by implementations that don't
 /// have a LineString concept
-pub struct UnimplementedLineString<T: CoordNum>(PhantomData<T>);
+pub struct UnimplementedLineString<T>(PhantomData<T>);
 
-impl<T: CoordNum> LineStringTrait for UnimplementedLineString<T> {
+impl<T> LineStringTrait for UnimplementedLineString<T> {
     type T = T;
     type CoordType<'a> = UnimplementedCoord<Self::T> where Self: 'a;
 

--- a/geo-traits/src/multi_line_string.rs
+++ b/geo-traits/src/multi_line_string.rs
@@ -3,6 +3,7 @@ use std::marker::PhantomData;
 use crate::iterator::MultiLineStringIterator;
 use crate::line_string::UnimplementedLineString;
 use crate::{Dimensions, LineStringTrait};
+#[cfg(feature = "geo-types")]
 use geo_types::{CoordNum, LineString, MultiLineString};
 
 /// A trait for accessing data from a generic MultiLineString.
@@ -12,7 +13,7 @@ use geo_types::{CoordNum, LineString, MultiLineString};
 /// Refer to [geo_types::MultiLineString] for information about semantics and validity.
 pub trait MultiLineStringTrait: Sized {
     /// The coordinate type of this geometry
-    type T: CoordNum;
+    type T;
 
     /// The type of each underlying LineString, which implements [LineStringTrait]
     type LineStringType<'a>: 'a + LineStringTrait<T = Self::T>
@@ -50,6 +51,7 @@ pub trait MultiLineStringTrait: Sized {
     unsafe fn line_string_unchecked(&self, i: usize) -> Self::LineStringType<'_>;
 }
 
+#[cfg(feature = "geo-types")]
 impl<T: CoordNum> MultiLineStringTrait for MultiLineString<T> {
     type T = T;
     type LineStringType<'a> = &'a LineString<Self::T> where Self: 'a;
@@ -67,6 +69,7 @@ impl<T: CoordNum> MultiLineStringTrait for MultiLineString<T> {
     }
 }
 
+#[cfg(feature = "geo-types")]
 impl<'a, T: CoordNum> MultiLineStringTrait for &'a MultiLineString<T> {
     type T = T;
     type LineStringType<'b> = &'a LineString<Self::T> where Self: 'b;
@@ -88,9 +91,9 @@ impl<'a, T: CoordNum> MultiLineStringTrait for &'a MultiLineString<T> {
 ///
 /// This can be used as the `MultiLineStringType` of the `GeometryTrait` by implementations that
 /// don't have a MultiLineString concept
-pub struct UnimplementedMultiLineString<T: CoordNum>(PhantomData<T>);
+pub struct UnimplementedMultiLineString<T>(PhantomData<T>);
 
-impl<T: CoordNum> MultiLineStringTrait for UnimplementedMultiLineString<T> {
+impl<T> MultiLineStringTrait for UnimplementedMultiLineString<T> {
     type T = T;
     type LineStringType<'a> = UnimplementedLineString<Self::T> where Self: 'a;
 

--- a/geo-traits/src/multi_point.rs
+++ b/geo-traits/src/multi_point.rs
@@ -2,6 +2,7 @@ use std::marker::PhantomData;
 
 use crate::iterator::MultiPointIterator;
 use crate::{Dimensions, PointTrait, UnimplementedPoint};
+#[cfg(feature = "geo-types")]
 use geo_types::{CoordNum, MultiPoint, Point};
 
 /// A trait for accessing data from a generic MultiPoint.
@@ -11,7 +12,7 @@ use geo_types::{CoordNum, MultiPoint, Point};
 /// Refer to [geo_types::MultiPoint] for information about semantics and validity.
 pub trait MultiPointTrait: Sized {
     /// The coordinate type of this geometry
-    type T: CoordNum;
+    type T;
 
     /// The type of each underlying Point, which implements [PointTrait]
     type PointType<'a>: 'a + PointTrait<T = Self::T>
@@ -47,6 +48,7 @@ pub trait MultiPointTrait: Sized {
     unsafe fn point_unchecked(&self, i: usize) -> Self::PointType<'_>;
 }
 
+#[cfg(feature = "geo-types")]
 impl<T: CoordNum> MultiPointTrait for MultiPoint<T> {
     type T = T;
     type PointType<'a> = &'a Point<Self::T> where Self: 'a;
@@ -64,6 +66,7 @@ impl<T: CoordNum> MultiPointTrait for MultiPoint<T> {
     }
 }
 
+#[cfg(feature = "geo-types")]
 impl<'a, T: CoordNum> MultiPointTrait for &'a MultiPoint<T> {
     type T = T;
     type PointType<'b> = &'a Point<Self::T> where Self: 'b;
@@ -85,9 +88,9 @@ impl<'a, T: CoordNum> MultiPointTrait for &'a MultiPoint<T> {
 ///
 /// This can be used as the `MultiPointType` of the `GeometryTrait` by implementations that don't
 /// have a MultiPoint concept
-pub struct UnimplementedMultiPoint<T: CoordNum>(PhantomData<T>);
+pub struct UnimplementedMultiPoint<T>(PhantomData<T>);
 
-impl<T: CoordNum> MultiPointTrait for UnimplementedMultiPoint<T> {
+impl<T> MultiPointTrait for UnimplementedMultiPoint<T> {
     type T = T;
     type PointType<'a> = UnimplementedPoint<Self::T> where Self: 'a;
 

--- a/geo-traits/src/multi_polygon.rs
+++ b/geo-traits/src/multi_polygon.rs
@@ -3,6 +3,7 @@ use std::marker::PhantomData;
 use crate::iterator::MultiPolygonIterator;
 use crate::polygon::UnimplementedPolygon;
 use crate::{Dimensions, PolygonTrait};
+#[cfg(feature = "geo-types")]
 use geo_types::{CoordNum, MultiPolygon, Polygon};
 
 /// A trait for accessing data from a generic MultiPolygon.
@@ -10,7 +11,7 @@ use geo_types::{CoordNum, MultiPolygon, Polygon};
 /// Refer to [geo_types::MultiPolygon] for information about semantics and validity.
 pub trait MultiPolygonTrait: Sized {
     /// The coordinate type of this geometry
-    type T: CoordNum;
+    type T;
 
     /// The type of each underlying Polygon, which implements [PolygonTrait]
     type PolygonType<'a>: 'a + PolygonTrait<T = Self::T>
@@ -48,6 +49,7 @@ pub trait MultiPolygonTrait: Sized {
     unsafe fn polygon_unchecked(&self, i: usize) -> Self::PolygonType<'_>;
 }
 
+#[cfg(feature = "geo-types")]
 impl<T: CoordNum> MultiPolygonTrait for MultiPolygon<T> {
     type T = T;
     type PolygonType<'a> = &'a Polygon<Self::T> where Self: 'a;
@@ -65,6 +67,7 @@ impl<T: CoordNum> MultiPolygonTrait for MultiPolygon<T> {
     }
 }
 
+#[cfg(feature = "geo-types")]
 impl<'a, T: CoordNum> MultiPolygonTrait for &'a MultiPolygon<T> {
     type T = T;
     type PolygonType<'b> = &'a Polygon<Self::T> where Self: 'b;
@@ -86,9 +89,9 @@ impl<'a, T: CoordNum> MultiPolygonTrait for &'a MultiPolygon<T> {
 ///
 /// This can be used as the `MultiPolygonType` of the `GeometryTrait` by implementations that don't
 /// have a MultiPolygon concept
-pub struct UnimplementedMultiPolygon<T: CoordNum>(PhantomData<T>);
+pub struct UnimplementedMultiPolygon<T>(PhantomData<T>);
 
-impl<T: CoordNum> MultiPolygonTrait for UnimplementedMultiPolygon<T> {
+impl<T> MultiPolygonTrait for UnimplementedMultiPolygon<T> {
     type T = T;
     type PolygonType<'a> = UnimplementedPolygon<Self::T> where Self: 'a;
 

--- a/geo-traits/src/point.rs
+++ b/geo-traits/src/point.rs
@@ -1,5 +1,6 @@
 use std::marker::PhantomData;
 
+#[cfg(feature = "geo-types")]
 use geo_types::{Coord, CoordNum, Point};
 
 use crate::{CoordTrait, Dimensions, UnimplementedCoord};
@@ -9,7 +10,7 @@ use crate::{CoordTrait, Dimensions, UnimplementedCoord};
 /// Refer to [geo_types::Point] for information about semantics and validity.
 pub trait PointTrait {
     /// The coordinate type of this geometry
-    type T: CoordNum;
+    type T;
 
     /// The type of the underlying coordinate, which implements [CoordTrait]
     type CoordType<'a>: 'a + CoordTrait<T = Self::T>
@@ -32,6 +33,7 @@ pub trait PointTrait {
     fn coord(&self) -> Option<Self::CoordType<'_>>;
 }
 
+#[cfg(feature = "geo-types")]
 impl<T: CoordNum> PointTrait for Point<T> {
     type T = T;
     type CoordType<'a> = &'a Coord<Self::T> where Self: 'a;
@@ -45,6 +47,7 @@ impl<T: CoordNum> PointTrait for Point<T> {
     }
 }
 
+#[cfg(feature = "geo-types")]
 impl<T: CoordNum> PointTrait for &Point<T> {
     type T = T;
     type CoordType<'a> = &'a Coord<Self::T> where Self: 'a;
@@ -62,9 +65,9 @@ impl<T: CoordNum> PointTrait for &Point<T> {
 ///
 /// This can be used as the `PointType` of the `GeometryTrait` by implementations that don't have a
 /// Point concept
-pub struct UnimplementedPoint<T: CoordNum>(PhantomData<T>);
+pub struct UnimplementedPoint<T>(PhantomData<T>);
 
-impl<T: CoordNum> PointTrait for UnimplementedPoint<T> {
+impl<T> PointTrait for UnimplementedPoint<T> {
     type T = T;
     type CoordType<'a> = UnimplementedCoord<Self::T> where Self: 'a;
 

--- a/geo-traits/src/polygon.rs
+++ b/geo-traits/src/polygon.rs
@@ -3,6 +3,7 @@ use std::marker::PhantomData;
 use crate::iterator::PolygonInteriorIterator;
 use crate::line_string::UnimplementedLineString;
 use crate::{Dimensions, LineStringTrait};
+#[cfg(feature = "geo-types")]
 use geo_types::{CoordNum, LineString, Polygon};
 
 /// A trait for accessing data from a generic Polygon.
@@ -14,7 +15,7 @@ use geo_types::{CoordNum, LineString, Polygon};
 /// Refer to [geo_types::Polygon] for information about semantics and validity.
 pub trait PolygonTrait: Sized {
     /// The coordinate type of this geometry
-    type T: CoordNum;
+    type T;
 
     /// The type of each underlying ring, which implements [LineStringTrait]
     type RingType<'a>: 'a + LineStringTrait<T = Self::T>
@@ -53,6 +54,7 @@ pub trait PolygonTrait: Sized {
     unsafe fn interior_unchecked(&self, i: usize) -> Self::RingType<'_>;
 }
 
+#[cfg(feature = "geo-types")]
 impl<T: CoordNum> PolygonTrait for Polygon<T> {
     type T = T;
     type RingType<'a> = &'a LineString<Self::T> where Self: 'a;
@@ -79,6 +81,7 @@ impl<T: CoordNum> PolygonTrait for Polygon<T> {
     }
 }
 
+#[cfg(feature = "geo-types")]
 impl<'a, T: CoordNum> PolygonTrait for &'a Polygon<T> {
     type T = T;
     type RingType<'b> = &'a LineString<Self::T> where
@@ -110,9 +113,9 @@ impl<'a, T: CoordNum> PolygonTrait for &'a Polygon<T> {
 ///
 /// This can be used as the `PolygonType` of the `GeometryTrait` by implementations that don't have a
 /// Polygon concept
-pub struct UnimplementedPolygon<T: CoordNum>(PhantomData<T>);
+pub struct UnimplementedPolygon<T>(PhantomData<T>);
 
-impl<T: CoordNum> PolygonTrait for UnimplementedPolygon<T> {
+impl<T> PolygonTrait for UnimplementedPolygon<T> {
     type T = T;
     type RingType<'a> = UnimplementedLineString<Self::T> where Self: 'a;
 

--- a/geo-traits/src/rect.rs
+++ b/geo-traits/src/rect.rs
@@ -1,5 +1,6 @@
 use std::marker::PhantomData;
 
+#[cfg(feature = "geo-types")]
 use geo_types::{Coord, CoordNum, Rect};
 
 use crate::{CoordTrait, Dimensions, UnimplementedCoord};
@@ -10,7 +11,7 @@ use crate::{CoordTrait, Dimensions, UnimplementedCoord};
 /// defined by minimum and maximum [`Point`s][CoordTrait].
 pub trait RectTrait {
     /// The coordinate type of this geometry
-    type T: CoordNum;
+    type T;
 
     /// The type of each underlying coordinate, which implements [CoordTrait]
     type CoordType<'a>: 'a + CoordTrait<T = Self::T>
@@ -27,6 +28,7 @@ pub trait RectTrait {
     fn max(&self) -> Self::CoordType<'_>;
 }
 
+#[cfg(feature = "geo-types")]
 impl<'a, T: CoordNum + 'a> RectTrait for Rect<T> {
     type T = T;
     type CoordType<'b> = Coord<T> where Self: 'b;
@@ -44,6 +46,7 @@ impl<'a, T: CoordNum + 'a> RectTrait for Rect<T> {
     }
 }
 
+#[cfg(feature = "geo-types")]
 impl<'a, T: CoordNum + 'a> RectTrait for &'a Rect<T> {
     type T = T;
     type CoordType<'b> = Coord<T> where Self: 'b;
@@ -65,9 +68,9 @@ impl<'a, T: CoordNum + 'a> RectTrait for &'a Rect<T> {
 ///
 /// This can be used as the `RectType` of the `GeometryTrait` by implementations that don't
 /// have a Rect concept
-pub struct UnimplementedRect<T: CoordNum>(PhantomData<T>);
+pub struct UnimplementedRect<T>(PhantomData<T>);
 
-impl<T: CoordNum> RectTrait for UnimplementedRect<T> {
+impl<T> RectTrait for UnimplementedRect<T> {
     type T = T;
     type CoordType<'a> = UnimplementedCoord<Self::T> where Self: 'a;
 

--- a/geo-traits/src/triangle.rs
+++ b/geo-traits/src/triangle.rs
@@ -1,6 +1,7 @@
 use std::marker::PhantomData;
 
 use crate::{CoordTrait, Dimensions, UnimplementedCoord};
+#[cfg(feature = "geo-types")]
 use geo_types::{Coord, CoordNum, Triangle};
 
 /// A trait for accessing data from a generic Triangle.
@@ -10,7 +11,7 @@ use geo_types::{Coord, CoordNum, Triangle};
 /// Refer to [geo_types::Triangle] for information about semantics and validity.
 pub trait TriangleTrait: Sized {
     /// The coordinate type of this geometry
-    type T: CoordNum;
+    type T;
 
     /// The type of each underlying coordinate, which implements [CoordTrait]
     type CoordType<'a>: 'a + CoordTrait<T = Self::T>
@@ -35,6 +36,7 @@ pub trait TriangleTrait: Sized {
     }
 }
 
+#[cfg(feature = "geo-types")]
 impl<T: CoordNum> TriangleTrait for Triangle<T> {
     type T = T;
     type CoordType<'a> = &'a Coord<Self::T> where Self: 'a;
@@ -56,6 +58,7 @@ impl<T: CoordNum> TriangleTrait for Triangle<T> {
     }
 }
 
+#[cfg(feature = "geo-types")]
 impl<'a, T: CoordNum> TriangleTrait for &'a Triangle<T> {
     type T = T;
     type CoordType<'b> = &'a Coord<Self::T> where Self: 'b;
@@ -81,9 +84,9 @@ impl<'a, T: CoordNum> TriangleTrait for &'a Triangle<T> {
 ///
 /// This can be used as the `TriangleType` of the `GeometryTrait` by implementations that don't
 /// have a Triangle concept
-pub struct UnimplementedTriangle<T: CoordNum>(PhantomData<T>);
+pub struct UnimplementedTriangle<T>(PhantomData<T>);
 
-impl<T: CoordNum> TriangleTrait for UnimplementedTriangle<T> {
+impl<T> TriangleTrait for UnimplementedTriangle<T> {
     type T = T;
     type CoordType<'a> = UnimplementedCoord<Self::T> where Self: 'a;
 


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Putting this up for discussion:

Right now `geo-traits` only has a dependency on `geo-types` to

1. add a trait bound on `T` for `CoordNum`
2. add implementations of the traits on `geo_types` objects

As I was cleaning up https://github.com/kylebarron/wkb, I realized that `geo-traits` doesn't really _need_ to have the `CoordNum` trait bound, because the consumer can require it separately.

What do people think about making the `geo-types` dep optional? 