### PR TITLE
Fix a math error in Rhumb distance calculations

### DIFF
--- a/geo/src/algorithm/line_measures/length.rs
+++ b/geo/src/algorithm/line_measures/length.rs
@@ -102,7 +102,7 @@ mod tests {
             Geodesic.length(&line).round()
         );
         assert_eq!(
-            341_088., // meters
+            343_572., // meters
             Rhumb.length(&line).round()
         );
         assert_eq!(
@@ -136,7 +136,7 @@ mod tests {
             Geodesic.length(&line_string).round()
         );
         assert_eq!(
-            6_332_790., // meters
+            6_308_683., // meters
             Rhumb.length(&line_string).round()
         );
         assert_eq!(

--- a/geo/src/algorithm/rhumb/distance.rs
+++ b/geo/src/algorithm/rhumb/distance.rs
@@ -84,7 +84,7 @@ mod test {
         let b = Point::new(-77.009080, 38.889825);
         #[allow(deprecated)]
         let distance = a.rhumb_distance(&b);
-        assert_relative_eq!(distance, 2526.7031699343006_f64, epsilon = 1.0e-6);
+        assert_relative_eq!(distance, 2526.823513863995_f64, epsilon = 1.0e-6);
     }
 
     #[test]
@@ -94,6 +94,6 @@ mod test {
         let b = Point::<f32>::new(-77.00908, 38.889825);
         #[allow(deprecated)]
         let distance = a.rhumb_distance(&b);
-        assert_relative_eq!(distance, 2526.7273_f32, epsilon = 1.0e-6);
+        assert_relative_eq!(distance, 2527.4585_f32, epsilon = 1.0e-6);
     }
 }

--- a/geo/src/algorithm/rhumb/mod.rs
+++ b/geo/src/algorithm/rhumb/mod.rs
@@ -74,7 +74,7 @@ impl<T: CoordFloat + FromPrimitive> RhumbCalculations<T> {
 
     pub(crate) fn delta(&self) -> T {
         let threshold = T::from(10.0e-12).unwrap();
-        let q = if self.delta_psi > threshold {
+        let q = if self.delta_psi.abs() > threshold {
             self.delta_phi / self.delta_psi
         } else {
             self.phi1.cos()


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

When I implemented Rhumb geometry operations in #1090 , it turns out I made a mistake in porting over the formula for distance. The Rhumb distance operation special-cases east-west lines (there's a `tan` in the calculations for all other lines whose value is undefined for east-west lines), and the check to test if we're on an east-west line was missing an absolute-value in my implementation, which meant some non-EW lines were getting calculated with the EW-line formula, which produces slightly incorrect results for some, but not all, rhumb lines. See for reference [this line](https://github.com/Turfjs/turf/blob/212d1664368db93361f29f626172412e0babf87c/packages/turf-rhumb-distance/index.ts#L95) in Turf, which does the same check and does include the required `abs`.

This change also required updating some tests. I've confirmed against the Turf implementation that our values are now correct. I had noticed that they were slightly different from Turf's in the first pass, but incorrectly attributed the difference to a different earth-radius constant, but we're now pretty much bang-on. In hindsight, I probably should have noticed that in one of these test cases, we were saying a rhumb distance between two points was shorter than the haversine distance between those same points, which ought to have been a red flag. Also note that the analogous check in the `calculate_destination` function _did_ already have the `abs` as expected.