### PR TITLE
Add `Haversine:distance` for Line vs. Point (same as CrossTrackDistance)

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* BREAKING: Make `CrossTrackDistance` generic both to clarify when it is using Haversine, but also implement it for Euclidean.
+* Add `Haversine:distance` for Line vs. Point (same as CrossTrackDistance)
 
 ## 0.29.0 - 2024.10.30
 

--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* BREAKING: Make `CrossTrackDistance` generic both to clarify when it is using Haversine, but also implement it for Euclidean.
 
 ## 0.29.0 - 2024.10.30
 

--- a/geo/src/algorithm/cross_track_distance.rs
+++ b/geo/src/algorithm/cross_track_distance.rs
@@ -4,6 +4,8 @@ use num_traits::FromPrimitive;
 
 /// Determine the cross track distance (also known as the cross track error) which is the shortest
 /// distance between a point and a continuous line.
+///
+/// Distance is measured in meters, using the Haversine formula.
 pub trait CrossTrackDistance<T, Rhs = Self>
 where
     T: CoordFloat + FromPrimitive,
@@ -37,31 +39,22 @@ where
     ///     distance.round()
     /// );
     /// ```
-    fn cross_track_distance<MetricSpace>(&self, line_point_a: &Rhs, line_point_b: &Rhs) -> T
-    where
-        MetricSpace: for<'a> Distance<T, &'a Line<T>, &'a Point<T>>;
+    fn cross_track_distance(&self, line_point_a: &Rhs, line_point_b: &Rhs) -> T;
 }
 
 impl<T> CrossTrackDistance<T, Point<T>> for Point<T>
 where
     T: CoordFloat + FromPrimitive,
 {
-    fn cross_track_distance<MetricSpace>(
-        &self,
-        line_point_a: &Point<T>,
-        line_point_b: &Point<T>,
-    ) -> T
-    where
-        MetricSpace: for<'a> Distance<T, &'a Line<T>, &'a Point<T>>,
-    {
-        MetricSpace::distance(&Line::new(*line_point_a, *line_point_b), self)
+    fn cross_track_distance(&self, line_point_a: &Point<T>, line_point_b: &Point<T>) -> T {
+        crate::Haversine::distance(&Line::new(*line_point_a, *line_point_b), self)
     }
 }
 
 #[cfg(test)]
 mod test {
     use crate::Point;
-    use crate::{CrossTrackDistance, Distance, Euclidean, Haversine};
+    use crate::{CrossTrackDistance, Distance, Haversine};
 
     #[test]
     fn distance1_test() {
@@ -69,7 +62,7 @@ mod test {
         let line_point_a = Point::new(-1.7297, 53.3206);
         let line_point_b = Point::new(0.1334, 53.1887);
         assert_relative_eq!(
-            p.cross_track_distance::<Haversine>(&line_point_a, &line_point_b),
+            p.cross_track_distance(&line_point_a, &line_point_b),
             307.549995,
             epsilon = 1.0e-6
         );
@@ -82,7 +75,7 @@ mod test {
         let line_point_b = Point::new(2., 0.);
 
         assert_relative_eq!(
-            p.cross_track_distance::<Haversine>(&line_point_a, &line_point_b),
+            p.cross_track_distance(&line_point_a, &line_point_b),
             0.,
             epsilon = 1.0e-6
         );
@@ -95,13 +88,13 @@ mod test {
         let line_point_b = Point::new(1., 1.);
 
         assert_relative_eq!(
-            p.cross_track_distance::<Haversine>(&line_point_a, &line_point_b),
+            p.cross_track_distance(&line_point_a, &line_point_b),
             Haversine::distance(p, Point::new(1., 0.)),
             epsilon = 1.0e-6
         );
 
         assert_relative_eq!(
-            p.cross_track_distance::<Haversine>(&line_point_b, &line_point_a),
+            p.cross_track_distance(&line_point_b, &line_point_a),
             Haversine::distance(p, Point::new(1., 0.)),
             epsilon = 1.0e-6
         );
@@ -113,15 +106,7 @@ mod test {
         let line_point_a = Point::new(-80.1918f64, 25.7617f64);
         let line_point_b = Point::new(-120.7401f64, 47.7511f64);
 
-        let haversine_distance = p1.cross_track_distance::<Haversine>(&line_point_a, &line_point_b);
+        let haversine_distance = p1.cross_track_distance(&line_point_a, &line_point_b);
         assert_relative_eq!(haversine_distance, 1_547_104., epsilon = 1.0);
-
-        // Same as above, but projected to EPSG:5070 to test Euclidean
-        let p1 = Point::new(1826303.9422258963, 2179112.0732980534);
-        let line_point_a = Point::new(1594077.349564382, 434470.0414052719);
-        let line_point_b = Point::new(-1847681.2454118263, 2992574.0850278544);
-
-        let euclidean_distance = p1.cross_track_distance::<Euclidean>(&line_point_a, &line_point_b);
-        assert_relative_eq!(euclidean_distance, 1_538_764., epsilon = 1.0);
     }
 }

--- a/geo/src/algorithm/line_measures/distance.rs
+++ b/geo/src/algorithm/line_measures/distance.rs
@@ -10,3 +10,18 @@ pub trait Distance<F, Origin, Destination> {
     /// - returns: depends on the trait implementation.
     fn distance(origin: Origin, destination: Destination) -> F;
 }
+
+// Distance is a symmetric operation, so we can implement it once for both
+macro_rules! symmetric_distance_impl {
+    ($a:ty, $b:ty, for: $metric_space: ty, where: $($bound:tt)+) => {
+        impl<F> $crate::Distance<F, $a, $b> for $metric_space
+        where
+            F: $($bound)+,
+        {
+            fn distance(a: $a, b: $b) -> F {
+                Self::distance(b, a)
+            }
+        }
+    };
+}
+pub(crate) use symmetric_distance_impl;

--- a/geo/src/algorithm/line_measures/metric_spaces/haversine.rs
+++ b/geo/src/algorithm/line_measures/metric_spaces/haversine.rs
@@ -152,12 +152,17 @@ impl<F: CoordFloat + FromPrimitive> Distance<F, Point<F>, Point<F>> for Haversin
     }
 }
 
-impl<F: CoordFloat + FromPrimitive> Distance<F, Line<F>, Point<F>> for Haversine {
-    fn distance(origin: Line<F>, destination: Point<F>) -> F {
-        todo!()
+impl<F: CoordFloat + FromPrimitive> Distance<F, &Line<F>, &Point<F>> for Haversine {
+    fn distance(line: &Line<F>, point: &Point<F>) -> F {
+        let mean_earth_radius = F::from(MEAN_EARTH_RADIUS).unwrap();
+        let l_delta_13 = Haversine::distance(line.start_point(), *point) / mean_earth_radius;
+        let theta_13 = Haversine::bearing(line.start_point(), *point).to_radians();
+        let theta_12 = Haversine::bearing(line.start_point(), line.end_point()).to_radians();
+        let l_delta_xt = (l_delta_13.sin() * (theta_12 - theta_13).sin()).asin();
+        mean_earth_radius * l_delta_xt.abs()
     }
 }
-symmetric_distance_impl!(Point<F>, Line<F>, for: Haversine, where: CoordFloat + FromPrimitive);
+symmetric_distance_impl!(&Point<F>, &Line<F>, for: Haversine, where: CoordFloat + FromPrimitive);
 
 /// Interpolate Point(s) along a [great circle].
 ///

--- a/geo/src/algorithm/line_measures/metric_spaces/haversine.rs
+++ b/geo/src/algorithm/line_measures/metric_spaces/haversine.rs
@@ -1,8 +1,9 @@
 use num_traits::FromPrimitive;
 
 use super::super::{Bearing, Destination, Distance, InterpolatePoint};
+use crate::line_measures::distance::symmetric_distance_impl;
 use crate::utils::normalize_longitude;
-use crate::{CoordFloat, Point, MEAN_EARTH_RADIUS};
+use crate::{CoordFloat, Line, Point, MEAN_EARTH_RADIUS};
 
 /// A spherical model of the earth using the [haversine formula].
 ///
@@ -150,6 +151,13 @@ impl<F: CoordFloat + FromPrimitive> Distance<F, Point<F>, Point<F>> for Haversin
         F::from(MEAN_EARTH_RADIUS).unwrap() * c
     }
 }
+
+impl<F: CoordFloat + FromPrimitive> Distance<F, Line<F>, Point<F>> for Haversine {
+    fn distance(origin: Line<F>, destination: Point<F>) -> F {
+        todo!()
+    }
+}
+symmetric_distance_impl!(Point<F>, Line<F>, for: Haversine, where: CoordFloat + FromPrimitive);
 
 /// Interpolate Point(s) along a [great circle].
 ///


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Part of #1181 

At first I also made CrossTrackDistance generic so that you could:
```diff
- let distance = point.cross_track_distance(line_start, line_end);
+ let distance = point.cross_track_distance::<Haversine>(line_start, line_end);
+ let distance = point.cross_track_distance::<Euclidean>(line_start, line_end);
```

But I decided to avoid the breaking change for now and rolled it back (since we just released a breaking change 2 hours ago 😅)

At this point, I consider CrossTrackDistance to be wholly redundant with Line x Point distance, but maybe it's worth keeping around just because it's a well know (?) algorithm name people will be searching for. I'm willing to be convinced otherwise though.