### PR TITLE
prepare for geo bugfix release

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -1,6 +1,6 @@
 # Changes
 
-## Unreleased
+## 0.29.3 - 2024.12.03
 
 - Fix crash in `BoolOps` by updating `i_overlay` to 1.9.0.
   - <https://github.com/georust/geo/pull/1275>

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "geo"
 description = "Geospatial primitives and algorithms"
-version = "0.29.2"
+version = "0.29.3"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/georust/geo"
 documentation = "https://docs.rs/geo/"


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

The only change since 0.29.2 are bug fixes to BoolOps  - some of theme are pretty severe: ~~#1270~~, #1273


**edit:** Oh yeah, #1270 was fixed in 0.29.2 by pinning to i_overlay 1.7, so I guess this release would only fix #1273.

Anything else we should be waiting for? Since the symptom is pretty severe, I don't want to wait around too long. 