### PR TITLE
Add multithreading support to Multi* geometries

### DIFF
--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 * Add rstar compatibility for MultiPolygon
+* Add multi-threading support to Multi* geometries. 
+  * Feature-gated ('multithreading'), disabled by default, enabled by default when geo-types is used by geo
 
 ## 0.7.13
 

--- a/geo-types/Cargo.toml
+++ b/geo-types/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2021"
 [features]
 default = ["std"]
 std = ["approx?/std", "num-traits/std", "serde?/std"]
+multithreading = ["rayon"]
 # Prefer `use-rstar` feature rather than enabling rstar directly.
 # rstar integration relies on the optional approx crate, but implicit features cannot yet enable other features.
 # See: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#namespaced-features
@@ -25,6 +26,7 @@ use-rstar_0_11 = ["rstar_0_11", "approx"]
 use-rstar_0_12 = ["rstar_0_12", "approx"]
 
 [dependencies]
+rayon = { version = "1.10.0", optional = true }
 approx = { version = ">= 0.4.0, < 0.6.0", optional = true, default-features = false }
 arbitrary = { version = "1.2.0", optional = true }
 num-traits = { version = "0.2", default-features = false, features = ["libm"] }

--- a/geo-types/src/geometry/multi_line_string.rs
+++ b/geo-types/src/geometry/multi_line_string.rs
@@ -5,6 +5,8 @@ use alloc::vec::Vec;
 #[cfg(any(feature = "approx", test))]
 use approx::{AbsDiffEq, RelativeEq};
 use core::iter::FromIterator;
+#[cfg(feature = "multithreading")]
+use rayon::prelude::*;
 
 /// A collection of
 /// [`LineString`s](line_string/struct.LineString.html). Can
@@ -115,6 +117,36 @@ impl<T: CoordNum> MultiLineString<T> {
 
     pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut LineString<T>> {
         self.0.iter_mut()
+    }
+}
+
+#[cfg(feature = "multithreading")]
+impl<T: CoordNum + Send> IntoParallelIterator for MultiLineString<T> {
+    type Item = LineString<T>;
+    type Iter = rayon::vec::IntoIter<LineString<T>>;
+
+    fn into_par_iter(self) -> Self::Iter {
+        self.0.into_par_iter()
+    }
+}
+
+#[cfg(feature = "multithreading")]
+impl<'a, T: CoordNum + Sync> IntoParallelIterator for &'a MultiLineString<T> {
+    type Item = &'a LineString<T>;
+    type Iter = rayon::slice::Iter<'a, LineString<T>>;
+
+    fn into_par_iter(self) -> Self::Iter {
+        self.0.par_iter()
+    }
+}
+
+#[cfg(feature = "multithreading")]
+impl<'a, T: CoordNum + Send + Sync> IntoParallelIterator for &'a mut MultiLineString<T> {
+    type Item = &'a mut LineString<T>;
+    type Iter = rayon::slice::IterMut<'a, LineString<T>>;
+
+    fn into_par_iter(self) -> Self::Iter {
+        self.0.par_iter_mut()
     }
 }
 

--- a/geo-types/src/geometry/multi_line_string.rs
+++ b/geo-types/src/geometry/multi_line_string.rs
@@ -240,8 +240,8 @@ mod test {
         let mut multimut: MultiLineString<i32> = wkt! {
             MULTILINESTRING((0 0,2 0,1 2,0 0), (10 10,12 10,11 12,10 10))
         };
-        let _ = multi.par_iter().for_each(|_p| ());
-        let _ = multimut.par_iter_mut().for_each(|_p| ());
+        multi.par_iter().for_each(|_p| ());
+        multimut.par_iter_mut().for_each(|_p| ());
         let _ = &multi.into_par_iter().for_each(|_p| ());
         let _ = &mut multimut.par_iter_mut().for_each(|_p| ());
     }

