### PR TITLE
implement `From<&(T, T)>` and `From<&[T; 2]>` for `Point<T>`

### DIFF
--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -6,6 +6,7 @@
   NOTE: because geo-types allows some representations which are not supported by standard WKT, not all debug output is valid WKT. Do not attempt to treat debug as a stable format - it's unsuitable for interacting with programmatically. See the [`wkt` crate](https://crates.io/crates/wkt) for that.
 - Rect and Triangle's `lines` and `coords` iterators and `to_polygon` method now return ccw-oriented geometry
   - https://github.com/georust/geo/pull/1308
+- Points can now be created from &(T, T) and &[T; 2]
 
 ## 0.7.15 - 2025-01-14
 

--- a/geo-types/src/geometry/point.rs
+++ b/geo-types/src/geometry/point.rs
@@ -42,8 +42,20 @@ impl<T: CoordNum> From<(T, T)> for Point<T> {
     }
 }
 
+impl<T: CoordNum> From<&(T, T)> for Point<T> {
+    fn from(coords: &(T, T)) -> Self {
+        Point::new(coords.0, coords.1)
+    }
+}
+
 impl<T: CoordNum> From<[T; 2]> for Point<T> {
     fn from(coords: [T; 2]) -> Self {
+        Point::new(coords[0], coords[1])
+    }
+}
+
+impl<T: CoordNum> From<&[T; 2]> for Point<T> {
+    fn from(coords: &[T; 2]) -> Self {
         Point::new(coords[0], coords[1])
     }
 }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

This allows users to create points from borrowed tuples and slices, increasing flexibility