### PR TITLE
impl approx::UlpsEqual for geo-types

### DIFF
--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -4,8 +4,11 @@
 
 - Add more concise Debug output for geometries (like WKT).
   NOTE: because geo-types allows some representations which are not supported by standard WKT, not all debug output is valid WKT. Do not attempt to treat debug as a stable format - it's unsuitable for interacting with programmatically. See the [`wkt` crate](https://crates.io/crates/wkt) for that.
+  - https://github.com/georust/geo/pull/1302
 - Rect and Triangle's `lines` and `coords` iterators and `to_polygon` method now return ccw-oriented geometry
   - https://github.com/georust/geo/pull/1308
+- Implement approx::UlpsEq for geo-types, allowing a new kind of approximate equality check, based on counting the number of floats between two numbers.
+  - https://github.com/georust/geo/pull/1312
 
 ## 0.7.15 - 2025-01-14
 

--- a/geo-types/src/geometry/coord.rs
+++ b/geo-types/src/geometry/coord.rs
@@ -1,8 +1,5 @@
 use crate::{coord, CoordNum, Point};
 
-#[cfg(any(feature = "approx", test))]
-use approx::{AbsDiffEq, RelativeEq, UlpsEq};
-
 /// A lightweight struct used to store coordinates on the 2-dimensional
 /// Cartesian plane.
 ///
@@ -268,54 +265,57 @@ impl<T: CoordNum> Zero for Coord<T> {
 }
 
 #[cfg(any(feature = "approx", test))]