--- a/geo-types/src/geometry/multi_line_string.rs
+++ b/geo-types/src/geometry/multi_line_string.rs
@@ -231,6 +231,7 @@ mod test {
     use super::*;
     use crate::{line_string, wkt};
 
+    #[cfg(feature = "multithreading")]
     #[test]
     fn test_multithreading_linestring() {
         let multi: MultiLineString<i32> = wkt! {

--- a/geo-types/src/geometry/multi_line_string.rs
+++ b/geo-types/src/geometry/multi_line_string.rs
@@ -232,6 +232,20 @@ mod test {
     use crate::{line_string, wkt};
 
     #[test]
+    fn test_multithreading_linestring() {
+        let multi: MultiLineString<i32> = wkt! {
+            MULTILINESTRING((0 0,2 0,1 2,0 0), (10 10,12 10,11 12,10 10))
+        };
+        let mut multimut: MultiLineString<i32> = wkt! {
+            MULTILINESTRING((0 0,2 0,1 2,0 0), (10 10,12 10,11 12,10 10))
+        };
+        let _ = multi.par_iter().for_each(|_p| ());
+        let _ = multimut.par_iter_mut().for_each(|_p| ());
+        let _ = &multi.into_par_iter().for_each(|_p| ());
+        let _ = &mut multimut.par_iter_mut().for_each(|_p| ());
+    }
+
+    #[test]
     fn test_iter() {
         let multi: MultiLineString<i32> = wkt! {
             MULTILINESTRING((0 0,2 0,1 2,0 0), (10 10,12 10,11 12,10 10))

--- a/geo-types/src/geometry/multi_point.rs
+++ b/geo-types/src/geometry/multi_point.rs
@@ -6,6 +6,8 @@ use approx::{AbsDiffEq, RelativeEq};
 use alloc::vec;
 use alloc::vec::Vec;
 use core::iter::FromIterator;
+#[cfg(feature = "multithreading")]
+use rayon::prelude::*;
 
 /// A collection of [`Point`s](struct.Point.html). Can
 /// be created from a `Vec` of `Point`s, or from an
@@ -82,6 +84,36 @@ impl<'a, T: CoordNum> IntoIterator for &'a mut MultiPoint<T> {
 
     fn into_iter(self) -> Self::IntoIter {
         (self.0).iter_mut()
+    }
+}
+
+#[cfg(feature = "multithreading")]
+impl<T: CoordNum + Send> IntoParallelIterator for MultiPoint<T> {
+    type Item = Point<T>;
+    type Iter = rayon::vec::IntoIter<Point<T>>;
+
+    fn into_par_iter(self) -> Self::Iter {
+        self.0.into_par_iter()
+    }
+}
+
+#[cfg(feature = "multithreading")]
+impl<'a, T: CoordNum + Sync> IntoParallelIterator for &'a MultiPoint<T> {
+    type Item = &'a Point<T>;
+    type Iter = rayon::slice::Iter<'a, Point<T>>;
+
+    fn into_par_iter(self) -> Self::Iter {
+        self.0.par_iter()
+    }
+}
+
+#[cfg(feature = "multithreading")]
+impl<'a, T: CoordNum + Send + Sync> IntoParallelIterator for &'a mut MultiPoint<T> {
+    type Item = &'a mut Point<T>;
+    type Iter = rayon::slice::IterMut<'a, Point<T>>;
+
+    fn into_par_iter(self) -> Self::Iter {
+        self.0.par_iter_mut()
     }
 }
 

--- a/geo-types/src/geometry/multi_polygon.rs
+++ b/geo-types/src/geometry/multi_polygon.rs
@@ -284,6 +284,21 @@ mod test {
     }
 
     #[test]
+    fn test_par_iter() {
+        let multi = MultiPolygon::new(vec![
+            polygon![(x: 0, y: 0), (x: 2, y: 0), (x: 1, y: 2), (x:0, y:0)],
+            polygon![(x: 10, y: 10), (x: 12, y: 10), (x: 11, y: 12), (x:10, y:10)],
+        ]);
+        let mut multimut = MultiPolygon::new(vec![
+            polygon![(x: 0, y: 0), (x: 2, y: 0), (x: 1, y: 2), (x:0, y:0)],
+            polygon![(x: 10, y: 10), (x: 12, y: 10), (x: 11, y: 12), (x:10, y:10)],
+        ]);
+        let _ = multi.par_iter().for_each(|_p| ());
+        let _ = &multimut.par_iter_mut().for_each(|_p| ());
+        let _ = &multi.into_par_iter().for_each(|_p| ());
+        let _ = &mut multimut.par_iter_mut().for_each(|_p| ());
+    }
+    #[test]
     fn test_iter_mut() {
         let mut multi = MultiPolygon::new(vec![
             polygon![(x: 0, y: 0), (x: 2, y: 0), (x: 1, y: 2), (x:0, y:0)],

--- a/geo-types/src/geometry/multi_polygon.rs
+++ b/geo-types/src/geometry/multi_polygon.rs
@@ -283,6 +283,7 @@ mod test {
         }
     }
 
+    #[cfg(feature = "multithreading")]
     #[test]
     fn test_par_iter() {
         let multi = MultiPolygon::new(vec![

--- a/geo-types/src/geometry/multi_polygon.rs
+++ b/geo-types/src/geometry/multi_polygon.rs
@@ -81,7 +81,7 @@ impl<'a, T: CoordNum> IntoIterator for &'a mut MultiPolygon<T> {
 #[cfg(feature = "multithreading")]
 impl<T: CoordNum + Send> IntoParallelIterator for MultiPolygon<T> {
     type Item = Polygon<T>;
-    type Iter = rayon::vec::IntoIter<Polygon<T>>; // Parallel iterator type for Vec<Polygon<T>>
+    type Iter = rayon::vec::IntoIter<Polygon<T>>;
 
     fn into_par_iter(self) -> Self::Iter {
         self.0.into_par_iter()
@@ -91,7 +91,7 @@ impl<T: CoordNum + Send> IntoParallelIterator for MultiPolygon<T> {
 #[cfg(feature = "multithreading")]
 impl<'a, T: CoordNum + Sync> IntoParallelIterator for &'a MultiPolygon<T> {
     type Item = &'a Polygon<T>;
-    type Iter = rayon::slice::Iter<'a, Polygon<T>>; // Parallel iterator type for a slice of Polygon<T>
+    type Iter = rayon::slice::Iter<'a, Polygon<T>>;
 
     fn into_par_iter(self) -> Self::Iter {
         self.0.par_iter()
@@ -101,7 +101,7 @@ impl<'a, T: CoordNum + Sync> IntoParallelIterator for &'a MultiPolygon<T> {
 #[cfg(feature = "multithreading")]
 impl<'a, T: CoordNum + Send + Sync> IntoParallelIterator for &'a mut MultiPolygon<T> {
     type Item = &'a mut Polygon<T>;
-    type Iter = rayon::slice::IterMut<'a, Polygon<T>>; // Parallel iterator type for a mutable slice of Polygon<T>
+    type Iter = rayon::slice::IterMut<'a, Polygon<T>>;
 
     fn into_par_iter(self) -> Self::Iter {
         self.0.par_iter_mut()

--- a/geo-types/src/geometry/multi_polygon.rs
+++ b/geo-types/src/geometry/multi_polygon.rs
@@ -294,7 +294,7 @@ mod test {
             polygon![(x: 0, y: 0), (x: 2, y: 0), (x: 1, y: 2), (x:0, y:0)],
             polygon![(x: 10, y: 10), (x: 12, y: 10), (x: 11, y: 12), (x:10, y:10)],
         ]);
-        let _ = multi.par_iter().for_each(|_p| ());
+        multi.par_iter().for_each(|_p| ());
         let _ = &multimut.par_iter_mut().for_each(|_p| ());
         let _ = &multi.into_par_iter().for_each(|_p| ());
         let _ = &mut multimut.par_iter_mut().for_each(|_p| ());

--- a/geo-types/src/lib.rs
+++ b/geo-types/src/lib.rs
@@ -62,6 +62,8 @@
 //! The following optional [Cargo features] are available:
 //!
 //! - `std`: Enables use of the full `std` library. Enabled by default.
+//! - `multithread`: Enables multi-threaded iteration over `Multi*` geometries. **Disabled**
+//!    by default but **enabled** by `geo`'s default features.
 //! - `approx`: Allows geometry types to be checked for approximate equality with [approx]
 //! - `arbitrary`: Allows geometry types to be created from unstructured input with [arbitrary]
 //! - `serde`: Allows geometry types to be serialized and deserialized with [Serde]

--- a/geo-types/src/lib.rs
+++ b/geo-types/src/lib.rs
@@ -62,7 +62,7 @@
 //! The following optional [Cargo features] are available:
 //!
 //! - `std`: Enables use of the full `std` library. Enabled by default.
-//! - `multithread`: Enables multi-threaded iteration over `Multi*` geometries. **Disabled**
+//! - `multithreading`: Enables multi-threaded iteration over `Multi*` geometries. **Disabled**
 //!    by default but **enabled** by `geo`'s default features.
 //! - `approx`: Allows geometry types to be checked for approximate equality with [approx]
 //! - `arbitrary`: Allows geometry types to be created from unstructured input with [arbitrary]

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -17,7 +17,7 @@ default = ["earcutr", "spade", "multithreading"]
 use-proj = ["proj"]
 proj-network = ["use-proj", "proj/network"]
 use-serde = ["serde", "geo-types/serde"]
-multithreading = ["i_overlay/allow_multithreading"]
+multithreading = ["i_overlay/allow_multithreading", "geo-types/multithreading"]
 
 [dependencies]
 earcutr = { version = "0.4.2", optional = true }

--- a/geo/src/lib.rs
+++ b/geo/src/lib.rs
@@ -191,7 +191,8 @@
 //!     - Allows geometry types to be serialized and deserialized with [Serde].
 //!     - ☐ Disabled by default.
 //! - `multithreading`:
-//!     - Enables multithreading support for the `i_overlay` crate.
+//!     - Enables multithreading support for the `i_overlay` crate (via Rayon), and activates the `multithreading` flag
+//!       in `geo-types`, enabling multi-threaded iteration over `Multi*` geometries.
 //!     - ☑ Enabled by default.
 //!
 //! # Ecosystem


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

I think I've set up the Cargo features correctly – the `multithreading` feature is disabled by default in `geo-types`, but enabled by `geo` when `geo`'s default features are active. I just want to make sure the other `geo-types` default features aren't impacted.

Closes #1257.

This PR should merge before #1246.