### PR TITLE
Customizable metric space for line measures

### DIFF
--- a/geo/benches/euclidean_distance.rs
+++ b/geo/benches/euclidean_distance.rs
@@ -37,7 +37,7 @@ fn criterion_benchmark(c: &mut criterion::Criterion) {
             (x: -6.064453, y: 68.49604),
         ];
         bencher.iter(|| {
-            criterion::black_box(Euclidean::distance(&poly1, &poly2));
+            criterion::black_box(Euclidean.distance(&poly1, &poly2));
         });
     });
 
@@ -79,7 +79,7 @@ fn criterion_benchmark(c: &mut criterion::Criterion) {
             ]
             .convex_hull();
             bencher.iter(|| {
-                criterion::black_box(Euclidean::distance(&poly1, &poly2));
+                criterion::black_box(Euclidean.distance(&poly1, &poly2));
             });
         },
     );

--- a/geo/benches/geodesic_distance.rs
+++ b/geo/benches/geodesic_distance.rs
@@ -7,7 +7,7 @@ fn criterion_benchmark(c: &mut criterion::Criterion) {
         let b = geo::Point::new(16.372477, 48.208810);
 
         bencher.iter(|| {
-            criterion::black_box(criterion::black_box(Geodesic::distance(a, b)));
+            criterion::black_box(criterion::black_box(Geodesic.distance(a, b)));
         });
     });
 }

--- a/geo/src/algorithm/centroid.rs
+++ b/geo/src/algorithm/centroid.rs
@@ -466,7 +466,7 @@ impl<T: GeoFloat> CentroidOperation<T> {
         match line.dimensions() {
             ZeroDimensional => self.add_coord(line.start),
             OneDimensional => {
-                self.add_centroid(OneDimensional, line.centroid().0, line.length(&Euclidean))
+                self.add_centroid(OneDimensional, line.centroid().0, Euclidean.length(line))
             }
             _ => unreachable!("Line must be zero or one dimensional"),
         }

--- a/geo/src/algorithm/centroid.rs
+++ b/geo/src/algorithm/centroid.rs
@@ -465,11 +465,9 @@ impl<T: GeoFloat> CentroidOperation<T> {
     fn add_line(&mut self, line: &Line<T>) {
         match line.dimensions() {
             ZeroDimensional => self.add_coord(line.start),
-            OneDimensional => self.add_centroid(
-                OneDimensional,
-                line.centroid().0,
-                line.length::<Euclidean>(),
-            ),
+            OneDimensional => {
+                self.add_centroid(OneDimensional, line.centroid().0, line.length(&Euclidean))
+            }
             _ => unreachable!("Line must be zero or one dimensional"),
         }
     }

--- a/geo/src/algorithm/closest_point.rs
+++ b/geo/src/algorithm/closest_point.rs
@@ -52,7 +52,7 @@ impl<F: GeoFloat> ClosestPoint<F> for Point<F> {
 #[allow(clippy::many_single_char_names)]
 impl<F: GeoFloat> ClosestPoint<F> for Line<F> {
     fn closest_point(&self, p: &Point<F>) -> Closest<F> {
-        let line_length = self.length::<Euclidean>();
+        let line_length = self.length(&Euclidean);
         if line_length == F::zero() {
             // if we've got a zero length line, technically the entire line
             // is the closest point...

--- a/geo/src/algorithm/closest_point.rs
+++ b/geo/src/algorithm/closest_point.rs
@@ -52,7 +52,7 @@ impl<F: GeoFloat> ClosestPoint<F> for Point<F> {
 #[allow(clippy::many_single_char_names)]
 impl<F: GeoFloat> ClosestPoint<F> for Line<F> {
     fn closest_point(&self, p: &Point<F>) -> Closest<F> {
-        let line_length = self.length(&Euclidean);
+        let line_length = Euclidean.length(self);
         if line_length == F::zero() {
             // if we've got a zero length line, technically the entire line
             // is the closest point...

--- a/geo/src/algorithm/concave_hull.rs
+++ b/geo/src/algorithm/concave_hull.rs
@@ -116,7 +116,7 @@ where
     T: GeoFloat + RTreeNum,
 {
     let h = max_dist + max_dist;
-    let w = line.length(&Euclidean) + h;
+    let w = Euclidean.length(&line) + h;
     let two = T::add(T::one(), T::one());
     let search_dist = T::div(T::sqrt(T::powi(w, 2) + T::powi(h, 2)), two);
     let centroid = line.centroid();
@@ -217,7 +217,7 @@ where
         line_tree.insert(line);
     }
     while let Some(line) = line_queue.pop_front() {
-        let edge_length = line.length(&Euclidean);
+        let edge_length = Euclidean.length(&line);
         let dist = edge_length / concavity;
         let possible_closest_point = find_point_closest_to_line(
             &interior_points_tree,

--- a/geo/src/algorithm/concave_hull.rs
+++ b/geo/src/algorithm/concave_hull.rs
@@ -116,7 +116,7 @@ where
     T: GeoFloat + RTreeNum,
 {
     let h = max_dist + max_dist;
-    let w = line.length::<Euclidean>() + h;
+    let w = line.length(&Euclidean) + h;
     let two = T::add(T::one(), T::one());
     let search_dist = T::div(T::sqrt(T::powi(w, 2) + T::powi(h, 2)), two);
     let centroid = line.centroid();
@@ -134,8 +134,8 @@ where
             let closest_point =
                 candidates.fold(Point::new(point.x, point.y), |acc_point, candidate| {
                     let candidate_point = Point::new(candidate.x, candidate.y);
-                    if Euclidean::distance(&line, &acc_point)
-                        > Euclidean::distance(&line, &candidate_point)
+                    if Euclidean.distance(&line, &acc_point)
+                        > Euclidean.distance(&line, &candidate_point)
                     {
                         candidate_point
                     } else {
@@ -154,8 +154,8 @@ where
             let closest_edge_option = match peeked_edge {
                 None => None,
                 Some(&edge) => Some(edges_nearby_point.fold(*edge, |acc, candidate| {
-                    if Euclidean::distance(&closest_point, &acc)
-                        > Euclidean::distance(&closest_point, candidate)
+                    if Euclidean.distance(&closest_point, &acc)
+                        > Euclidean.distance(&closest_point, candidate)
                     {
                         *candidate
                     } else {
@@ -164,8 +164,8 @@ where
                 })),
             };
             let decision_distance = partial_min(
-                Euclidean::distance(&closest_point, &line.start_point()),
-                Euclidean::distance(&closest_point, &line.end_point()),
+                Euclidean.distance(&closest_point, &line.start_point()),
+                Euclidean.distance(&closest_point, &line.end_point()),
             );
             if let Some(closest_edge) = closest_edge_option {
                 let far_enough = edge_length / decision_distance > concavity;
@@ -217,7 +217,7 @@ where
         line_tree.insert(line);
     }
     while let Some(line) = line_queue.pop_front() {
-        let edge_length = line.length::<Euclidean>();
+        let edge_length = line.length(&Euclidean);
         let dist = edge_length / concavity;
         let possible_closest_point = find_point_closest_to_line(
             &interior_points_tree,

--- a/geo/src/algorithm/cross_track_distance.rs
+++ b/geo/src/algorithm/cross_track_distance.rs
@@ -43,9 +43,9 @@ where
 {
     fn cross_track_distance(&self, line_point_a: &Point<T>, line_point_b: &Point<T>) -> T {
         let mean_earth_radius = T::from(MEAN_EARTH_RADIUS).unwrap();
-        let l_delta_13: T = Haversine::distance(*line_point_a, *self) / mean_earth_radius;
-        let theta_13: T = Haversine::bearing(*line_point_a, *self).to_radians();
-        let theta_12: T = Haversine::bearing(*line_point_a, *line_point_b).to_radians();
+        let l_delta_13: T = Haversine.distance(*line_point_a, *self) / mean_earth_radius;
+        let theta_13: T = Haversine.bearing(*line_point_a, *self).to_radians();
+        let theta_12: T = Haversine.bearing(*line_point_a, *line_point_b).to_radians();
         let l_delta_xt: T = (l_delta_13.sin() * (theta_12 - theta_13).sin()).asin();
         mean_earth_radius * l_delta_xt.abs()
     }
@@ -90,13 +90,13 @@ mod test {
 
         assert_relative_eq!(
             p.cross_track_distance(&line_point_a, &line_point_b),
-            Haversine::distance(p, Point::new(1., 0.)),
+            Haversine.distance(p, Point::new(1., 0.)),
             epsilon = 1.0e-6
         );
 
         assert_relative_eq!(
             p.cross_track_distance(&line_point_b, &line_point_a),
-            Haversine::distance(p, Point::new(1., 0.)),
+            Haversine.distance(p, Point::new(1., 0.)),
             epsilon = 1.0e-6
         );
     }

--- a/geo/src/algorithm/densify_haversine.rs
+++ b/geo/src/algorithm/densify_haversine.rs
@@ -10,7 +10,7 @@ use crate::{
 
 #[deprecated(
     since = "0.29.0",
-    note = "Please use the `line.densify::<Haversine>()` via the `Densify` trait instead."
+    note = "Please use the `line.densify(&Haversine)` via the `Densify` trait instead."
 )]
 /// Returns a new spherical geometry containing both existing and new interpolated coordinates with
 /// a maximum distance of `max_distance` between them.
@@ -50,7 +50,7 @@ where
     type Output = MultiPolygon<T>;
 
     fn densify_haversine(&self, max_distance: T) -> Self::Output {
-        self.densify::<Haversine>(max_distance)
+        self.densify(&Haversine, max_distance)
     }
 }
 
@@ -64,7 +64,7 @@ where
     type Output = Polygon<T>;
 
     fn densify_haversine(&self, max_distance: T) -> Self::Output {
-        self.densify::<Haversine>(max_distance)
+        self.densify(&Haversine, max_distance)
     }
 }
 
@@ -78,7 +78,7 @@ where
     type Output = MultiLineString<T>;
 
     fn densify_haversine(&self, max_distance: T) -> Self::Output {
-        self.densify::<Haversine>(max_distance)
+        self.densify(&Haversine, max_distance)
     }
 }
 
@@ -92,7 +92,7 @@ where
     type Output = LineString<T>;
 
     fn densify_haversine(&self, max_distance: T) -> Self::Output {
-        self.densify::<Haversine>(max_distance)
+        self.densify(&Haversine, max_distance)
     }
 }
 
@@ -106,7 +106,7 @@ where
     type Output = LineString<T>;
 
     fn densify_haversine(&self, max_distance: T) -> Self::Output {
-        self.densify::<Haversine>(max_distance)
+        self.densify(&Haversine, max_distance)
     }
 }
 
@@ -120,7 +120,7 @@ where
     type Output = Polygon<T>;
 
     fn densify_haversine(&self, max_distance: T) -> Self::Output {
-        self.densify::<Haversine>(max_distance)
+        self.densify(&Haversine, max_distance)
     }
 }
 
@@ -134,7 +134,7 @@ where
     type Output = Polygon<T>;
 
     fn densify_haversine(&self, max_distance: T) -> Self::Output {
-        self.densify::<Haversine>(max_distance)
+        self.densify(&Haversine, max_distance)
     }
 }
 

--- a/geo/src/algorithm/densify_haversine.rs
+++ b/geo/src/algorithm/densify_haversine.rs
@@ -10,7 +10,7 @@ use crate::{
 
 #[deprecated(
     since = "0.29.0",
-    note = "Please use the `line.densify(&Haversine)` via the `Densify` trait instead."
+    note = "Please use the `Haversine.densify(&line)` via the `Densify` trait instead."
 )]
 /// Returns a new spherical geometry containing both existing and new interpolated coordinates with
 /// a maximum distance of `max_distance` between them.
@@ -50,7 +50,7 @@ where
     type Output = MultiPolygon<T>;
 
     fn densify_haversine(&self, max_distance: T) -> Self::Output {
-        self.densify(&Haversine, max_distance)
+        Haversine.densify(self, max_distance)
     }
 }
 
@@ -64,7 +64,7 @@ where
     type Output = Polygon<T>;
 
     fn densify_haversine(&self, max_distance: T) -> Self::Output {
-        self.densify(&Haversine, max_distance)
+        Haversine.densify(self, max_distance)
     }
 }
 
@@ -78,7 +78,7 @@ where
     type Output = MultiLineString<T>;
 
     fn densify_haversine(&self, max_distance: T) -> Self::Output {
-        self.densify(&Haversine, max_distance)
+        Haversine.densify(self, max_distance)
     }
 }
 
@@ -92,7 +92,7 @@ where
     type Output = LineString<T>;
 
     fn densify_haversine(&self, max_distance: T) -> Self::Output {
-        self.densify(&Haversine, max_distance)
+        Haversine.densify(self, max_distance)
     }
 }
 
@@ -106,7 +106,7 @@ where
     type Output = LineString<T>;
 
     fn densify_haversine(&self, max_distance: T) -> Self::Output {
-        self.densify(&Haversine, max_distance)
+        Haversine.densify(self, max_distance)
     }
 }
 
@@ -120,7 +120,7 @@ where
     type Output = Polygon<T>;
 
     fn densify_haversine(&self, max_distance: T) -> Self::Output {
-        self.densify(&Haversine, max_distance)
+        Haversine.densify(self, max_distance)
     }
 }
 
@@ -134,7 +134,7 @@ where
     type Output = Polygon<T>;
 
     fn densify_haversine(&self, max_distance: T) -> Self::Output {
-        self.densify(&Haversine, max_distance)
+        Haversine.densify(self, max_distance)
     }
 }
 

--- a/geo/src/algorithm/euclidean_distance.rs
+++ b/geo/src/algorithm/euclidean_distance.rs
@@ -11,7 +11,7 @@ use rstar::RTreeNum;
 
 #[deprecated(
     since = "0.29.0",
-    note = "Please use the `Euclidean::distance` method from the `Distance` trait instead"
+    note = "Please use the `Euclidean.distance` method from the `Distance` trait instead"
 )]
 /// Returns the distance between two geometries.
 pub trait EuclideanDistance<T, Rhs = Self> {
@@ -105,7 +105,7 @@ where
 {
     /// Minimum distance between two `Coord`s
     fn euclidean_distance(&self, c: &Coord<T>) -> T {
-        Euclidean::distance(Point(*self), Point(*c))
+        Euclidean.distance(Point(*self), Point(*c))
     }
 }
 
@@ -116,7 +116,7 @@ where
 {
     /// Minimum distance from a `Coord` to a `Line`
     fn euclidean_distance(&self, line: &Line<T>) -> T {
-        Euclidean::distance(&Point(*self), line)
+        Euclidean.distance(&Point(*self), line)
     }
 }
 
@@ -131,7 +131,7 @@ where
 {
     /// Minimum distance between two Points
     fn euclidean_distance(&self, p: &Point<T>) -> T {
-        Euclidean::distance(*self, *p)
+        Euclidean.distance(*self, *p)
     }
 }
 
@@ -142,7 +142,7 @@ where
 {
     /// Minimum distance from a Line to a Point
     fn euclidean_distance(&self, line: &Line<T>) -> T {
-        Euclidean::distance(self, line)
+        Euclidean.distance(self, line)
     }
 }
 
@@ -153,7 +153,7 @@ where
 {
     /// Minimum distance from a Point to a LineString
     fn euclidean_distance(&self, line_string: &LineString<T>) -> T {
-        Euclidean::distance(self, line_string)
+        Euclidean.distance(self, line_string)
     }
 }
 
@@ -164,7 +164,7 @@ where
 {
     /// Minimum distance from a Point to a Polygon
     fn euclidean_distance(&self, polygon: &Polygon<T>) -> T {
-        Euclidean::distance(self, polygon)
+        Euclidean.distance(self, polygon)
     }
 }
 
@@ -179,7 +179,7 @@ where
 {
     /// Minimum distance from a `Line` to a `Coord`
     fn euclidean_distance(&self, coord: &Coord<T>) -> T {
-        Euclidean::distance(self, *coord)
+        Euclidean.distance(self, *coord)
     }
 }
 
@@ -190,7 +190,7 @@ where
 {
     /// Minimum distance from a Line to a Point
     fn euclidean_distance(&self, point: &Point<T>) -> T {
-        Euclidean::distance(self, point)
+        Euclidean.distance(self, point)
     }
 }
 
@@ -201,7 +201,7 @@ where
     T: GeoFloat + FloatConst + Signed + RTreeNum,
 {
     fn euclidean_distance(&self, other: &Line<T>) -> T {
-        Euclidean::distance(self, other)
+        Euclidean.distance(self, other)
     }
 }
 
@@ -212,7 +212,7 @@ where
     T: GeoFloat + FloatConst + Signed + RTreeNum,
 {
     fn euclidean_distance(&self, other: &LineString<T>) -> T {
-        Euclidean::distance(self, other)
+        Euclidean.distance(self, other)
     }
 }
 
@@ -223,7 +223,7 @@ where
     T: GeoFloat + Signed + RTreeNum + FloatConst,
 {
     fn euclidean_distance(&self, other: &Polygon<T>) -> T {
-        Euclidean::distance(self, other)
+        Euclidean.distance(self, other)
     }
 }
 
@@ -238,7 +238,7 @@ where
 {
     /// Minimum distance from a LineString to a Point
     fn euclidean_distance(&self, point: &Point<T>) -> T {
-        Euclidean::distance(self, point)
+        Euclidean.distance(self, point)
     }
 }
 
@@ -249,7 +249,7 @@ where
     T: GeoFloat + FloatConst + Signed + RTreeNum,
 {
     fn euclidean_distance(&self, other: &Line<T>) -> T {
-        Euclidean::distance(self, other)
+        Euclidean.distance(self, other)
     }
 }
 
@@ -260,7 +260,7 @@ where
     T: GeoFloat + Signed + RTreeNum,
 {
     fn euclidean_distance(&self, other: &LineString<T>) -> T {
-        Euclidean::distance(self, other)
+        Euclidean.distance(self, other)
     }
 }
 
@@ -271,7 +271,7 @@ where
     T: GeoFloat + FloatConst + Signed + RTreeNum,
 {
     fn euclidean_distance(&self, other: &Polygon<T>) -> T {
-        Euclidean::distance(self, other)
+        Euclidean.distance(self, other)
     }
 }
 
@@ -286,7 +286,7 @@ where
 {
     /// Minimum distance from a Polygon to a Point
     fn euclidean_distance(&self, point: &Point<T>) -> T {
-        Euclidean::distance(self, point)
+        Euclidean.distance(self, point)
     }
 }
 
@@ -297,7 +297,7 @@ where
     T: GeoFloat + FloatConst + Signed + RTreeNum,
 {
     fn euclidean_distance(&self, other: &Line<T>) -> T {
-        Euclidean::distance(self, other)
+        Euclidean.distance(self, other)
     }
 }
 
@@ -308,7 +308,7 @@ where
     T: GeoFloat + FloatConst + Signed + RTreeNum,
 {
     fn euclidean_distance(&self, other: &LineString<T>) -> T {
-        Euclidean::distance(self, other)
+        Euclidean.distance(self, other)
     }
 }
 
@@ -319,7 +319,7 @@ where
     T: GeoFloat + FloatConst + RTreeNum,
 {
     fn euclidean_distance(&self, poly2: &Polygon<T>) -> T {
-        Euclidean::distance(self, poly2)
+        Euclidean.distance(self, poly2)
     }
 }
 
@@ -337,7 +337,7 @@ macro_rules! impl_euclidean_distance_for_polygonlike_geometry {
               T: GeoFloat + Signed + RTreeNum + FloatConst,
           {
               fn euclidean_distance(&self, other: &$target) -> T {
-                  Euclidean::distance(self, other)
+                  Euclidean.distance(self, other)
               }
           }
       )*
@@ -357,7 +357,7 @@ macro_rules! impl_euclidean_distance_to_polygonlike_geometry {
               T: GeoFloat + Signed + RTreeNum + FloatConst,
           {
               fn euclidean_distance(&self, other: &$target) -> T {
-                  Euclidean::distance(self, other)
+                  Euclidean.distance(self, other)
               }
           }
       )*
@@ -387,7 +387,7 @@ macro_rules! impl_euclidean_distance_for_iter_geometry {
               T: GeoFloat + FloatConst + RTreeNum,
           {
               fn euclidean_distance(&self, target: &$target) -> T {
-                  Euclidean::distance(self, target)
+                  Euclidean.distance(self, target)
               }
           }
       )*
@@ -410,7 +410,7 @@ macro_rules! impl_euclidean_distance_from_iter_geometry {
             T: GeoFloat + FloatConst + RTreeNum
         {
           fn euclidean_distance(&self, target: &$target) -> T {
-              Euclidean::distance(self, target)
+              Euclidean.distance(self, target)
           }
         }
       )*
@@ -438,7 +438,7 @@ macro_rules! impl_euclidean_distance_to_geometry_for_specific {
               T: GeoFloat + FloatConst + RTreeNum,
           {
               fn euclidean_distance(&self, geom: &Geometry<T>) -> T {
-                Euclidean::distance(self, geom)
+                Euclidean.distance(self, geom)
               }
           }
       )*
@@ -486,7 +486,7 @@ where
 
 #[deprecated(
     since = "0.29.0",
-    note = "Please use the `Euclidean::distance` method from the `Distance` trait instead"
+    note = "Please use the `Euclidean.distance` method from the `Distance` trait instead"
 )]
 /// Uses an R* tree and nearest-neighbour lookups to calculate minimum distances
 // This is somewhat slow and memory-inefficient, but certainly better than quadratic time

--- a/geo/src/algorithm/euclidean_length.rs
+++ b/geo/src/algorithm/euclidean_length.rs
@@ -5,7 +5,7 @@ use crate::{CoordFloat, Euclidean, Length, Line, LineString, MultiLineString};
 /// Calculation of the length
 #[deprecated(
     since = "0.29.0",
-    note = "Please use the `line.length(&Euclidean)` via the `Length` trait instead."
+    note = "Please use the `Euclidean.length(&line)` via the `Length` trait instead."
 )]
 pub trait EuclideanLength<T, RHS = Self> {
     /// Calculation of the length of a Line
@@ -35,7 +35,7 @@ where
     T: CoordFloat,
 {
     fn euclidean_length(&self) -> T {
-        self.length(&Euclidean)
+        Euclidean.length(self)
     }
 }
 
@@ -45,7 +45,7 @@ where
     T: CoordFloat + Sum,
 {
     fn euclidean_length(&self) -> T {
-        self.length(&Euclidean)
+        Euclidean.length(self)
     }
 }
 
@@ -55,7 +55,7 @@ where
     T: CoordFloat + Sum,
 {
     fn euclidean_length(&self) -> T {
-        self.length(&Euclidean)
+        Euclidean.length(self)
     }
 }
 

--- a/geo/src/algorithm/euclidean_length.rs
+++ b/geo/src/algorithm/euclidean_length.rs
@@ -5,7 +5,7 @@ use crate::{CoordFloat, Euclidean, Length, Line, LineString, MultiLineString};
 /// Calculation of the length
 #[deprecated(
     since = "0.29.0",
-    note = "Please use the `line.length::<Euclidean>()` via the `Length` trait instead."
+    note = "Please use the `line.length(&Euclidean)` via the `Length` trait instead."
 )]
 pub trait EuclideanLength<T, RHS = Self> {
     /// Calculation of the length of a Line
@@ -35,7 +35,7 @@ where
     T: CoordFloat,
 {
     fn euclidean_length(&self) -> T {
-        self.length::<Euclidean>()
+        self.length(&Euclidean)
     }
 }
 
@@ -45,7 +45,7 @@ where
     T: CoordFloat + Sum,
 {
     fn euclidean_length(&self) -> T {
-        self.length::<Euclidean>()
+        self.length(&Euclidean)
     }
 }
 
@@ -55,7 +55,7 @@ where
     T: CoordFloat + Sum,
 {
     fn euclidean_length(&self) -> T {
-        self.length::<Euclidean>()
+        self.length(&Euclidean)
     }
 }
 

--- a/geo/src/algorithm/frechet_distance.rs
+++ b/geo/src/algorithm/frechet_distance.rs
@@ -78,7 +78,7 @@ where
 
         for (i, &a) in self.ls_a.coords().enumerate() {
             for (j, &b) in self.ls_b.coords().enumerate() {
-                let dist = Euclidean::distance(a, b);
+                let dist = Euclidean.distance(a, b);
 
                 self.cache[i * columns_count + j] = match (i, j) {
                     (0, 0) => dist,
@@ -105,7 +105,7 @@ mod test {
         let ls_a = LineString::from(vec![(1., 1.)]);
         let ls_b = LineString::from(vec![(0., 2.)]);
         assert_relative_eq!(
-            Euclidean::distance(ls_a.0[0], ls_b.0[0]),
+            Euclidean.distance(ls_a.0[0], ls_b.0[0]),
             ls_a.frechet_distance(&ls_b)
         );
     }

--- a/geo/src/algorithm/geodesic_area.rs
+++ b/geo/src/algorithm/geodesic_area.rs
@@ -380,7 +380,7 @@ mod test {
 
         // Confirm that the exterior ring geodesic_length is the same as the perimeter
         assert_relative_eq!(
-            polygon.exterior().length(&Geodesic),
+            Geodesic.length(polygon.exterior()),
             polygon.geodesic_perimeter()
         );
     }
@@ -410,7 +410,7 @@ mod test {
 
         // Confirm that the exterior ring geodesic_length is the same as the perimeter
         assert_relative_eq!(
-            polygon.exterior().length(&Geodesic),
+            Geodesic.length(polygon.exterior()),
             polygon.geodesic_perimeter()
         );
     }
@@ -440,7 +440,7 @@ mod test {
 
         // Confirm that the exterior ring geodesic_length is the same as the perimeter
         assert_relative_eq!(
-            polygon.exterior().length(&Geodesic),
+            Geodesic.length(polygon.exterior()),
             polygon.geodesic_perimeter()
         );
     }

--- a/geo/src/algorithm/geodesic_area.rs
+++ b/geo/src/algorithm/geodesic_area.rs
@@ -380,7 +380,7 @@ mod test {
 
         // Confirm that the exterior ring geodesic_length is the same as the perimeter
         assert_relative_eq!(
-            polygon.exterior().length::<Geodesic>(),
+            polygon.exterior().length(&Geodesic),
             polygon.geodesic_perimeter()
         );
     }
@@ -410,7 +410,7 @@ mod test {
 
         // Confirm that the exterior ring geodesic_length is the same as the perimeter
         assert_relative_eq!(
-            polygon.exterior().length::<Geodesic>(),
+            polygon.exterior().length(&Geodesic),
             polygon.geodesic_perimeter()
         );
     }
@@ -440,7 +440,7 @@ mod test {
 
         // Confirm that the exterior ring geodesic_length is the same as the perimeter
         assert_relative_eq!(
-            polygon.exterior().length::<Geodesic>(),
+            polygon.exterior().length(&Geodesic),
             polygon.geodesic_perimeter()
         );
     }

--- a/geo/src/algorithm/geodesic_bearing.rs
+++ b/geo/src/algorithm/geodesic_bearing.rs
@@ -10,7 +10,7 @@ use geographiclib_rs::{Geodesic, InverseGeodesic};
 pub trait GeodesicBearing<T: CoordNum> {
     #[deprecated(
         since = "0.29.0",
-        note = "Please use the `Geodesic::bearing` method from the `Bearing` trait instead"
+        note = "Please use the `Geodesic.bearing` method from the `Bearing` trait instead"
     )]
     /// Returns the bearing to another Point in degrees, where North is 0° and East is 90°.
     ///

--- a/geo/src/algorithm/geodesic_destination.rs
+++ b/geo/src/algorithm/geodesic_destination.rs
@@ -4,7 +4,7 @@ use geo_types::CoordNum;
 
 #[deprecated(
     since = "0.29.0",
-    note = "Please use the `Geodesic::destination` method from the `Destination` trait instead"
+    note = "Please use the `Geodesic.destination` method from the `Destination` trait instead"
 )]
 /// Returns a new Point using the distance to the existing Point and a bearing for the direction on a geodesic.
 ///
@@ -43,7 +43,7 @@ pub trait GeodesicDestination<T: CoordNum> {
 #[allow(deprecated)]
 impl GeodesicDestination<f64> for Point<f64> {
     fn geodesic_destination(&self, bearing: f64, distance: f64) -> Point<f64> {
-        Geodesic::destination(*self, bearing, distance)
+        Geodesic.destination(*self, bearing, distance)
     }
 }
 

--- a/geo/src/algorithm/geodesic_distance.rs
+++ b/geo/src/algorithm/geodesic_distance.rs
@@ -2,7 +2,7 @@ use crate::{Distance, Geodesic, Point};
 
 #[deprecated(
     since = "0.29.0",
-    note = "Please use the `Geodesic::distance` method from the `Distance` trait instead"
+    note = "Please use the `Geodesic.distance` method from the `Distance` trait instead"
 )]
 /// Determine the distance between two geometries on an ellipsoidal model of the earth.
 ///
