### PR TITLE
Don't borrow epsilon in the Simplify* traits

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+# Unreleased
+
+- BREAKING: The `Simplify`, `SimplifyVw`, and `SimplifyVwIdx` traits no longer require a borrowed `epsilon` parameter as these are `Copy` types
+
 ## 0.30.0 - 2025-03-24
 
 - Bump `geo` MSRV to 1.81

--- a/geo/benches/simplify.rs
+++ b/geo/benches/simplify.rs
@@ -5,14 +5,14 @@ fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("simplify simple f32", |bencher| {
         let ls = geo_test_fixtures::louisiana::<f32>();
         bencher.iter(|| {
-            criterion::black_box(criterion::black_box(&ls).simplify(criterion::black_box(&0.01)));
+            criterion::black_box(criterion::black_box(&ls).simplify(criterion::black_box(0.01)));
         });
     });
 
     c.bench_function("simplify simple f64", |bencher| {
         let ls = geo_test_fixtures::louisiana::<f64>();
         bencher.iter(|| {
-            criterion::black_box(criterion::black_box(&ls).simplify(criterion::black_box(&0.01)));
+            criterion::black_box(criterion::black_box(&ls).simplify(criterion::black_box(0.01)));
         });
     });
 }

--- a/geo/benches/simplifyvw.rs
+++ b/geo/benches/simplifyvw.rs
@@ -7,7 +7,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         let ls = geo_test_fixtures::louisiana::<f32>();
         bencher.iter(|| {
             criterion::black_box(
-                criterion::black_box(&ls).simplify_vw(criterion::black_box(&0.0005)),
+                criterion::black_box(&ls).simplify_vw(criterion::black_box(0.0005)),
             );
         });
     });
@@ -16,7 +16,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         let ls = geo_test_fixtures::louisiana::<f64>();
         bencher.iter(|| {
             criterion::black_box(
-                criterion::black_box(&ls).simplify_vw(criterion::black_box(&0.0005)),
+                criterion::black_box(&ls).simplify_vw(criterion::black_box(0.0005)),
             );
         });
     });
@@ -25,7 +25,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         let ls = geo_test_fixtures::louisiana::<f32>();
         bencher.iter(|| {
             criterion::black_box(
-                criterion::black_box(&ls).simplify_vw_preserve(criterion::black_box(&0.0005)),
+                criterion::black_box(&ls).simplify_vw_preserve(criterion::black_box(0.0005)),
             );
         });
     });
@@ -34,7 +34,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         let ls = geo_test_fixtures::louisiana::<f64>();
         bencher.iter(|| {
             criterion::black_box(
-                criterion::black_box(&ls).simplify_vw_preserve(criterion::black_box(&0.0005)),
+                criterion::black_box(&ls).simplify_vw_preserve(criterion::black_box(0.0005)),
             );
         });
     });

--- a/geo/fuzz/fuzz_targets/simplify.rs
+++ b/geo/fuzz/fuzz_targets/simplify.rs
@@ -7,7 +7,7 @@ use libfuzzer_sys::fuzz_target;
 fuzz_target!(|tuple: (geo_types::Polygon<f32>, f32)| {
     let (polygon, epsilon) = tuple;
 
-    let simplified = polygon.simplify(&epsilon);
+    let simplified = polygon.simplify(epsilon);
 
     check_result(polygon, simplified);
 });


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Fixes #1339 
