### PR TITLE
Fix Relate for Point/MultiPoint (broken just yesterday)

### DIFF
--- a/geo/benches/prepared_geometry.rs
+++ b/geo/benches/prepared_geometry.rs
@@ -1,13 +1,48 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use geo::algorithm::Relate;
 use geo::PreparedGeometry;
 use geo_types::MultiPolygon;
 
 fn criterion_benchmark(c: &mut Criterion) {
-    c.bench_function("relate prepared polygons", |bencher| {
-        let plot_polygons: MultiPolygon = geo_test_fixtures::nl_plots_wgs84();
-        let zone_polygons = geo_test_fixtures::nl_zones();
+    let plot_polygons: MultiPolygon = geo_test_fixtures::nl_plots_wgs84();
+    let zone_polygons = geo_test_fixtures::nl_zones();
+    c.bench_function("build prepared polygons", |bencher| {
+        bencher.iter(|| {
+            let plot_polygons = plot_polygons
+                .iter()
+                .map(PreparedGeometry::from)
+                .collect::<Vec<_>>();
 
+            let zone_polygons = zone_polygons
+                .iter()
+                .map(PreparedGeometry::from)
+                .collect::<Vec<_>>();
+
+            black_box((&plot_polygons, &zone_polygons));
+        });
+    });
+
+    c.bench_function("relate already prepared polygons", |bencher| {
+        let plot_polygons = plot_polygons
+            .iter()
+            .map(PreparedGeometry::from)
+            .collect::<Vec<_>>();
+
+        let zone_polygons = zone_polygons
+            .iter()
+            .map(PreparedGeometry::from)
+            .collect::<Vec<_>>();
+
+        bencher.iter(|| {
+            for a in &plot_polygons {
+                for b in &zone_polygons {
+                    black_box(a.relate(b).is_intersects());
+                }
+            }
+        });
+    });
+
+    c.bench_function("build and relate prepared polygons", |bencher| {
         bencher.iter(|| {
             let mut intersects = 0;
             let mut non_intersects = 0;
@@ -24,7 +59,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
             for a in &plot_polygons {
                 for b in &zone_polygons {
-                    if criterion::black_box(a.relate(b).is_intersects()) {
+                    if black_box(a.relate(b).is_intersects()) {
                         intersects += 1;
                     } else {
                         non_intersects += 1;
@@ -37,7 +72,9 @@ fn criterion_benchmark(c: &mut Criterion) {
         });
     });
 
-    c.bench_function("relate unprepared polygons", |bencher| {
+    let mut slow_group = c.benchmark_group("unprepared polygons");
+    slow_group.sample_size(10);
+    slow_group.bench_function("relate unprepared polygons", |bencher| {
         let plot_polygons: MultiPolygon = geo_test_fixtures::nl_plots_wgs84();
         let zone_polygons = geo_test_fixtures::nl_zones();
 
@@ -47,7 +84,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
             for a in &plot_polygons {
                 for b in &zone_polygons {
-                    if criterion::black_box(a.relate(b).is_intersects()) {
+                    if black_box(a.relate(b).is_intersects()) {
                         intersects += 1;
                     } else {
                         non_intersects += 1;


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

I broke this in https://github.com/georust/geo/commit/44816ebf6e874a6995d6f3f57c887c16d15e074e (merged yesterday, not yet released) by attempting to reuse the bbox from the geometry graph's RTree.

The problem was that the RTree only contains the Geometry's _segments_, but Point and MultiPoint have no segments - they're zero-dimensional geometries.

I don't often use `Relate` with zero dimensional geometries, so it's only luck that an unrelated example I was writing triggered an assert!

To be clear, we're still getting *most* of the perf benefit from #1317 - we're still caching the bbox. Now we have to compute it 1 time. Previously we were trying to compute it zero times by re-using the one from the RTree.

== PERF

There was only a small loss from this change, indicating it was probably a bad
idea from the start.

    build prepared polygons time:   [4.5677 ms 4.5717 ms 4.5764 ms]
                            change: [+1.1094% +1.2751% +1.4241%] (p = 0.00 < 0.05)
                            Performance has regressed.

    relate already prepared polygons
                            time:   [18.889 ms 18.912 ms 18.942 ms]
                            change: [+0.5218% +0.6533% +0.8127%] (p = 0.00 < 0.05)
                            Change within noise threshold.

    build and relate prepared polygons
                            time:   [23.598 ms 23.632 ms 23.671 ms]
                            change: [+0.4791% +0.6917% +0.9029%] (p = 0.00 < 0.05)
                            Change within noise threshold.

    unprepared polygons/relate unprepared polygons
                            time:   [744.51 ms 749.08 ms 754.49 ms]
                            change: [-1.2051% -0.1460% +0.8681%] (p = 0.80 > 0.05)
                            No change in performance detected.