### PR TITLE
Document InteriorPoint at the top level

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add top-level doc link for `InteriorPoint`
 - Add Unary Union algorithm for fast union ops on adjacent / overlapping geometries
   - <https://github.com/georust/geo/pull/1246>
 - Loosen bounds on `RemoveRepeatedPoints` trait (`num_traits::FromPrimitive` isn't required)

--- a/geo/src/lib.rs
+++ b/geo/src/lib.rs
@@ -95,6 +95,8 @@
 //! - **[`LineLocatePoint`]**: Calculate the
 //!   fraction of a line’s total length representing the location of the closest point on the
 //!   line to the given point
+//! - **[`InteriorPoint`]**:
+//!     Calculates a representative point inside a `Geometry`
 //!
 //! ## Topology
 //!


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Closes #1282 
