### PR TITLE
Update i_overlay to 2.0.0

### DIFF
--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -31,7 +31,7 @@ proj = { version = "0.28.0", optional = true }
 robust = "1.1.0"
 rstar = "0.12.0"
 serde = { version = "1.0", optional = true, features = ["derive"] }
-i_overlay = { version = "1.10.0, < 1.11.0", default-features = false }
+i_overlay = { version = "2.0.0, < 2.1.0", default-features = false }
 
 [dev-dependencies]
 approx = ">= 0.4.0, < 0.6.0"


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Updates the `i_overlay` internal package to 2.0.0 - 2.1.0 

This is motivated by the fact that `i_overlay` now appears to offer the only implementation of polygon-offset style buffering in the ecosystem right now. 

I would be interested in doing a buffer trait + methods here at some point in the future, but for now a dependency bump is the first step in getting it in there. 

I have run `cargo test` with both current `main` and this change - both had tests fail for 

```
    algorithm::line_measures::metric_spaces::geodesic::tests::destination::interpolate_point::points_along_line_with_endpoints
    algorithm::line_measures::metric_spaces::geodesic::tests::destination::interpolate_point::points_along_line_without_endpoints
    algorithm::line_measures::metric_spaces::geodesic::tests::test_non_standard_geoid
```

which appear to be small floating point precision errors. Updating this library does not appear to have regressed anything else. 


