### PR TITLE
Speed up Relate for PreparedGeometry

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -79,6 +79,10 @@
   - <https://github.com/georust/geo/pull/1314>
 - Bump `geo` MSRV to 1.80 and update CI
   - <https://github.com/georust/geo/pull/1311>
+- BREAKING: Speed up `Relate` for `PreparedGeometry` - this did require
+  changing some trait constraints, but they are unlikely to affect you in
+  practice unless you have your own Relate implementation.
+  - <https://github.com/georust/geo/pull/1317>
 
 ## 0.29.3 - 2024.12.03
 

--- a/geo/src/algorithm/relate/geomgraph/edge_end_bundle_star.rs
+++ b/geo/src/algorithm/relate/geomgraph/edge_end_bundle_star.rs
@@ -83,7 +83,7 @@ impl<F: GeoFloat> LabeledEdgeEndBundleStar<F> {
         debug!("edge_end_bundle_star: {:?}", self);
     }
 
-    fn propagate_side_labels(&mut self, geom_index: usize, geometry_graph: &GeometryGraph<F>) {
+    fn propagate_side_labels(&mut self, geom_index: usize, _geometry_graph: &GeometryGraph<F>) {
         let mut start_position = None;
 
         for edge_ends in self.edge_end_bundles_iter() {
@@ -108,11 +108,11 @@ impl<F: GeoFloat> LabeledEdgeEndBundleStar<F> {
                 let left_position = label.position(geom_index, Direction::Left);
                 let right_position = label.position(geom_index, Direction::Right);
 
-                if let Some(right_position) = right_position {
+                if let Some(_right_position) = right_position {
                     #[cfg(debug_assertions)]
-                    if right_position != current_position {
+                    if _right_position != current_position {
                         use crate::algorithm::Validation;
-                        if geometry_graph.geometry().is_valid() {
+                        if _geometry_graph.geometry().is_valid() {
                             debug_assert!(false, "topology position conflict with coordinate — this can happen with invalid geometries. coordinate: {:?}, right_location: {:?}, current_location: {:?}", edge_ends.coordinate(), right_position, current_position);
                         } else {
                             warn!("topology position conflict with coordinate — this can happen with invalid geometries. coordinate: {:?}, right_location: {:?}, current_location: {:?}", edge_ends.coordinate(), right_position, current_position);

--- a/geo/src/algorithm/relate/geomgraph/intersection_matrix.rs
+++ b/geo/src/algorithm/relate/geomgraph/intersection_matrix.rs
@@ -1,4 +1,6 @@
-use crate::{coordinate_position::CoordPos, dimensions::Dimensions, GeoNum, GeometryCow};
+use crate::{
+    coordinate_position::CoordPos, dimensions::Dimensions, GeoNum, GeometryCow, HasDimensions,
+};
 
 use crate::geometry_cow::GeometryCow::Point;
 use crate::relate::geomgraph::intersection_matrix::dimension_matcher::DimensionMatcher;
@@ -125,12 +127,11 @@ impl IntersectionMatrix {
 
     /// If the Geometries are disjoint, we need to enter their dimension and boundary dimension in
     /// the `Outside` rows in the IM
-    pub(crate) fn compute_disjoint<F: GeoNum>(
+    pub(crate) fn compute_disjoint(
         &mut self,
-        geometry_a: &GeometryCow<F>,
-        geometry_b: &GeometryCow<F>,
+        geometry_a: &(impl HasDimensions + ?Sized),
+        geometry_b: &(impl HasDimensions + ?Sized),
     ) {
-        use crate::algorithm::dimensions::HasDimensions;
         {
             let dimensions = geometry_a.dimensions();
             if dimensions != Dimensions::Empty {


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Primarily: We cache the `bounding_rect` computation on the `PreparedGeometry`, which gets us most of our perf gain.

Secondarily: I realized we can skip building the geometry graph if the bbox check fails (which is a modest speedup for both prepared and unprepared geometries).

```
$ cargo bench --bench prepared_geometry -- --baseline=main
   Compiling geo v0.29.3 (/Users/mkirk/src/georust/geo/geo)
   Compiling jts-test-runner v0.1.0 (/Users/mkirk/src/georust/geo/jts-test-runner)
    Finished `bench` profile [optimized] target(s) in 6.35s
     Running benches/prepared_geometry.rs (target/release/deps/prepared_geometry-b11c776cecdacd91)
Gnuplot not found, using plotters backend
relate prepared polygons
                        time:   [25.355 ms 25.456 ms 25.562 ms]
                        change: [-47.861% -47.612% -47.365%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

Benchmarking relate unprepared polygons: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 82.0s, or reduce sample count to 10.
relate unprepared polygons
                        time:   [761.98 ms 764.63 ms 767.56 ms]
                        change: [-6.1618% -5.7402% -5.3188%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
```