-impl<T: CoordNum + AbsDiffEq> AbsDiffEq for Coord<T>
-where
-    T::Epsilon: Copy,
-{
-    type Epsilon = T::Epsilon;
+mod approx_integration {
+    use super::*;
+    use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 
-    #[inline]
-    fn default_epsilon() -> T::Epsilon {
-        T::default_epsilon()
+    impl<T> AbsDiffEq for Coord<T>
+    where
+        T: CoordNum + AbsDiffEq<Epsilon = T>,
+    {
+        type Epsilon = T::Epsilon;
+
+        #[inline]
+        fn default_epsilon() -> T::Epsilon {
+            T::default_epsilon()
+        }
+
+        #[inline]
+        fn abs_diff_eq(&self, other: &Self, epsilon: T::Epsilon) -> bool {
+            T::abs_diff_eq(&self.x, &other.x, epsilon) && T::abs_diff_eq(&self.y, &other.y, epsilon)
+        }
     }
 
-    #[inline]
-    fn abs_diff_eq(&self, other: &Self, epsilon: T::Epsilon) -> bool {
-        T::abs_diff_eq(&self.x, &other.x, epsilon) && T::abs_diff_eq(&self.y, &other.y, epsilon)
-    }
-}
+    impl<T> RelativeEq for Coord<T>
+    where
+        T: CoordNum + RelativeEq<Epsilon = T>,
+    {
+        #[inline]
+        fn default_max_relative() -> T::Epsilon {
+            T::default_max_relative()
+        }
 
-#[cfg(any(feature = "approx", test))]
-impl<T: CoordNum + RelativeEq> RelativeEq for Coord<T>
-where
-    T::Epsilon: Copy,
-{
-    #[inline]
-    fn default_max_relative() -> T::Epsilon {
-        T::default_max_relative()
-    }
-
-    #[inline]
-    fn relative_eq(&self, other: &Self, epsilon: T::Epsilon, max_relative: T::Epsilon) -> bool {
-        T::relative_eq(&self.x, &other.x, epsilon, max_relative)
-            && T::relative_eq(&self.y, &other.y, epsilon, max_relative)
-    }
-}
-
-#[cfg(any(feature = "approx", test))]
-impl<T: CoordNum + UlpsEq> UlpsEq for Coord<T>
-where
-    T::Epsilon: Copy,
-{
-    #[inline]
-    fn default_max_ulps() -> u32 {
-        T::default_max_ulps()
+        #[inline]
+        fn relative_eq(&self, other: &Self, epsilon: T::Epsilon, max_relative: T::Epsilon) -> bool {
+            T::relative_eq(&self.x, &other.x, epsilon, max_relative)
+                && T::relative_eq(&self.y, &other.y, epsilon, max_relative)
+        }
     }
 
-    #[inline]
-    fn ulps_eq(&self, other: &Self, epsilon: T::Epsilon, max_ulps: u32) -> bool {
-        T::ulps_eq(&self.x, &other.x, epsilon, max_ulps)
-            && T::ulps_eq(&self.y, &other.y, epsilon, max_ulps)
+    impl<T> UlpsEq for Coord<T>
+    where
+        T: CoordNum + UlpsEq<Epsilon = T>,
+    {
+        #[inline]
+        fn default_max_ulps() -> u32 {
+            T::default_max_ulps()
+        }
+
+        #[inline]
+        fn ulps_eq(&self, other: &Self, epsilon: T::Epsilon, max_ulps: u32) -> bool {
+            T::ulps_eq(&self.x, &other.x, epsilon, max_ulps)
+                && T::ulps_eq(&self.y, &other.y, epsilon, max_ulps)
+        }
     }
 }
 

--- a/geo-types/src/geometry/multi_line_string.rs
+++ b/geo-types/src/geometry/multi_line_string.rs
@@ -3,7 +3,6 @@ use crate::{CoordNum, LineString};
 use alloc::vec;
 use alloc::vec::Vec;
 #[cfg(any(feature = "approx", test))]
-use approx::{AbsDiffEq, RelativeEq};
 use core::iter::FromIterator;
 #[cfg(feature = "multithreading")]
 use rayon::prelude::*;
@@ -151,78 +150,100 @@ impl<'a, T: CoordNum + Send + Sync> IntoParallelIterator for &'a mut MultiLineSt
 }
 
 #[cfg(any(feature = "approx", test))]
-impl<T> RelativeEq for MultiLineString<T>
-where
-    T: AbsDiffEq<Epsilon = T> + CoordNum + RelativeEq,
-{
-    #[inline]
-    fn default_max_relative() -> Self::Epsilon {
-        T::default_max_relative()
-    }
+mod approx_integration {
+    use super::*;
+    use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 
-    /// Equality assertion within a relative limit.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use geo_types::{MultiLineString, line_string};
-    ///
-    /// let a = MultiLineString::new(vec![line_string![(x: 0., y: 0.), (x: 10., y: 10.)]]);
-    /// let b = MultiLineString::new(vec![line_string![(x: 0., y: 0.), (x: 10.01, y: 10.)]]);
-    ///
-    /// approx::assert_relative_eq!(a, b, max_relative=0.1);
-    /// approx::assert_relative_ne!(a, b, max_relative=0.0001);
-    /// ```
-    #[inline]
-    fn relative_eq(
-        &self,
-        other: &Self,
-        epsilon: Self::Epsilon,
-        max_relative: Self::Epsilon,
-    ) -> bool {
-        if self.0.len() != other.0.len() {
-            return false;
+    impl<T> RelativeEq for MultiLineString<T>
+    where
+        T: CoordNum + RelativeEq<Epsilon = T>,
+    {
+        #[inline]
+        fn default_max_relative() -> Self::Epsilon {
+            T::default_max_relative()
         }
 
-        let mut mp_zipper = self.iter().zip(other.iter());
-        mp_zipper.all(|(lhs, rhs)| lhs.relative_eq(rhs, epsilon, max_relative))
+        /// Equality assertion within a relative limit.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use geo_types::{MultiLineString, line_string};
+        ///
+        /// let a = MultiLineString::new(vec![line_string![(x: 0., y: 0.), (x: 10., y: 10.)]]);
+        /// let b = MultiLineString::new(vec![line_string![(x: 0., y: 0.), (x: 10.01, y: 10.)]]);
+        ///
+        /// approx::assert_relative_eq!(a, b, max_relative=0.1);
+        /// approx::assert_relative_ne!(a, b, max_relative=0.0001);
+        /// ```
+        #[inline]
+        fn relative_eq(
+            &self,
+            other: &Self,
+            epsilon: Self::Epsilon,
+            max_relative: Self::Epsilon,
+        ) -> bool {
+            if self.0.len() != other.0.len() {
+                return false;
+            }
+
+            let mut mp_zipper = self.iter().zip(other.iter());
+            mp_zipper.all(|(lhs, rhs)| lhs.relative_eq(rhs, epsilon, max_relative))
+        }
     }
-}
 
-#[cfg(any(feature = "approx", test))]
-impl<T> AbsDiffEq for MultiLineString<T>
-where
-    T: AbsDiffEq<Epsilon = T> + CoordNum,
-    T::Epsilon: Copy,
-{
-    type Epsilon = T;
+    impl<T> AbsDiffEq for MultiLineString<T>
+    where
+        T: CoordNum + AbsDiffEq<Epsilon = T>,
+    {
+        type Epsilon = T;
 
-    #[inline]
-    fn default_epsilon() -> Self::Epsilon {
-        T::default_epsilon()
-    }
-
-    /// Equality assertion with an absolute limit.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use geo_types::{MultiLineString, line_string};
-    ///
-    /// let a = MultiLineString::new(vec![line_string![(x: 0., y: 0.), (x: 10., y: 10.)]]);
-    /// let b = MultiLineString::new(vec![line_string![(x: 0., y: 0.), (x: 10.01, y: 10.)]]);
-    ///
-    /// approx::abs_diff_eq!(a, b, epsilon=0.1);
-    /// approx::abs_diff_ne!(a, b, epsilon=0.001);
-    /// ```
-    #[inline]
-    fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
-        if self.0.len() != other.0.len() {
-            return false;
+        #[inline]
+        fn default_epsilon() -> Self::Epsilon {
+            T::default_epsilon()
         }
 
-        let mut mp_zipper = self.into_iter().zip(other);
-        mp_zipper.all(|(lhs, rhs)| lhs.abs_diff_eq(rhs, epsilon))
+        /// Equality assertion with an absolute limit.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use geo_types::{MultiLineString, line_string};
+        ///
+        /// let a = MultiLineString::new(vec![line_string![(x: 0., y: 0.), (x: 10., y: 10.)]]);
+        /// let b = MultiLineString::new(vec![line_string![(x: 0., y: 0.), (x: 10.01, y: 10.)]]);
+        ///
+        /// approx::abs_diff_eq!(a, b, epsilon=0.1);
+        /// approx::abs_diff_ne!(a, b, epsilon=0.001);
+        /// ```
+        #[inline]
+        fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
+            if self.0.len() != other.0.len() {
+                return false;
+            }
+
+            self.into_iter()
+                .zip(other)
+                .all(|(lhs, rhs)| lhs.abs_diff_eq(rhs, epsilon))
+        }
+    }
+
+    impl<T> UlpsEq for MultiLineString<T>
+    where
+        T: CoordNum + UlpsEq<Epsilon = T>,
+    {
+        fn default_max_ulps() -> u32 {
+            T::default_max_ulps()
+        }
+
+        fn ulps_eq(&self, other: &Self, epsilon: Self::Epsilon, max_ulps: u32) -> bool {
+            if self.0.len() != other.0.len() {
+                return false;
+            }
+            self.into_iter()
+                .zip(other)
+                .all(|(lhs, rhs)| lhs.ulps_eq(rhs, epsilon, max_ulps))
+        }
     }
 }
 

--- a/geo-types/src/geometry/multi_point.rs
+++ b/geo-types/src/geometry/multi_point.rs
@@ -1,8 +1,5 @@
 use crate::{CoordNum, Point};
 
-#[cfg(any(feature = "approx", test))]
-use approx::{AbsDiffEq, RelativeEq};
-
 use alloc::vec;
 use alloc::vec::Vec;
 use core::iter::FromIterator;
@@ -140,85 +137,105 @@ impl<T: CoordNum> MultiPoint<T> {
 }
 
 #[cfg(any(feature = "approx", test))]
-impl<T> RelativeEq for MultiPoint<T>
-where
-    T: AbsDiffEq<Epsilon = T> + CoordNum + RelativeEq,
-{
-    #[inline]
-    fn default_max_relative() -> Self::Epsilon {
-        T::default_max_relative()
-    }
+mod approx_integration {
+    use super::*;
+    use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 
-    /// Equality assertion within a relative limit.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use geo_types::MultiPoint;
-    /// use geo_types::point;
-    ///
-    /// let a = MultiPoint::new(vec![point![x: 0., y: 0.], point![x: 10., y: 10.]]);
-    /// let b = MultiPoint::new(vec![point![x: 0., y: 0.], point![x: 10.001, y: 10.]]);
-    ///
-    /// approx::assert_relative_eq!(a, b, max_relative=0.1)
-    /// ```
-    #[inline]
-    fn relative_eq(
-        &self,
-        other: &Self,
-        epsilon: Self::Epsilon,
-        max_relative: Self::Epsilon,
-    ) -> bool {
-        if self.0.len() != other.0.len() {
-            return false;
+    impl<T> RelativeEq for MultiPoint<T>
+    where
+        T: CoordNum + RelativeEq<Epsilon = T>,
+    {
+        #[inline]
+        fn default_max_relative() -> Self::Epsilon {
+            T::default_max_relative()
         }
 
-        let mut mp_zipper = self.iter().zip(other.iter());
-        mp_zipper.all(|(lhs, rhs)| lhs.relative_eq(rhs, epsilon, max_relative))
+        /// Equality assertion within a relative limit.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use geo_types::MultiPoint;
+        /// use geo_types::point;
+        ///
+        /// let a = MultiPoint::new(vec![point![x: 0., y: 0.], point![x: 10., y: 10.]]);
+        /// let b = MultiPoint::new(vec![point![x: 0., y: 0.], point![x: 10.001, y: 10.]]);
+        ///
+        /// approx::assert_relative_eq!(a, b, max_relative=0.1)
+        /// ```
+        #[inline]
+        fn relative_eq(
+            &self,
+            other: &Self,
+            epsilon: Self::Epsilon,
+            max_relative: Self::Epsilon,
+        ) -> bool {
+            if self.0.len() != other.0.len() {
+                return false;
+            }
+
+            let mut mp_zipper = self.iter().zip(other.iter());
+            mp_zipper.all(|(lhs, rhs)| lhs.relative_eq(rhs, epsilon, max_relative))
+        }
     }
-}
 
-#[cfg(any(feature = "approx", test))]
-impl<T> AbsDiffEq for MultiPoint<T>
-where
-    T: AbsDiffEq<Epsilon = T> + CoordNum,
-    T::Epsilon: Copy,
-{
-    type Epsilon = T;
+    impl<T> AbsDiffEq for MultiPoint<T>
+    where
+        T: CoordNum + AbsDiffEq<Epsilon = T>,
+    {
+        type Epsilon = T;
 
-    #[inline]
-    fn default_epsilon() -> Self::Epsilon {
-        T::default_epsilon()
-    }
-
-    /// Equality assertion with an absolute limit.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use geo_types::MultiPoint;
-    /// use geo_types::point;
-    ///
-    /// let a = MultiPoint::new(vec![point![x: 0., y: 0.], point![x: 10., y: 10.]]);
-    /// let b = MultiPoint::new(vec![point![x: 0., y: 0.], point![x: 10.001, y: 10.]]);
-    ///
-    /// approx::abs_diff_eq!(a, b, epsilon=0.1);
-    /// ```
-    #[inline]
-    fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
-        if self.0.len() != other.0.len() {
-            return false;
+        #[inline]
+        fn default_epsilon() -> Self::Epsilon {
+            T::default_epsilon()
         }
 
-        let mut mp_zipper = self.into_iter().zip(other);
-        mp_zipper.all(|(lhs, rhs)| lhs.abs_diff_eq(rhs, epsilon))
+        /// Equality assertion with an absolute limit.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use geo_types::MultiPoint;
+        /// use geo_types::point;
+        ///
+        /// let a = MultiPoint::new(vec![point![x: 0., y: 0.], point![x: 10., y: 10.]]);
+        /// let b = MultiPoint::new(vec![point![x: 0., y: 0.], point![x: 10.001, y: 10.]]);
+        ///
+        /// approx::abs_diff_eq!(a, b, epsilon=0.1);
+        /// ```
+        #[inline]
+        fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
+            if self.0.len() != other.0.len() {
+                return false;
+            }
+
+            let mut mp_zipper = self.into_iter().zip(other);
+            mp_zipper.all(|(lhs, rhs)| lhs.abs_diff_eq(rhs, epsilon))
+        }
+    }
+
+    impl<T> UlpsEq for MultiPoint<T>
+    where
+        T: CoordNum + UlpsEq<Epsilon = T>,
+    {
+        fn default_max_ulps() -> u32 {
+            T::default_max_ulps()
+        }
+
+        fn ulps_eq(&self, other: &Self, epsilon: Self::Epsilon, max_ulps: u32) -> bool {
+            if self.0.len() != other.0.len() {
+                return false;
+            }
+            let mut mp_zipper = self.into_iter().zip(other);
+            mp_zipper.all(|(lhs, rhs)| lhs.ulps_eq(rhs, epsilon, max_ulps))
+        }
     }
 }
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use crate::{point, wkt};
+    use approx::{AbsDiffEq, RelativeEq};
 
     #[test]
     fn test_iter() {

--- a/geo-types/src/geometry/multi_polygon.rs
+++ b/geo-types/src/geometry/multi_polygon.rs
@@ -2,8 +2,6 @@ use crate::{CoordNum, Polygon};
 
 use alloc::vec;
 use alloc::vec::Vec;
-#[cfg(any(feature = "approx", test))]
-use approx::{AbsDiffEq, RelativeEq};
 
 use core::iter::FromIterator;
 #[cfg(feature = "multithreading")]
@@ -124,82 +122,102 @@ impl<T: CoordNum> MultiPolygon<T> {
 }
 
 #[cfg(any(feature = "approx", test))]
-impl<T> RelativeEq for MultiPolygon<T>
-where
-    T: AbsDiffEq<Epsilon = T> + CoordNum + RelativeEq,
-{
-    #[inline]
-    fn default_max_relative() -> Self::Epsilon {
-        T::default_max_relative()
-    }
+mod approx_integration {
+    use super::*;
+    use approx::{AbsDiffEq, RelativeEq, UlpsEq};
 
-    /// Equality assertion within a relative limit.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use geo_types::{polygon, Polygon, MultiPolygon};
-    ///
-    /// let a_el: Polygon<f32> = polygon![(x: 0., y: 0.), (x: 5., y: 0.), (x: 7., y: 9.), (x: 0., y: 0.)];
-    /// let a = MultiPolygon::new(vec![a_el]);
-    /// let b_el: Polygon<f32> = polygon![(x: 0., y: 0.), (x: 5., y: 0.), (x: 7.01, y: 9.), (x: 0., y: 0.)];
-    /// let b = MultiPolygon::new(vec![b_el]);
-    ///
-    /// approx::assert_relative_eq!(a, b, max_relative=0.1);
-    /// approx::assert_relative_ne!(a, b, max_relative=0.001);
-    /// ```
-    #[inline]
-    fn relative_eq(
-        &self,
-        other: &Self,
-        epsilon: Self::Epsilon,
-        max_relative: Self::Epsilon,
-    ) -> bool {
-        if self.0.len() != other.0.len() {
-            return false;
+    impl<T> RelativeEq for MultiPolygon<T>
+    where
+        T: CoordNum + RelativeEq<Epsilon = T>,
+    {
+        #[inline]
+        fn default_max_relative() -> Self::Epsilon {
+            T::default_max_relative()
         }
 
-        let mut mp_zipper = self.iter().zip(other.iter());
-        mp_zipper.all(|(lhs, rhs)| lhs.relative_eq(rhs, epsilon, max_relative))
+        /// Equality assertion within a relative limit.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use geo_types::{polygon, Polygon, MultiPolygon};
+        ///
+        /// let a_el: Polygon<f32> = polygon![(x: 0., y: 0.), (x: 5., y: 0.), (x: 7., y: 9.), (x: 0., y: 0.)];
+        /// let a = MultiPolygon::new(vec![a_el]);
+        /// let b_el: Polygon<f32> = polygon![(x: 0., y: 0.), (x: 5., y: 0.), (x: 7.01, y: 9.), (x: 0., y: 0.)];
+        /// let b = MultiPolygon::new(vec![b_el]);
+        ///
+        /// approx::assert_relative_eq!(a, b, max_relative=0.1);
+        /// approx::assert_relative_ne!(a, b, max_relative=0.001);
+        /// ```
+        #[inline]
+        fn relative_eq(
+            &self,
+            other: &Self,
+            epsilon: Self::Epsilon,
+            max_relative: Self::Epsilon,
+        ) -> bool {
+            if self.0.len() != other.0.len() {
+                return false;
+            }
+
+            let mut mp_zipper = self.iter().zip(other.iter());
+            mp_zipper.all(|(lhs, rhs)| lhs.relative_eq(rhs, epsilon, max_relative))
+        }
     }
-}
 
-#[cfg(any(feature = "approx", test))]
-impl<T> AbsDiffEq for MultiPolygon<T>
-where
-    T: AbsDiffEq<Epsilon = T> + CoordNum,
-    T::Epsilon: Copy,
-{
-    type Epsilon = T;
+    impl<T> AbsDiffEq for MultiPolygon<T>
+    where
+        T: CoordNum + AbsDiffEq<Epsilon = T>,
+    {
+        type Epsilon = T;
 
-    #[inline]
-    fn default_epsilon() -> Self::Epsilon {
-        T::default_epsilon()
-    }
-
-    /// Equality assertion with an absolute limit.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use geo_types::{polygon, Polygon, MultiPolygon};
-    ///
-    /// let a_el: Polygon<f32> = polygon![(x: 0., y: 0.), (x: 5., y: 0.), (x: 7., y: 9.), (x: 0., y: 0.)];
-    /// let a = MultiPolygon::new(vec![a_el]);
-    /// let b_el: Polygon<f32> = polygon![(x: 0., y: 0.), (x: 5., y: 0.), (x: 7.01, y: 9.), (x: 0., y: 0.)];
-    /// let b = MultiPolygon::new(vec![b_el]);
-    ///
-    /// approx::abs_diff_eq!(a, b, epsilon=0.1);
-    /// approx::abs_diff_ne!(a, b, epsilon=0.001);
-    /// ```
-    #[inline]
-    fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
-        if self.0.len() != other.0.len() {
-            return false;
+        #[inline]
+        fn default_epsilon() -> Self::Epsilon {
+            T::default_epsilon()
         }
 
-        let mut mp_zipper = self.into_iter().zip(other);
-        mp_zipper.all(|(lhs, rhs)| lhs.abs_diff_eq(rhs, epsilon))
+        /// Equality assertion with an absolute limit.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use geo_types::{polygon, Polygon, MultiPolygon};
+        ///
+        /// let a_el: Polygon<f32> = polygon![(x: 0., y: 0.), (x: 5., y: 0.), (x: 7., y: 9.), (x: 0., y: 0.)];
+        /// let a = MultiPolygon::new(vec![a_el]);
+        /// let b_el: Polygon<f32> = polygon![(x: 0., y: 0.), (x: 5., y: 0.), (x: 7.01, y: 9.), (x: 0., y: 0.)];
+        /// let b = MultiPolygon::new(vec![b_el]);
+        ///
+        /// approx::abs_diff_eq!(a, b, epsilon=0.1);
+        /// approx::abs_diff_ne!(a, b, epsilon=0.001);
+        /// ```
+        #[inline]
+        fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
+            if self.0.len() != other.0.len() {
+                return false;
+            }
+
+            let mut mp_zipper = self.into_iter().zip(other);
+            mp_zipper.all(|(lhs, rhs)| lhs.abs_diff_eq(rhs, epsilon))
+        }
+    }
+
+    impl<T> UlpsEq for MultiPolygon<T>
+    where
+        T: CoordNum + UlpsEq<Epsilon = T>,
+    {
+        fn default_max_ulps() -> u32 {
+            T::default_max_ulps()
+        }
+
+        fn ulps_eq(&self, other: &Self, epsilon: Self::Epsilon, max_ulps: u32) -> bool {
+            if self.0.len() != other.0.len() {
+                return false;
+            }
+            let mut mp_zipper = self.into_iter().zip(other);
+            mp_zipper.all(|(lhs, rhs)| lhs.ulps_eq(rhs, epsilon, max_ulps))
+        }
     }
 }
 


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

I assumed we implemented all the "approximate equality" traits from approx long ago, but we missed one!

As a reminder, an ULPS comparison is effectively counting "how many floating point numbers are between these two numbers". For the most part it solves the same problems as relative_eq, but it's a little better behaved at the extremes, like when the "max_relative" factor you want to use is itself affected by floating point error.