### PR TITLE
Upgrade to i_overlay ~~1.8~~ 1.9

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Fix crash in `BoolOps` by updating `i_overlay` to 1.9.0.
+  - <https://github.com/georust/geo/pull/1275>
+
 ## 0.29.2 - 2024.11.15
 
 - Pin `i_overlay` to < 1.8.0 to work around [recursion bug](https://github.com/georust/geo/issues/1270).

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -31,7 +31,7 @@ proj = { version = "0.27.0", optional = true }
 robust = "1.1.0"
 rstar = "0.12.0"
 serde = { version = "1.0", optional = true, features = ["derive"] }
-i_overlay = { version = "1.7.2, < 1.8.0", default-features = false }
+i_overlay = { version = "1.8.0, < 1.9.0", default-features = false }
 
 [dev-dependencies]
 approx = ">= 0.4.0, < 0.6.0"

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -31,7 +31,7 @@ proj = { version = "0.27.0", optional = true }
 robust = "1.1.0"
 rstar = "0.12.0"
 serde = { version = "1.0", optional = true, features = ["derive"] }
-i_overlay = { version = "1.8.0, < 1.9.0", default-features = false }
+i_overlay = { version = "1.9.0, < 1.10.0", default-features = false }
 
 [dev-dependencies]
 approx = ">= 0.4.0, < 0.6.0"

--- a/geo/src/algorithm/bool_ops/i_overlay_integration.rs
+++ b/geo/src/algorithm/bool_ops/i_overlay_integration.rs
@@ -1,290 +1,71 @@
 use crate::geometry::Coord;
 use crate::GeoNum;
-use i_overlay::core::fill_rule::FillRule;
-use i_overlay::core::overlay::ShapeType;
-use i_overlay::core::overlay_rule::OverlayRule;
-use i_overlay::string::clip::ClipRule;
+use i_overlay::i_float::float::compatible::FloatPointCompatible;
+use i_overlay::i_float::float::number::FloatNumber;
 
-pub trait BoolOpsCoord<T>: Copy {
-    fn new(x: T, y: T) -> Self;
-    fn x(&self) -> T;
-    fn y(&self) -> T;
-}
+/// A geometry coordinate scalar suitable for performing geometric boolean operations.
+pub trait BoolOpsNum: GeoNum + FloatNumber {}
+impl<T: GeoNum + FloatNumber> BoolOpsNum for T {}
 
-/// A geometry coordinate number suitable for performing geometric boolean operations.
-pub trait BoolOpsNum: GeoNum {
-    type CoordType: BoolOpsCoord<Self>;
-    type OverlayType: BoolOpsOverlay<CoordType = Self::CoordType>;
-    type StringOverlayType: BoolOpsStringOverlay<CoordType = Self::CoordType>;
+/// New type for `Coord` that implements `FloatPointCompatible` for `BoolOpsNum` to
+/// circumvent orphan rule, since Coord is defined in geo_types.
+#[derive(Copy, Clone, Debug)]
+pub struct BoolOpsCoord<T: BoolOpsNum>(pub(crate) Coord<T>);
 
-    fn to_bops_coord(geo_coord: Coord<Self>) -> Self::CoordType {
-        Self::CoordType::new(geo_coord.x, geo_coord.y)
+impl<T: BoolOpsNum> FloatPointCompatible<T> for BoolOpsCoord<T> {
+    fn from_xy(x: T, y: T) -> Self {
+        Self(Coord { x, y })
     }
 
-    fn to_geo_coord(bops_coord: Self::CoordType) -> Coord<Self> {
-        Coord {
-            x: bops_coord.x(),
-            y: bops_coord.y(),
-        }
-    }
-}
-
-pub trait BoolOpsOverlay {
-    type CoordType;
-    type OverlayGraph: BoolOpsOverlayGraph<CoordType = Self::CoordType>;
-    fn new() -> Self;
-    fn add_path(&mut self, path: Vec<Self::CoordType>, shape_type: ShapeType);
-    fn into_graph(self, fill_rule: FillRule) -> Self::OverlayGraph;
-}
-
-pub(super) trait BoolOpsOverlayGraph {
-    type CoordType;
-    fn extract_shapes(&self, overlay_rule: OverlayRule) -> Vec<Vec<Vec<Self::CoordType>>>;
-}
-
-pub trait BoolOpsStringOverlay {
-    type CoordType;
-    type StringGraph: BoolOpsStringGraph<CoordType = Self::CoordType>;
-    fn new() -> Self;
-    fn add_shape_path(&mut self, path: Vec<Self::CoordType>);
-    fn add_string_line(&mut self, path: [Self::CoordType; 2]);
-    fn into_graph(self, fill_rule: FillRule) -> Self::StringGraph;
-}
-
-pub(super) trait BoolOpsStringGraph {
-    type CoordType;
-    fn clip_string_lines(&self, clip_rule: ClipRule) -> Vec<Vec<Self::CoordType>>;
-}
-
-mod f64 {
-    use super::{ClipRule, FillRule, OverlayRule, ShapeType};
-    use i_overlay::f64::{
-        graph::F64OverlayGraph,
-        overlay::F64Overlay,
-        string::{F64StringGraph, F64StringOverlay},
-    };
-    use i_overlay::i_float::f64_point::F64Point;
-
-    impl super::BoolOpsNum for f64 {
-        type CoordType = F64Point;
-        type OverlayType = F64Overlay;
-        type StringOverlayType = F64StringOverlay;
+    fn x(&self) -> T {
+        self.0.x
     }
 
-    impl super::BoolOpsCoord<f64> for F64Point {
-        #[inline]
-        fn new(x: f64, y: f64) -> Self {
-            Self::new(x, y)
-        }
-
-        #[inline]
-        fn x(&self) -> f64 {
-            self.x
-        }
-
-        #[inline]
-        fn y(&self) -> f64 {
-            self.y
-        }
-    }
-
-    impl super::BoolOpsOverlay for F64Overlay {
-        type CoordType = F64Point;
-        type OverlayGraph = F64OverlayGraph;
-
-        #[inline]
-        fn new() -> Self {
-            Self::new()
-        }
-
-        #[inline]
-        fn add_path(&mut self, path: Vec<F64Point>, shape_type: ShapeType) {
-            self.add_path(path, shape_type)
-        }
-
-        #[inline]
-        fn into_graph(self, fill_rule: FillRule) -> Self::OverlayGraph {
-            self.into_graph(fill_rule)
-        }
-    }
-
-    impl super::BoolOpsOverlayGraph for F64OverlayGraph {
-        type CoordType = F64Point;
-
-        #[inline]
-        fn extract_shapes(&self, overlay_rule: OverlayRule) -> Vec<Vec<Vec<F64Point>>> {
-            self.extract_shapes(overlay_rule)
-        }
-    }
-
-    impl super::BoolOpsStringOverlay for F64StringOverlay {
-        type CoordType = F64Point;
-        type StringGraph = F64StringGraph;
-
-        #[inline]
-        fn new() -> Self {
-            Self::new()
-        }
-
-        #[inline]
-        fn add_shape_path(&mut self, path: Vec<Self::CoordType>) {
-            self.add_shape_path(path)
-        }
-
-        #[inline]
-        fn add_string_line(&mut self, path: [Self::CoordType; 2]) {
-            self.add_string_line(path)
-        }
-
-        #[inline]
-        fn into_graph(self, fill_rule: FillRule) -> Self::StringGraph {
-            self.into_graph(fill_rule)
-        }
-    }
-
-    impl super::BoolOpsStringGraph for F64StringGraph {
-        type CoordType = F64Point;
-
-        #[inline]
-        fn clip_string_lines(&self, clip_rule: ClipRule) -> Vec<Vec<Self::CoordType>> {
-            self.clip_string_lines(clip_rule)
-        }
-    }
-}
-
-mod f32 {
-    use i_overlay::core::fill_rule::FillRule;
-    use i_overlay::core::overlay::ShapeType;
-    use i_overlay::core::overlay_rule::OverlayRule;
-    use i_overlay::f32::graph::F32OverlayGraph;
-    use i_overlay::f32::overlay::F32Overlay;
-    use i_overlay::f32::string::{F32StringGraph, F32StringOverlay};
-    use i_overlay::i_float::f32_point::F32Point;
-    use i_overlay::string::clip::ClipRule;
-
-    impl super::BoolOpsNum for f32 {
-        type CoordType = F32Point;
-        type OverlayType = F32Overlay;
-        type StringOverlayType = F32StringOverlay;
-    }
-
-    impl super::BoolOpsCoord<f32> for F32Point {
-        #[inline]
-        fn new(x: f32, y: f32) -> Self {
-            Self::new(x, y)
-        }
-        #[inline]
-        fn x(&self) -> f32 {
-            self.x
-        }
-        #[inline]
-        fn y(&self) -> f32 {
-            self.y
-        }
-    }
-
-    impl super::BoolOpsOverlay for F32Overlay {
-        type CoordType = F32Point;
-        type OverlayGraph = F32OverlayGraph;
-
-        #[inline]
-        fn new() -> Self {
-            Self::new()
-        }
-
-        #[inline]
-        fn add_path(&mut self, path: Vec<Self::CoordType>, shape_type: ShapeType) {
-            self.add_path(path, shape_type)
-        }
-
-        #[inline]
-        fn into_graph(self, fill_rule: FillRule) -> Self::OverlayGraph {
-            self.into_graph(fill_rule)
-        }
-    }
-
-    impl super::BoolOpsOverlayGraph for F32OverlayGraph {
-        type CoordType = F32Point;
-
-        #[inline]
-        fn extract_shapes(&self, overlay_rule: OverlayRule) -> Vec<Vec<Vec<F32Point>>> {
-            self.extract_shapes(overlay_rule)
-        }
-    }
-
-    impl super::BoolOpsStringOverlay for F32StringOverlay {
-        type CoordType = F32Point;
-        type StringGraph = F32StringGraph;
-
-        #[inline]
-        fn new() -> Self {
-            Self::new()
-        }
-
-        #[inline]
-        fn add_shape_path(&mut self, path: Vec<Self::CoordType>) {
-            self.add_shape_path(path)
-        }
-
-        #[inline]
-        fn add_string_line(&mut self, path: [Self::CoordType; 2]) {
-            self.add_string_line(path)
-        }
-
-        #[inline]
-        fn into_graph(self, fill_rule: FillRule) -> Self::StringGraph {
-            self.into_graph(fill_rule)
-        }
-    }
-
-    impl super::BoolOpsStringGraph for F32StringGraph {
-        type CoordType = F32Point;
-
-        #[inline]
-        fn clip_string_lines(&self, clip_rule: ClipRule) -> Vec<Vec<Self::CoordType>> {
-            self.clip_string_lines(clip_rule)
-        }
+    fn y(&self) -> T {
+        self.0.y
     }
 }
 
 pub(super) mod convert {
     use super::super::OpType;
-    use super::{BoolOpsNum, OverlayRule};
+    use super::BoolOpsNum;
+    use crate::bool_ops::i_overlay_integration::BoolOpsCoord;
     use crate::geometry::{LineString, MultiLineString, MultiPolygon, Polygon};
+    use i_overlay::core::overlay_rule::OverlayRule;
 
-    pub fn line_string_from_path<T: BoolOpsNum>(path: Vec<T::CoordType>) -> LineString<T> {
-        let coords = path.into_iter().map(T::to_geo_coord);
-        LineString(coords.collect())
+    pub fn line_string_from_path<T: BoolOpsNum>(path: Vec<BoolOpsCoord<T>>) -> LineString<T> {
+        let coords = path.into_iter().map(|bops_coord| bops_coord.0).collect();
+        LineString(coords)
     }
 
     pub fn multi_line_string_from_paths<T: BoolOpsNum>(
-        paths: Vec<Vec<T::CoordType>>,
+        paths: Vec<Vec<BoolOpsCoord<T>>>,
     ) -> MultiLineString<T> {
         let line_strings = paths.into_iter().map(|p| line_string_from_path(p));
         MultiLineString(line_strings.collect())
     }
 
-    pub fn polygon_from_shape<T: BoolOpsNum>(shape: Vec<Vec<T::CoordType>>) -> Polygon<T> {
+    pub fn polygon_from_shape<T: BoolOpsNum>(shape: Vec<Vec<BoolOpsCoord<T>>>) -> Polygon<T> {
         let mut rings = shape.into_iter().map(|p| line_string_from_path(p));
         let exterior = rings.next().unwrap_or(LineString::new(vec![]));
         Polygon::new(exterior, rings.collect())
     }
 
     pub fn multi_polygon_from_shapes<T: BoolOpsNum>(
-        shapes: Vec<Vec<Vec<T::CoordType>>>,
+        shapes: Vec<Vec<Vec<BoolOpsCoord<T>>>>,
     ) -> MultiPolygon<T> {
         let polygons = shapes.into_iter().map(|s| polygon_from_shape(s));
         MultiPolygon(polygons.collect())
     }
 
-    pub fn ring_to_shape_path<T: BoolOpsNum>(line_string: &LineString<T>) -> Vec<T::CoordType> {
+    pub fn ring_to_shape_path<T: BoolOpsNum>(line_string: &LineString<T>) -> Vec<BoolOpsCoord<T>> {
         if line_string.0.is_empty() {
             return vec![];
         }
         // In geo, Polygon rings are explicitly closed LineStrings — their final coordinate is the same as their first coordinate,
         // however in i_overlay, shape paths are implicitly closed, so we skip the last coordinate.
         let coords = &line_string.0[..line_string.0.len() - 1];
-        coords.iter().copied().map(T::to_bops_coord).collect()
+        coords.iter().copied().map(BoolOpsCoord).collect()
     }
 
     impl From<OpType> for OverlayRule {
@@ -308,7 +89,7 @@ mod tests {
     #[test]
     fn two_empty_polygons() {
         let p1: Polygon = wkt!(POLYGON EMPTY);
-        let p2 = wkt!(POLYGON EMPTY);
+        let p2: Polygon = wkt!(POLYGON EMPTY);
         assert_eq!(&p1.union(&p2), &wkt!(MULTIPOLYGON EMPTY));
         assert_eq!(&p1.intersection(&p2), &wkt!(MULTIPOLYGON EMPTY));
     }
@@ -316,7 +97,7 @@ mod tests {
     #[test]
     fn one_empty_polygon() {
         let p1: Polygon = wkt!(POLYGON((0. 0., 0. 1., 1. 1., 1. 0., 0. 0.)));
-        let p2 = wkt!(POLYGON EMPTY);
+        let p2: Polygon = wkt!(POLYGON EMPTY);
         assert_eq!(&p1.union(&p2), &MultiPolygon(vec![p1.clone()]));
         assert_eq!(&p1.intersection(&p2), &wkt!(MULTIPOLYGON EMPTY));
     }

--- a/geo/src/algorithm/bool_ops/tests.rs
+++ b/geo/src/algorithm/bool_ops/tests.rs
@@ -1,5 +1,6 @@
 use super::BooleanOps;
 use crate::{wkt, Convert, MultiPolygon, Relate};
+use wkt::ToWkt;
 
 #[test]
 fn jts_test_overlay_la_1() {
@@ -50,7 +51,12 @@ fn jts_test_overlay_la_1() {
     .convert();
 
     let im = actual.relate(&expected);
-    assert!(im.is_equal_topo());
+    assert!(
+        im.is_equal_topo(),
+        "actual: {:#?}, expected: {:#?}",
+        actual.wkt_string(),
+        expected.wkt_string()
+    );
 }
 
 mod gh_issues {
@@ -181,7 +187,7 @@ mod gh_issues {
             wkt!(POLYGON((3.3493652 -55.80127,171.22443 -300.,195.83728 -300.,-46.650635 30.80127,3.3493652 -55.80127))),
         ];
 
-        let mut multi = MultiPolygon::new(Vec::new());
+        let mut multi: MultiPolygon<f32> = MultiPolygon::new(Vec::new());
         for poly in polygons {
             multi = multi.union(&MultiPolygon::new(vec![poly]));
         }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

This ~~is~~ was a draft because it's a little bit slower (see "**Performance**"). It might solve a problem #1273 (?), in which case, it's probably worth merging this and taking the modest perf hit.

There's actually an even newer release (1.9) (see my branch: [mkirk/i_overlay_1.9](https://github.com/georust/geo/tree/mkirk/i_overlay_1.9)) but it has some more serious performance regressions. ~~I'll open an issue upstream about that.~~ **updated:** here it is: https://github.com/iShape-Rust/iOverlay/issues/13

**update**:

I now think we should update all the way to 1.9.

@urschrei has verified that both 1.8 and 1.9 solve his crash *and* I have at least a probable explanation for the performance regression seen in 1.9 - see https://github.com/iShape-Rust/iOverlay/issues/13

(I've also verified the crash is fixed with my branch [mkirk/cascaded_union](https://github.com/georust/geo/compare/mkirk/cascaded_union?expand=1#diff-24e5d2cacbe0da21a9d0db3b1d00f0572bd5dc591792e220a8bae547fe70c434R23))

Further, the perf regression is with our benchmarks which use synthetic geometries. I think it's more interesting that @urschrei is seeing moderate performance improvements with his real world data. Plus, I'd rather leave any performance twiddling as a responsibility of upstream rather than having our own customizations optimized for our benchmarks.

---

### Description of Changes

i_overlay 1.8 introduced a new trait based approach which allows us to
remove some of our own trait juggling.

However, our old friend, the orphan trait rule, prevents this from
happening easily. For now, I'm creating wrapper structs in geo for this
algo.

i_overlay 1.8 also introduced a new method signature for doing bool_ops,
removing the old ones. This caused our trait juggling to infinitely
recurse: See https://github.com/georust/geo/issues/1270

Now that we're using the new methods, the problem is avoided.

Note that I've also opened https://github.com/iShape-Rust/iOverlay/issues/12 to discuss using semver with i_overlay for future releases. For now though, until we hear otherwise, I think we should assume that breaking changes will occur in minor release - the `Y` in `X.Y.Z`.

FIXES #1270

## Performance

Bench output is a little mixed, but mostly a bit slower:

<details>
<summary>bench output with i_overlay 1.8</summary>

```
$ cargo bench --bench=boolean_ops -- --baseline=main                                                                                                  
                                                                                                                                                      
   Compiling geo v0.29.2 (/Users/mkirk/src/georust/geo/geo)                                                                                           
   Compiling jts-test-runner v0.1.0 (/Users/mkirk/src/georust/geo/jts-test-runner)                                                                    
   Compiling geo-bool-ops-benches v0.1.0 (/Users/mkirk/src/georust/geo/geo-bool-ops-benches)                                                          
    Finished `bench` profile [optimized] target(s) in 4.23s                                                                                           
     Running benches/boolean_ops.rs (target/release/deps/boolean_ops-e4f1a59740387ff9)                                                                
Gnuplot not found, using plotters backend                                                                                                             
Circular polygon boolean-ops/bops::intersection/256                                                                                                   
                        time:   [456.73 µs 460.23 µs 464.58 µs]                                                                                       
                        change: [-3.5765% -3.1482% -2.6752%] (p = 0.00 < 0.05)                                                                        
                        Performance has improved.                                                                                                     
Found 1 outliers among 10 measurements (10.00%)                                                                                                       
  1 (10.00%) high severe                                                                                                                              
Circular polygon boolean-ops/bops::union/256                                                                                                          
                        time:   [466.67 µs 468.54 µs 472.49 µs]                                                                                       
                        change: [-2.0193% -1.4161% -0.7974%] (p = 0.00 < 0.05)                                                                        
                        Change within noise threshold.                                                                                                
Circular polygon boolean-ops/bops::intersection/512                                                                                                   
                        time:   [1.4295 ms 1.4399 ms 1.4487 ms]                                                                                       
                        change: [+3.6040% +4.3318% +5.0995%] (p = 0.00 < 0.05)                                                                        
                        Performance has regressed.                                                                                                    
Circular polygon boolean-ops/bops::union/512                                                                                                          
                        time:   [1.4589 ms 1.4682 ms 1.4806 ms]                                                                                       
                        change: [+2.0346% +3.1412% +4.1578%] (p = 0.00 < 0.05)                                                                        
                        Performance has regressed.
Circular polygon boolean-ops/bops::intersection/1024                                                                                                  
                        time:   [4.4927 ms 4.5238 ms 4.5523 ms]                                                                                       
                        change: [+5.2243% +6.2935% +7.2200%] (p = 0.00 < 0.05)                                                                        
                        Performance has regressed.                                                                                                    
Circular polygon boolean-ops/bops::union/1024                                                                                                         
                        time:   [4.5848 ms 4.6039 ms 4.6151 ms]                                                                                       
                        change: [+6.8274% +7.5795% +8.3237%] (p = 0.00 < 0.05)                                                                        
                        Performance has regressed.                                                                                                    
Circular polygon boolean-ops/bops::intersection/2048                                                                                                  
                        time:   [13.835 ms 13.969 ms 14.052 ms]                                                                                       
                        change: [+7.9433% +9.2997% +10.496%] (p = 0.00 < 0.05)                                                                        
                        Performance has regressed.                                                                                                    
Circular polygon boolean-ops/bops::union/2048                                                                                                         
                        time:   [13.962 ms 13.988 ms 14.025 ms]                                                                                       
                        change: [+10.815% +12.081% +13.461%] (p = 0.00 < 0.05)                                                                        
                        Performance has regressed.                                                                                                    
Circular polygon boolean-ops/bops::intersection/4096                                                                                                  
                        time:   [50.950 ms 51.183 ms 51.395 ms]                                                                                       
                        change: [+14.277% +15.022% +15.799%] (p = 0.00 < 0.05)                                                                        
                        Performance has regressed.                                                                                                    
Circular polygon boolean-ops/bops::union/4096                                                                                                         
                        time:   [50.868 ms 51.255 ms 51.602 ms]                                                                                       
                        change: [+13.931% +14.919% +15.835%] (p = 0.00 < 0.05)                                                                        
                        Performance has regressed.                                                                                                    
Found 2 outliers among 10 measurements (20.00%)                                                                                                       
  1 (10.00%) low mild                                                                                                                                 
  1 (10.00%) high mild                                                                                                                                
Circular polygon boolean-ops/bops::intersection/8192                                                                                                  
                        time:   [188.90 ms 189.52 ms 190.23 ms]                                                                                       
                        change: [+12.707% +15.285% +16.939%] (p = 0.00 < 0.05)                                                                        
                        Performance has regressed.                                                                                                    
Circular polygon boolean-ops/bops::union/8192                                                                                                         
                        time:   [188.93 ms 189.41 ms 189.97 ms]                                                                                       
                        change: [+13.351% +14.859% +16.227%] (p = 0.00 < 0.05)                                                                        
                        Performance has regressed.                                                                                                    
Found 1 outliers among 10 measurements (10.00%)                                                                                                       
  1 (10.00%) high mild

```

</details>

<details>
<summary>bench output with i_overlay 1.9</summary>

```
georust/geo$ cargo bench --bench=boolean_ops -- --baseline=main
Circular polygon boolean-ops/bops::intersection/256                                                                                                   
                        time:   [438.45 µs 440.68 µs 445.14 µs]                                                                                       
                        change: [-7.0558% -6.1120% -4.8985%] (p = 0.00 < 0.05)                                                                        
                        Performance has improved.                                                                                                     
Circular polygon boolean-ops/bops::union/256                                                                                                          
                        time:   [448.53 µs 450.78 µs 454.71 µs]                                                                                       
                        change: [-6.2725% -5.7614% -5.0363%] (p = 0.00 < 0.05)                                                                        
                        Performance has improved.                                                                                                     
Found 2 outliers among 10 measurements (20.00%)                                                                                                       
  1 (10.00%) high mild                                                                                                                                
  1 (10.00%) high severe                                                                                                                              
Circular polygon boolean-ops/bops::intersection/512                                                                                                   
                        time:   [1.4381 ms 1.4409 ms 1.4442 ms]                                                                                       
                        change: [+4.0769% +4.3027% +4.4898%] (p = 0.00 < 0.05)                                                                        
                        Performance has regressed.                                                                                                    
Found 1 outliers among 10 measurements (10.00%)                                                                                                       
  1 (10.00%) low mild                                                                                                                                 
Circular polygon boolean-ops/bops::union/512                                                                                                          
                        time:   [1.4642 ms 1.4880 ms 1.5130 ms]                                                                                       
                        change: [+1.8288% +3.2331% +4.8314%] (p = 0.00 < 0.05)                                                                        
                        Performance has regressed.                                                                                                    
Found 1 outliers among 10 measurements (10.00%)                                                                                                       
  1 (10.00%) high mild                                                                                                                                
Circular polygon boolean-ops/bops::intersection/1024                                                                                                  
                        time:   [4.3295 ms 4.3493 ms 4.3684 ms]                                                                                       
                        change: [+1.1227% +2.1430% +3.0016%] (p = 0.00 < 0.05)                                                                        
                        Performance has regressed.                                                                                                    
Found 1 outliers among 10 measurements (10.00%)                                                                                                       
  1 (10.00%) high mild                                                                                                                                
Circular polygon boolean-ops/bops::union/1024                                                                                                         
                        time:   [4.3625 ms 4.3922 ms 4.4093 ms]                                                                                       
                        change: [+1.7493% +2.4971% +3.2026%] (p = 0.00 < 0.05)                                                                        
                        Performance has regressed.
Circular polygon boolean-ops/bops::intersection/2048
                        time:   [14.057 ms 14.115 ms 14.157 ms]
                        change: [+9.0224% +10.438% +11.658%] (p = 0.00 < 0.05)
                        Performance has regressed.
Circular polygon boolean-ops/bops::union/2048
                        time:   [14.012 ms 14.071 ms 14.134 ms]
                        change: [+11.212% +12.141% +13.317%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Circular polygon boolean-ops/bops::intersection/4096
                        time:   [360.66 ms 361.18 ms 361.83 ms]
                        change: [+709.38% +713.12% +716.34%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high severe
Circular polygon boolean-ops/bops::union/4096
                        time:   [361.35 ms 361.71 ms 362.13 ms]
                        change: [+710.58% +713.76% +716.59%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking Circular polygon boolean-ops/bops::intersection/8192: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 15.4s.
Circular polygon boolean-ops/bops::intersection/8192
                        time:   [1.5360 s 1.5404 s 1.5452 s]
                        change: [+816.16% +837.03% +850.36%] (p = 0.00 < 0.05)
                        Performance has regressed.
Benchmarking Circular polygon boolean-ops/bops::union/8192: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 15.4s.
Circular polygon boolean-ops/bops::union/8192
                        time:   [1.5359 s 1.5375 s 1.5393 s]
                        change: [+820.30% +832.33% +843.12%] (p = 0.00 < 0.05)
                        Performance has regressed.
```
</details>
