### PR TITLE
Rename Spade* to Delaunay in new, identical module

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Rename `triangulate_spade` and `TriangulateSpade` to `triangulate_delaunay` and `TriangulateDelaunay`
 - Docs: Fix page location of citation for mean earth radius used in Haversine calculations
 - Docs: Add top-level doc link for `InteriorPoint`
 - Add Unary Union algorithm for fast union ops on adjacent / overlapping geometries

--- a/geo/benches/triangulate.rs
+++ b/geo/benches/triangulate.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main};
-use geo::algorithm::{TriangulateEarcut, TriangulateSpade};
+use geo::algorithm::{TriangulateDelaunay, TriangulateEarcut};
 use geo::geometry::Polygon;
-use geo::triangulate_spade::SpadeTriangulationConfig;
+use geo::triangulate_delaunay::DelaunayTriangulationConfig;
 
 fn criterion_benchmark(c: &mut criterion::Criterion) {
     c.bench_function(
@@ -11,7 +11,7 @@ fn criterion_benchmark(c: &mut criterion::Criterion) {
             bencher.iter(|| {
                 for poly in &multi_poly {
                     let triangulation =
-                        TriangulateSpade::unconstrained_triangulation(poly).unwrap();
+                        TriangulateDelaunay::unconstrained_triangulation(poly).unwrap();
                     assert!(triangulation.len() > 1);
                     criterion::black_box(triangulation);
                 }
@@ -23,9 +23,9 @@ fn criterion_benchmark(c: &mut criterion::Criterion) {
         let multi_poly = geo_test_fixtures::nl_zones::<f64>();
         bencher.iter(|| {
             for poly in &multi_poly {
-                let triangulation = TriangulateSpade::constrained_triangulation(
+                let triangulation = TriangulateDelaunay::constrained_triangulation(
                     poly,
-                    SpadeTriangulationConfig { snap_radius: 1e-8 },
+                    DelaunayTriangulationConfig { snap_radius: 1e-8 },
                 )
                 .unwrap();
                 assert!(triangulation.len() > 1);
@@ -48,7 +48,7 @@ fn criterion_benchmark(c: &mut criterion::Criterion) {
     c.bench_function("TriangulateSpade (unconstrained) - large_poly", |bencher| {
         let poly = Polygon::new(geo_test_fixtures::norway_main::<f64>(), vec![]);
         bencher.iter(|| {
-            let triangulation = TriangulateSpade::unconstrained_triangulation(&poly).unwrap();
+            let triangulation = TriangulateDelaunay::unconstrained_triangulation(&poly).unwrap();
             assert!(triangulation.len() > 1);
             criterion::black_box(triangulation);
         });
@@ -57,9 +57,9 @@ fn criterion_benchmark(c: &mut criterion::Criterion) {
     c.bench_function("TriangulateSpade (constrained) - large_poly", |bencher| {
         let poly = Polygon::new(geo_test_fixtures::norway_main::<f64>(), vec![]);
         bencher.iter(|| {
-            let triangulation = TriangulateSpade::constrained_triangulation(
+            let triangulation = TriangulateDelaunay::constrained_triangulation(
                 &poly,
-                SpadeTriangulationConfig { snap_radius: 1e-8 },
+                DelaunayTriangulationConfig { snap_radius: 1e-8 },
             )
             .unwrap();
             assert!(triangulation.len() > 1);

--- a/geo/src/algorithm/mod.rs
+++ b/geo/src/algorithm/mod.rs
@@ -263,8 +263,20 @@ pub use triangulate_earcut::TriangulateEarcut;
 
 /// Triangulate polygons using an (un)constrained [Delaunay Triangulation](https://en.wikipedia.org/wiki/Delaunay_triangulation) algorithm.
 #[cfg(feature = "spade")]
+pub mod triangulate_delaunay;
+#[cfg(feature = "spade")]
+pub use triangulate_delaunay::TriangulateDelaunay;
+
+/// Triangulate polygons using an (un)constrained [Delaunay Triangulation](https://en.wikipedia.org/wiki/Delaunay_triangulation) algorithm.
+#[cfg(feature = "spade")]
+#[deprecated(
+    since = "0.29.4",
+    note = "please use the `triangulate_delaunay` module instead"
+)]
 pub mod triangulate_spade;
 #[cfg(feature = "spade")]
+#[deprecated(since = "0.29.4", note = "please use `TriangulateDelaunay` instead")]
+#[allow(deprecated)]
 pub use triangulate_spade::TriangulateSpade;
 
 /// Vector Operations for 2D coordinates

--- a/geo/src/lib.rs
+++ b/geo/src/lib.rs
@@ -116,7 +116,7 @@
 //! ## Triangulation
 //!
 //! - **[`TriangulateEarcut`](triangulate_earcut)**: Triangulate polygons using the earcut algorithm. Requires the `earcutr` feature, which is enabled by default
-//! - **[`TriangulateSpade`](triangulate_spade)**: Produce constrained or unconstrained Delaunay triangulations of polygons. Requires the `spade` feature, which is enabled by default
+//! - **[`TriangulateDelaunay`](triangulate_delaunay)**: Produce constrained or unconstrained Delaunay triangulations of polygons. Requires the `spade` feature, which is enabled by default
 //! ## Winding
 //!
 //! - **[`Orient`]**: Apply a specified winding [`Direction`](orient::Direction) to a [`Polygon`]’s interior and exterior rings


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

The `Spade` suffix is an implementation detail, since we only happen to use the `spade` crate for Delaunay triangulations. It's also not semantically meaningful, whereas `Delaunay` is. I've left some non-public uses of `Spade` in the new code (where it refers to errors etc).

I've marked the existing module as deprecated, which is causing a lot of warnings as module-internal functions are called. I'm open to suggestions to suppress these or otherwise stop them annoying everyone.
