### PR TITLE
geo-traits: Add UnimplementedGeometryCollection

### DIFF
--- a/geo-traits/src/geometry.rs
+++ b/geo-traits/src/geometry.rs
@@ -1,3 +1,5 @@
+use std::marker::PhantomData;
+
 #[cfg(feature = "geo-types")]
 use geo_types::{
     CoordNum, Geometry, GeometryCollection, Line, LineString, MultiLineString, MultiPoint,
@@ -7,6 +9,9 @@ use geo_types::{
 use crate::{
     Dimensions, GeometryCollectionTrait, LineStringTrait, LineTrait, MultiLineStringTrait,
     MultiPointTrait, MultiPolygonTrait, PointTrait, PolygonTrait, RectTrait, TriangleTrait,
+    UnimplementedGeometryCollection, UnimplementedLine, UnimplementedLineString,
+    UnimplementedMultiLineString, UnimplementedMultiPoint, UnimplementedMultiPolygon,
+    UnimplementedPoint, UnimplementedPolygon, UnimplementedRect, UnimplementedTriangle,
 };
 
 /// A trait for accessing data from a generic Geometry.
@@ -431,3 +436,76 @@ impl_specialization!(GeometryCollection);
 impl_specialization!(Rect);
 impl_specialization!(Triangle);
 impl_specialization!(Line);
+
+/// An empty struct that implements [GeometryTrait].
+///
+/// This is used internally for [`UnimplementedGeometryCollection`], so that
+/// `UnimplementedGeometryCollection` can be used as the `GeometryCollectionType` of the
+/// `GeometryTrait` by implementations that don't have a GeometryCollection concept
+pub struct UnimplementedGeometry<T>(PhantomData<T>);
+
+impl<T> GeometryTrait for UnimplementedGeometry<T> {
+    type T = T;
+    type PointType<'b>
+        = UnimplementedPoint<T>
+    where
+        Self: 'b;
+    type LineStringType<'b>
+        = UnimplementedLineString<Self::T>
+    where
+        Self: 'b;
+    type PolygonType<'b>
+        = UnimplementedPolygon<Self::T>
+    where
+        Self: 'b;
+    type MultiPointType<'b>
+        = UnimplementedMultiPoint<Self::T>
+    where
+        Self: 'b;
+    type MultiLineStringType<'b>
+        = UnimplementedMultiLineString<Self::T>
+    where
+        Self: 'b;
+    type MultiPolygonType<'b>
+        = UnimplementedMultiPolygon<Self::T>
+    where
+        Self: 'b;
+    type GeometryCollectionType<'b>
+        = UnimplementedGeometryCollection<Self::T>
+    where
+        Self: 'b;
+    type RectType<'b>
+        = UnimplementedRect<Self::T>
+    where
+        Self: 'b;
+    type TriangleType<'b>
+        = UnimplementedTriangle<Self::T>
+    where
+        Self: 'b;
+    type LineType<'b>
+        = UnimplementedLine<Self::T>
+    where
+        Self: 'b;
+
+    fn dim(&self) -> Dimensions {
+        unimplemented!()
+    }
+
+    fn as_type(
+        &self,
+    ) -> GeometryType<
+        '_,
+        Self::PointType<'_>,
+        Self::LineStringType<'_>,
+        Self::PolygonType<'_>,
+        Self::MultiPointType<'_>,
+        Self::MultiLineStringType<'_>,
+        Self::MultiPolygonType<'_>,
+        Self::GeometryCollectionType<'_>,
+        Self::RectType<'_>,
+        Self::TriangleType<'_>,
+        Self::LineType<'_>,
+    > {
+        unimplemented!()
+    }
+}

--- a/geo-traits/src/geometry_collection.rs
+++ b/geo-traits/src/geometry_collection.rs
@@ -1,5 +1,7 @@
+use std::marker::PhantomData;
+
 use crate::iterator::GeometryCollectionIterator;
-use crate::{Dimensions, GeometryTrait};
+use crate::{Dimensions, GeometryTrait, UnimplementedGeometry};
 #[cfg(feature = "geo-types")]
 use geo_types::{CoordNum, Geometry, GeometryCollection};
 
@@ -85,5 +87,31 @@ impl<'a, T: CoordNum> GeometryCollectionTrait for &'a GeometryCollection<T> {
 
     unsafe fn geometry_unchecked(&self, i: usize) -> Self::GeometryType<'_> {
         self.0.get_unchecked(i)
+    }
+}
+
+/// An empty struct that implements [GeometryCollectionTrait].
+///
+/// This can be used as the `GeometryCollectionType` of the `GeometryTrait` by implementations that
+/// don't have a GeometryCollection concept
+pub struct UnimplementedGeometryCollection<T>(PhantomData<T>);
+
+impl<T> GeometryCollectionTrait for UnimplementedGeometryCollection<T> {
+    type T = T;
+    type GeometryType<'a>
+        = UnimplementedGeometry<Self::T>
+    where
+        Self: 'a;
+
+    fn dim(&self) -> Dimensions {
+        unimplemented!()
+    }
+
+    fn num_geometries(&self) -> usize {
+        unimplemented!()
+    }
+
+    unsafe fn geometry_unchecked(&self, _i: usize) -> Self::GeometryType<'_> {
+        unimplemented!()
     }
 }

--- a/geo-traits/src/lib.rs
+++ b/geo-traits/src/lib.rs
@@ -19,8 +19,8 @@
 
 pub use coord::{CoordTrait, UnimplementedCoord};
 pub use dimension::Dimensions;
-pub use geometry::{GeometryTrait, GeometryType};
-pub use geometry_collection::GeometryCollectionTrait;
+pub use geometry::{GeometryTrait, GeometryType, UnimplementedGeometry};
+pub use geometry_collection::{GeometryCollectionTrait, UnimplementedGeometryCollection};
 pub use line::{LineTrait, UnimplementedLine};
 pub use line_string::{LineStringTrait, UnimplementedLineString};
 pub use multi_line_string::{MultiLineStringTrait, UnimplementedMultiLineString};


### PR DESCRIPTION
- [ ] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

It was an omission that we don't have an `UnimplementedGeometryCollection` already in `geo-traits`.

I found this out while working with Shapefile, which doesn't have a GeometryCollection concept.