@@ -46,6 +46,6 @@ pub trait GeodesicDistance<T, Rhs = Self> {
 #[allow(deprecated)]
 impl GeodesicDistance<f64> for Point {
     fn geodesic_distance(&self, rhs: &Point) -> f64 {
-        Geodesic::distance(*self, *rhs)
+        Geodesic.distance(*self, *rhs)
     }
 }

--- a/geo/src/algorithm/geodesic_intermediate.rs
+++ b/geo/src/algorithm/geodesic_intermediate.rs
@@ -8,7 +8,7 @@ use crate::{CoordFloat, Geodesic, InterpolatePoint, Point};
 pub trait GeodesicIntermediate<T: CoordFloat> {
     #[deprecated(
         since = "0.29.0",
-        note = "Please use `Geodesic::point_at_ratio_between` from the `InterpolatePoint` trait instead"
+        note = "Please use `Geodesic.point_at_ratio_between` from the `InterpolatePoint` trait instead"
     )]
     /// Returns a new Point along a route between two existing points on an ellipsoidal model of the earth
     ///
@@ -39,7 +39,7 @@ pub trait GeodesicIntermediate<T: CoordFloat> {
 
     #[deprecated(
         since = "0.29.0",
-        note = "Please use `Geodesic::points_along_line` from the `InterpolatePoint` trait instead"
+        note = "Please use `Geodesic.points_along_line` from the `InterpolatePoint` trait instead"
     )]
     fn geodesic_intermediate_fill(
         &self,
@@ -52,7 +52,7 @@ pub trait GeodesicIntermediate<T: CoordFloat> {
 #[allow(deprecated)]
 impl GeodesicIntermediate<f64> for Point {
     fn geodesic_intermediate(&self, other: &Point, f: f64) -> Point {
-        Geodesic::point_at_ratio_between(*self, *other, f)
+        Geodesic.point_at_ratio_between(*self, *other, f)
     }
 
     fn geodesic_intermediate_fill(
@@ -61,7 +61,9 @@ impl GeodesicIntermediate<f64> for Point {
         max_dist: f64,
         include_ends: bool,
     ) -> Vec<Point> {
-        Geodesic::points_along_line(*self, *other, max_dist, include_ends).collect()
+        Geodesic
+            .points_along_line(*self, *other, max_dist, include_ends)
+            .collect()
     }
 }
 

--- a/geo/src/algorithm/geodesic_length.rs
+++ b/geo/src/algorithm/geodesic_length.rs
@@ -2,7 +2,7 @@ use crate::{Geodesic, Length, Line, LineString, MultiLineString};
 
 #[deprecated(
     since = "0.29.0",
-    note = "Please use the `line.length::<Geodesic>()` via the `Length` trait instead."
+    note = "Please use the `line.length(&Geodesic)` via the `Length` trait instead."
 )]
 /// Determine the length of a geometry on an ellipsoidal model of the earth.
 ///
@@ -52,20 +52,20 @@ pub trait GeodesicLength<T, RHS = Self> {
 impl GeodesicLength<f64> for Line {
     /// The units of the returned value is meters.
     fn geodesic_length(&self) -> f64 {
-        self.length::<Geodesic>()
+        self.length(&Geodesic)
     }
 }
 
 #[allow(deprecated)]
 impl GeodesicLength<f64> for LineString {
     fn geodesic_length(&self) -> f64 {
-        self.length::<Geodesic>()
+        self.length(&Geodesic)
     }
 }
 
 #[allow(deprecated)]
 impl GeodesicLength<f64> for MultiLineString {
     fn geodesic_length(&self) -> f64 {
-        self.length::<Geodesic>()
+        self.length(&Geodesic)
     }
 }

--- a/geo/src/algorithm/geodesic_length.rs
+++ b/geo/src/algorithm/geodesic_length.rs
@@ -2,7 +2,7 @@ use crate::{Geodesic, Length, Line, LineString, MultiLineString};
 
 #[deprecated(
     since = "0.29.0",
-    note = "Please use the `line.length(&Geodesic)` via the `Length` trait instead."
+    note = "Please use the `Geodesic.length(&line)` via the `Length` trait instead."
 )]
 /// Determine the length of a geometry on an ellipsoidal model of the earth.
 ///
@@ -52,20 +52,20 @@ pub trait GeodesicLength<T, RHS = Self> {
 impl GeodesicLength<f64> for Line {
     /// The units of the returned value is meters.
     fn geodesic_length(&self) -> f64 {
-        self.length(&Geodesic)
+        Geodesic.length(self)
     }
 }
 
 #[allow(deprecated)]
 impl GeodesicLength<f64> for LineString {
     fn geodesic_length(&self) -> f64 {
-        self.length(&Geodesic)
+        Geodesic.length(self)
     }
 }
 
 #[allow(deprecated)]
 impl GeodesicLength<f64> for MultiLineString {
     fn geodesic_length(&self) -> f64 {
-        self.length(&Geodesic)
+        Geodesic.length(self)
     }
 }

--- a/geo/src/algorithm/hausdorff_distance.rs
+++ b/geo/src/algorithm/hausdorff_distance.rs
@@ -34,7 +34,7 @@ where
             .coords_iter()
             .map(|c| {
                 rhs.coords_iter()
-                    .map(|c2| Euclidean::distance(c, c2))
+                    .map(|c2| Euclidean.distance(c, c2))
                     .fold(<T as Bounded>::max_value(), |accum, val| accum.min(val))
             })
             .fold(<T as Bounded>::min_value(), |accum, val| accum.max(val));
@@ -44,7 +44,7 @@ where
             .coords_iter()
             .map(|c| {
                 self.coords_iter()
-                    .map(|c2| Euclidean::distance(c, c2))
+                    .map(|c2| Euclidean.distance(c, c2))
                     .fold(<T as Bounded>::max_value(), |accum, val| accum.min(val))
             })
             .fold(<T as Bounded>::min_value(), |accum, val| accum.max(val));

--- a/geo/src/algorithm/haversine_bearing.rs
+++ b/geo/src/algorithm/haversine_bearing.rs
@@ -2,7 +2,7 @@ use crate::{CoordFloat, Point};
 
 #[deprecated(
     since = "0.29.0",
-    note = "Please use the `Haversine::bearing` method from the `Bearing` trait instead"
+    note = "Please use the `Haversine.bearing` method from the `Bearing` trait instead"
 )]
 /// Returns the bearing to another Point in degrees.
 ///

--- a/geo/src/algorithm/haversine_closest_point.rs
+++ b/geo/src/algorithm/haversine_closest_point.rs
@@ -92,7 +92,7 @@ where
         }
 
         // This can probably be done cheaper
-        let d3 = Haversine::distance(p2, p1);
+        let d3 = Haversine.distance(p2, p1);
         if d3 <= T::epsilon() {
             // I think here it should be return Closest::SinglePoint(p1)
             // If the line segment is degenerated to a point, that point is still the closest
@@ -102,18 +102,18 @@ where
         }
 
         let pi = T::from(std::f64::consts::PI).unwrap();
-        let crs_ad = Haversine::bearing(p1, *from).to_radians();
-        let crs_ab = Haversine::bearing(p1, p2).to_radians();
+        let crs_ad = Haversine.bearing(p1, *from).to_radians();
+        let crs_ab = Haversine.bearing(p1, p2).to_radians();
         let crs_ba = if crs_ab > T::zero() {
             crs_ab - pi
         } else {
             crs_ab + pi
         };
-        let crs_bd = Haversine::bearing(p2, *from).to_radians();
+        let crs_bd = Haversine.bearing(p2, *from).to_radians();
         let d_crs1 = crs_ad - crs_ab;
         let d_crs2 = crs_bd - crs_ba;
 
-        let d1 = Haversine::distance(p1, *from);
+        let d1 = Haversine.distance(p1, *from);
 
         // d1, d2, d3 are in principle not needed, only the sign matters
         let projection1 = d_crs1.cos();
@@ -127,13 +127,13 @@ where
             if xtd < T::epsilon() {
                 return Closest::Intersection(*from);
             } else {
-                return Closest::SinglePoint(Haversine::destination(p1, crs_ab.to_degrees(), atd));
+                return Closest::SinglePoint(Haversine.destination(p1, crs_ab.to_degrees(), atd));
             }
         }
 
         // Projected falls outside the GC Arc
         // Return shortest distance pt, project either on point sp1 or sp2
-        let d2 = Haversine::distance(p2, *from);
+        let d2 = Haversine.distance(p2, *from);
         if d1 < d2 {
             return Closest::SinglePoint(p1);
         }
@@ -166,7 +166,7 @@ where
                     return intersect;
                 }
                 Closest::SinglePoint(pt) => {
-                    let dist = Haversine::distance(pt, *from);
+                    let dist = Haversine.distance(pt, *from);
                     if dist < min_distance {
                         min_distance = dist;
                         rv = Closest::SinglePoint(pt);
@@ -198,7 +198,7 @@ where
                 return (intersect, T::zero());
             }
             Closest::SinglePoint(pt) => {
-                let dist = Haversine::distance(pt, *from);
+                let dist = Haversine.distance(pt, *from);
                 if dist < min_distance {
                     min_distance = dist;
                     rv = Closest::SinglePoint(pt);
@@ -301,7 +301,7 @@ where
             // This mean on top of the line.
             Closest::Intersection(pt) => return Closest::Intersection(pt),
             Closest::SinglePoint(pt) => {
-                let dist = Haversine::distance(pt, *from);
+                let dist = Haversine.distance(pt, *from);
                 if dist < min_distance {
                     min_distance = dist;
                     rv = Closest::SinglePoint(pt);

--- a/geo/src/algorithm/haversine_destination.rs
+++ b/geo/src/algorithm/haversine_destination.rs
@@ -3,7 +3,7 @@ use num_traits::FromPrimitive;
 
 #[deprecated(
     since = "0.29.0",
-    note = "Please use the `Haversine::destination` method from the `Destination` trait instead"
+    note = "Please use the `Haversine.destination` method from the `Destination` trait instead"
 )]
 /// Returns a new Point using the distance to the existing Point and a bearing for the direction
 ///
@@ -39,7 +39,7 @@ where
     T: CoordFloat + FromPrimitive,
 {
     fn haversine_destination(&self, bearing: T, distance: T) -> Point<T> {
-        Haversine::destination(*self, bearing, distance)
+        Haversine.destination(*self, bearing, distance)
     }
 }
 

--- a/geo/src/algorithm/haversine_distance.rs
+++ b/geo/src/algorithm/haversine_distance.rs
@@ -3,7 +3,7 @@ use num_traits::FromPrimitive;
 
 #[deprecated(
     since = "0.29.0",
-    note = "Please use the `Haversine::distance` method from the `Distance` trait instead"
+    note = "Please use the `Haversine.distance` method from the `Distance` trait instead"
 )]
 /// Determine the distance between two geometries using the [haversine formula].
 ///
@@ -55,7 +55,7 @@ where
     T: CoordFloat + FromPrimitive,
 {
     fn haversine_distance(&self, rhs: &Point<T>) -> T {
-        Haversine::distance(*self, *rhs)
+        Haversine.distance(*self, *rhs)
     }
 }
 

--- a/geo/src/algorithm/haversine_intermediate.rs
+++ b/geo/src/algorithm/haversine_intermediate.rs
@@ -9,7 +9,7 @@ use num_traits::FromPrimitive;
 pub trait HaversineIntermediate<T: CoordFloat> {
     #[deprecated(
         since = "0.29.0",
-        note = "Please use `Haversine::point_at_ratio_between` from the `InterpolatePoint` trait instead"
+        note = "Please use `Haversine.point_at_ratio_between` from the `InterpolatePoint` trait instead"
     )]
     /// Returns a new `Point` along a great circle route between `self` and `other`.
     ///
