### PR TITLE
fixup unary_union docs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
       - geo_postgis
       - geo_fuzz
       - bench
+      - docs
     if: success()
     steps:
       - name: Mark the job as a success

--- a/geo/src/algorithm/bool_ops/mod.rs
+++ b/geo/src/algorithm/bool_ops/mod.rs
@@ -39,7 +39,7 @@ use i_overlay::string::clip::ClipRule;
 ///
 /// # Performance
 ///
-/// For union operations on a large number of [`Polygon`]s or [`MultiPolygons`],
+/// For union operations on a large number of [`Polygon`]s or [`MultiPolygon`]s,
 /// using [`unary_union`] will yield far better performance.
 pub trait BooleanOps {
     type Scalar: BoolOpsNum;
@@ -129,7 +129,7 @@ pub enum OpType {
 /// This is typically much faster than `union`ing a bunch of geometries together one at a time.
 ///
 /// Note: Geometries can be wound in either direction, but the winding order must be consistent,
-/// and the polygon's interiors must be wound opposite to its exterior.
+/// and each polygon's interior rings must be wound opposite to its exterior.
 ///
 /// See [Orient] for more information.
 ///


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [n/a] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

In my tizzy of rebasing #1246, I lost [this doc edit](https://github.com/georust/geo/pull/1246#discussion_r1893020161).

Also, #1246 merged even when the docs were failing to compile because I long ago forgot to add the docs build to our "success" criteria.

😮‍💨 