### PR TITLE
Implement `RTreeObject` for `Triangle`

### DIFF
--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Implement `RTreeObject` for `Triangle`.
+
 ## 0.7.14
 
 - POSSIBLY BREAKING: Minimum supported version of Rust (MSRV) is now 1.75

--- a/geo-types/src/geometry/line.rs
+++ b/geo-types/src/geometry/line.rs
@@ -237,8 +237,7 @@ macro_rules! impl_rstar_line {
             type Envelope = ::$rstar::AABB<Point<T>>;
 
             fn envelope(&self) -> Self::Envelope {
-                let bounding_rect = crate::private_utils::line_bounding_rect(*self);
-                ::$rstar::AABB::from_corners(bounding_rect.min().into(), bounding_rect.max().into())
+                ::$rstar::AABB::from_corners(self.start_point(), self.end_point())
             }
         }
 

--- a/geo-types/src/geometry/triangle.rs
+++ b/geo-types/src/geometry/triangle.rs
@@ -1,4 +1,4 @@
-use crate::{polygon, Coord, CoordNum, Line, Polygon};
+use crate::{polygon, Coord, CoordNum, Line, Point, Polygon};
 
 #[cfg(any(feature = "approx", test))]
 use approx::{AbsDiffEq, RelativeEq};
@@ -148,3 +148,42 @@ where
         true
     }
 }
+
+#[cfg(any(
+    feature = "rstar_0_8",
+    feature = "rstar_0_9",
+    feature = "rstar_0_10",
+    feature = "rstar_0_11",
+    feature = "rstar_0_12"
+))]
+macro_rules! impl_rstar_triangle {
+    ($rstar:ident) => {
+        impl<T> ::$rstar::RTreeObject for Triangle<T>
+        where
+            T: ::num_traits::Float + ::$rstar::RTreeNum,
+        {
+            type Envelope = ::$rstar::AABB<Point<T>>;
+
+            fn envelope(&self) -> Self::Envelope {
+                let bounding_rect =
+                    crate::private_utils::get_bounding_rect(self.to_array().into_iter()).unwrap();
+                ::$rstar::AABB::from_corners(bounding_rect.min().into(), bounding_rect.max().into())
+            }
+        }
+    };
+}
+
+#[cfg(feature = "rstar_0_8")]
+impl_rstar_triangle!(rstar_0_8);
+
+#[cfg(feature = "rstar_0_9")]
+impl_rstar_triangle!(rstar_0_9);
+
+#[cfg(feature = "rstar_0_10")]
+impl_rstar_triangle!(rstar_0_10);
+
+#[cfg(feature = "rstar_0_11")]
+impl_rstar_triangle!(rstar_0_11);
+
+#[cfg(feature = "rstar_0_12")]
+impl_rstar_triangle!(rstar_0_12);


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Found that this was missing when playing around.