@@ -40,7 +40,7 @@ pub trait HaversineIntermediate<T: CoordFloat> {
 
     #[deprecated(
         since = "0.29.0",
-        note = "Please use `Haversine::points_along_line` from the `InterpolatePoint` trait instead"
+        note = "Please use `Haversine.points_along_line` from the `InterpolatePoint` trait instead"
     )]
     /// Interpolates `Point`s along a great circle route between self and `other`.
     ///
@@ -62,7 +62,7 @@ where
     T: CoordFloat + FromPrimitive,
 {
     fn haversine_intermediate(&self, other: &Point<T>, ratio: T) -> Point<T> {
-        Haversine::point_at_ratio_between(*self, *other, ratio)
+        Haversine.point_at_ratio_between(*self, *other, ratio)
     }
 
     fn haversine_intermediate_fill(
@@ -71,7 +71,9 @@ where
         max_dist: T,
         include_ends: bool,
     ) -> Vec<Point<T>> {
-        Haversine::points_along_line(*self, *other, max_dist, include_ends).collect()
+        Haversine
+            .points_along_line(*self, *other, max_dist, include_ends)
+            .collect()
     }
 }
 

--- a/geo/src/algorithm/haversine_length.rs
+++ b/geo/src/algorithm/haversine_length.rs
@@ -5,7 +5,7 @@ use crate::{Haversine, Length};
 
 #[deprecated(
     since = "0.29.0",
-    note = "Please use the `line.length::<Haversine>()` via the `Length` trait instead."
+    note = "Please use the `line.length(&Haversine)` via the `Length` trait instead."
 )]
 /// Determine the length of a geometry using the [haversine formula].
 ///
@@ -51,7 +51,7 @@ where
     T: CoordFloat + FromPrimitive,
 {
     fn haversine_length(&self) -> T {
-        self.length::<Haversine>()
+        self.length(&Haversine)
     }
 }
 
@@ -61,7 +61,7 @@ where
     T: CoordFloat + FromPrimitive,
 {
     fn haversine_length(&self) -> T {
-        self.length::<Haversine>()
+        self.length(&Haversine)
     }
 }
 
@@ -71,6 +71,6 @@ where
     T: CoordFloat + FromPrimitive,
 {
     fn haversine_length(&self) -> T {
-        self.length::<Haversine>()
+        self.length(&Haversine)
     }
 }

--- a/geo/src/algorithm/haversine_length.rs
+++ b/geo/src/algorithm/haversine_length.rs
@@ -5,7 +5,7 @@ use crate::{Haversine, Length};
 
 #[deprecated(
     since = "0.29.0",
-    note = "Please use the `line.length(&Haversine)` via the `Length` trait instead."
+    note = "Please use the `Haversine.length(&line)` via the `Length` trait instead."
 )]
 /// Determine the length of a geometry using the [haversine formula].
 ///
@@ -51,7 +51,7 @@ where
     T: CoordFloat + FromPrimitive,
 {
     fn haversine_length(&self) -> T {
-        self.length(&Haversine)
+        Haversine.length(self)
     }
 }
 
@@ -61,7 +61,7 @@ where
     T: CoordFloat + FromPrimitive,
 {
     fn haversine_length(&self) -> T {
-        self.length(&Haversine)
+        Haversine.length(self)
     }
 }
 
@@ -71,6 +71,6 @@ where
     T: CoordFloat + FromPrimitive,
 {
     fn haversine_length(&self) -> T {
-        self.length(&Haversine)
+        Haversine.length(self)
     }
 }

--- a/geo/src/algorithm/interior_point.rs
+++ b/geo/src/algorithm/interior_point.rs
@@ -112,7 +112,7 @@ where
                     .iter()
                     .map(|coord| {
                         let pt = Point::from(*coord);
-                        (pt, Euclidean::distance(pt, centroid))
+                        (pt, Euclidean.distance(pt, centroid))
                     })
                     .min_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(Ordering::Less))
                     .map(|(pt, _distance)| pt)
@@ -135,7 +135,7 @@ where
                 .filter_map(|linestring| {
                     linestring
                         .interior_point()
-                        .map(|pt| (pt, Euclidean::distance(pt, centroid)))
+                        .map(|pt| (pt, Euclidean.distance(pt, centroid)))
                 })
                 .min_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(Ordering::Less))
                 .map(|(pt, _distance)| pt)
@@ -313,7 +313,7 @@ where
     fn interior_point(&self) -> Self::Output {
         if let Some(centroid) = self.centroid() {
             self.iter()
-                .map(|pt| (pt, Euclidean::distance(pt, &centroid)))
+                .map(|pt| (pt, Euclidean.distance(pt, &centroid)))
                 .min_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(Ordering::Less))
                 .map(|(pt, _distance)| *pt)
         } else {
@@ -347,10 +347,7 @@ where
                         (
                             pt,
                             // maximize dimensions, minimize distance
-                            (
-                                Reverse(geom.dimensions()),
-                                Euclidean::distance(pt, centroid),
-                            ),
+                            (Reverse(geom.dimensions()), Euclidean.distance(pt, centroid)),
                         )
                     })
                 })

--- a/geo/src/algorithm/line_measures/bearing.rs
+++ b/geo/src/algorithm/line_measures/bearing.rs
@@ -9,5 +9,5 @@ pub trait Bearing<F: CoordFloat> {
     /// # Units
     /// - `origin`, `destination`: Point where the units of x/y depend on the [trait implementation](#implementors).
     /// - returns: degrees, where: North: 0°, East: 90°, South: 180°, West: 270°
-    fn bearing(origin: Point<F>, destination: Point<F>) -> F;
+    fn bearing(&self, origin: Point<F>, destination: Point<F>) -> F;
 }

--- a/geo/src/algorithm/line_measures/destination.rs
+++ b/geo/src/algorithm/line_measures/destination.rs
@@ -15,5 +15,5 @@ pub trait Destination<F: CoordFloat> {
     /// - returns: Point where the units of x/y depend on the [trait implementation](#implementors).
     ///
     /// [`metric_spaces`]: super::metric_spaces
-    fn destination(origin: Point<F>, bearing: F, distance: F) -> Point<F>;
+    fn destination(&self, origin: Point<F>, bearing: F, distance: F) -> Point<F>;
 }

--- a/geo/src/algorithm/line_measures/distance.rs
+++ b/geo/src/algorithm/line_measures/distance.rs
@@ -8,5 +8,5 @@ pub trait Distance<F, Origin, Destination> {
     ///
     /// - `origin`, `destination`: geometry where the units of x/y depend on the trait implementation.
     /// - returns: depends on the trait implementation.
-    fn distance(origin: Origin, destination: Destination) -> F;
+    fn distance(&self, origin: Origin, destination: Destination) -> F;
 }

