### PR TITLE
Implement `AsRef<Coord>` for `Point` and `Coord`

### DIFF
--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Implement `RTreeObject` for `Triangle`.
+- Implement `AsRef<Coord>` for `Point` and `Coord`.
 
 ## 0.7.14
 

--- a/geo-types/src/geometry/coord.rs
+++ b/geo-types/src/geometry/coord.rs
@@ -498,3 +498,9 @@ where
         }
     }
 }
+
+impl<T: CoordNum> AsRef<Coord<T>> for Coord<T> {
+    fn as_ref(&self) -> &Coord<T> {
+        self
+    }
+}

--- a/geo-types/src/geometry/point.rs
+++ b/geo-types/src/geometry/point.rs
@@ -732,6 +732,12 @@ where
     }
 }
 
+impl<T: CoordNum> AsRef<Coord<T>> for Point<T> {
+    fn as_ref(&self) -> &Coord<T> {
+        &self.0
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/geo-types/src/geometry/triangle.rs
+++ b/geo-types/src/geometry/triangle.rs
@@ -166,7 +166,7 @@ macro_rules! impl_rstar_triangle {
 
             fn envelope(&self) -> Self::Envelope {
                 let bounding_rect =
-                    crate::private_utils::get_bounding_rect(self.to_array().into_iter()).unwrap();
+                    crate::private_utils::get_bounding_rect(self.to_array()).unwrap();
                 ::$rstar::AABB::from_corners(bounding_rect.min().into(), bounding_rect.max().into())
             }
         }

--- a/geo-types/src/private_utils.rs
+++ b/geo-types/src/private_utils.rs
@@ -9,7 +9,7 @@ pub fn line_string_bounding_rect<T>(line_string: &LineString<T>) -> Option<Rect<
 where
     T: CoordNum,
 {
-    get_bounding_rect(line_string.coords().cloned())
+    get_bounding_rect(&line_string.0)
 }
 
 pub fn line_bounding_rect<T>(line: Line<T>) -> Rect<T>
@@ -19,17 +19,19 @@ where
     Rect::new(line.start, line.end)
 }
 
-pub fn get_bounding_rect<I, T>(collection: I) -> Option<Rect<T>>
+pub fn get_bounding_rect<I, C, T>(collection: I) -> Option<Rect<T>>
 where
     T: CoordNum,
-    I: IntoIterator<Item = Coord<T>>,
+    C: AsRef<Coord<T>>,
+    I: IntoIterator<Item = C>,
 {
     let mut iter = collection.into_iter();
     if let Some(pnt) = iter.next() {
+        let pnt = pnt.as_ref();
         let mut xrange = (pnt.x, pnt.x);
         let mut yrange = (pnt.y, pnt.y);
         for pnt in iter {
-            let (px, py) = pnt.x_y();
+            let (px, py) = pnt.as_ref().x_y();
             xrange = get_min_max(px, xrange.0, xrange.1);
             yrange = get_min_max(py, yrange.0, yrange.1);
         }

--- a/geo/src/algorithm/bounding_rect.rs
+++ b/geo/src/algorithm/bounding_rect.rs
@@ -65,7 +65,7 @@ where
     ///
     /// Return the BoundingRect for a MultiPoint
     fn bounding_rect(&self) -> Self::Output {
-        get_bounding_rect(self.0.iter().map(|p| p.0))
+        get_bounding_rect(&self.0)
     }
 }
 
@@ -102,7 +102,7 @@ where
     ///
     /// Return the BoundingRect for a MultiLineString
     fn bounding_rect(&self) -> Self::Output {
-        get_bounding_rect(self.iter().flat_map(|line| line.0.iter().cloned()))
+        get_bounding_rect(self.iter().flat_map(|line| &line.0))
     }
 }
 
@@ -116,7 +116,7 @@ where
     /// Return the BoundingRect for a Polygon
     fn bounding_rect(&self) -> Self::Output {
         let line = self.exterior();
-        get_bounding_rect(line.0.iter().cloned())
+        get_bounding_rect(&line.0)
     }
 }
 
@@ -129,10 +129,7 @@ where
     ///
     /// Return the BoundingRect for a MultiPolygon
     fn bounding_rect(&self) -> Self::Output {
-        get_bounding_rect(
-            self.iter()
-                .flat_map(|poly| poly.exterior().0.iter().cloned()),
-        )
+        get_bounding_rect(self.iter().flat_map(|poly| &poly.exterior().0))
     }
 }
 
@@ -143,7 +140,7 @@ where
     type Output = Rect<T>;
 
     fn bounding_rect(&self) -> Self::Output {
-        get_bounding_rect(self.to_array().iter().cloned()).unwrap()
+        get_bounding_rect(self.to_array()).unwrap()
     }
 }
 

--- a/geo/src/algorithm/monotone/mono_poly.rs
+++ b/geo/src/algorithm/monotone/mono_poly.rs
@@ -53,7 +53,7 @@ impl<T: GeoNum> MonoPoly<T> {
         debug_assert_eq!(top.0.first(), bot.0.first());
         debug_assert_eq!(top.0.last(), bot.0.last());
         debug_assert_ne!(top.0.first(), top.0.last());
-        let bounds = get_bounding_rect(top.0.iter().chain(bot.0.iter()).cloned()).unwrap();
+        let bounds = get_bounding_rect(top.0.iter().chain(bot.0.iter())).unwrap();
         Self { top, bot, bounds }
     }
 


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Add `AsRef<Coord>` for `Point` and `Coord`. 

There might be other places in the codebase deserving adaptation in case this is accepted as a way forward. 

Emerged and splitted from #1294.