### PR TITLE
Remove associated type `T` on `geo-traits` traits.

### DIFF
--- a/geo-traits/src/geometry.rs
+++ b/geo-traits/src/geometry.rs
@@ -12,56 +12,53 @@ use crate::{
 /// A trait for accessing data from a generic Geometry.
 #[allow(clippy::type_complexity)]
 pub trait GeometryTrait {
-    /// The coordinate type of this geometry
-    type T;
-
     /// The type of each underlying Point, which implements [PointTrait]
-    type PointType<'a>: 'a + PointTrait<T = Self::T>
+    type PointType<'a>: 'a + PointTrait
     where
         Self: 'a;
 
     /// The type of each underlying LineString, which implements [LineStringTrait]
-    type LineStringType<'a>: 'a + LineStringTrait<T = Self::T>
+    type LineStringType<'a>: 'a + LineStringTrait
     where
         Self: 'a;
 
     /// The type of each underlying Polygon, which implements [PolygonTrait]
-    type PolygonType<'a>: 'a + PolygonTrait<T = Self::T>
+    type PolygonType<'a>: 'a + PolygonTrait
     where
         Self: 'a;
 
     /// The type of each underlying MultiPoint, which implements [MultiPointTrait]
-    type MultiPointType<'a>: 'a + MultiPointTrait<T = Self::T>
+    type MultiPointType<'a>: 'a + MultiPointTrait
     where
         Self: 'a;
 
     /// The type of each underlying MultiLineString, which implements [MultiLineStringTrait]
-    type MultiLineStringType<'a>: 'a + MultiLineStringTrait<T = Self::T>
+    type MultiLineStringType<'a>: 'a + MultiLineStringTrait
     where
         Self: 'a;
 
     /// The type of each underlying MultiPolygon, which implements [MultiPolygonTrait]
-    type MultiPolygonType<'a>: 'a + MultiPolygonTrait<T = Self::T>
+    type MultiPolygonType<'a>: 'a + MultiPolygonTrait
     where
         Self: 'a;
 
     /// The type of each underlying GeometryCollection, which implements [GeometryCollectionTrait]
-    type GeometryCollectionType<'a>: 'a + GeometryCollectionTrait<T = Self::T>
+    type GeometryCollectionType<'a>: 'a + GeometryCollectionTrait
     where
         Self: 'a;
 
     /// The type of each underlying Rect, which implements [RectTrait]
-    type RectType<'a>: 'a + RectTrait<T = Self::T>
+    type RectType<'a>: 'a + RectTrait
     where
         Self: 'a;
 
     /// The type of each underlying Triangle, which implements [TriangleTrait]
-    type TriangleType<'a>: 'a + TriangleTrait<T = Self::T>
+    type TriangleType<'a>: 'a + TriangleTrait
     where
         Self: 'a;
 
     /// The type of each underlying Line, which implements [LineTrait]
-    type LineType<'a>: 'a + LineTrait<T = Self::T>
+    type LineType<'a>: 'a + LineTrait
     where
         Self: 'a;
 
@@ -127,17 +124,46 @@ where
 
 #[cfg(feature = "geo-types")]
 impl<'a, T: CoordNum + 'a> GeometryTrait for Geometry<T> {
-    type T = T;
-    type PointType<'b> = Point<Self::T> where Self: 'b;
-    type LineStringType<'b> = LineString<Self::T> where Self: 'b;
-    type PolygonType<'b> = Polygon<Self::T> where Self: 'b;
-    type MultiPointType<'b> = MultiPoint<Self::T> where Self: 'b;
-    type MultiLineStringType<'b> = MultiLineString<Self::T> where Self: 'b;
-    type MultiPolygonType<'b> = MultiPolygon<Self::T> where Self: 'b;
-    type GeometryCollectionType<'b> = GeometryCollection<Self::T> where Self: 'b;
-    type RectType<'b> = Rect<Self::T> where Self: 'b;
-    type TriangleType<'b> = Triangle<Self::T> where Self: 'b;
-    type LineType<'b> = Line<Self::T> where Self: 'b;
+    type PointType<'b>
+        = Point<T>
+    where
+        Self: 'b;
+    type LineStringType<'b>
+        = LineString<T>
+    where
+        Self: 'b;
+    type PolygonType<'b>
+        = Polygon<T>
+    where
+        Self: 'b;
+    type MultiPointType<'b>
+        = MultiPoint<T>
+    where
+        Self: 'b;
+    type MultiLineStringType<'b>
+        = MultiLineString<T>
+    where
+        Self: 'b;
+    type MultiPolygonType<'b>
+        = MultiPolygon<T>
+    where
+        Self: 'b;
+    type GeometryCollectionType<'b>
+        = GeometryCollection<T>
+    where
+        Self: 'b;
+    type RectType<'b>
+        = Rect<T>
+    where
+        Self: 'b;
+    type TriangleType<'b>
+        = Triangle<T>
+    where
+        Self: 'b;
+    type LineType<'b>
+        = Line<T>
+    where
+        Self: 'b;
 
     fn dim(&self) -> Dimensions {
         Dimensions::Xy
@@ -175,17 +201,46 @@ impl<'a, T: CoordNum + 'a> GeometryTrait for Geometry<T> {
 
 #[cfg(feature = "geo-types")]
 impl<'a, T: CoordNum + 'a> GeometryTrait for &'a Geometry<T> {
-    type T = T;
-    type PointType<'b> = Point<Self::T> where Self: 'b;
-    type LineStringType<'b> = LineString<Self::T> where Self: 'b;
-    type PolygonType<'b> = Polygon<Self::T> where Self: 'b;
-    type MultiPointType<'b> = MultiPoint<Self::T> where Self: 'b;
-    type MultiLineStringType<'b> = MultiLineString<Self::T> where Self: 'b;
-    type MultiPolygonType<'b> = MultiPolygon<Self::T> where Self: 'b;
-    type GeometryCollectionType<'b> = GeometryCollection<Self::T> where Self: 'b;
-    type RectType<'b> = Rect<Self::T> where Self: 'b;
-    type TriangleType<'b> = Triangle<Self::T> where Self: 'b;
-    type LineType<'b> = Line<Self::T> where Self: 'b;
+    type PointType<'b>
+        = Point<T>
+    where
+        Self: 'b;
+    type LineStringType<'b>
+        = LineString<T>
+    where
+        Self: 'b;
+    type PolygonType<'b>
+        = Polygon<T>
+    where
+        Self: 'b;
+    type MultiPointType<'b>
+        = MultiPoint<T>
+    where
+        Self: 'b;
+    type MultiLineStringType<'b>
+        = MultiLineString<T>
+    where
+        Self: 'b;
+    type MultiPolygonType<'b>
+        = MultiPolygon<T>
+    where
+        Self: 'b;
+    type GeometryCollectionType<'b>
+        = GeometryCollection<T>
+    where
+        Self: 'b;
+    type RectType<'b>
+        = Rect<T>
+    where
+        Self: 'b;
+    type TriangleType<'b>
+        = Triangle<T>
+    where
+        Self: 'b;
+    type LineType<'b>
+        = Line<T>
+    where
+        Self: 'b;
 
     fn dim(&self) -> Dimensions {
         Dimensions::Xy
@@ -227,17 +282,46 @@ macro_rules! impl_specialization {
     ($geometry_type:ident) => {
         #[cfg(feature = "geo-types")]
         impl<T: CoordNum> GeometryTrait for $geometry_type<T> {
-            type T = T;
-            type PointType<'b> = Point<Self::T> where Self: 'b;
-            type LineStringType<'b> = LineString<Self::T> where Self: 'b;
-            type PolygonType<'b> = Polygon<Self::T> where Self: 'b;
-            type MultiPointType<'b> = MultiPoint<Self::T> where Self: 'b;
-            type MultiLineStringType<'b> = MultiLineString<Self::T> where Self: 'b;
-            type MultiPolygonType<'b> = MultiPolygon<Self::T> where Self: 'b;
-            type GeometryCollectionType<'b> = GeometryCollection<Self::T> where Self: 'b;
-            type RectType<'b> = Rect<Self::T> where Self: 'b;
-            type TriangleType<'b> = Triangle<Self::T> where Self: 'b;
-            type LineType<'b> = Line<Self::T> where Self: 'b;
+            type PointType<'b>
+                = Point<T>
+            where
+                Self: 'b;
+            type LineStringType<'b>
+                = LineString<T>
+            where
+                Self: 'b;
+            type PolygonType<'b>
+                = Polygon<T>
+            where
+                Self: 'b;
+            type MultiPointType<'b>
+                = MultiPoint<T>
+            where
+                Self: 'b;
+            type MultiLineStringType<'b>
+                = MultiLineString<T>
+            where
+                Self: 'b;
+            type MultiPolygonType<'b>
+                = MultiPolygon<T>
+            where
+                Self: 'b;
+            type GeometryCollectionType<'b>
+                = GeometryCollection<T>
+            where
+                Self: 'b;
+            type RectType<'b>
+                = Rect<T>
+            where
+                Self: 'b;
+            type TriangleType<'b>
+                = Triangle<T>
+            where
+                Self: 'b;
+            type LineType<'b>
+                = Line<T>
+            where
+                Self: 'b;
 
             fn dim(&self) -> Dimensions {
                 Dimensions::Xy
@@ -264,17 +348,46 @@ macro_rules! impl_specialization {
 
         #[cfg(feature = "geo-types")]
         impl<'a, T: CoordNum + 'a> GeometryTrait for &'a $geometry_type<T> {
-            type T = T;
-            type PointType<'b> = Point<Self::T> where Self: 'b;
-            type LineStringType<'b> = LineString<Self::T> where Self: 'b;
-            type PolygonType<'b> = Polygon<Self::T> where Self: 'b;
-            type MultiPointType<'b> = MultiPoint<Self::T> where Self: 'b;
-            type MultiLineStringType<'b> = MultiLineString<Self::T> where Self: 'b;
-            type MultiPolygonType<'b> = MultiPolygon<Self::T> where Self: 'b;
-            type GeometryCollectionType<'b> = GeometryCollection<Self::T> where Self: 'b;
-            type RectType<'b> = Rect<Self::T> where Self: 'b;
-            type TriangleType<'b> = Triangle<Self::T> where Self: 'b;
-            type LineType<'b> = Line<Self::T> where Self: 'b;
+            type PointType<'b>
+                = Point<T>
+            where
+                Self: 'b;
+            type LineStringType<'b>
+                = LineString<T>
+            where
+                Self: 'b;
+            type PolygonType<'b>
+                = Polygon<T>
+            where
+                Self: 'b;
+            type MultiPointType<'b>
+                = MultiPoint<T>
+            where
+                Self: 'b;
+            type MultiLineStringType<'b>
+                = MultiLineString<T>
+            where
+                Self: 'b;
+            type MultiPolygonType<'b>
+                = MultiPolygon<T>
+            where
+                Self: 'b;
+            type GeometryCollectionType<'b>
+                = GeometryCollection<T>
+            where
+                Self: 'b;
+            type RectType<'b>
+                = Rect<T>
+            where
+                Self: 'b;
+            type TriangleType<'b>
+                = Triangle<T>
+            where
+                Self: 'b;
+            type LineType<'b>
+                = Line<T>
+            where
+                Self: 'b;
 
             fn dim(&self) -> Dimensions {
                 Dimensions::Xy

--- a/geo-traits/src/geometry_collection.rs
+++ b/geo-traits/src/geometry_collection.rs
@@ -7,11 +7,8 @@ use geo_types::{CoordNum, Geometry, GeometryCollection};
 ///
 /// A GeometryCollection is a collection of [Geometry][GeometryTrait] types.
 pub trait GeometryCollectionTrait: Sized {
-    /// The coordinate type of this geometry
-    type T;
-
     /// The type of each underlying geometry, which implements [GeometryTrait]
-    type GeometryType<'a>: 'a + GeometryTrait<T = Self::T>
+    type GeometryType<'a>: 'a + GeometryTrait
     where
         Self: 'a;
 
@@ -48,8 +45,8 @@ pub trait GeometryCollectionTrait: Sized {
 
 #[cfg(feature = "geo-types")]
 impl<T: CoordNum> GeometryCollectionTrait for GeometryCollection<T> {
-    type T = T;
-    type GeometryType<'a> = &'a Geometry<Self::T>
+    type GeometryType<'a>
+        = &'a Geometry<T>
     where
         Self: 'a;
 
@@ -68,8 +65,9 @@ impl<T: CoordNum> GeometryCollectionTrait for GeometryCollection<T> {
 
 #[cfg(feature = "geo-types")]
 impl<'a, T: CoordNum> GeometryCollectionTrait for &'a GeometryCollection<T> {
-    type T = T;
-    type GeometryType<'b> = &'a Geometry<Self::T> where
+    type GeometryType<'b>
+        = &'a Geometry<T>
+    where
         Self: 'b;
 
     fn dim(&self) -> Dimensions {

--- a/geo-traits/src/iterator.rs
+++ b/geo-traits/src/iterator.rs
@@ -8,21 +8,16 @@ macro_rules! impl_iterator {
         /// An iterator over the parts of this geometry.
         pub(crate) struct $struct_name<
             'a,
-            T,
-            $item_type: 'a + $item_trait<T = T>,
-            G: $self_trait<T = T, $item_type<'a> = $item_type>,
+            $item_type: 'a + $item_trait,
+            G: $self_trait<$item_type<'a> = $item_type>,
         > {
             geom: &'a G,
             index: usize,
             end: usize,
         }
 
-        impl<
-                'a,
-                T,
-                $item_type: 'a + $item_trait<T = T>,
-                G: $self_trait<T = T, $item_type<'a> = $item_type>,
-            > $struct_name<'a, T, $item_type, G>
+        impl<'a, $item_type: 'a + $item_trait, G: $self_trait<$item_type<'a> = $item_type>>
+            $struct_name<'a, $item_type, G>
         {
             /// Create a new iterator
             pub fn new(geom: &'a G, index: usize, end: usize) -> Self {
@@ -30,12 +25,8 @@ macro_rules! impl_iterator {
             }
         }
 
-        impl<
-                'a,
-                T,
-                $item_type: 'a + $item_trait<T = T>,
-                G: $self_trait<T = T, $item_type<'a> = $item_type>,
-            > Iterator for $struct_name<'a, T, $item_type, G>
+        impl<'a, $item_type: 'a + $item_trait, G: $self_trait<$item_type<'a> = $item_type>> Iterator
+            for $struct_name<'a, $item_type, G>
         {
             type Item = $item_type;
 
@@ -55,21 +46,13 @@ macro_rules! impl_iterator {
             }
         }
 
-        impl<
-                'a,
-                T,
-                $item_type: 'a + $item_trait<T = T>,
-                G: $self_trait<T = T, $item_type<'a> = $item_type>,
-            > ExactSizeIterator for $struct_name<'a, T, $item_type, G>
+        impl<'a, $item_type: 'a + $item_trait, G: $self_trait<$item_type<'a> = $item_type>>
+            ExactSizeIterator for $struct_name<'a, $item_type, G>
         {
         }
 
-        impl<
-                'a,
-                T,
-                $item_type: 'a + $item_trait<T = T>,
-                G: $self_trait<T = T, $item_type<'a> = $item_type>,
-            > DoubleEndedIterator for $struct_name<'a, T, $item_type, G>
+        impl<'a, $item_type: 'a + $item_trait, G: $self_trait<$item_type<'a> = $item_type>>
+            DoubleEndedIterator for $struct_name<'a, $item_type, G>
         {
             #[inline]
             fn next_back(&mut self) -> Option<Self::Item> {

--- a/geo-traits/src/line.rs
+++ b/geo-traits/src/line.rs
@@ -10,11 +10,8 @@ use geo_types::{Coord, CoordNum, Line};
 ///
 /// Refer to [geo_types::Line] for information about semantics and validity.
 pub trait LineTrait: Sized {
-    /// The coordinate type of this geometry
-    type T;
-
     /// The type of each underlying coordinate, which implements [CoordTrait]
-    type CoordType<'a>: 'a + CoordTrait<T = Self::T>
+    type CoordType<'a>: 'a + CoordTrait
     where
         Self: 'a;
 
@@ -35,8 +32,10 @@ pub trait LineTrait: Sized {
 
 #[cfg(feature = "geo-types")]
 impl<T: CoordNum> LineTrait for Line<T> {
-    type T = T;
-    type CoordType<'a> = &'a Coord<Self::T> where Self: 'a;
+    type CoordType<'a>
+        = &'a Coord<T>
+    where
+        Self: 'a;
 
     fn dim(&self) -> Dimensions {
         Dimensions::Xy
@@ -53,8 +52,10 @@ impl<T: CoordNum> LineTrait for Line<T> {
 
 #[cfg(feature = "geo-types")]
 impl<'a, T: CoordNum> LineTrait for &'a Line<T> {
-    type T = T;
-    type CoordType<'b> = &'a Coord<Self::T> where Self: 'b;
+    type CoordType<'b>
+        = &'a Coord<T>
+    where
+        Self: 'b;
 
     fn dim(&self) -> Dimensions {
         Dimensions::Xy
@@ -76,8 +77,10 @@ impl<'a, T: CoordNum> LineTrait for &'a Line<T> {
 pub struct UnimplementedLine<T>(PhantomData<T>);
 
 impl<T> LineTrait for UnimplementedLine<T> {
-    type T = T;
-    type CoordType<'a> = UnimplementedCoord<Self::T> where Self: 'a;
+    type CoordType<'a>
+        = UnimplementedCoord<T>
+    where
+        Self: 'a;
 
     fn dim(&self) -> Dimensions {
         unimplemented!()

--- a/geo-traits/src/line_string.rs
+++ b/geo-traits/src/line_string.rs
@@ -12,11 +12,8 @@ use geo_types::{Coord, CoordNum, LineString};
 ///
 /// Refer to [geo_types::LineString] for information about semantics and validity.
 pub trait LineStringTrait: Sized {
-    /// The coordinate type of this geometry
-    type T;
-
     /// The type of each underlying coordinate, which implements [CoordTrait]
-    type CoordType<'a>: 'a + CoordTrait<T = Self::T>
+    type CoordType<'a>: 'a + CoordTrait
     where
         Self: 'a;
 
@@ -52,8 +49,10 @@ pub trait LineStringTrait: Sized {
 
 #[cfg(feature = "geo-types")]
 impl<T: CoordNum> LineStringTrait for LineString<T> {
-    type T = T;
-    type CoordType<'a> = &'a Coord<Self::T> where Self: 'a;
+    type CoordType<'a>
+        = &'a Coord<T>
+    where
+        Self: 'a;
 
     fn dim(&self) -> Dimensions {
         Dimensions::Xy
@@ -70,8 +69,10 @@ impl<T: CoordNum> LineStringTrait for LineString<T> {
 
 #[cfg(feature = "geo-types")]
 impl<'a, T: CoordNum> LineStringTrait for &'a LineString<T> {
-    type T = T;
-    type CoordType<'b> = &'a Coord<Self::T> where Self: 'b;
+    type CoordType<'b>
+        = &'a Coord<T>
+    where
+        Self: 'b;
 
     fn dim(&self) -> Dimensions {
         Dimensions::Xy
@@ -93,8 +94,10 @@ impl<'a, T: CoordNum> LineStringTrait for &'a LineString<T> {
 pub struct UnimplementedLineString<T>(PhantomData<T>);
 
 impl<T> LineStringTrait for UnimplementedLineString<T> {
-    type T = T;
-    type CoordType<'a> = UnimplementedCoord<Self::T> where Self: 'a;
+    type CoordType<'a>
+        = UnimplementedCoord<T>
+    where
+        Self: 'a;
 
     fn dim(&self) -> Dimensions {
         unimplemented!()

--- a/geo-traits/src/multi_line_string.rs
+++ b/geo-traits/src/multi_line_string.rs
@@ -12,11 +12,8 @@ use geo_types::{CoordNum, LineString, MultiLineString};
 ///
 /// Refer to [geo_types::MultiLineString] for information about semantics and validity.
 pub trait MultiLineStringTrait: Sized {
-    /// The coordinate type of this geometry
-    type T;
-
     /// The type of each underlying LineString, which implements [LineStringTrait]
-    type LineStringType<'a>: 'a + LineStringTrait<T = Self::T>
+    type LineStringType<'a>: 'a + LineStringTrait
     where
         Self: 'a;
 
@@ -53,8 +50,10 @@ pub trait MultiLineStringTrait: Sized {
 
 #[cfg(feature = "geo-types")]
 impl<T: CoordNum> MultiLineStringTrait for MultiLineString<T> {
-    type T = T;
-    type LineStringType<'a> = &'a LineString<Self::T> where Self: 'a;
+    type LineStringType<'a>
+        = &'a LineString<T>
+    where
+        Self: 'a;
 
     fn dim(&self) -> Dimensions {
         Dimensions::Xy
@@ -71,8 +70,10 @@ impl<T: CoordNum> MultiLineStringTrait for MultiLineString<T> {
 
 #[cfg(feature = "geo-types")]
 impl<'a, T: CoordNum> MultiLineStringTrait for &'a MultiLineString<T> {
-    type T = T;
-    type LineStringType<'b> = &'a LineString<Self::T> where Self: 'b;
+    type LineStringType<'b>
+        = &'a LineString<T>
+    where
+        Self: 'b;
 
     fn dim(&self) -> Dimensions {
         Dimensions::Xy
@@ -94,8 +95,10 @@ impl<'a, T: CoordNum> MultiLineStringTrait for &'a MultiLineString<T> {
 pub struct UnimplementedMultiLineString<T>(PhantomData<T>);
 
 impl<T> MultiLineStringTrait for UnimplementedMultiLineString<T> {
-    type T = T;
-    type LineStringType<'a> = UnimplementedLineString<Self::T> where Self: 'a;
+    type LineStringType<'a>
+        = UnimplementedLineString<T>
+    where
+        Self: 'a;
 
     fn dim(&self) -> Dimensions {
         unimplemented!()

--- a/geo-traits/src/multi_point.rs
+++ b/geo-traits/src/multi_point.rs
@@ -11,11 +11,8 @@ use geo_types::{CoordNum, MultiPoint, Point};
 ///
 /// Refer to [geo_types::MultiPoint] for information about semantics and validity.
 pub trait MultiPointTrait: Sized {
-    /// The coordinate type of this geometry
-    type T;
-
     /// The type of each underlying Point, which implements [PointTrait]
-    type PointType<'a>: 'a + PointTrait<T = Self::T>
+    type PointType<'a>: 'a + PointTrait
     where
         Self: 'a;
 
@@ -50,8 +47,10 @@ pub trait MultiPointTrait: Sized {
 
 #[cfg(feature = "geo-types")]
 impl<T: CoordNum> MultiPointTrait for MultiPoint<T> {
-    type T = T;
-    type PointType<'a> = &'a Point<Self::T> where Self: 'a;
+    type PointType<'a>
+        = &'a Point<T>
+    where
+        Self: 'a;
 
     fn dim(&self) -> Dimensions {
         Dimensions::Xy
@@ -68,8 +67,10 @@ impl<T: CoordNum> MultiPointTrait for MultiPoint<T> {
 
 #[cfg(feature = "geo-types")]
 impl<'a, T: CoordNum> MultiPointTrait for &'a MultiPoint<T> {
-    type T = T;
-    type PointType<'b> = &'a Point<Self::T> where Self: 'b;
+    type PointType<'b>
+        = &'a Point<T>
+    where
+        Self: 'b;
 
     fn dim(&self) -> Dimensions {
         Dimensions::Xy
@@ -91,8 +92,10 @@ impl<'a, T: CoordNum> MultiPointTrait for &'a MultiPoint<T> {
 pub struct UnimplementedMultiPoint<T>(PhantomData<T>);
 
 impl<T> MultiPointTrait for UnimplementedMultiPoint<T> {
-    type T = T;
-    type PointType<'a> = UnimplementedPoint<Self::T> where Self: 'a;
+    type PointType<'a>
+        = UnimplementedPoint<T>
+    where
+        Self: 'a;
 
     fn dim(&self) -> Dimensions {
         unimplemented!()

--- a/geo-traits/src/multi_polygon.rs
+++ b/geo-traits/src/multi_polygon.rs
@@ -10,11 +10,8 @@ use geo_types::{CoordNum, MultiPolygon, Polygon};
 ///
 /// Refer to [geo_types::MultiPolygon] for information about semantics and validity.
 pub trait MultiPolygonTrait: Sized {
-    /// The coordinate type of this geometry
-    type T;
-
     /// The type of each underlying Polygon, which implements [PolygonTrait]
-    type PolygonType<'a>: 'a + PolygonTrait<T = Self::T>
+    type PolygonType<'a>: 'a + PolygonTrait
     where
         Self: 'a;
 
@@ -51,8 +48,10 @@ pub trait MultiPolygonTrait: Sized {
 
 #[cfg(feature = "geo-types")]
 impl<T: CoordNum> MultiPolygonTrait for MultiPolygon<T> {
-    type T = T;
-    type PolygonType<'a> = &'a Polygon<Self::T> where Self: 'a;
+    type PolygonType<'a>
+        = &'a Polygon<T>
+    where
+        Self: 'a;
 
     fn dim(&self) -> Dimensions {
         Dimensions::Xy
@@ -69,8 +68,10 @@ impl<T: CoordNum> MultiPolygonTrait for MultiPolygon<T> {
 
 #[cfg(feature = "geo-types")]
 impl<'a, T: CoordNum> MultiPolygonTrait for &'a MultiPolygon<T> {
-    type T = T;
-    type PolygonType<'b> = &'a Polygon<Self::T> where Self: 'b;
+    type PolygonType<'b>
+        = &'a Polygon<T>
+    where
+        Self: 'b;
 
     fn dim(&self) -> Dimensions {
         Dimensions::Xy
@@ -92,8 +93,10 @@ impl<'a, T: CoordNum> MultiPolygonTrait for &'a MultiPolygon<T> {
 pub struct UnimplementedMultiPolygon<T>(PhantomData<T>);
 
 impl<T> MultiPolygonTrait for UnimplementedMultiPolygon<T> {
-    type T = T;
-    type PolygonType<'a> = UnimplementedPolygon<Self::T> where Self: 'a;
+    type PolygonType<'a>
+        = UnimplementedPolygon<T>
+    where
+        Self: 'a;
 
     fn dim(&self) -> Dimensions {
         unimplemented!()

--- a/geo-traits/src/polygon.rs
+++ b/geo-traits/src/polygon.rs
@@ -14,11 +14,8 @@ use geo_types::{CoordNum, LineString, Polygon};
 ///
 /// Refer to [geo_types::Polygon] for information about semantics and validity.
 pub trait PolygonTrait: Sized {
-    /// The coordinate type of this geometry
-    type T;
-
     /// The type of each underlying ring, which implements [LineStringTrait]
-    type RingType<'a>: 'a + LineStringTrait<T = Self::T>
+    type RingType<'a>: 'a + LineStringTrait
     where
         Self: 'a;
 
@@ -56,8 +53,10 @@ pub trait PolygonTrait: Sized {
 
 #[cfg(feature = "geo-types")]
 impl<T: CoordNum> PolygonTrait for Polygon<T> {
-    type T = T;
-    type RingType<'a> = &'a LineString<Self::T> where Self: 'a;
+    type RingType<'a>
+        = &'a LineString<T>
+    where
+        Self: 'a;
 
     fn dim(&self) -> Dimensions {
         Dimensions::Xy
@@ -83,8 +82,9 @@ impl<T: CoordNum> PolygonTrait for Polygon<T> {
 
 #[cfg(feature = "geo-types")]
 impl<'a, T: CoordNum> PolygonTrait for &'a Polygon<T> {
-    type T = T;
-    type RingType<'b> = &'a LineString<Self::T> where
+    type RingType<'b>
+        = &'a LineString<T>
+    where
         Self: 'b;
 
     fn dim(&self) -> Dimensions {
@@ -116,8 +116,10 @@ impl<'a, T: CoordNum> PolygonTrait for &'a Polygon<T> {
 pub struct UnimplementedPolygon<T>(PhantomData<T>);
 
 impl<T> PolygonTrait for UnimplementedPolygon<T> {
-    type T = T;
-    type RingType<'a> = UnimplementedLineString<Self::T> where Self: 'a;
+    type RingType<'a>
+        = UnimplementedLineString<T>
+    where
+        Self: 'a;
 
     fn dim(&self) -> Dimensions {
         unimplemented!()


### PR DESCRIPTION
- [ ] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Do we need to specify `T` for each of the traits?