### PR TITLE
There is a bug in rstar 0.12.1, so pin for now.

### DIFF
--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -2,7 +2,8 @@
 
 ## UNRELEASED
 
-* Pin to rstar 0.12.0, to avoid a bug in 0.12.1
+* Pin to rstar 0.12.2, to avoid a bug in 0.12.1
+  * <https://github.com/georust/geo/pull/1261>
 
 ## 0.7.13
 

--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## UNRELEASED
+
+* Pin to rstar 0.12.0, to avoid a bug in 0.12.1
+
 ## 0.7.13
 
 * POSSIBLY BREAKING: Minimum supported version of Rust (MSRV) is now 1.70

--- a/geo-types/Cargo.toml
+++ b/geo-types/Cargo.toml
@@ -32,7 +32,8 @@ rstar_0_8 = { package = "rstar", version = "0.8", optional = true }
 rstar_0_9 = { package = "rstar", version = "0.9", optional = true }
 rstar_0_10 = { package = "rstar", version = "0.10", optional = true }
 rstar_0_11 = { package = "rstar", version = "0.11", optional = true }
-rstar_0_12 = { package = "rstar", version = "0.12", optional = true }
+# Note: there is a bug in rstar 0.12.1, fixed in https://github.com/georust/rstar/pull/184
+rstar_0_12 = { package = "rstar", version = "0.12.2", optional = true }
 serde = { version = "1", optional = true, default-features = false, features = ["alloc", "derive"] }
 
 [dev-dependencies]

--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Pin to rstar 0.12.2, to avoid a bug in 0.12.1
+  * <https://github.com/georust/geo/pull/1261>
+
 ## 0.29.1 - 2024.11.01
 
 - Allow configuring of the `i_overlay` Rayon transitive dependency with a new Cargo `multithreading` flag.

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -29,9 +29,8 @@ log = "0.4.11"
 num-traits = "0.2"
 proj = { version = "0.27.0", optional = true }
 robust = "1.1.0"
-# There is a bug in rstar 0.12.1, so pin for  now.
-# see: https://github.com/georust/rstar/pull/181
-rstar = "=0.12.0"
+# Note: there is a bug in rstar 0.12.1, fixed in https://github.com/georust/rstar/pull/184
+rstar = "0.12.2"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 i_overlay = { version = "1.7.2", default-features = false }
 

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -29,7 +29,9 @@ log = "0.4.11"
 num-traits = "0.2"
 proj = { version = "0.27.0", optional = true }
 robust = "1.1.0"
-rstar = "0.12.0"
+# There is a bug in rstar 0.12.1, so pin for  now.
+# see: https://github.com/georust/rstar/pull/181
+rstar = "=0.12.0"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 i_overlay = { version = "1.7.2", default-features = false }
 


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

FIXES #1260 

see: https://github.com/georust/rstar/pull/181

We don't have to do this - we could wait a bit if we think an rstar fix is forthcoming.