--- a/geo/src/algorithm/line_measures/interpolate_point.rs
+++ b/geo/src/algorithm/line_measures/interpolate_point.rs
@@ -6,6 +6,7 @@ pub trait InterpolatePoint<F: CoordFloat> {
     ///
     /// See [specific implementations](#implementors) for details.
     fn point_at_distance_between(
+        &self,
         start: Point<F>,
         end: Point<F>,
         distance_from_start: F,
@@ -14,7 +15,12 @@ pub trait InterpolatePoint<F: CoordFloat> {
     /// Returns a new Point along a line between two existing points.
     ///
     /// See [specific implementations](#implementors) for details.
-    fn point_at_ratio_between(start: Point<F>, end: Point<F>, ratio_from_start: F) -> Point<F>;
+    fn point_at_ratio_between(
+        &self,
+        start: Point<F>,
+        end: Point<F>,
+        ratio_from_start: F,
+    ) -> Point<F>;
 
     /// Interpolates `Point`s along a line between `start` and `end`.
     ///
@@ -26,6 +32,7 @@ pub trait InterpolatePoint<F: CoordFloat> {
     ///
     /// `include_ends`: Should the start and end points be included in the output?
     fn points_along_line(
+        &self,
         start: Point<F>,
         end: Point<F>,
         max_distance: F,
@@ -43,16 +50,16 @@ mod tests {
         let end = Point::new(1.0, 1.0);
 
         let ratio = 0.0;
-        assert_eq!(Haversine::point_at_ratio_between(start, end, ratio), start);
-        assert_eq!(Euclidean::point_at_ratio_between(start, end, ratio), start);
-        assert_eq!(Geodesic::point_at_ratio_between(start, end, ratio), start);
-        assert_eq!(Rhumb::point_at_ratio_between(start, end, ratio), start);
+        assert_eq!(Haversine.point_at_ratio_between(start, end, ratio), start);
+        assert_eq!(Euclidean.point_at_ratio_between(start, end, ratio), start);
+        assert_eq!(Geodesic.point_at_ratio_between(start, end, ratio), start);
+        assert_eq!(Rhumb.point_at_ratio_between(start, end, ratio), start);
 
         let ratio = 1.0;
-        assert_eq!(Haversine::point_at_ratio_between(start, end, ratio), end);
-        assert_eq!(Euclidean::point_at_ratio_between(start, end, ratio), end);
-        assert_eq!(Geodesic::point_at_ratio_between(start, end, ratio), end);
-        assert_eq!(Rhumb::point_at_ratio_between(start, end, ratio), end);
+        assert_eq!(Haversine.point_at_ratio_between(start, end, ratio), end);
+        assert_eq!(Euclidean.point_at_ratio_between(start, end, ratio), end);
+        assert_eq!(Geodesic.point_at_ratio_between(start, end, ratio), end);
+        assert_eq!(Rhumb.point_at_ratio_between(start, end, ratio), end);
     }
 
     mod degenerate {
@@ -63,40 +70,22 @@ mod tests {
             let start = Point::new(1.0, 1.0);
 
             let ratio = 0.0;
-            assert_eq!(
-                Haversine::point_at_ratio_between(start, start, ratio),
-                start
-            );
-            assert_eq!(
-                Euclidean::point_at_ratio_between(start, start, ratio),
-                start
-            );
-            assert_eq!(Geodesic::point_at_ratio_between(start, start, ratio), start);
-            assert_eq!(Rhumb::point_at_ratio_between(start, start, ratio), start);
+            assert_eq!(Haversine.point_at_ratio_between(start, start, ratio), start);
+            assert_eq!(Euclidean.point_at_ratio_between(start, start, ratio), start);
+            assert_eq!(Geodesic.point_at_ratio_between(start, start, ratio), start);
+            assert_eq!(Rhumb.point_at_ratio_between(start, start, ratio), start);
 
             let ratio = 0.5;
-            assert_eq!(
-                Haversine::point_at_ratio_between(start, start, ratio),
-                start
-            );
-            assert_eq!(
-                Euclidean::point_at_ratio_between(start, start, ratio),
-                start
-            );
-            assert_eq!(Geodesic::point_at_ratio_between(start, start, ratio), start);
-            assert_eq!(Rhumb::point_at_ratio_between(start, start, ratio), start);
+            assert_eq!(Haversine.point_at_ratio_between(start, start, ratio), start);
+            assert_eq!(Euclidean.point_at_ratio_between(start, start, ratio), start);
+            assert_eq!(Geodesic.point_at_ratio_between(start, start, ratio), start);
+            assert_eq!(Rhumb.point_at_ratio_between(start, start, ratio), start);
 
             let ratio = 1.0;
-            assert_eq!(
-                Haversine::point_at_ratio_between(start, start, ratio),
-                start
-            );
-            assert_eq!(
-                Euclidean::point_at_ratio_between(start, start, ratio),
-                start
-            );
-            assert_eq!(Geodesic::point_at_ratio_between(start, start, ratio), start);
-            assert_eq!(Rhumb::point_at_ratio_between(start, start, ratio), start);
+            assert_eq!(Haversine.point_at_ratio_between(start, start, ratio), start);
+            assert_eq!(Euclidean.point_at_ratio_between(start, start, ratio), start);
+            assert_eq!(Geodesic.point_at_ratio_between(start, start, ratio), start);
+            assert_eq!(Rhumb.point_at_ratio_between(start, start, ratio), start);
         }
 
         #[test]
@@ -107,19 +96,19 @@ mod tests {
 
             let distance = 0.0;
             assert_eq!(
-                Haversine::point_at_distance_between(start, start, distance),
+                Haversine.point_at_distance_between(start, start, distance),
                 start
             );
 
-            let euclidean_result = Euclidean::point_at_distance_between(start, start, distance);
+            let euclidean_result = Euclidean.point_at_distance_between(start, start, distance);
             assert!(euclidean_result.x().is_nan());
             assert!(euclidean_result.y().is_nan());
             assert_eq!(
-                Geodesic::point_at_distance_between(start, start, distance),
+                Geodesic.point_at_distance_between(start, start, distance),
                 start
             );
             assert_eq!(
-                Rhumb::point_at_distance_between(start, start, distance),
+                Rhumb.point_at_distance_between(start, start, distance),
                 start
             );
 
@@ -127,20 +116,20 @@ mod tests {
             let due_north = Point::new(1.0, 1.9);
             let due_south = Point::new(1.0, 0.1);
             assert_relative_eq!(
-                Haversine::point_at_distance_between(start, start, distance),
+                Haversine.point_at_distance_between(start, start, distance),
                 due_north,
                 epsilon = 1.0e-1
             );
-            let euclidean_result = Euclidean::point_at_distance_between(start, start, distance);
+            let euclidean_result = Euclidean.point_at_distance_between(start, start, distance);
             assert!(euclidean_result.x().is_nan());
             assert!(euclidean_result.y().is_nan());
             assert_relative_eq!(
-                Geodesic::point_at_distance_between(start, start, distance),
+                Geodesic.point_at_distance_between(start, start, distance),
                 due_south,
                 epsilon = 1.0e-1
             );
             assert_relative_eq!(
-                Rhumb::point_at_distance_between(start, start, distance),
+                Rhumb.point_at_distance_between(start, start, distance),
                 due_north,
                 epsilon = 1.0e-1
             );
@@ -153,37 +142,45 @@ mod tests {
             let max_distance = 1.0;
 
             let include_ends = true;
-            let points: Vec<_> =
-                Haversine::points_along_line(start, start, max_distance, include_ends).collect();
+            let points: Vec<_> = Haversine
+                .points_along_line(start, start, max_distance, include_ends)
+                .collect();
             assert_eq!(points, vec![start, start]);
 
-            let points: Vec<_> =
-                Euclidean::points_along_line(start, start, max_distance, include_ends).collect();
+            let points: Vec<_> = Euclidean
+                .points_along_line(start, start, max_distance, include_ends)
+                .collect();
             assert_eq!(points, vec![start, start]);
 
-            let points: Vec<_> =
-                Geodesic::points_along_line(start, start, max_distance, include_ends).collect();
+            let points: Vec<_> = Geodesic
+                .points_along_line(start, start, max_distance, include_ends)
+                .collect();
             assert_eq!(points, vec![start, start]);
 
-            let points: Vec<_> =
-                Rhumb::points_along_line(start, start, max_distance, include_ends).collect();
+            let points: Vec<_> = Rhumb
+                .points_along_line(start, start, max_distance, include_ends)
+                .collect();
             assert_eq!(points, vec![start, start]);
 
             let include_ends = false;
-            let points: Vec<_> =
-                Haversine::points_along_line(start, start, max_distance, include_ends).collect();
+            let points: Vec<_> = Haversine
+                .points_along_line(start, start, max_distance, include_ends)
+                .collect();
             assert_eq!(points, vec![]);
 
-            let points: Vec<_> =
-                Euclidean::points_along_line(start, start, max_distance, include_ends).collect();
+            let points: Vec<_> = Euclidean
+                .points_along_line(start, start, max_distance, include_ends)
+                .collect();
             assert_eq!(points, vec![]);
 
-            let points: Vec<_> =
-                Geodesic::points_along_line(start, start, max_distance, include_ends).collect();
+            let points: Vec<_> = Geodesic
+                .points_along_line(start, start, max_distance, include_ends)
+                .collect();
             assert_eq!(points, vec![]);
 
-            let points: Vec<_> =
-                Rhumb::points_along_line(start, start, max_distance, include_ends).collect();
+            let points: Vec<_> = Rhumb
+                .points_along_line(start, start, max_distance, include_ends)
+                .collect();
             assert_eq!(points, vec![]);
         }
     }

--- a/geo/src/algorithm/line_measures/length.rs
+++ b/geo/src/algorithm/line_measures/length.rs
@@ -1,11 +1,38 @@
 use super::Distance;
 use crate::{CoordFloat, Line, LineString, MultiLineString, Point};
 
-/// Calculate the length of a `Line`, `LineString`, or `MultiLineString` in a given [metric space](crate::algorithm::line_measures::metric_spaces).
+/// Calculate the length of a `Line`, `LineString`, or `MultiLineString` using a given [metric space](crate::algorithm::line_measures::metric_spaces).
 ///
 /// # Examples
 /// ```
 /// use geo::algorithm::line_measures::{Length, Euclidean, Haversine};
+///
+/// let line_string = geo::wkt!(LINESTRING(
+///     0.0 0.0,
+///     3.0 4.0,
+///     3.0 5.0
+/// ));
+/// assert_eq!(Euclidean.length(&line_string), 6.);
+///
+/// let line_string_lon_lat = geo::wkt!(LINESTRING (
+///     -47.9292 -15.7801f64,
+///     -58.4173 -34.6118,
+///     -70.6483 -33.4489
+/// ));
+/// assert_eq!(Haversine.length(&line_string_lon_lat).round(), 3_474_956.0);
+/// ```
+pub trait Length<F: CoordFloat> {
+    fn length(&self, geometry: &impl LengthMeasurable<F>) -> F;
+}
+
+/// Something which can be measured by a [metric space](crate::algorithm::line_measures::metric_spaces),
+/// such as a `Line`, `LineString`, or `MultiLineString`.
+///
+/// It's typically more convenient to use the [`Length`] trait instead of this trait directly.
+///
+/// # Examples
+/// ```
+/// use geo::algorithm::line_measures::{LengthMeasurable, Euclidean, Haversine};
 ///
 /// let line_string = geo::wkt!(LINESTRING(
 ///     0.0 0.0,
@@ -21,17 +48,23 @@ use crate::{CoordFloat, Line, LineString, MultiLineString, Point};
 /// ));
 /// assert_eq!(line_string_lon_lat.length(&Haversine).round(), 3_474_956.0);
 /// ```
-pub trait Length<F: CoordFloat> {
+pub trait LengthMeasurable<F: CoordFloat> {
     fn length(&self, metric_space: &impl Distance<F, Point<F>, Point<F>>) -> F;
 }
 
-impl<F: CoordFloat> Length<F> for Line<F> {
+impl<F: CoordFloat, PointDistance: Distance<F, Point<F>, Point<F>>> Length<F> for PointDistance {
+    fn length(&self, geometry: &impl LengthMeasurable<F>) -> F {
+        geometry.length(self)
+    }
+}
+
+impl<F: CoordFloat> LengthMeasurable<F> for Line<F> {
     fn length(&self, metric_space: &impl Distance<F, Point<F>, Point<F>>) -> F {
         metric_space.distance(self.start_point(), self.end_point())
     }
 }
 
-impl<F: CoordFloat> Length<F> for LineString<F> {
+impl<F: CoordFloat> LengthMeasurable<F> for LineString<F> {
     fn length(&self, metric_space: &impl Distance<F, Point<F>, Point<F>>) -> F {
         let mut length = F::zero();
         for line in self.lines() {
@@ -41,7 +74,7 @@ impl<F: CoordFloat> Length<F> for LineString<F> {
     }
 }
 
-impl<F: CoordFloat> Length<F> for MultiLineString<F> {
+impl<F: CoordFloat> LengthMeasurable<F> for MultiLineString<F> {
     fn length(&self, metric_space: &impl Distance<F, Point<F>, Point<F>>) -> F {
         let mut length = F::zero();
         for line in self {
@@ -66,28 +99,28 @@ mod tests {
 
         assert_eq!(
             343_923., // meters
-            line.length(&Geodesic).round()
+            Geodesic.length(&line).round()
         );
         assert_eq!(
             341_088., // meters
-            line.length(&Rhumb).round()
+            Rhumb.length(&line).round()
         );
         assert_eq!(
             343_557., // meters
-            line.length(&Haversine).round()
+            Haversine.length(&line).round()
         );
 
         // computing Euclidean length of an unprojected (lng/lat) line gives a nonsense answer
         assert_eq!(
             4., // nonsense!
-            line.length(&Euclidean).round()
+            Euclidean.length(&line).round()
         );
         // london to paris in EPSG:3035
         let projected_line = Line::new(
             coord!(x: 3620451.74f64, y: 3203901.44),
             coord!(x: 3760771.86, y: 2889484.80),
         );
-        assert_eq!(344_307., projected_line.length(&Euclidean).round());
+        assert_eq!(344_307., Euclidean.length(&projected_line).round());
     }
 
     #[test]
@@ -100,21 +133,21 @@ mod tests {
 
         assert_eq!(
             6_302_220., // meters
-            line_string.length(&Geodesic).round()
+            Geodesic.length(&line_string).round()
         );
         assert_eq!(
             6_332_790., // meters
-            line_string.length(&Rhumb).round()
+            Rhumb.length(&line_string).round()
         );
         assert_eq!(
             6_304_387., // meters
-            line_string.length(&Haversine).round()
+            Haversine.length(&line_string).round()
         );
 
         // computing Euclidean length of an unprojected (lng/lat) gives a nonsense answer
         assert_eq!(
             59., // nonsense!
-            line_string.length(&Euclidean).round()
+            Euclidean.length(&line_string).round()
         );
         // EPSG:102033
         let projected_line_string = LineString::from(vec![
@@ -122,6 +155,6 @@ mod tests {
             coord!(x: -1797084.08, y: 583528.84),    // Lima, Peru
             coord!(x: 1240052.27, y: 207169.12),     // Brasília, Brazil
         ]);
-        assert_eq!(6_237_538., projected_line_string.length(&Euclidean).round());
+        assert_eq!(6_237_538., Euclidean.length(&projected_line_string).round());
     }
 }

--- a/geo/src/algorithm/line_measures/metric_spaces/euclidean/distance.rs
+++ b/geo/src/algorithm/line_measures/metric_spaces/euclidean/distance.rs
@@ -14,8 +14,8 @@ macro_rules! symmetric_distance_impl {
         where
             F: $t,
         {
-            fn distance(a: $a, b: $b) -> F {
-                Self::distance(b, a)
+            fn distance(&self, a: $a, b: $b) -> F {
+                self.distance(b, a)
             }
         }
     };
@@ -26,13 +26,13 @@ macro_rules! symmetric_distance_impl {
 // └───────────────────────────┘
 
 impl<F: CoordFloat> Distance<F, Coord<F>, Coord<F>> for Euclidean {
-    fn distance(origin: Coord<F>, destination: Coord<F>) -> F {
+    fn distance(&self, origin: Coord<F>, destination: Coord<F>) -> F {
         let delta = origin - destination;
         delta.x.hypot(delta.y)
     }
 }
 impl<F: CoordFloat> Distance<F, Coord<F>, &Line<F>> for Euclidean {
-    fn distance(coord: Coord<F>, line: &Line<F>) -> F {
+    fn distance(&self, coord: Coord<F>, line: &Line<F>) -> F {
         ::geo_types::private_utils::point_line_euclidean_distance(Point(coord), *line)
     }
 }
@@ -59,7 +59,7 @@ impl<F: CoordFloat> Distance<F, Point<F>, Point<F>> for Euclidean {
     /// let new_york_city = Point::new(-8238310.24, 4942194.78);
     /// // web mercator
     /// let london = Point::new(-14226.63, 6678077.70);
-    /// let distance: f64 = Euclidean::distance(new_york_city, london);
+    /// let distance: f64 = Euclidean.distance(new_york_city, london);
     ///
     /// assert_eq!(
     ///     8_405_286., // meters in web mercator
@@ -70,31 +70,31 @@ impl<F: CoordFloat> Distance<F, Point<F>, Point<F>> for Euclidean {
     /// [`Haversine`]: crate::line_measures::metric_spaces::Haversine
     /// [`Geodesic`]: crate::line_measures::metric_spaces::Geodesic
     /// [metric spaces]: crate::line_measures::metric_spaces
-    fn distance(origin: Point<F>, destination: Point<F>) -> F {
-        Self::distance(origin.0, destination.0)
+    fn distance(&self, origin: Point<F>, destination: Point<F>) -> F {
+        self.distance(origin.0, destination.0)
     }
 }
 
 impl<F: CoordFloat> Distance<F, &Point<F>, &Point<F>> for Euclidean {
-    fn distance(origin: &Point<F>, destination: &Point<F>) -> F {
-        Self::distance(*origin, *destination)
+    fn distance(&self, origin: &Point<F>, destination: &Point<F>) -> F {
+        self.distance(*origin, *destination)
     }
 }
 
 impl<F: CoordFloat> Distance<F, &Point<F>, &Line<F>> for Euclidean {
-    fn distance(origin: &Point<F>, destination: &Line<F>) -> F {
+    fn distance(&self, origin: &Point<F>, destination: &Line<F>) -> F {
         geo_types::private_utils::point_line_euclidean_distance(*origin, *destination)
     }
 }
 
 impl<F: CoordFloat> Distance<F, &Point<F>, &LineString<F>> for Euclidean {
-    fn distance(origin: &Point<F>, destination: &LineString<F>) -> F {
+    fn distance(&self, origin: &Point<F>, destination: &LineString<F>) -> F {
         geo_types::private_utils::point_line_string_euclidean_distance(*origin, destination)
     }
 }
 
 impl<F: GeoFloat> Distance<F, &Point<F>, &Polygon<F>> for Euclidean {
-    fn distance(point: &Point<F>, polygon: &Polygon<F>) -> F {
+    fn distance(&self, point: &Point<F>, polygon: &Polygon<F>) -> F {
         // No need to continue if the polygon intersects the point, or is zero-length
         if polygon.exterior().0.is_empty() || polygon.intersects(point) {
             return F::zero();
@@ -104,7 +104,7 @@ impl<F: GeoFloat> Distance<F, &Point<F>, &Polygon<F>> for Euclidean {
         polygon
             .interiors()
             .iter()
-            .map(|ring| Self::distance(point, ring))
+            .map(|ring| self.distance(point, ring))
             .fold(Bounded::max_value(), |accum: F, val| accum.min(val))
             .min(
                 polygon
@@ -128,30 +128,30 @@ symmetric_distance_impl!(CoordFloat, &Line<F>, Coord<F>);
 symmetric_distance_impl!(CoordFloat, &Line<F>, &Point<F>);
 
 impl<F: GeoFloat> Distance<F, &Line<F>, &Line<F>> for Euclidean {
-    fn distance(line_a: &Line<F>, line_b: &Line<F>) -> F {
+    fn distance(&self, line_a: &Line<F>, line_b: &Line<F>) -> F {
         if line_a.intersects(line_b) {
             return F::zero();
         }
         // minimum of all Point-Line distances
-        Self::distance(&line_a.start_point(), line_b)
-            .min(Self::distance(&line_a.end_point(), line_b))
-            .min(Self::distance(&line_b.start_point(), line_a))
-            .min(Self::distance(&line_b.end_point(), line_a))
+        self.distance(&line_a.start_point(), line_b)
+            .min(self.distance(&line_a.end_point(), line_b))
+            .min(self.distance(&line_b.start_point(), line_a))
+            .min(self.distance(&line_b.end_point(), line_a))
     }
 }
 
 impl<F: GeoFloat> Distance<F, &Line<F>, &LineString<F>> for Euclidean {
-    fn distance(line: &Line<F>, line_string: &LineString<F>) -> F {
+    fn distance(&self, line: &Line<F>, line_string: &LineString<F>) -> F {
         line_string
             .lines()
             .fold(Bounded::max_value(), |acc, segment| {
-                acc.min(Self::distance(line, &segment))
+                acc.min(self.distance(line, &segment))
             })
     }
 }
 
 impl<F: GeoFloat> Distance<F, &Line<F>, &Polygon<F>> for Euclidean {
-    fn distance(line: &Line<F>, polygon: &Polygon<F>) -> F {
+    fn distance(&self, line: &Line<F>, polygon: &Polygon<F>) -> F {
         if line.intersects(polygon) {
             return F::zero();
         }
@@ -160,7 +160,7 @@ impl<F: GeoFloat> Distance<F, &Line<F>, &Polygon<F>> for Euclidean {
         std::iter::once(polygon.exterior())
             .chain(polygon.interiors().iter())
             .fold(Bounded::max_value(), |acc, line_string| {
-                acc.min(Self::distance(line, line_string))
+                acc.min(self.distance(line, line_string))
             })
     }
 }
@@ -173,7 +173,7 @@ symmetric_distance_impl!(CoordFloat, &LineString<F>, &Point<F>);
 symmetric_distance_impl!(GeoFloat, &LineString<F>, &Line<F>);
 
 impl<F: GeoFloat> Distance<F, &LineString<F>, &LineString<F>> for Euclidean {
-    fn distance(line_string_a: &LineString<F>, line_string_b: &LineString<F>) -> F {
+    fn distance(&self, line_string_a: &LineString<F>, line_string_b: &LineString<F>) -> F {
         if line_string_a.intersects(line_string_b) {
             F::zero()
         } else {
@@ -183,7 +183,7 @@ impl<F: GeoFloat> Distance<F, &LineString<F>, &LineString<F>> for Euclidean {
 }
 
 impl<F: GeoFloat> Distance<F, &LineString<F>, &Polygon<F>> for Euclidean {
-    fn distance(line_string: &LineString<F>, polygon: &Polygon<F>) -> F {
+    fn distance(&self, line_string: &LineString<F>, polygon: &Polygon<F>) -> F {
         if line_string.intersects(polygon) {
             F::zero()
         } else if !polygon.interiors().is_empty()
@@ -210,7 +210,7 @@ symmetric_distance_impl!(GeoFloat, &Polygon<F>, &Point<F>);
 symmetric_distance_impl!(GeoFloat, &Polygon<F>, &Line<F>);
 symmetric_distance_impl!(GeoFloat, &Polygon<F>, &LineString<F>);
 impl<F: GeoFloat> Distance<F, &Polygon<F>, &Polygon<F>> for Euclidean {
-    fn distance(polygon_a: &Polygon<F>, polygon_b: &Polygon<F>) -> F {
+    fn distance(&self, polygon_a: &Polygon<F>, polygon_b: &Polygon<F>) -> F {
         if polygon_a.intersects(polygon_b) {
             return F::zero();
         }
@@ -248,15 +248,15 @@ macro_rules! impl_euclidean_distance_for_polygonlike_geometry {
   ($polygonlike:ty,  [$($geometry_b:ty),*]) => {
       impl<F: GeoFloat> Distance<F, $polygonlike, $polygonlike> for Euclidean
       {
-          fn distance(origin: $polygonlike, destination: $polygonlike) -> F {
-              Self::distance(&origin.to_polygon(), destination)
+          fn distance(&self, origin: $polygonlike, destination: $polygonlike) -> F {
+              self.distance(&origin.to_polygon(), destination)
           }
       }
       $(
           impl<F: GeoFloat> Distance<F, $polygonlike, $geometry_b> for Euclidean
           {
-              fn distance(polygonlike: $polygonlike, geometry_b: $geometry_b) -> F {
-                    Self::distance(&polygonlike.to_polygon(), geometry_b)
+              fn distance(&self, polygonlike: $polygonlike, geometry_b: $geometry_b) -> F {
+                    self.distance(&polygonlike.to_polygon(), geometry_b)
               }
           }
           symmetric_distance_impl!(GeoFloat, $geometry_b, $polygonlike);
@@ -275,21 +275,21 @@ impl_euclidean_distance_for_polygonlike_geometry!(&Rect<F>,      [&Point<F>, &Li
 macro_rules! impl_euclidean_distance_for_iter_geometry {
     ($iter_geometry:ty,  [$($to_geometry:ty),*]) => {
         impl<F: GeoFloat> Distance<F, $iter_geometry, $iter_geometry> for Euclidean {
-            fn distance(origin: $iter_geometry, destination: $iter_geometry) -> F {
+            fn distance(&self, origin: $iter_geometry, destination: $iter_geometry) -> F {
                 origin
                     .iter()
                     .fold(Bounded::max_value(), |accum: F, member| {
-                        accum.min(Self::distance(member, destination))
+                        accum.min(self.distance(member, destination))
                     })
              }
         }
         $(
             impl<F: GeoFloat> Distance<F, $iter_geometry, $to_geometry> for Euclidean {
-                fn distance(iter_geometry: $iter_geometry, to_geometry: $to_geometry) -> F {
+                fn distance(&self, iter_geometry: $iter_geometry, to_geometry: $to_geometry) -> F {
                     iter_geometry
                         .iter()
                         .fold(Bounded::max_value(), |accum: F, member| {
-                            accum.min(Self::distance(member, to_geometry))
+                            accum.min(self.distance(member, to_geometry))
                         })
                 }
             }
@@ -312,18 +312,18 @@ macro_rules! impl_euclidean_distance_for_geometry_and_variant {
   ([$($target:ty),*]) => {
       $(
           impl<F: GeoFloat> Distance<F, $target, &Geometry<F>> for Euclidean {
-              fn distance(origin: $target, destination: &Geometry<F>) -> F {
+              fn distance(&self, origin: $target, destination: &Geometry<F>) -> F {
                   match destination {
-                      Geometry::Point(point) => Self::distance(origin, point),
-                      Geometry::Line(line) => Self::distance(origin, line),
-                      Geometry::LineString(line_string) => Self::distance(origin, line_string),
-                      Geometry::Polygon(polygon) => Self::distance(origin, polygon),
-                      Geometry::MultiPoint(multi_point) => Self::distance(origin, multi_point),
-                      Geometry::MultiLineString(multi_line_string) => Self::distance(origin, multi_line_string),
-                      Geometry::MultiPolygon(multi_polygon) => Self::distance(origin, multi_polygon),
-                      Geometry::GeometryCollection(geometry_collection) => Self::distance(origin, geometry_collection),
-                      Geometry::Rect(rect) => Self::distance(origin, rect),
-                      Geometry::Triangle(triangle) => Self::distance(origin, triangle),
+                      Geometry::Point(point) => self.distance(origin, point),
+                      Geometry::Line(line) => self.distance(origin, line),
+                      Geometry::LineString(line_string) => self.distance(origin, line_string),
+                      Geometry::Polygon(polygon) => self.distance(origin, polygon),
+                      Geometry::MultiPoint(multi_point) => self.distance(origin, multi_point),
+                      Geometry::MultiLineString(multi_line_string) => self.distance(origin, multi_line_string),
+                      Geometry::MultiPolygon(multi_polygon) => self.distance(origin, multi_polygon),
+                      Geometry::GeometryCollection(geometry_collection) => self.distance(origin, geometry_collection),
+                      Geometry::Rect(rect) => self.distance(origin, rect),
+                      Geometry::Triangle(triangle) => self.distance(origin, triangle),
                   }
               }
           }
@@ -335,22 +335,22 @@ macro_rules! impl_euclidean_distance_for_geometry_and_variant {
 impl_euclidean_distance_for_geometry_and_variant!([&Point<F>, &MultiPoint<F>, &Line<F>, &LineString<F>, &MultiLineString<F>, &Polygon<F>, &MultiPolygon<F>, &Triangle<F>, &Rect<F>, &GeometryCollection<F>]);
 
 impl<F: GeoFloat> Distance<F, &Geometry<F>, &Geometry<F>> for Euclidean {
-    fn distance(origin: &Geometry<F>, destination: &Geometry<F>) -> F {
+    fn distance(&self, origin: &Geometry<F>, destination: &Geometry<F>) -> F {
         match origin {
-            Geometry::Point(point) => Self::distance(point, destination),
-            Geometry::Line(line) => Self::distance(line, destination),
-            Geometry::LineString(line_string) => Self::distance(line_string, destination),
-            Geometry::Polygon(polygon) => Self::distance(polygon, destination),
-            Geometry::MultiPoint(multi_point) => Self::distance(multi_point, destination),
+            Geometry::Point(point) => self.distance(point, destination),
+            Geometry::Line(line) => self.distance(line, destination),
+            Geometry::LineString(line_string) => self.distance(line_string, destination),
+            Geometry::Polygon(polygon) => self.distance(polygon, destination),
+            Geometry::MultiPoint(multi_point) => self.distance(multi_point, destination),
             Geometry::MultiLineString(multi_line_string) => {
-                Self::distance(multi_line_string, destination)
+                self.distance(multi_line_string, destination)
             }
-            Geometry::MultiPolygon(multi_polygon) => Self::distance(multi_polygon, destination),
+            Geometry::MultiPolygon(multi_polygon) => self.distance(multi_polygon, destination),
             Geometry::GeometryCollection(geometry_collection) => {
-                Self::distance(geometry_collection, destination)
+                self.distance(geometry_collection, destination)
             }
-            Geometry::Rect(rect) => Self::distance(rect, destination),
-            Geometry::Triangle(triangle) => Self::distance(triangle, destination),
+            Geometry::Rect(rect) => self.distance(rect, destination),
+            Geometry::Triangle(triangle) => self.distance(triangle, destination),
         }
     }
 }
@@ -369,11 +369,11 @@ fn nearest_neighbour_distance<F: GeoFloat>(geom1: &LineString<F>, geom2: &LineSt
         .points()
         .fold(Bounded::max_value(), |acc: F, point| {
             let nearest = tree_a.nearest_neighbor(&point).unwrap();
-            acc.min(Euclidean::distance(nearest as &Line<F>, &point))
+            acc.min(Euclidean.distance(nearest as &Line<F>, &point))
         })
         .min(geom1.points().fold(Bounded::max_value(), |acc, point| {
             let nearest = tree_b.nearest_neighbor(&point).unwrap();
-            acc.min(Euclidean::distance(nearest as &Line<F>, &point))
+            acc.min(Euclidean.distance(nearest as &Line<F>, &point))
         }))
 }
 
@@ -433,7 +433,7 @@ mod test {
         let poly = Polygon::new(ls, vec![]);
         // A Random point outside the octagon
         let p = Point::new(2.5, 0.5);
-        let dist = Euclidean::distance(&p, &poly);
+        let dist = Euclidean.distance(&p, &poly);
         assert_relative_eq!(dist, 2.1213203435596424);
     }
     #[test]
@@ -455,7 +455,7 @@ mod test {
         let poly = Polygon::new(ls, vec![]);
         // A Random point inside the octagon
         let p = Point::new(5.5, 2.1);
-        let dist = Euclidean::distance(&p, &poly);
+        let dist = Euclidean.distance(&p, &poly);
         assert_relative_eq!(dist, 0.0);
     }
     #[test]
@@ -477,7 +477,7 @@ mod test {
         let poly = Polygon::new(ls, vec![]);
         // A point on the octagon
         let p = Point::new(5.0, 1.0);
-        let dist = Euclidean::distance(&p, &poly);
+        let dist = Euclidean.distance(&p, &poly);
         assert_relative_eq!(dist, 0.0);
     }
     #[test]
@@ -493,7 +493,7 @@ mod test {
 
         let poly = Polygon::new(exterior, vec![]);
         let bugged_point = Point::new(0.0001, 0.);
-        assert_relative_eq!(Euclidean::distance(&poly, &bugged_point), 0.);
+        assert_relative_eq!(Euclidean.distance(&poly, &bugged_point), 0.);
     }
     #[test]
     // Point to Polygon, empty Polygon
@@ -504,7 +504,7 @@ mod test {
         let poly = Polygon::new(ls, vec![]);
         // A point on the octagon
         let p = Point::new(2.5, 0.5);
-        let dist = Euclidean::distance(&p, &poly);
+        let dist = Euclidean.distance(&p, &poly);
         assert_relative_eq!(dist, 0.0);
     }
     #[test]
@@ -529,7 +529,7 @@ mod test {
         let poly = Polygon::new(ls_ext, vec![ls_int]);
         // A point inside the cutout triangle
         let p = Point::new(3.5, 2.5);
-        let dist = Euclidean::distance(&p, &poly);
+        let dist = Euclidean.distance(&p, &poly);
 
         // 0.41036467732879783 <-- Shapely
         assert_relative_eq!(dist, 0.41036467732879767);
@@ -569,8 +569,8 @@ mod test {
         let pnt1 = Point::new(0.0, 15.0);
         let pnt2 = Point::new(10.0, 20.0);
         let ln = Line::new(pnt1.0, pnt2.0);
-        let dist_mp_ln = Euclidean::distance(&ln, &mp);
-        let dist_pol1_ln = Euclidean::distance(&ln, &pol1);
+        let dist_mp_ln = Euclidean.distance(&ln, &mp);
+        let dist_pol1_ln = Euclidean.distance(&ln, &pol1);
         assert_relative_eq!(dist_mp_ln, dist_pol1_ln);
     }
 
@@ -582,7 +582,7 @@ mod test {
         let p2 = Polygon::new(ls2, vec![]);
         let mp = MultiPolygon::new(vec![p1, p2]);
         let p = Point::new(50.0, 50.0);
-        assert_relative_eq!(Euclidean::distance(&p, &mp), 60.959002616512684);
+        assert_relative_eq!(Euclidean.distance(&p, &mp), 60.959002616512684);
     }
     #[test]
     // Point to LineString
@@ -601,7 +601,7 @@ mod test {
         let ls = LineString::from(points);
         // A Random point "inside" the LineString
         let p = Point::new(5.5, 2.1);
-        let dist = Euclidean::distance(&p, &ls);
+        let dist = Euclidean.distance(&p, &ls);
         assert_relative_eq!(dist, 1.1313708498984762);
     }
     #[test]
@@ -621,7 +621,7 @@ mod test {
         let ls = LineString::from(points);
         // A point which lies on the LineString
         let p = Point::new(5.0, 4.0);
-        let dist = Euclidean::distance(&p, &ls);
+        let dist = Euclidean.distance(&p, &ls);
         assert_relative_eq!(dist, 0.0);
     }
     #[test]
@@ -630,7 +630,7 @@ mod test {
         let points = vec![(3.5, 3.5), (4.4, 2.0), (2.6, 2.0), (3.5, 3.5)];
         let ls = LineString::from(points);
         let p = Point::new(3.5, 2.5);
-        let dist = Euclidean::distance(&p, &ls);
+        let dist = Euclidean.distance(&p, &ls);
         assert_relative_eq!(dist, 0.5);
     }
     #[test]
@@ -639,7 +639,7 @@ mod test {
         let points = vec![];
         let ls = LineString::new(points);
         let p = Point::new(5.0, 4.0);
-        let dist = Euclidean::distance(&p, &ls);
+        let dist = Euclidean.distance(&p, &ls);
         assert_relative_eq!(dist, 0.0);
     }
     #[test]
@@ -648,19 +648,18 @@ mod test {
         let v2 = LineString::from(vec![(1.0, 10.0), (2.0, 0.0), (3.0, 1.0)]);
         let mls = MultiLineString::new(vec![v1, v2]);
         let p = Point::new(50.0, 50.0);
-        assert_relative_eq!(Euclidean::distance(&p, &mls), 63.25345840347388);
+        assert_relative_eq!(Euclidean.distance(&p, &mls), 63.25345840347388);
     }
     #[test]
     fn distance1_test() {
         assert_relative_eq!(
-            Euclidean::distance(&Point::new(0., 0.), &Point::new(1., 0.)),
+            Euclidean.distance(&Point::new(0., 0.), &Point::new(1., 0.)),
             1.
         );
     }
     #[test]
     fn distance2_test() {
-        let dist =
-            Euclidean::distance(&Point::new(-72.1235, 42.3521), &Point::new(72.1260, 70.612));
+        let dist = Euclidean.distance(&Point::new(-72.1235, 42.3521), &Point::new(72.1260, 70.612));
         assert_relative_eq!(dist, 146.99163308930207);
     }
     #[test]
@@ -678,7 +677,7 @@ mod test {
         ];
         let mp = MultiPoint::new(v);
         let p = Point::new(50.0, 50.0);
-        assert_relative_eq!(Euclidean::distance(&p, &mp), 64.03124237432849)
+        assert_relative_eq!(Euclidean.distance(&p, &mp), 64.03124237432849)
     }
     #[test]
     fn distance_line_test() {
@@ -686,21 +685,21 @@ mod test {
         let p0 = Point::new(2., 3.);
         let p1 = Point::new(3., 0.);
         let p2 = Point::new(6., 0.);
-        assert_relative_eq!(Euclidean::distance(&line0, &p0), 3.);
-        assert_relative_eq!(Euclidean::distance(&p0, &line0), 3.);
+        assert_relative_eq!(Euclidean.distance(&line0, &p0), 3.);
+        assert_relative_eq!(Euclidean.distance(&p0, &line0), 3.);
 
-        assert_relative_eq!(Euclidean::distance(&line0, &p1), 0.);
-        assert_relative_eq!(Euclidean::distance(&p1, &line0), 0.);
+        assert_relative_eq!(Euclidean.distance(&line0, &p1), 0.);
+        assert_relative_eq!(Euclidean.distance(&p1, &line0), 0.);
 
-        assert_relative_eq!(Euclidean::distance(&line0, &p2), 1.);
-        assert_relative_eq!(Euclidean::distance(&p2, &line0), 1.);
+        assert_relative_eq!(Euclidean.distance(&line0, &p2), 1.);
+        assert_relative_eq!(Euclidean.distance(&p2, &line0), 1.);
     }
     #[test]
     fn distance_line_line_test() {
         let line0 = Line::from([(0., 0.), (5., 0.)]);
         let line1 = Line::from([(2., 1.), (7., 2.)]);
-        assert_relative_eq!(Euclidean::distance(&line0, &line1), 1.);
-        assert_relative_eq!(Euclidean::distance(&line1, &line0), 1.);
+        assert_relative_eq!(Euclidean.distance(&line0, &line1), 1.);
+        assert_relative_eq!(Euclidean.distance(&line1, &line0), 1.);
     }
     #[test]
     // See https://github.com/georust/geo/issues/476
@@ -733,7 +732,7 @@ mod test {
                 y: -0.15433610862574643,
             },
         ];
-        assert_eq!(Euclidean::distance(&line, &poly), 0.18752558079168907);
+        assert_eq!(Euclidean.distance(&line, &poly), 0.18752558079168907);
     }
     #[test]
     // test edge-vertex minimum distance
@@ -844,7 +843,7 @@ mod test {
             (4.921875, 66.33750501996518),
         ];
         let poly2 = Polygon::new(vec2.into(), vec![]);
-        let distance = Euclidean::distance(&poly1, &poly2);
+        let distance = Euclidean.distance(&poly1, &poly2);
         // GEOS says 2.2864896295566055
         assert_relative_eq!(distance, 2.2864896295566055);
     }
@@ -858,14 +857,14 @@ mod test {
         // inside is "inside" outside's ring, but they are disjoint
         let outside = Polygon::new(shell, vec![ring]);
         let inside = Polygon::new(poly_in_ring, vec![]);
-        assert_relative_eq!(Euclidean::distance(&outside, &inside), 5.992772737231033);
+        assert_relative_eq!(Euclidean.distance(&outside, &inside), 5.992772737231033);
     }
     #[test]
     // two ring LineStrings; one encloses the other but they neither touch nor intersect
     fn test_linestring_distance() {
         let ring = geo_test_fixtures::ring::<f64>();
         let poly_in_ring = geo_test_fixtures::poly_in_ring::<f64>();
-        assert_relative_eq!(Euclidean::distance(&ring, &poly_in_ring), 5.992772737231033);
+        assert_relative_eq!(Euclidean.distance(&ring, &poly_in_ring), 5.992772737231033);
     }
     #[test]
     // Line-Polygon test: closest point on Polygon is NOT nearest to a Line end-point
@@ -873,7 +872,7 @@ mod test {
         let line = Line::from([(0.0, 0.0), (0.0, 3.0)]);
         let v = vec![(5.0, 1.0), (5.0, 2.0), (0.25, 1.5), (5.0, 1.0)];
         let poly = Polygon::new(v.into(), vec![]);
-        assert_relative_eq!(Euclidean::distance(&line, &poly), 0.25);
+        assert_relative_eq!(Euclidean.distance(&line, &poly), 0.25);
     }
     #[test]
     // Line-Polygon test: Line intersects Polygon
@@ -881,7 +880,7 @@ mod test {
         let line = Line::from([(0.5, 0.0), (0.0, 3.0)]);
         let v = vec![(5.0, 1.0), (5.0, 2.0), (0.25, 1.5), (5.0, 1.0)];
         let poly = Polygon::new(v.into(), vec![]);
-        assert_relative_eq!(Euclidean::distance(&line, &poly), 0.0);
+        assert_relative_eq!(Euclidean.distance(&line, &poly), 0.0);
     }
     #[test]
     // Line-Polygon test: Line contained by interior ring
@@ -890,14 +889,14 @@ mod test {
         let v = vec![(5.0, 1.0), (5.0, 2.0), (0.25, 1.0), (5.0, 1.0)];
         let v2 = vec![(4.5, 1.2), (4.5, 1.8), (3.5, 1.2), (4.5, 1.2)];
         let poly = Polygon::new(v.into(), vec![v2.into()]);
-        assert_relative_eq!(Euclidean::distance(&line, &poly), 0.04999999999999982);
+        assert_relative_eq!(Euclidean.distance(&line, &poly), 0.04999999999999982);
     }
     #[test]
     // LineString-Line test
     fn test_linestring_line_distance() {
         let line = Line::from([(0.0, 0.0), (0.0, 2.0)]);
         let ls: LineString<_> = vec![(3.0, 0.0), (1.0, 1.0), (3.0, 2.0)].into();
-        assert_relative_eq!(Euclidean::distance(&ls, &line), 1.0);
+        assert_relative_eq!(Euclidean.distance(&ls, &line), 1.0);
     }
 
     #[test]
@@ -905,7 +904,7 @@ mod test {
     fn test_triangle_point_on_vertex_distance() {
         let triangle = Triangle::from([(0.0, 0.0), (2.0, 0.0), (2.0, 2.0)]);
         let point = Point::new(0.0, 0.0);
-        assert_relative_eq!(Euclidean::distance(&triangle, &point), 0.0);
+        assert_relative_eq!(Euclidean.distance(&triangle, &point), 0.0);
     }
 
     #[test]
@@ -913,7 +912,7 @@ mod test {
     fn test_triangle_point_on_edge_distance() {
         let triangle = Triangle::from([(0.0, 0.0), (2.0, 0.0), (2.0, 2.0)]);
         let point = Point::new(1.5, 0.0);
-        assert_relative_eq!(Euclidean::distance(&triangle, &point), 0.0);
+        assert_relative_eq!(Euclidean.distance(&triangle, &point), 0.0);
     }
 
     #[test]
@@ -921,7 +920,7 @@ mod test {
     fn test_triangle_point_distance() {
         let triangle = Triangle::from([(0.0, 0.0), (2.0, 0.0), (2.0, 2.0)]);
         let point = Point::new(2.0, 3.0);
-        assert_relative_eq!(Euclidean::distance(&triangle, &point), 1.0);
+        assert_relative_eq!(Euclidean.distance(&triangle, &point), 1.0);
     }
 
     #[test]
@@ -929,7 +928,7 @@ mod test {
     fn test_triangle_point_inside_distance() {
         let triangle = Triangle::from([(0.0, 0.0), (2.0, 0.0), (2.0, 2.0)]);
         let point = Point::new(1.0, 0.5);
-        assert_relative_eq!(Euclidean::distance(&triangle, &point), 0.0);
+        assert_relative_eq!(Euclidean.distance(&triangle, &point), 0.0);
     }
 
     #[test]
@@ -954,7 +953,7 @@ mod test {
         let second_polygon = Polygon::new(ls2, vec![]);
 
         assert_relative_eq!(
-            Euclidean::distance(&first_polygon, &second_polygon),
+            Euclidean.distance(&first_polygon, &second_polygon),
             224.35357967013238
         );
     }
@@ -987,10 +986,10 @@ mod test {
             (x: 50_f64, y: 200_f64),
         )
         .orient(Direction::Reversed);
-        assert_eq!(Euclidean::distance(&p1, &p2), 50.0f64);
-        assert_eq!(Euclidean::distance(&p3, &p4), 50.0f64);
-        assert_eq!(Euclidean::distance(&p1, &p4), 50.0f64);
-        assert_eq!(Euclidean::distance(&p2, &p3), 50.0f64);
+        assert_eq!(Euclidean.distance(&p1, &p2), 50.0f64);
+        assert_eq!(Euclidean.distance(&p3, &p4), 50.0f64);
+        assert_eq!(Euclidean.distance(&p1, &p4), 50.0f64);
+        assert_eq!(Euclidean.distance(&p2, &p3), 50.0f64);
     }
     #[test]
     fn all_types_geometry_collection_test() {
@@ -1040,22 +1039,22 @@ mod test {
         ]);
 
         let test_p = Point::new(50., 50.);
-        assert_relative_eq!(Euclidean::distance(&test_p, &gc), 60.959002616512684);
+        assert_relative_eq!(Euclidean.distance(&test_p, &gc), 60.959002616512684);
 
         let test_multipoint = MultiPoint::new(vec![test_p]);
         assert_relative_eq!(
-            Euclidean::distance(&test_multipoint, &gc),
+            Euclidean.distance(&test_multipoint, &gc),
             60.959002616512684
         );
 
         let test_line = Line::from([(50., 50.), (60., 60.)]);
-        assert_relative_eq!(Euclidean::distance(&test_line, &gc), 60.959002616512684);
+        assert_relative_eq!(Euclidean.distance(&test_line, &gc), 60.959002616512684);
 
         let test_ls = LineString::from(vec![(50., 50.), (60., 60.), (70., 70.)]);
-        assert_relative_eq!(Euclidean::distance(&test_ls, &gc), 60.959002616512684);
+        assert_relative_eq!(Euclidean.distance(&test_ls, &gc), 60.959002616512684);
 
         let test_mls = MultiLineString::new(vec![test_ls]);
-        assert_relative_eq!(Euclidean::distance(&test_mls, &gc), 60.959002616512684);
+        assert_relative_eq!(Euclidean.distance(&test_mls, &gc), 60.959002616512684);
 
         let test_poly = Polygon::new(
             LineString::from(vec![
@@ -1067,21 +1066,18 @@ mod test {
             ]),
             vec![],
         );
-        assert_relative_eq!(Euclidean::distance(&test_poly, &gc), 60.959002616512684);
+        assert_relative_eq!(Euclidean.distance(&test_poly, &gc), 60.959002616512684);
 
         let test_multipoly = MultiPolygon::new(vec![test_poly]);
-        assert_relative_eq!(
-            Euclidean::distance(&test_multipoly, &gc),
-            60.959002616512684
-        );
+        assert_relative_eq!(Euclidean.distance(&test_multipoly, &gc), 60.959002616512684);
 
         let test_tri = Triangle::from([(50., 50.), (60., 50.), (55., 55.)]);
-        assert_relative_eq!(Euclidean::distance(&test_tri, &gc), 60.959002616512684);
+        assert_relative_eq!(Euclidean.distance(&test_tri, &gc), 60.959002616512684);
 
         let test_rect = Rect::new(coord! { x: 50., y: 50. }, coord! { x: 60., y: 60. });
-        assert_relative_eq!(Euclidean::distance(&test_rect, &gc), 60.959002616512684);
+        assert_relative_eq!(Euclidean.distance(&test_rect, &gc), 60.959002616512684);
 
         let test_gc = GeometryCollection(vec![Geometry::Rect(test_rect)]);
-        assert_relative_eq!(Euclidean::distance(&test_gc, &gc), 60.959002616512684);
+        assert_relative_eq!(Euclidean.distance(&test_gc, &gc), 60.959002616512684);
     }
 }

--- a/geo/src/algorithm/line_measures/metric_spaces/euclidean/mod.rs
+++ b/geo/src/algorithm/line_measures/metric_spaces/euclidean/mod.rs
@@ -39,6 +39,7 @@ impl<F: CoordFloat + FromPrimitive> InterpolatePoint<F> for Euclidean {
     /// [`Geodesic`]: crate::line_measures::Geodesic
     /// [metric spaces]: crate::line_measures::metric_spaces
     fn point_at_distance_between(
+        &self,
         start: Point<F>,
         end: Point<F>,
         distance_from_start: F,
@@ -61,7 +62,12 @@ impl<F: CoordFloat + FromPrimitive> InterpolatePoint<F> for Euclidean {
     /// [`Haversine`]: crate::line_measures::Haversine
     /// [`Geodesic`]: crate::line_measures::Geodesic
     /// [metric spaces]: crate::line_measures::metric_spaces
-    fn point_at_ratio_between(start: Point<F>, end: Point<F>, ratio_from_start: F) -> Point<F> {
+    fn point_at_ratio_between(
+        &self,
+        start: Point<F>,
+        end: Point<F>,
+        ratio_from_start: F,
+    ) -> Point<F> {
         let diff = end - start;
         start + diff * ratio_from_start
     }
@@ -85,6 +91,7 @@ impl<F: CoordFloat + FromPrimitive> InterpolatePoint<F> for Euclidean {
     /// [`Geodesic`]: crate::line_measures::Geodesic
     /// [metric spaces]: crate::line_measures::metric_spaces
     fn points_along_line(
+        &self,
         start: Point<F>,
         end: Point<F>,
         max_distance: F,
@@ -94,7 +101,7 @@ impl<F: CoordFloat + FromPrimitive> InterpolatePoint<F> for Euclidean {
         if include_ends {
             container.push(start);
         }
-        densify_between::<F, Self>(start, end, &mut container, max_distance);
+        densify_between(self, start, end, &mut container, max_distance);
         if include_ends {
             container.push(end);
         }
@@ -106,8 +113,6 @@ impl<F: CoordFloat + FromPrimitive> InterpolatePoint<F> for Euclidean {
 mod tests {
     use super::*;
 
-    type MetricSpace = Euclidean;
-
     mod distance {
         use super::*;
 
@@ -117,7 +122,7 @@ mod tests {
             let new_york_city = Point::new(-8238310.24, 4942194.78);
             // web mercator
             let london = Point::new(-14226.63, 6678077.70);
-            let distance: f64 = MetricSpace::distance(new_york_city, london);
+            let distance: f64 = Euclidean.distance(new_york_city, london);
 
             assert_relative_eq!(
                 8_405_286., // meters in web mercator
@@ -130,14 +135,14 @@ mod tests {
             let new_york_city = Point::new(-8_238_310.24, 4_942_194.78);
             // web mercator
             let london = Point::new(-14_226.63, 6_678_077.70);
-            let start = MetricSpace::point_at_distance_between(new_york_city, london, 0.0);
+            let start = Euclidean.point_at_distance_between(new_york_city, london, 0.0);
             assert_relative_eq!(new_york_city, start);
 
             let midway =
-                MetricSpace::point_at_distance_between(new_york_city, london, 8_405_286.0 / 2.0);
+                Euclidean.point_at_distance_between(new_york_city, london, 8_405_286.0 / 2.0);
             assert_relative_eq!(Point::new(-4_126_268., 5_810_136.), midway, epsilon = 1.0);
 
-            let end = MetricSpace::point_at_distance_between(new_york_city, london, 8_405_286.0);
+            let end = Euclidean.point_at_distance_between(new_york_city, london, 8_405_286.0);
             assert_relative_eq!(london, end, epsilon = 1.0);
         }
     }

--- a/geo/src/algorithm/line_measures/metric_spaces/geodesic.rs
+++ b/geo/src/algorithm/line_measures/metric_spaces/geodesic.rs
@@ -25,7 +25,7 @@ impl Bearing<f64> for Geodesic {
     ///
     /// let origin = Point::new(9.0, 10.0);
     /// let destination = Point::new(9.5, 10.1);
-    /// let bearing = Geodesic::bearing(origin, destination);
+    /// let bearing = Geodesic.bearing(origin, destination);
     /// // A little north of east
     /// assert_relative_eq!(bearing, 78.54, epsilon = 1.0e-2);
     /// ```
@@ -36,7 +36,7 @@ impl Bearing<f64> for Geodesic {
     ///
     /// [geodesic line]: https://en.wikipedia.org/wiki/Geodesics_on_an_ellipsoid
     /// [Karney (2013)]:  https://arxiv.org/pdf/1109.4448.pdf
-    fn bearing(origin: Point<f64>, destination: Point<f64>) -> f64 {
+    fn bearing(&self, origin: Point<f64>, destination: Point<f64>) -> f64 {
         let (azi1, _, _) = geographiclib_rs::Geodesic::wgs84().inverse(
             origin.y(),
             origin.x(),
@@ -71,7 +71,7 @@ impl Destination<f64> for Geodesic {
     /// let northeast_bearing = 45.0;
     /// let distance = 100_000.0;
     ///
-    /// let northeast_of_jfk = Geodesic::destination(jfk, northeast_bearing, distance);
+    /// let northeast_of_jfk = Geodesic.destination(jfk, northeast_bearing, distance);
     /// assert_relative_eq!(Point::new(-72.94, 41.27), northeast_of_jfk, epsilon = 1.0e-2);
     /// ```
     ///
@@ -81,7 +81,7 @@ impl Destination<f64> for Geodesic {
     ///
     /// [geodesic line]: https://en.wikipedia.org/wiki/Geodesics_on_an_ellipsoid
     /// [Karney (2013)]:  https://arxiv.org/pdf/1109.4448.pdf
-    fn destination(origin: Point<f64>, bearing: f64, distance: f64) -> Point<f64> {
+    fn destination(&self, origin: Point<f64>, bearing: f64, distance: f64) -> Point<f64> {
         let (lat, lon) =
             geographiclib_rs::Geodesic::wgs84().direct(origin.y(), origin.x(), bearing, distance);
         Point::new(lon, lat)
@@ -106,7 +106,7 @@ impl Distance<f64, Point<f64>, Point<f64>> for Geodesic {
     /// // London
     /// let london = Point::new(-0.1278, 51.5074);
     ///
-    /// let distance = Geodesic::distance(new_york_city, london);
+    /// let distance = Geodesic.distance(new_york_city, london);
     ///
     /// assert_eq!(
     ///     5_585_234., // meters
@@ -120,7 +120,7 @@ impl Distance<f64, Point<f64>, Point<f64>> for Geodesic {
     ///
     /// [geodesic line]: https://en.wikipedia.org/wiki/Geodesics_on_an_ellipsoid
     /// [Karney (2013)]:  https://arxiv.org/pdf/1109.4448.pdf
-    fn distance(origin: Point<f64>, destination: Point<f64>) -> f64 {
+    fn distance(&self, origin: Point<f64>, destination: Point<f64>) -> f64 {
         geographiclib_rs::Geodesic::wgs84().inverse(
             origin.y(),
             origin.x(),
@@ -150,10 +150,10 @@ impl InterpolatePoint<f64> for Geodesic {
     /// let p1 = Point::new(10.0, 20.0);
     /// let p2 = Point::new(125.0, 25.0);
     ///
-    /// let closer_to_p1 = Geodesic::point_at_distance_between(p1, p2, 100_000.0);
+    /// let closer_to_p1 = Geodesic.point_at_distance_between(p1, p2, 100_000.0);
     /// assert_relative_eq!(closer_to_p1, Point::new(10.81, 20.49), epsilon = 1.0e-2);
     ///
-    /// let closer_to_p2 = Geodesic::point_at_distance_between(p1, p2, 10_000_000.0);
+    /// let closer_to_p2 = Geodesic.point_at_distance_between(p1, p2, 10_000_000.0);
     /// assert_relative_eq!(closer_to_p2, Point::new(112.20, 30.67), epsilon = 1.0e-2);
     /// ```
     ///
@@ -164,6 +164,7 @@ impl InterpolatePoint<f64> for Geodesic {
     /// [geodesic line]: https://en.wikipedia.org/wiki/Geodesics_on_an_ellipsoid
     /// [Karney (2013)]:  https://arxiv.org/pdf/1109.4448.pdf
     fn point_at_distance_between(
+        &self,
         start: Point<f64>,
         end: Point<f64>,
         meters_from_start: f64,
@@ -171,8 +172,8 @@ impl InterpolatePoint<f64> for Geodesic {
         if meters_from_start == 0.0 {
             return start;
         }
-        let bearing = Self::bearing(start, end);
-        Self::destination(start, bearing, meters_from_start)
+        let bearing = Self.bearing(start, end);
+        Self.destination(start, bearing, meters_from_start)
     }
 
     /// Returns a new Point along a [geodesic line] between two existing points on an ellipsoidal model of the earth.
@@ -187,13 +188,13 @@ impl InterpolatePoint<f64> for Geodesic {
     /// let p1 = Point::new(10.0, 20.0);
     /// let p2 = Point::new(125.0, 25.0);
     ///
-    /// let closer_to_p1 = Geodesic::point_at_ratio_between(p1, p2, 0.1);
+    /// let closer_to_p1 = Geodesic.point_at_ratio_between(p1, p2, 0.1);
     /// assert_relative_eq!(closer_to_p1, Point::new(19.52, 25.31), epsilon = 1.0e-2);
     ///
-    /// let closer_to_p2 = Geodesic::point_at_ratio_between(p1, p2, 0.9);
+    /// let closer_to_p2 = Geodesic.point_at_ratio_between(p1, p2, 0.9);
     /// assert_relative_eq!(closer_to_p2, Point::new(114.73, 29.69), epsilon = 1.0e-2);
     ///
-    /// let midpoint = Geodesic::point_at_ratio_between(p1, p2, 0.5);
+    /// let midpoint = Geodesic.point_at_ratio_between(p1, p2, 0.5);
     /// assert_relative_eq!(midpoint, Point::new(65.88, 37.72), epsilon = 1.0e-2);
     /// ```
     ///
@@ -204,6 +205,7 @@ impl InterpolatePoint<f64> for Geodesic {
     /// [geodesic line]: https://en.wikipedia.org/wiki/Geodesics_on_an_ellipsoid
     /// [Karney (2013)]:  https://arxiv.org/pdf/1109.4448.pdf
     fn point_at_ratio_between(
+        &self,
         start: Point<f64>,
         end: Point<f64>,
         ratio_from_start: f64,
@@ -218,7 +220,7 @@ impl InterpolatePoint<f64> for Geodesic {
         let g = geographiclib_rs::Geodesic::wgs84();
         let (total_distance, azi1, _azi2, _a12) = g.inverse(start.y(), start.x(), end.y(), end.x());
         let distance = total_distance * ratio_from_start;
-        Self::destination(start, azi1, distance)
+        Self.destination(start, azi1, distance)
     }
 
     /// Interpolates `Point`s along a [geodesic line] between `start` and `end`.
@@ -236,6 +238,7 @@ impl InterpolatePoint<f64> for Geodesic {
     /// [geodesic line]: https://en.wikipedia.org/wiki/Geodesics_on_an_ellipsoid
     /// [Karney (2013)]:  https://arxiv.org/pdf/1109.4448.pdf
     fn points_along_line(
+        &self,
         start: Point<f64>,
         end: Point<f64>,
         max_distance: f64,
@@ -277,8 +280,6 @@ impl InterpolatePoint<f64> for Geodesic {
 mod tests {
     use super::*;
 
-    type MetricSpace = Geodesic;
-
     mod bearing {
         use super::*;
 
@@ -286,28 +287,28 @@ mod tests {
         fn north() {
             let origin = Point::new(0.0, 0.0);
             let destination = Point::new(0.0, 1.0);
-            assert_relative_eq!(0.0, MetricSpace::bearing(origin, destination));
+            assert_relative_eq!(0.0, Geodesic.bearing(origin, destination));
         }
 
         #[test]
         fn east() {
             let origin = Point::new(0.0, 0.0);
             let destination = Point::new(1.0, 0.0);
-            assert_relative_eq!(90.0, MetricSpace::bearing(origin, destination));
+            assert_relative_eq!(90.0, Geodesic.bearing(origin, destination));
         }
 
         #[test]
         fn south() {
             let origin = Point::new(0.0, 0.0);
             let destination = Point::new(0.0, -1.0);
-            assert_relative_eq!(180.0, MetricSpace::bearing(origin, destination));
+            assert_relative_eq!(180.0, Geodesic.bearing(origin, destination));
         }
 
         #[test]
         fn west() {
             let origin = Point::new(0.0, 0.0);
             let destination = Point::new(-1.0, 0.0);
-            assert_relative_eq!(270.0, MetricSpace::bearing(origin, destination));
+            assert_relative_eq!(270.0, Geodesic.bearing(origin, destination));
         }
     }
 
@@ -320,7 +321,7 @@ mod tests {
             let bearing = 0.0;
             assert_relative_eq!(
                 Point::new(0.0, 0.9043687229127633),
-                MetricSpace::destination(origin, bearing, 100_000.0)
+                Geodesic.destination(origin, bearing, 100_000.0)
             );
         }
 
@@ -330,7 +331,7 @@ mod tests {
             let bearing = 90.0;
             assert_relative_eq!(
                 Point::new(0.8983152841195217, 0.0),
-                MetricSpace::destination(origin, bearing, 100_000.0)
+                Geodesic.destination(origin, bearing, 100_000.0)
             );
         }
 
@@ -340,7 +341,7 @@ mod tests {
             let bearing = 180.0;
             assert_relative_eq!(
                 Point::new(0.0, -0.9043687229127633),
-                MetricSpace::destination(origin, bearing, 100_000.0)
+                Geodesic.destination(origin, bearing, 100_000.0)
             );
         }
 
@@ -350,7 +351,7 @@ mod tests {
             let bearing = 270.0;
             assert_relative_eq!(
                 Point::new(-0.8983152841195217, 0.0),
-                MetricSpace::destination(origin, bearing, 100_000.0)
+                Geodesic.destination(origin, bearing, 100_000.0)
             );
         }
 
@@ -362,7 +363,7 @@ mod tests {
                 let new_york_city = Point::new(-74.006f64, 40.7128f64);
                 let london = Point::new(-0.1278f64, 51.5074f64);
 
-                let distance = MetricSpace::distance(new_york_city, london);
+                let distance = Geodesic.distance(new_york_city, london);
 
                 assert_relative_eq!(
                     5_585_234.0, // meters
@@ -378,7 +379,7 @@ mod tests {
             fn point_at_ratio_between_midpoint() {
                 let start = Point::new(10.0, 20.0);
                 let end = Point::new(125.0, 25.0);
-                let midpoint = MetricSpace::point_at_ratio_between(start, end, 0.5);
+                let midpoint = Geodesic.point_at_ratio_between(start, end, 0.5);
                 assert_relative_eq!(midpoint, Point::new(65.87936072133309, 37.72225378005785));
             }
 
@@ -387,8 +388,9 @@ mod tests {
                 let start = Point::new(10.0, 20.0);
                 let end = Point::new(125.0, 25.0);
                 let max_dist = 1000000.0; // meters
-                let route =
-                    MetricSpace::points_along_line(start, end, max_dist, true).collect::<Vec<_>>();
+                let route = Geodesic
+                    .points_along_line(start, end, max_dist, true)
+                    .collect::<Vec<_>>();
                 assert_eq!(route.len(), 13);
                 assert_eq!(route[0], start);
                 assert_eq!(route.last().unwrap(), &end);
@@ -400,8 +402,9 @@ mod tests {
                 let start = Point::new(10.0, 20.0);
                 let end = Point::new(125.0, 25.0);
                 let max_dist = 1000000.0; // meters
-                let route =
-                    MetricSpace::points_along_line(start, end, max_dist, false).collect::<Vec<_>>();
+                let route = Geodesic
+                    .points_along_line(start, end, max_dist, false)
+                    .collect::<Vec<_>>();
                 assert_eq!(route.len(), 11);
                 assert_relative_eq!(route[0], Point::new(17.878754355562464, 24.466667836189565));
             }

--- a/geo/src/algorithm/line_measures/metric_spaces/haversine.rs
+++ b/geo/src/algorithm/line_measures/metric_spaces/haversine.rs
@@ -39,7 +39,7 @@ impl<F: CoordFloat + FromPrimitive> Bearing<F> for Haversine {
     ///
     /// let origin = Point::new(9.0, 10.0);
     /// let destination = Point::new(9.5, 10.1);
-    /// let bearing = Haversine::bearing(origin, destination);
+    /// let bearing = Haversine.bearing(origin, destination);
     /// // A little north of east
     /// assert_relative_eq!(bearing, 78.47, epsilon = 1.0e-2);
     /// ```
@@ -50,7 +50,7 @@ impl<F: CoordFloat + FromPrimitive> Bearing<F> for Haversine {
     /// (<https://dtcenter.org/met/users/docs/write_ups/gc_simple.pdf>)
     ///
     /// [great circle]: https://en.wikipedia.org/wiki/Great_circle
-    fn bearing(origin: Point<F>, destination: Point<F>) -> F {
+    fn bearing(&self, origin: Point<F>, destination: Point<F>) -> F {
         let three_sixty =
             F::from(360.0).expect("Numeric type to be constructable from primitive 360");
         let (lng_a, lat_a) = (origin.x().to_radians(), origin.y().to_radians());
@@ -83,7 +83,7 @@ impl<F: CoordFloat + FromPrimitive> Destination<F> for Haversine {
     /// use geo::Point;
     ///
     /// let origin = Point::new(9.177789688110352, 48.776781529534965);
-    /// let destination = Haversine::destination(origin, 45., 10000.);
+    /// let destination = Haversine.destination(origin, 45., 10000.);
     /// assert_relative_eq!(Point::new(9.274409949623532, 48.84033274015048), destination);
     /// ```
     ///
@@ -93,7 +93,7 @@ impl<F: CoordFloat + FromPrimitive> Destination<F> for Haversine {
     /// the IUGG](ftp://athena.fsv.cvut.cz/ZFG/grs80-Moritz.pdf)
     ///
     /// [great circle]: https://en.wikipedia.org/wiki/Great_circle
-    fn destination(origin: Point<F>, bearing: F, meters: F) -> Point<F> {
+    fn destination(&self, origin: Point<F>, bearing: F, meters: F) -> Point<F> {
         let center_lng = origin.x().to_radians();
         let center_lat = origin.y().to_radians();
         let bearing_rad = bearing.to_radians();
@@ -129,7 +129,7 @@ impl<F: CoordFloat + FromPrimitive> Distance<F, Point<F>, Point<F>> for Haversin
     /// let new_york_city = Point::new(-74.006f64, 40.7128f64);
     /// let london = Point::new(-0.1278f64, 51.5074f64);
     ///
-    /// let distance = Haversine::distance(new_york_city, london);
+    /// let distance = Haversine.distance(new_york_city, london);
     ///
     /// assert_relative_eq!(
     ///     5_570_230., // meters
@@ -143,7 +143,7 @@ impl<F: CoordFloat + FromPrimitive> Distance<F, Point<F>, Point<F>> for Haversin
     /// the IUGG](ftp://athena.fsv.cvut.cz/ZFG/grs80-Moritz.pdf)
     ///
     /// [haversine formula]: https://en.wikipedia.org/wiki/Haversine_formula
-    fn distance(origin: Point<F>, destination: Point<F>) -> F {
+    fn distance(&self, origin: Point<F>, destination: Point<F>) -> F {
         let two = F::one() + F::one();
         let theta1 = origin.y().to_radians();
         let theta2 = destination.y().to_radians();
@@ -172,17 +172,22 @@ impl<F: CoordFloat + FromPrimitive> InterpolatePoint<F> for Haversine {
     /// let p1 = Point::new(10.0, 20.0);
     /// let p2 = Point::new(125.0, 25.0);
     ///
-    /// let closer_to_p1 = Haversine::point_at_distance_between(p1, p2, 100_000.0);
+    /// let closer_to_p1 = Haversine.point_at_distance_between(p1, p2, 100_000.0);
     /// assert_relative_eq!(closer_to_p1, Point::new(10.81, 20.49), epsilon = 1.0e-2);
     ///
-    /// let closer_to_p2 = Haversine::point_at_distance_between(p1, p2, 10_000_000.0);
+    /// let closer_to_p2 = Haversine.point_at_distance_between(p1, p2, 10_000_000.0);
     /// assert_relative_eq!(closer_to_p2, Point::new(112.33, 30.57), epsilon = 1.0e-2);
     /// ```
     ///
     /// [great circle]: https://en.wikipedia.org/wiki/Great_circle
-    fn point_at_distance_between(start: Point<F>, end: Point<F>, meters_from_start: F) -> Point<F> {
-        let bearing = Self::bearing(start, end);
-        Self::destination(start, bearing, meters_from_start)
+    fn point_at_distance_between(
+        &self,
+        start: Point<F>,
+        end: Point<F>,
+        meters_from_start: F,
+    ) -> Point<F> {
+        let bearing = Self.bearing(start, end);
+        Self.destination(start, bearing, meters_from_start)
     }
 
     /// Returns a new Point along a [great circle] between two existing points.
@@ -197,18 +202,23 @@ impl<F: CoordFloat + FromPrimitive> InterpolatePoint<F> for Haversine {
     /// let p1 = Point::new(10.0, 20.0);
     /// let p2 = Point::new(125.0, 25.0);
     ///
-    /// let closer_to_p1 = Haversine::point_at_ratio_between(p1, p2, 0.1);
+    /// let closer_to_p1 = Haversine.point_at_ratio_between(p1, p2, 0.1);
     /// assert_relative_eq!(closer_to_p1, Point::new(19.52, 25.27), epsilon = 1.0e-2);
     ///
-    /// let closer_to_p2 = Haversine::point_at_ratio_between(p1, p2, 0.9);
+    /// let closer_to_p2 = Haversine.point_at_ratio_between(p1, p2, 0.9);
     /// assert_relative_eq!(closer_to_p2, Point::new(114.72, 29.65), epsilon = 1.0e-2);
     ///
-    /// let midpoint = Haversine::point_at_ratio_between(p1, p2, 0.5);
+    /// let midpoint = Haversine.point_at_ratio_between(p1, p2, 0.5);
     /// assert_relative_eq!(midpoint, Point::new(65.87, 37.62), epsilon = 1.0e-2);
     /// ```
     ///
     /// [great circle]: https://en.wikipedia.org/wiki/Great_circle
-    fn point_at_ratio_between(start: Point<F>, end: Point<F>, ratio_from_start: F) -> Point<F> {
+    fn point_at_ratio_between(
+        &self,
+        start: Point<F>,
+        end: Point<F>,
+        ratio_from_start: F,
+    ) -> Point<F> {
         if start == end || ratio_from_start == F::zero() {
             return start;
         }
@@ -230,6 +240,7 @@ impl<F: CoordFloat + FromPrimitive> InterpolatePoint<F> for Haversine {
     /// [great circle]: https://en.wikipedia.org/wiki/Great_circle
     /// [haversine formula]: https://en.wikipedia.org/wiki/Haversine_formula
     fn points_along_line(
+        &self,
         start: Point<F>,
         end: Point<F>,
         max_distance: F,
@@ -350,8 +361,6 @@ impl<T: CoordFloat + FromPrimitive> HaversineIntermediateFillCalculation<T> {
 mod tests {
     use super::*;
 
-    type MetricSpace = Haversine;
-
     mod bearing {
         use super::*;
 
@@ -359,28 +368,28 @@ mod tests {
         fn north() {
             let origin = Point::new(0.0, 0.0);
             let destination = Point::new(0.0, 1.0);
-            assert_relative_eq!(0.0, MetricSpace::bearing(origin, destination));
+            assert_relative_eq!(0.0, Haversine.bearing(origin, destination));
         }
 
         #[test]
         fn east() {
             let origin = Point::new(0.0, 0.0);
             let destination = Point::new(1.0, 0.0);
-            assert_relative_eq!(90.0, MetricSpace::bearing(origin, destination));
+            assert_relative_eq!(90.0, Haversine.bearing(origin, destination));
         }
 
         #[test]
         fn south() {
             let origin = Point::new(0.0, 0.0);
             let destination = Point::new(0.0, -1.0);
-            assert_relative_eq!(180.0, MetricSpace::bearing(origin, destination));
+            assert_relative_eq!(180.0, Haversine.bearing(origin, destination));
         }
 
         #[test]
         fn west() {
             let origin = Point::new(0.0, 0.0);
             let destination = Point::new(-1.0, 0.0);
-            assert_relative_eq!(270.0, MetricSpace::bearing(origin, destination));
+            assert_relative_eq!(270.0, Haversine.bearing(origin, destination));
         }
     }
 
@@ -393,7 +402,7 @@ mod tests {
             let bearing = 0.0;
             assert_relative_eq!(
                 Point::new(0.0, 0.899320363724538),
-                MetricSpace::destination(origin, bearing, 100_000.0)
+                Haversine.destination(origin, bearing, 100_000.0)
             );
         }
 
@@ -403,7 +412,7 @@ mod tests {
             let bearing = 90.0;
             assert_relative_eq!(
                 Point::new(0.8993203637245415, 5.506522912913066e-17),
-                MetricSpace::destination(origin, bearing, 100_000.0)
+                Haversine.destination(origin, bearing, 100_000.0)
             );
         }
 
@@ -413,7 +422,7 @@ mod tests {
             let bearing = 180.0;
             assert_relative_eq!(
                 Point::new(0.0, -0.899320363724538),
-                MetricSpace::destination(origin, bearing, 100_000.0)
+                Haversine.destination(origin, bearing, 100_000.0)
             );
         }
 
@@ -423,7 +432,7 @@ mod tests {
             let bearing = 270.0;
             assert_relative_eq!(
                 Point::new(-0.8993203637245415, -1.6519568738739197e-16),
-                MetricSpace::destination(origin, bearing, 100_000.0)
+                Haversine.destination(origin, bearing, 100_000.0)
             );
         }
     }
@@ -436,7 +445,7 @@ mod tests {
             let new_york_city = Point::new(-74.006f64, 40.7128f64);
             let london = Point::new(-0.1278f64, 51.5074f64);
 
-            let distance = MetricSpace::distance(new_york_city, london);
+            let distance = Haversine.distance(new_york_city, london);
 
             assert_relative_eq!(
                 5_570_230., // meters
@@ -451,7 +460,7 @@ mod tests {
         fn point_at_ratio_between_midpoint() {
             let start = Point::new(10.0, 20.0);
             let end = Point::new(125.0, 25.0);
-            let midpoint = MetricSpace::point_at_ratio_between(start, end, 0.5);
+            let midpoint = Haversine.point_at_ratio_between(start, end, 0.5);
             assert_relative_eq!(midpoint, Point::new(65.87394172511485, 37.61809316888599));
         }
         #[test]
@@ -459,8 +468,9 @@ mod tests {
             let start = Point::new(10.0, 20.0);
             let end = Point::new(125.0, 25.0);
             let max_dist = 1000000.0; // meters
-            let route =
-                MetricSpace::points_along_line(start, end, max_dist, true).collect::<Vec<_>>();
+            let route = Haversine
+                .points_along_line(start, end, max_dist, true)
+                .collect::<Vec<_>>();
             assert_eq!(route.len(), 13);
             assert_eq!(route[0], start);
             assert_eq!(route.last().unwrap(), &end);
@@ -471,8 +481,9 @@ mod tests {
             let start = Point::new(10.0, 20.0);
             let end = Point::new(125.0, 25.0);
             let max_dist = 1000000.0; // meters
-            let route =
-                MetricSpace::points_along_line(start, end, max_dist, false).collect::<Vec<_>>();
+            let route = Haversine
+                .points_along_line(start, end, max_dist, false)
+                .collect::<Vec<_>>();
             assert_eq!(route.len(), 11);
             assert_relative_eq!(route[0], Point::new(17.882467331860965, 24.435542998803793));
         }

--- a/geo/src/algorithm/line_measures/metric_spaces/mod.rs
+++ b/geo/src/algorithm/line_measures/metric_spaces/mod.rs
@@ -5,7 +5,7 @@ mod geodesic;
 pub use geodesic::Geodesic;
 
 mod haversine;
-pub use haversine::Haversine;
+pub use haversine::{CustomHaversine, Haversine};
 
 mod rhumb;
 pub use rhumb::Rhumb;

--- a/geo/src/algorithm/line_measures/metric_spaces/rhumb.rs
+++ b/geo/src/algorithm/line_measures/metric_spaces/rhumb.rs
@@ -39,7 +39,7 @@ impl<F: CoordFloat + FromPrimitive> Bearing<F> for Rhumb {
     ///
     /// let origin = Point::new(9.177789688110352, 48.776781529534965);
     /// let destination = Point::new(9.274348757829898, 48.84037308229984);
-    /// let bearing = Rhumb::bearing(origin, destination);
+    /// let bearing = Rhumb.bearing(origin, destination);
     /// assert_relative_eq!(bearing, 45., epsilon = 1.0e-6);
     /// ```
     ///
@@ -49,7 +49,7 @@ impl<F: CoordFloat + FromPrimitive> Bearing<F> for Rhumb {
     ///
     /// Bullock, R.: Great Circle Distances and Bearings Between Two Locations, 2007.
     /// (<https://dtcenter.org/met/users/docs/write_ups/gc_simple.pdf>)
-    fn bearing(origin: Point<F>, destination: Point<F>) -> F {
+    fn bearing(&self, origin: Point<F>, destination: Point<F>) -> F {
         let three_sixty = F::from(360.0f64).unwrap();
 
         let calculations = RhumbCalculations::new(&origin, &destination);
@@ -76,12 +76,12 @@ impl<F: CoordFloat + FromPrimitive> Destination<F> for Rhumb {
     /// use geo::Point;
     ///
     /// let p_1 = Point::new(9.177789688110352, 48.776781529534965);
-    /// let p_2 = Rhumb::destination(p_1, 45., 10000.);
+    /// let p_2 = Rhumb.destination(p_1, 45., 10000.);
     /// assert_relative_eq!(p_2, Point::new(9.274348757829898, 48.84037308229984))
     /// ```
     ///
     /// [rhumb line]: https://en.wikipedia.org/wiki/Rhumb_line
-    fn destination(origin: Point<F>, bearing: F, distance: F) -> Point<F> {
+    fn destination(&self, origin: Point<F>, bearing: F, distance: F) -> Point<F> {
         let delta = distance / F::from(MEAN_EARTH_RADIUS).unwrap(); // angular distance in radians
         let lambda1 = origin.x().to_radians();
         let phi1 = origin.y().to_radians();
@@ -111,7 +111,7 @@ impl<F: CoordFloat + FromPrimitive> Distance<F, Point<F>, Point<F>> for Rhumb {
     /// // London
     /// let p2 = point!(x: -0.1278, y: 51.5074);
     ///
-    /// let distance = Rhumb::distance(p1, p2);
+    /// let distance = Rhumb.distance(p1, p2);
     ///
     /// assert_eq!(
     ///     5_794_129., // meters
@@ -120,7 +120,7 @@ impl<F: CoordFloat + FromPrimitive> Distance<F, Point<F>, Point<F>> for Rhumb {
     /// ```
     ///
     /// [rhumb line]: https://en.wikipedia.org/wiki/Rhumb_line
-    fn distance(origin: Point<F>, destination: Point<F>) -> F {
+    fn distance(&self, origin: Point<F>, destination: Point<F>) -> F {
         let calculations = RhumbCalculations::new(&origin, &destination);
         calculations.delta() * F::from(MEAN_EARTH_RADIUS).unwrap()
     }
@@ -142,17 +142,22 @@ impl<F: CoordFloat + FromPrimitive> InterpolatePoint<F> for Rhumb {
     /// let p1 = Point::new(10.0, 20.0);
     /// let p2 = Point::new(125.0, 25.0);
     ///
-    /// let closer_to_p1 = Rhumb::point_at_distance_between(p1, p2, 100_000.0);
+    /// let closer_to_p1 = Rhumb.point_at_distance_between(p1, p2, 100_000.0);
     /// assert_relative_eq!(closer_to_p1, Point::new(10.96, 20.04), epsilon = 1.0e-2);
     ///
-    /// let closer_to_p2 = Rhumb::point_at_distance_between(p1, p2, 10_000_000.0);
+    /// let closer_to_p2 = Rhumb.point_at_distance_between(p1, p2, 10_000_000.0);
     /// assert_relative_eq!(closer_to_p2, Point::new(107.00, 24.23), epsilon = 1.0e-2);
     /// ```
     ///
     /// [rhumb line]: https://en.wikipedia.org/wiki/Rhumb_line
-    fn point_at_distance_between(start: Point<F>, end: Point<F>, meters_from_start: F) -> Point<F> {
-        let bearing = Self::bearing(start, end);
-        Self::destination(start, bearing, meters_from_start)
+    fn point_at_distance_between(
+        &self,
+        start: Point<F>,
+        end: Point<F>,
+        meters_from_start: F,
+    ) -> Point<F> {
+        let bearing = Self.bearing(start, end);
+        Self.destination(start, bearing, meters_from_start)
     }
 
     /// Returns a new Point along a [rhumb line] between two existing points.
@@ -167,18 +172,23 @@ impl<F: CoordFloat + FromPrimitive> InterpolatePoint<F> for Rhumb {
     /// let p1 = Point::new(10.0, 20.0);
     /// let p2 = Point::new(125.0, 25.0);
     ///
-    /// let closer_to_p1 = Rhumb::point_at_ratio_between(p1, p2, 0.1);
+    /// let closer_to_p1 = Rhumb.point_at_ratio_between(p1, p2, 0.1);
     /// assert_relative_eq!(closer_to_p1, Point::new(21.32, 20.50), epsilon = 1.0e-2);
     ///
-    /// let closer_to_p2 = Rhumb::point_at_ratio_between(p1, p2, 0.9);
+    /// let closer_to_p2 = Rhumb.point_at_ratio_between(p1, p2, 0.9);
     /// assert_relative_eq!(closer_to_p2, Point::new(113.31, 24.50), epsilon = 1.0e-2);
     ///
-    /// let midpoint = Rhumb::point_at_ratio_between(p1, p2, 0.5);
+    /// let midpoint = Rhumb.point_at_ratio_between(p1, p2, 0.5);
     /// assert_relative_eq!(midpoint, Point::new(66.98, 22.50), epsilon = 1.0e-2);
     /// ```
     ///
     /// [rhumb line]: https://en.wikipedia.org/wiki/Rhumb_line
-    fn point_at_ratio_between(start: Point<F>, end: Point<F>, ratio_from_start: F) -> Point<F> {
+    fn point_at_ratio_between(
+        &self,
+        start: Point<F>,
+        end: Point<F>,
+        ratio_from_start: F,
+    ) -> Point<F> {
         let calculations = RhumbCalculations::new(&start, &end);
         calculations.intermediate(ratio_from_start)
     }
@@ -193,6 +203,7 @@ impl<F: CoordFloat + FromPrimitive> InterpolatePoint<F> for Rhumb {
     ///
     /// [rhumb line]: https://en.wikipedia.org/wiki/Rhumb_line
     fn points_along_line(
+        &self,
         start: Point<F>,
         end: Point<F>,
         max_distance: F,
@@ -210,8 +221,6 @@ impl<F: CoordFloat + FromPrimitive> InterpolatePoint<F> for Rhumb {
 mod tests {
     use super::*;
 
-    type MetricSpace = Rhumb;
-
     mod bearing {
         use super::*;
 
@@ -219,28 +228,28 @@ mod tests {
         fn north() {
             let origin = Point::new(0.0, 0.0);
             let destination = Point::new(0.0, 1.0);
-            assert_relative_eq!(0.0, MetricSpace::bearing(origin, destination));
+            assert_relative_eq!(0.0, Rhumb.bearing(origin, destination));
         }
 
         #[test]
         fn east() {
             let origin = Point::new(0.0, 0.0);
             let destination = Point::new(1.0, 0.0);
-            assert_relative_eq!(90.0, MetricSpace::bearing(origin, destination));
+            assert_relative_eq!(90.0, Rhumb.bearing(origin, destination));
         }
 
         #[test]
         fn south() {
             let origin = Point::new(0.0, 0.0);
             let destination = Point::new(0.0, -1.0);
-            assert_relative_eq!(180.0, MetricSpace::bearing(origin, destination));
+            assert_relative_eq!(180.0, Rhumb.bearing(origin, destination));
         }
 
         #[test]
         fn west() {
             let origin = Point::new(0.0, 0.0);
             let destination = Point::new(-1.0, 0.0);
-            assert_relative_eq!(270.0, MetricSpace::bearing(origin, destination));
+            assert_relative_eq!(270.0, Rhumb.bearing(origin, destination));
         }
     }
 
@@ -253,7 +262,7 @@ mod tests {
             let bearing = 0.0;
             assert_relative_eq!(
                 Point::new(0.0, 0.899320363724538),
-                MetricSpace::destination(origin, bearing, 100_000.0)
+                Rhumb.destination(origin, bearing, 100_000.0)
             );
         }
 
@@ -263,7 +272,7 @@ mod tests {
             let bearing = 90.0;
             assert_relative_eq!(
                 Point::new(0.8993203637245415, 5.506522912913066e-17),
-                MetricSpace::destination(origin, bearing, 100_000.0)
+                Rhumb.destination(origin, bearing, 100_000.0)
             );
         }
 
@@ -273,7 +282,7 @@ mod tests {
             let bearing = 180.0;
             assert_relative_eq!(
                 Point::new(0.0, -0.899320363724538),
-                MetricSpace::destination(origin, bearing, 100_000.0)
+                Rhumb.destination(origin, bearing, 100_000.0)
             );
         }
 
@@ -283,7 +292,7 @@ mod tests {
             let bearing = 270.0;
             assert_relative_eq!(
                 Point::new(-0.8993203637245415, -1.6520247072649334e-16),
-                MetricSpace::destination(origin, bearing, 100_000.0)
+                Rhumb.destination(origin, bearing, 100_000.0)
             );
         }
     }
@@ -296,7 +305,7 @@ mod tests {
             let new_york_city = Point::new(-74.006, 40.7128);
             let london = Point::new(-0.1278, 51.5074);
 
-            let distance: f64 = MetricSpace::distance(new_york_city, london);
+            let distance: f64 = Rhumb.distance(new_york_city, london);
 
             assert_relative_eq!(
                 5_794_129., // meters
@@ -312,7 +321,7 @@ mod tests {
         fn point_at_ratio_between_midpoint() {
             let start = Point::new(10.0, 20.0);
             let end = Point::new(125.0, 25.0);
-            let midpoint = MetricSpace::point_at_ratio_between(start, end, 0.5);
+            let midpoint = Rhumb.point_at_ratio_between(start, end, 0.5);
             assert_relative_eq!(
                 midpoint,
                 Point::new(66.98011173721943, 22.500000000000007),
@@ -324,8 +333,9 @@ mod tests {
             let start = Point::new(10.0, 20.0);
             let end = Point::new(125.0, 25.0);
             let max_dist = 1000000.0; // meters
-            let route =
-                MetricSpace::points_along_line(start, end, max_dist, true).collect::<Vec<_>>();
+            let route = Rhumb
+                .points_along_line(start, end, max_dist, true)
+                .collect::<Vec<_>>();
             assert_eq!(route.len(), 13);
             assert_eq!(route[0], start);
             assert_eq!(route.last().unwrap(), &end);
@@ -340,8 +350,9 @@ mod tests {
             let start = Point::new(10.0, 20.0);
             let end = Point::new(125.0, 25.0);
             let max_dist = 1000000.0; // meters
-            let route =
-                MetricSpace::points_along_line(start, end, max_dist, false).collect::<Vec<_>>();
+            let route = Rhumb
+                .points_along_line(start, end, max_dist, false)
+                .collect::<Vec<_>>();
             assert_eq!(route.len(), 11);
             assert_relative_eq!(
                 route[0],

--- a/geo/src/algorithm/line_measures/mod.rs
+++ b/geo/src/algorithm/line_measures/mod.rs
@@ -13,10 +13,10 @@ mod interpolate_point;
 pub use interpolate_point::InterpolatePoint;
 
 mod length;
-pub use length::Length;
+pub use length::{Length, LengthMeasurable};
 
 mod densify;
-pub use densify::Densify;
+pub use densify::{Densifiable, Densify};
 
 pub mod metric_spaces;
 pub use metric_spaces::{Euclidean, Geodesic, Haversine, Rhumb};

--- a/geo/src/algorithm/linestring_segment.rs
+++ b/geo/src/algorithm/linestring_segment.rs
@@ -45,7 +45,7 @@ pub trait LineStringSegmentizeHaversine {
 }
 
 macro_rules! implement_segmentize {
-    ($trait_name:ident, $method_name:ident, $metric_space:ty) => {
+    ($trait_name:ident, $method_name:ident, $metric_space:expr) => {
         impl $trait_name for LineString {
             fn $method_name(&self, n: usize) -> Option<MultiLineString> {
                 if (n == usize::MIN) || (n == usize::MAX) {
@@ -56,11 +56,11 @@ macro_rules! implement_segmentize {
                 }
 
                 let mut res_coords: Vec<Vec<Coord>> = Vec::with_capacity(n);
-                let total_length = self.length::<$metric_space>();
+                let total_length = self.length(&$metric_space);
                 let mut cum_length = 0_f64;
                 let segment_prop = (1_f64) / (n as f64);
                 let segment_length = total_length * segment_prop;
-                let densified = self.densify::<$metric_space>(segment_length - f64::EPSILON);
+                let densified = self.densify(&$metric_space, segment_length - f64::EPSILON);
 
                 if densified.lines().count() == n {
                     let linestrings = densified
@@ -79,7 +79,7 @@ macro_rules! implement_segmentize {
                         ln_vec.push(segment.start)
                     }
 
-                    let length = segment.length::<$metric_space>();
+                    let length = segment.length(&$metric_space);
                     cum_length += length;
 
                     if (cum_length >= segment_length) && (i != (n_lines - 1)) {
@@ -148,10 +148,7 @@ mod test {
         let segments = linestring.line_segmentize(4).unwrap();
         assert_eq!(segments.0.len(), 4);
 
-        assert_eq!(
-            segments.length::<Euclidean>(),
-            linestring.length::<Euclidean>()
-        );
+        assert_eq!(segments.length(&Euclidean), linestring.length(&Euclidean));
     }
 
     #[test]
@@ -170,8 +167,8 @@ mod test {
         let segments = linestring.line_segmentize(5).unwrap();
         assert_eq!(segments.0.len(), 5);
         assert_relative_eq!(
-            linestring.length::<Euclidean>(),
-            segments.length::<Euclidean>(),
+            linestring.length(&Euclidean),
+            segments.length(&Euclidean),
             epsilon = f64::EPSILON
         );
     }
@@ -183,8 +180,8 @@ mod test {
         let segments = linestring.line_segmentize(5).unwrap();
         assert_eq!(segments.0.len(), 5);
         assert_relative_eq!(
-            linestring.length::<Euclidean>(),
-            segments.length::<Euclidean>(),
+            linestring.length(&Euclidean),
+            segments.length(&Euclidean),
             epsilon = f64::EPSILON
         );
     }
@@ -221,8 +218,8 @@ mod test {
         assert_eq!(segments.0.len(), 5);
 
         assert_relative_eq!(
-            linestring.length::<Euclidean>(),
-            segments.length::<Euclidean>(),
+            linestring.length(&Euclidean),
+            segments.length(&Euclidean),
             epsilon = f64::EPSILON
         );
     }
@@ -253,7 +250,7 @@ mod test {
         // assert that the lines are equal length
         let lens = segments
             .into_iter()
-            .map(|x| x.length::<Euclidean>())
+            .map(|x| x.length(&Euclidean))
             .collect::<Vec<f64>>();
 
         let first = lens[0];
@@ -270,8 +267,8 @@ mod test {
         let segments = linestring.line_segmentize(2).unwrap();
 
         assert_relative_eq!(
-            linestring.length::<Euclidean>(),
-            segments.length::<Euclidean>(),
+            linestring.length(&Euclidean),
+            segments.length(&Euclidean),
             epsilon = f64::EPSILON
         )
     }
@@ -329,7 +326,7 @@ mod test {
         let lens = segments
             .0
             .iter()
-            .map(|li| li.length::<Haversine>())
+            .map(|li| li.length(&Haversine))
             .collect::<Vec<_>>();
 
         let epsilon = 1e-6; // 6th decimal place which is micrometers
@@ -345,7 +342,7 @@ mod test {
         ]
         .into();
 
-        assert_relative_eq!(linestring.length::<Haversine>(), 83.3523000093029);
+        assert_relative_eq!(linestring.length(&Haversine), 83.3523000093029);
 
         let n = 8;
 
@@ -353,8 +350,8 @@ mod test {
 
         // different at 12th decimal which is a picometer
         assert_relative_eq!(
-            linestring.length::<Haversine>(),
-            segments.length::<Haversine>(),
+            linestring.length(&Haversine),
+            segments.length(&Haversine),
             epsilon = 1e-11
         );
     }

--- a/geo/src/algorithm/linestring_segment.rs
+++ b/geo/src/algorithm/linestring_segment.rs
@@ -56,11 +56,11 @@ macro_rules! implement_segmentize {
                 }
 
                 let mut res_coords: Vec<Vec<Coord>> = Vec::with_capacity(n);
-                let total_length = self.length(&$metric_space);
+                let total_length = $metric_space.length(self);
                 let mut cum_length = 0_f64;
                 let segment_prop = (1_f64) / (n as f64);
                 let segment_length = total_length * segment_prop;
-                let densified = self.densify(&$metric_space, segment_length - f64::EPSILON);
+                let densified = $metric_space.densify(self, segment_length - f64::EPSILON);
 
                 if densified.lines().count() == n {
                     let linestrings = densified
@@ -79,7 +79,7 @@ macro_rules! implement_segmentize {
                         ln_vec.push(segment.start)
                     }
 
-                    let length = segment.length(&$metric_space);
+                    let length = $metric_space.length(&segment);
                     cum_length += length;
 
                     if (cum_length >= segment_length) && (i != (n_lines - 1)) {
@@ -148,7 +148,7 @@ mod test {
         let segments = linestring.line_segmentize(4).unwrap();
         assert_eq!(segments.0.len(), 4);
 
-        assert_eq!(segments.length(&Euclidean), linestring.length(&Euclidean));
+        assert_eq!(Euclidean.length(&segments), Euclidean.length(&linestring));
     }
 
     #[test]
@@ -167,8 +167,8 @@ mod test {
         let segments = linestring.line_segmentize(5).unwrap();
         assert_eq!(segments.0.len(), 5);
         assert_relative_eq!(
-            linestring.length(&Euclidean),
-            segments.length(&Euclidean),
+            Euclidean.length(&linestring),
+            Euclidean.length(&segments),
             epsilon = f64::EPSILON
         );
     }
@@ -180,8 +180,8 @@ mod test {
         let segments = linestring.line_segmentize(5).unwrap();
         assert_eq!(segments.0.len(), 5);
         assert_relative_eq!(
-            linestring.length(&Euclidean),
-            segments.length(&Euclidean),
+            Euclidean.length(&linestring),
+            Euclidean.length(&segments),
             epsilon = f64::EPSILON
         );
     }
@@ -218,8 +218,8 @@ mod test {
         assert_eq!(segments.0.len(), 5);
 
         assert_relative_eq!(
-            linestring.length(&Euclidean),
-            segments.length(&Euclidean),
+            Euclidean.length(&linestring),
+            Euclidean.length(&segments),
             epsilon = f64::EPSILON
         );
     }
@@ -250,7 +250,7 @@ mod test {
         // assert that the lines are equal length
         let lens = segments
             .into_iter()
-            .map(|x| x.length(&Euclidean))
+            .map(|x| Euclidean.length(&x))
             .collect::<Vec<f64>>();
 
         let first = lens[0];
@@ -267,8 +267,8 @@ mod test {
         let segments = linestring.line_segmentize(2).unwrap();
 
         assert_relative_eq!(
-            linestring.length(&Euclidean),
-            segments.length(&Euclidean),
+            Euclidean.length(&linestring),
+            Euclidean.length(&segments),
             epsilon = f64::EPSILON
         )
     }
@@ -326,7 +326,7 @@ mod test {
         let lens = segments
             .0
             .iter()
-            .map(|li| li.length(&Haversine))
+            .map(|li| Haversine.length(li))
             .collect::<Vec<_>>();
 
         let epsilon = 1e-6; // 6th decimal place which is micrometers
@@ -342,7 +342,7 @@ mod test {
         ]
         .into();
 
-        assert_relative_eq!(linestring.length(&Haversine), 83.3523000093029);
+        assert_relative_eq!(Haversine.length(&linestring), 83.3523000093029);
 
         let n = 8;
 
@@ -350,8 +350,8 @@ mod test {
 
         // different at 12th decimal which is a picometer
         assert_relative_eq!(
-            linestring.length(&Haversine),
-            segments.length(&Haversine),
+            Haversine.length(&linestring),
+            Haversine.length(&segments),
             epsilon = 1e-11
         );
     }

--- a/geo/src/algorithm/mod.rs
+++ b/geo/src/algorithm/mod.rs
@@ -187,7 +187,7 @@ pub mod lines_iter;
 pub use lines_iter::LinesIter;
 
 pub mod line_measures;
-pub use line_measures::metric_spaces::{Euclidean, Geodesic, Haversine, Rhumb};
+pub use line_measures::metric_spaces::{CustomHaversine, Euclidean, Geodesic, Haversine, Rhumb};
 pub use line_measures::{Bearing, Densify, Destination, Distance, InterpolatePoint, Length};
 
 /// Split a LineString into n segments

--- a/geo/src/algorithm/rhumb/bearing.rs
+++ b/geo/src/algorithm/rhumb/bearing.rs
@@ -4,7 +4,7 @@ use crate::{Bearing, CoordFloat, Point, Rhumb};
 
 #[deprecated(
     since = "0.29.0",
-    note = "Please use the `Rhumb::bearing` method from the `Bearing` trait instead"
+    note = "Please use the `Rhumb.bearing` method from the `Bearing` trait instead"
 )]
 /// Returns the bearing to another Point in degrees.
 ///
@@ -37,7 +37,7 @@ where
     T: CoordFloat + FromPrimitive,
 {
     fn rhumb_bearing(&self, point: Point<T>) -> T {
-        Rhumb::bearing(*self, point)
+        Rhumb.bearing(*self, point)
     }
 }
 

--- a/geo/src/algorithm/rhumb/destination.rs
+++ b/geo/src/algorithm/rhumb/destination.rs
@@ -3,7 +3,7 @@ use num_traits::FromPrimitive;
 
 #[deprecated(
     since = "0.29.0",
-    note = "Please use the `Rhumb::destination` method from the `Destination` trait instead"
+    note = "Please use the `Rhumb.destination` method from the `Destination` trait instead"
 )]
 /// Returns the destination Point having travelled the given distance along a [rhumb line]
 /// from the origin geometry with the given bearing
@@ -41,7 +41,7 @@ where
     T: CoordFloat + FromPrimitive,
 {
     fn rhumb_destination(&self, bearing: T, distance: T) -> Point<T> {
-        Rhumb::destination(*self, bearing, distance)
+        Rhumb.destination(*self, bearing, distance)
     }
 }
 

--- a/geo/src/algorithm/rhumb/distance.rs
+++ b/geo/src/algorithm/rhumb/distance.rs
@@ -3,7 +3,7 @@ use num_traits::FromPrimitive;
 
 #[deprecated(
     since = "0.29.0",
-    note = "Please use the `Rhumb::distance` method from the `Distance` trait instead"
+    note = "Please use the `Rhumb.distance` method from the `Distance` trait instead"
 )]
 /// Determine the distance between two geometries along a [rhumb line].
 ///
@@ -49,7 +49,7 @@ where
     T: CoordFloat + FromPrimitive,
 {
     fn rhumb_distance(&self, rhs: &Point<T>) -> T {
-        Rhumb::distance(*self, *rhs)
+        Rhumb.distance(*self, *rhs)
     }
 }
 

--- a/geo/src/algorithm/rhumb/intermediate.rs
+++ b/geo/src/algorithm/rhumb/intermediate.rs
@@ -9,7 +9,7 @@ use num_traits::FromPrimitive;
 pub trait RhumbIntermediate<T: CoordFloat> {
     #[deprecated(
         since = "0.29.0",
-        note = "Please use `Rhumb::point_at_ratio_between` from the `InterpolatePoint` trait instead"
+        note = "Please use `Rhumb.point_at_ratio_between` from the `InterpolatePoint` trait instead"
     )]
     /// Returns a new Point along a [rhumb line] between two existing points.
     ///
@@ -44,7 +44,7 @@ pub trait RhumbIntermediate<T: CoordFloat> {
 
     #[deprecated(
         since = "0.29.0",
-        note = "Please use `Rhumb::points_along_line` from the `InterpolatePoint` trait instead"
+        note = "Please use `Rhumb.points_along_line` from the `InterpolatePoint` trait instead"
     )]
     fn rhumb_intermediate_fill(
         &self,
@@ -60,7 +60,7 @@ where
     T: CoordFloat + FromPrimitive,
 {
     fn rhumb_intermediate(&self, other: &Point<T>, f: T) -> Point<T> {
-        Rhumb::point_at_ratio_between(*self, *other, f)
+        Rhumb.point_at_ratio_between(*self, *other, f)
     }
 
     fn rhumb_intermediate_fill(
@@ -69,7 +69,9 @@ where
         max_dist: T,
         include_ends: bool,
     ) -> Vec<Point<T>> {
-        Rhumb::points_along_line(*self, *other, max_dist, include_ends).collect()
+        Rhumb
+            .points_along_line(*self, *other, max_dist, include_ends)
+            .collect()
     }
 }
 

--- a/geo/src/algorithm/rhumb/length.rs
+++ b/geo/src/algorithm/rhumb/length.rs
@@ -50,7 +50,7 @@ where
     T: CoordFloat + FromPrimitive,
 {
     fn rhumb_length(&self) -> T {
-        self.length::<Rhumb>()
+        self.length(&Rhumb)
     }
 }
 
@@ -60,7 +60,7 @@ where
     T: CoordFloat + FromPrimitive,
 {
     fn rhumb_length(&self) -> T {
-        self.length::<Rhumb>()
+        self.length(&Rhumb)
     }
 }
 
@@ -70,6 +70,6 @@ where
     T: CoordFloat + FromPrimitive,
 {
     fn rhumb_length(&self) -> T {
-        self.length::<Rhumb>()
+        self.length(&Rhumb)
     }
 }

--- a/geo/src/algorithm/rhumb/length.rs
+++ b/geo/src/algorithm/rhumb/length.rs
@@ -4,7 +4,7 @@ use crate::{CoordFloat, Length, Line, LineString, MultiLineString, Rhumb};
 
 #[deprecated(
     since = "0.29.0",
-    note = "Please use the `line.length::<Rhumb>()` via the `Length` trait instead."
+    note = "Please use the `Rhumb.length(&line)` via the `Length` trait instead."
 )]
 /// Determine the length of a geometry assuming each segment is a [rhumb line].
 ///
@@ -50,7 +50,7 @@ where
     T: CoordFloat + FromPrimitive,
 {
     fn rhumb_length(&self) -> T {
-        self.length(&Rhumb)
+        Rhumb.length(self)
     }
 }
 
@@ -60,7 +60,7 @@ where
     T: CoordFloat + FromPrimitive,
 {
     fn rhumb_length(&self) -> T {
-        self.length(&Rhumb)
+        Rhumb.length(self)
     }
 }
 
@@ -70,6 +70,6 @@ where
     T: CoordFloat + FromPrimitive,
 {
     fn rhumb_length(&self) -> T {
-        self.length(&Rhumb)
+        Rhumb.length(self)
     }
 }

--- a/geo/src/algorithm/simplify.rs
+++ b/geo/src/algorithm/simplify.rs
@@ -97,12 +97,7 @@ where
         .enumerate()
         .take(rdp_indices.len() - 1) // Don't include the last index
         .skip(1) // Don't include the first index
-        .map(|(index, rdp_index)| {
-            (
-                index,
-                Euclidean::distance(rdp_index.coord, &first_last_line),
-            )
-        })
+        .map(|(index, rdp_index)| (index, Euclidean.distance(rdp_index.coord, &first_last_line)))
         .fold(
             (0usize, T::zero()),
             |(farthest_index, farthest_distance), (index, distance)| {

--- a/geo/src/algorithm/triangulate_spade.rs
+++ b/geo/src/algorithm/triangulate_spade.rs
@@ -530,12 +530,13 @@ fn snap_or_register_point<T: SpadeTriangulationFloat>(
         .iter()
         // find closest
         .min_by(|a, b| {
-            Euclidean::distance(**a, point)
-                .partial_cmp(&Euclidean::distance(**b, point))
+            Euclidean
+                .distance(**a, point)
+                .partial_cmp(&Euclidean.distance(**b, point))
                 .expect("Couldn't compare coordinate distances")
         })
         // only snap if closest is within epsilon range
-        .filter(|nearest_point| Euclidean::distance(**nearest_point, point) < snap_radius)
+        .filter(|nearest_point| Euclidean.distance(**nearest_point, point) < snap_radius)
         .cloned()
         // otherwise register and use input point
         .unwrap_or_else(|| {

--- a/geo/src/types.rs
+++ b/geo/src/types.rs
@@ -29,7 +29,7 @@ impl<F: GeoFloat> Closest<F> {
             Closest::SinglePoint(r) => r,
         };
 
-        if Euclidean::distance(left, p) <= Euclidean::distance(right, p) {
+        if Euclidean.distance(left, p) <= Euclidean.distance(right, p) {
             *self
         } else {
             *other


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

## Motivation

Currently, our [`Haversine`](https://docs.rs/geo/latest/geo/algorithm/line_measures/metric_spaces/struct.Haversine.html) metric space calculation uses the IUGG's "mean radius", but there are several other reasonable values. Similarly, the [`Geodesic`](https://docs.rs/geo/latest/geo/algorithm/line_measures/metric_spaces/struct.Geodesic.html) internally uses Karney's geographic algorithms which support other geoid parameters.

## Proposal

By reorganizing our traits, we can let users take advantage of all the associated algorithms (length, densify, distance) for any given (potentially customizable) metric space. 

The trick is, almost nobody (by my count) actually wants this configurability, so the resultant API must not make it burdensome for those who want the "default" case. 

Some [conversation in #1274](https://github.com/georust/geo/pull/1274#issuecomment-2514454615) and [another in #1140](https://github.com/georust/geo/pull/1140#pullrequestreview-1907267868) lead me to revisit the recently overhauled line_measure traits, and that it's possible to support this kind of customization in a reasonable way.

There are a lot of changes, but they are pretty mechanical. You can get a pretty good idea of the kinds of changes our users will need to make by reviewing this diff. 

As well as being more expressive, I actually prefer where the code is now, without the turbo-fish. I just wish I'd avoided the churn by thinking of it before the big changes in the v0.29.0 (primarily #1216) were released (on 2024-10-30):

```rust
// Before v0.29.0)
p1.haversine_distance(p2);
line_string.haversine_length();
line_string.densify_haversine(100);

// Currently (as of v0.29.0)
Haversine::distance(p1, p2);
line_string.length::<Haversine>();
line_string.densify::<Haversine>(100);

// After (this PR)
Haversine.distance(p1, p2);
Haversine.length(&line_string);
Haversine.densify(&line_string, 100);

// and now you can do this:
let planet_mars = CustomHaversine::new(3_389_500.0);
planet_mars.densify(&line_string, 100);
```

### References 

This solves the same problem as https://github.com/georust/geo/pull/1220, but more generally.
Tracking issue for line_measure overhaul here #1181