### PR TITLE
Update traits in `geo-traits` to extend `GeometryTrait`

### DIFF
--- a/geo-traits/CHANGES.md
+++ b/geo-traits/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## Unreleased
+
+- BREAKING: All traits now extend `GeometryTrait`.
+  - <https://github.com/georust/geo/pull/1346>
+
 ## 0.2.0 - 2024.11.06
 
 - BREAKING: Mark `CoordTrait::nth_unchecked` as `unsafe` and add `CoordTrait::nth_or_panic`.

--- a/geo-traits/src/geometry.rs
+++ b/geo-traits/src/geometry.rs
@@ -538,7 +538,7 @@ mod test {
         let polygon: Polygon = Polygon::new(line_string.clone(), vec![]);
         requires_geometry_trait(&polygon);
 
-        let multi_point: MultiPoint = MultiPoint::from(vec![point.clone()]);
+        let multi_point: MultiPoint = MultiPoint::from(vec![point]);
         requires_geometry_trait(&multi_point);
 
         let multi_line_string: MultiLineString = MultiLineString(vec![line_string.clone()]);
@@ -548,7 +548,7 @@ mod test {
         requires_geometry_trait(&multi_polygon);
 
         let geometry_collection: GeometryCollection =
-            GeometryCollection::from(vec![Geometry::Point(point.clone())]);
+            GeometryCollection::from(vec![Geometry::Point(point)]);
         requires_geometry_trait(&geometry_collection);
 
         let rect: Rect = Rect::new(coord! { x: 0.0, y: 0.0 }, coord! { x: 1.0, y: 1.0 });

--- a/geo-traits/src/geometry.rs
+++ b/geo-traits/src/geometry.rs
@@ -509,3 +509,59 @@ impl<T> GeometryTrait for UnimplementedGeometry<T> {
         unimplemented!()
     }
 }
+
+#[cfg(test)]
+mod test {
+    // Ensures that all geo-types implement the GeometryTrait
+    #[test]
+    #[cfg(feature = "geo-types")]
+    fn geo_types_implement_geometry_trait() {
+        use geo_types::{
+            coord, Geometry, GeometryCollection, Line, LineString, MultiLineString, MultiPoint,
+            MultiPolygon, Point, Polygon, Rect, Triangle,
+        };
+
+        use crate::GeometryTrait;
+
+        fn requires_geometry_trait<G: GeometryTrait>(_geometry: &G) {}
+
+        let point: Point = Point::new(0.0, 0.0);
+        requires_geometry_trait(&point);
+
+        let line: Line = Line::new(coord! { x: 0.0, y: 0.0 }, coord! { x: 1.0, y: 1.0 });
+        requires_geometry_trait(&line);
+
+        let line_string: LineString =
+            LineString::from(vec![coord! { x: 0.0, y: 0.0 }, coord! { x: 1.0, y: 1.0 }]);
+        requires_geometry_trait(&line_string);
+
+        let polygon: Polygon = Polygon::new(line_string.clone(), vec![]);
+        requires_geometry_trait(&polygon);
+
+        let multi_point: MultiPoint = MultiPoint::from(vec![point.clone()]);
+        requires_geometry_trait(&multi_point);
+
+        let multi_line_string: MultiLineString = MultiLineString(vec![line_string.clone()]);
+        requires_geometry_trait(&multi_line_string);
+
+        let multi_polygon: MultiPolygon = MultiPolygon::from(vec![polygon.clone()]);
+        requires_geometry_trait(&multi_polygon);
+
+        let geometry_collection: GeometryCollection =
+            GeometryCollection::from(vec![Geometry::Point(point.clone())]);
+        requires_geometry_trait(&geometry_collection);
+
+        let rect: Rect = Rect::new(coord! { x: 0.0, y: 0.0 }, coord! { x: 1.0, y: 1.0 });
+        requires_geometry_trait(&rect);
+
+        let triangle: Triangle = Triangle::new(
+            coord! { x: 0.0, y: 0.0 },
+            coord! { x: 1.0, y: 0.0 },
+            coord! { x: 0.0, y: 1.0 },
+        );
+        requires_geometry_trait(&triangle);
+
+        let geometry: Geometry = Geometry::Point(point);
+        requires_geometry_trait(&geometry);
+    }
+}

--- a/geo-traits/src/geometry.rs
+++ b/geo-traits/src/geometry.rs
@@ -510,6 +510,158 @@ impl<T> GeometryTrait for UnimplementedGeometry<T> {
     }
 }
 
+// Specialized implementations on each unimplemented type.
+
+macro_rules! impl_unimplemented_specialization {
+    ($geometry_type:ident, $variant:expr) => {
+        impl<T> GeometryTrait for $geometry_type<T> {
+            type T = T;
+            type PointType<'b>
+                = UnimplementedPoint<Self::T>
+            where
+                Self: 'b;
+            type LineStringType<'b>
+                = UnimplementedLineString<Self::T>
+            where
+                Self: 'b;
+            type PolygonType<'b>
+                = UnimplementedPolygon<Self::T>
+            where
+                Self: 'b;
+            type MultiPointType<'b>
+                = UnimplementedMultiPoint<Self::T>
+            where
+                Self: 'b;
+            type MultiLineStringType<'b>
+                = UnimplementedMultiLineString<Self::T>
+            where
+                Self: 'b;
+            type MultiPolygonType<'b>
+                = UnimplementedMultiPolygon<Self::T>
+            where
+                Self: 'b;
+            type GeometryCollectionType<'b>
+                = UnimplementedGeometryCollection<Self::T>
+            where
+                Self: 'b;
+            type RectType<'b>
+                = UnimplementedRect<Self::T>
+            where
+                Self: 'b;
+            type TriangleType<'b>
+                = UnimplementedTriangle<Self::T>
+            where
+                Self: 'b;
+            type LineType<'b>
+                = UnimplementedLine<Self::T>
+            where
+                Self: 'b;
+
+            fn dim(&self) -> Dimensions {
+                unimplemented!()
+            }
+
+            fn as_type(
+                &self,
+            ) -> GeometryType<
+                '_,
+                Self::PointType<'_>,
+                Self::LineStringType<'_>,
+                Self::PolygonType<'_>,
+                Self::MultiPointType<'_>,
+                Self::MultiLineStringType<'_>,
+                Self::MultiPolygonType<'_>,
+                Self::GeometryCollectionType<'_>,
+                Self::RectType<'_>,
+                Self::TriangleType<'_>,
+                Self::LineType<'_>,
+            > {
+                $variant(self)
+            }
+        }
+
+        impl<'a, T> GeometryTrait for &'a $geometry_type<T> {
+            type T = T;
+            type PointType<'b>
+                = UnimplementedPoint<Self::T>
+            where
+                Self: 'b;
+            type LineStringType<'b>
+                = UnimplementedLineString<Self::T>
+            where
+                Self: 'b;
+            type PolygonType<'b>
+                = UnimplementedPolygon<Self::T>
+            where
+                Self: 'b;
+            type MultiPointType<'b>
+                = UnimplementedMultiPoint<Self::T>
+            where
+                Self: 'b;
+            type MultiLineStringType<'b>
+                = UnimplementedMultiLineString<Self::T>
+            where
+                Self: 'b;
+            type MultiPolygonType<'b>
+                = UnimplementedMultiPolygon<Self::T>
+            where
+                Self: 'b;
+            type GeometryCollectionType<'b>
+                = UnimplementedGeometryCollection<Self::T>
+            where
+                Self: 'b;
+            type RectType<'b>
+                = UnimplementedRect<Self::T>
+            where
+                Self: 'b;
+            type TriangleType<'b>
+                = UnimplementedTriangle<Self::T>
+            where
+                Self: 'b;
+            type LineType<'b>
+                = UnimplementedLine<Self::T>
+            where
+                Self: 'b;
+
+            fn dim(&self) -> Dimensions {
+                unimplemented!()
+            }
+
+            fn as_type(
+                &self,
+            ) -> GeometryType<
+                '_,
+                Self::PointType<'_>,
+                Self::LineStringType<'_>,
+                Self::PolygonType<'_>,
+                Self::MultiPointType<'_>,
+                Self::MultiLineStringType<'_>,
+                Self::MultiPolygonType<'_>,
+                Self::GeometryCollectionType<'_>,
+                Self::RectType<'_>,
+                Self::TriangleType<'_>,
+                Self::LineType<'_>,
+            > {
+                $variant(self)
+            }
+        }
+    };
+}
+
+impl_unimplemented_specialization!(UnimplementedPoint, GeometryType::Point);
+impl_unimplemented_specialization!(UnimplementedLineString, GeometryType::LineString);
+impl_unimplemented_specialization!(UnimplementedPolygon, GeometryType::Polygon);
+impl_unimplemented_specialization!(UnimplementedMultiPoint, GeometryType::MultiPoint);
+impl_unimplemented_specialization!(UnimplementedMultiLineString, GeometryType::MultiLineString);
+impl_unimplemented_specialization!(UnimplementedMultiPolygon, GeometryType::MultiPolygon);
+impl_unimplemented_specialization!(
+    UnimplementedGeometryCollection,
+    GeometryType::GeometryCollection
+);
+impl_unimplemented_specialization!(UnimplementedRect, GeometryType::Rect);
+impl_unimplemented_specialization!(UnimplementedTriangle, GeometryType::Triangle);
+impl_unimplemented_specialization!(UnimplementedLine, GeometryType::Line);
+
 #[cfg(test)]
 mod test {
     // Ensures that all geo-types implement the GeometryTrait

--- a/geo-traits/src/geometry_collection.rs
+++ b/geo-traits/src/geometry_collection.rs
@@ -1,11 +1,7 @@
 use std::marker::PhantomData;
 
 use crate::iterator::GeometryCollectionIterator;
-use crate::{
-    Dimensions, GeometryTrait, UnimplementedGeometry, UnimplementedLine, UnimplementedLineString,
-    UnimplementedMultiLineString, UnimplementedMultiPoint, UnimplementedMultiPolygon,
-    UnimplementedPoint, UnimplementedPolygon, UnimplementedRect, UnimplementedTriangle,
-};
+use crate::{GeometryTrait, UnimplementedGeometry};
 #[cfg(feature = "geo-types")]
 use geo_types::{CoordNum, Geometry, GeometryCollection};
 
@@ -96,71 +92,5 @@ impl<T> GeometryCollectionTrait for UnimplementedGeometryCollection<T> {
 
     unsafe fn geometry_unchecked(&self, _i: usize) -> Self::GeometryType<'_> {
         unimplemented!()
-    }
-}
-
-impl<T> GeometryTrait for UnimplementedGeometryCollection<T> {
-    type T = T;
-    type PointType<'a>
-        = UnimplementedPoint<T>
-    where
-        Self: 'a;
-    type LineStringType<'a>
-        = UnimplementedLineString<T>
-    where
-        Self: 'a;
-    type LineType<'a>
-        = UnimplementedLine<T>
-    where
-        Self: 'a;
-    type PolygonType<'a>
-        = UnimplementedPolygon<T>
-    where
-        Self: 'a;
-    type MultiPointType<'a>
-        = UnimplementedMultiPoint<T>
-    where
-        Self: 'a;
-    type MultiLineStringType<'a>
-        = UnimplementedMultiLineString<T>
-    where
-        Self: 'a;
-    type MultiPolygonType<'a>
-        = UnimplementedMultiPolygon<T>
-    where
-        Self: 'a;
-    type GeometryCollectionType<'a>
-        = Self
-    where
-        Self: 'a;
-    type RectType<'a>
-        = UnimplementedRect<T>
-    where
-        Self: 'a;
-    type TriangleType<'a>
-        = UnimplementedTriangle<T>
-    where
-        Self: 'a;
-
-    fn dim(&self) -> Dimensions {
-        unimplemented!()
-    }
-
-    fn as_type(
-        &self,
-    ) -> crate::geometry::GeometryType<
-        '_,
-        Self::PointType<'_>,
-        Self::LineStringType<'_>,
-        Self::PolygonType<'_>,
-        Self::MultiPointType<'_>,
-        Self::MultiLineStringType<'_>,
-        Self::MultiPolygonType<'_>,
-        Self::GeometryCollectionType<'_>,
-        Self::RectType<'_>,
-        Self::TriangleType<'_>,
-        Self::LineType<'_>,
-    > {
-        crate::geometry::GeometryType::GeometryCollection(self)
     }
 }

--- a/geo-traits/src/geometry_collection.rs
+++ b/geo-traits/src/geometry_collection.rs
@@ -1,24 +1,22 @@
 use std::marker::PhantomData;
 
 use crate::iterator::GeometryCollectionIterator;
-use crate::{Dimensions, GeometryTrait, UnimplementedGeometry};
+use crate::{
+    Dimensions, GeometryTrait, UnimplementedGeometry, UnimplementedLine, UnimplementedLineString,
+    UnimplementedMultiLineString, UnimplementedMultiPoint, UnimplementedMultiPolygon,
+    UnimplementedPoint, UnimplementedPolygon, UnimplementedRect, UnimplementedTriangle,
+};
 #[cfg(feature = "geo-types")]
 use geo_types::{CoordNum, Geometry, GeometryCollection};
 
 /// A trait for accessing data from a generic GeometryCollection.
 ///
 /// A GeometryCollection is a collection of [Geometry][GeometryTrait] types.
-pub trait GeometryCollectionTrait: Sized {
-    /// The coordinate type of this geometry
-    type T;
-
+pub trait GeometryCollectionTrait: Sized + GeometryTrait {
     /// The type of each underlying geometry, which implements [GeometryTrait]
     type GeometryType<'a>: 'a + GeometryTrait<T = Self::T>
     where
         Self: 'a;
-
-    /// The dimension of this geometry
-    fn dim(&self) -> Dimensions;
 
     /// An iterator over the geometries in this GeometryCollection
     fn geometries(
@@ -50,15 +48,10 @@ pub trait GeometryCollectionTrait: Sized {
 
 #[cfg(feature = "geo-types")]
 impl<T: CoordNum> GeometryCollectionTrait for GeometryCollection<T> {
-    type T = T;
     type GeometryType<'a>
         = &'a Geometry<Self::T>
     where
         Self: 'a;
-
-    fn dim(&self) -> Dimensions {
-        Dimensions::Xy
-    }
 
     fn num_geometries(&self) -> usize {
         self.0.len()
@@ -71,15 +64,10 @@ impl<T: CoordNum> GeometryCollectionTrait for GeometryCollection<T> {
 
 #[cfg(feature = "geo-types")]
 impl<'a, T: CoordNum> GeometryCollectionTrait for &'a GeometryCollection<T> {
-    type T = T;
     type GeometryType<'b>
         = &'a Geometry<Self::T>
     where
         Self: 'b;
-
-    fn dim(&self) -> Dimensions {
-        Dimensions::Xy
-    }
 
     fn num_geometries(&self) -> usize {
         self.0.len()
@@ -97,15 +85,10 @@ impl<'a, T: CoordNum> GeometryCollectionTrait for &'a GeometryCollection<T> {
 pub struct UnimplementedGeometryCollection<T>(PhantomData<T>);
 
 impl<T> GeometryCollectionTrait for UnimplementedGeometryCollection<T> {
-    type T = T;
     type GeometryType<'a>
         = UnimplementedGeometry<Self::T>
     where
         Self: 'a;
-
-    fn dim(&self) -> Dimensions {
-        unimplemented!()
-    }
 
     fn num_geometries(&self) -> usize {
         unimplemented!()
@@ -113,5 +96,71 @@ impl<T> GeometryCollectionTrait for UnimplementedGeometryCollection<T> {
 
     unsafe fn geometry_unchecked(&self, _i: usize) -> Self::GeometryType<'_> {
         unimplemented!()
+    }
+}
+
+impl<T> GeometryTrait for UnimplementedGeometryCollection<T> {
+    type T = T;
+    type PointType<'a>
+        = UnimplementedPoint<T>
+    where
+        Self: 'a;
+    type LineStringType<'a>
+        = UnimplementedLineString<T>
+    where
+        Self: 'a;
+    type LineType<'a>
+        = UnimplementedLine<T>
+    where
+        Self: 'a;
+    type PolygonType<'a>
+        = UnimplementedPolygon<T>
+    where
+        Self: 'a;
+    type MultiPointType<'a>
+        = UnimplementedMultiPoint<T>
+    where
+        Self: 'a;
+    type MultiLineStringType<'a>
+        = UnimplementedMultiLineString<T>
+    where
+        Self: 'a;
+    type MultiPolygonType<'a>
+        = UnimplementedMultiPolygon<T>
+    where
+        Self: 'a;
+    type GeometryCollectionType<'a>
+        = Self
+    where
+        Self: 'a;
+    type RectType<'a>
+        = UnimplementedRect<T>
+    where
+        Self: 'a;
+    type TriangleType<'a>
+        = UnimplementedTriangle<T>
+    where
+        Self: 'a;
+
+    fn dim(&self) -> Dimensions {
+        unimplemented!()
+    }
+
+    fn as_type(
+        &self,
+    ) -> crate::geometry::GeometryType<
+        '_,
+        Self::PointType<'_>,
+        Self::LineStringType<'_>,
+        Self::PolygonType<'_>,
+        Self::MultiPointType<'_>,
+        Self::MultiLineStringType<'_>,
+        Self::MultiPolygonType<'_>,
+        Self::GeometryCollectionType<'_>,
+        Self::RectType<'_>,
+        Self::TriangleType<'_>,
+        Self::LineType<'_>,
+    > {
+        crate::geometry::GeometryType::GeometryCollection(self)
     }
 }

--- a/geo-traits/src/iterator.rs
+++ b/geo-traits/src/iterator.rs
@@ -4,13 +4,13 @@ use super::{
 };
 
 macro_rules! impl_iterator {
-    ($struct_name:ident, $self_trait:ident, $item_trait:ident, $access_method:ident, $item_type:ident) => {
+    ($struct_name:ident, $self_trait:ident, $item_trait:ident, $access_method:ident, $item_type:ident, $associated_type:ident) => {
         /// An iterator over the parts of this geometry.
         pub(crate) struct $struct_name<
             'a,
             T,
             $item_type: 'a + $item_trait<T = T>,
-            G: $self_trait<T = T, $item_type<'a> = $item_type>,
+            G: $self_trait<T = T, $associated_type<'a> = $item_type>,
         > {
             geom: &'a G,
             index: usize,
@@ -21,7 +21,7 @@ macro_rules! impl_iterator {
                 'a,
                 T,
                 $item_type: 'a + $item_trait<T = T>,
-                G: $self_trait<T = T, $item_type<'a> = $item_type>,
+                G: $self_trait<T = T, $associated_type<'a> = $item_type>,
             > $struct_name<'a, T, $item_type, G>
         {
             /// Create a new iterator
@@ -34,7 +34,7 @@ macro_rules! impl_iterator {
                 'a,
                 T,
                 $item_type: 'a + $item_trait<T = T>,
-                G: $self_trait<T = T, $item_type<'a> = $item_type>,
+                G: $self_trait<T = T, $associated_type<'a> = $item_type>,
             > Iterator for $struct_name<'a, T, $item_type, G>
         {
             type Item = $item_type;
@@ -59,7 +59,7 @@ macro_rules! impl_iterator {
                 'a,
                 T,
                 $item_type: 'a + $item_trait<T = T>,
-                G: $self_trait<T = T, $item_type<'a> = $item_type>,
+                G: $self_trait<T = T, $associated_type<'a> = $item_type>,
             > ExactSizeIterator for $struct_name<'a, T, $item_type, G>
         {
         }
@@ -68,7 +68,7 @@ macro_rules! impl_iterator {
                 'a,
                 T,
                 $item_type: 'a + $item_trait<T = T>,
-                G: $self_trait<T = T, $item_type<'a> = $item_type>,
+                G: $self_trait<T = T, $associated_type<'a> = $item_type>,
             > DoubleEndedIterator for $struct_name<'a, T, $item_type, G>
         {
             #[inline]
@@ -85,44 +85,50 @@ macro_rules! impl_iterator {
 }
 
 impl_iterator!(
-    LineStringIterator,
-    LineStringTrait,
-    CoordTrait,
-    coord_unchecked,
-    CoordType
+    LineStringIterator, // struct_name
+    LineStringTrait,    // self_trait
+    CoordTrait,         // item_trait
+    coord_unchecked,    // access_method
+    CoordType,          // item_type
+    CoordType           // associated_type
 );
 impl_iterator!(
-    PolygonInteriorIterator,
-    PolygonTrait,
-    LineStringTrait,
-    interior_unchecked,
-    RingType
+    PolygonInteriorIterator, // struct_name
+    PolygonTrait,            // self_trait
+    LineStringTrait,         // item_trait
+    interior_unchecked,      // access_method
+    RingType,                // item_type
+    RingType                 // associated_type
 );
 impl_iterator!(
-    MultiPointIterator,
-    MultiPointTrait,
-    PointTrait,
-    point_unchecked,
-    PointType
+    MultiPointIterator, // struct_name
+    MultiPointTrait,    // self_trait
+    PointTrait,         // item_trait
+    point_unchecked,    // access_method
+    PointType,          // item_type
+    InnerPointType      // associated_type
 );
 impl_iterator!(
-    MultiLineStringIterator,
-    MultiLineStringTrait,
-    LineStringTrait,
-    line_string_unchecked,
-    LineStringType
+    MultiLineStringIterator, // struct_name
+    MultiLineStringTrait,    // self_trait
+    LineStringTrait,         // item_trait
+    line_string_unchecked,   // access_method
+    LineStringType,          // item_type
+    InnerLineStringType      // associated_type
 );
 impl_iterator!(
-    MultiPolygonIterator,
-    MultiPolygonTrait,
-    PolygonTrait,
-    polygon_unchecked,
-    PolygonType
+    MultiPolygonIterator, // struct_name
+    MultiPolygonTrait,    // self_trait
+    PolygonTrait,         // item_trait
+    polygon_unchecked,    // access_method
+    PolygonType,          // item_type
+    InnerPolygonType      // associated_type
 );
 impl_iterator!(
-    GeometryCollectionIterator,
-    GeometryCollectionTrait,
-    GeometryTrait,
-    geometry_unchecked,
-    GeometryType
+    GeometryCollectionIterator, // struct_name
+    GeometryCollectionTrait,    // self_trait
+    GeometryTrait,              // item_trait
+    geometry_unchecked,         // access_method
+    GeometryType,               // item_type
+    GeometryType                // associated_type
 );

--- a/geo-traits/src/line.rs
+++ b/geo-traits/src/line.rs
@@ -1,6 +1,11 @@
 use std::marker::PhantomData;
 
-use crate::{CoordTrait, Dimensions, UnimplementedCoord};
+use crate::{
+    CoordTrait, Dimensions, GeometryTrait, GeometryType, UnimplementedCoord,
+    UnimplementedGeometryCollection, UnimplementedLineString, UnimplementedMultiLineString,
+    UnimplementedMultiPoint, UnimplementedMultiPolygon, UnimplementedPoint, UnimplementedPolygon,
+    UnimplementedRect, UnimplementedTriangle,
+};
 #[cfg(feature = "geo-types")]
 use geo_types::{Coord, CoordNum, Line};
 
@@ -9,17 +14,11 @@ use geo_types::{Coord, CoordNum, Line};
 /// A Line is a line segment made up of exactly two [coordinates][CoordTrait].
 ///
 /// Refer to [geo_types::Line] for information about semantics and validity.
-pub trait LineTrait: Sized {
-    /// The coordinate type of this geometry
-    type T;
-
+pub trait LineTrait: Sized + GeometryTrait {
     /// The type of each underlying coordinate, which implements [CoordTrait]
     type CoordType<'a>: 'a + CoordTrait<T = Self::T>
     where
         Self: 'a;
-
-    /// The dimension of this geometry
-    fn dim(&self) -> Dimensions;
 
     /// Access the start coordinate in this Line
     fn start(&self) -> Self::CoordType<'_>;
@@ -35,15 +34,10 @@ pub trait LineTrait: Sized {
 
 #[cfg(feature = "geo-types")]
 impl<T: CoordNum> LineTrait for Line<T> {
-    type T = T;
     type CoordType<'a>
         = &'a Coord<Self::T>
     where
         Self: 'a;
-
-    fn dim(&self) -> Dimensions {
-        Dimensions::Xy
-    }
 
     fn start(&self) -> Self::CoordType<'_> {
         &self.start
@@ -56,15 +50,10 @@ impl<T: CoordNum> LineTrait for Line<T> {
 
 #[cfg(feature = "geo-types")]
 impl<'a, T: CoordNum> LineTrait for &'a Line<T> {
-    type T = T;
     type CoordType<'b>
         = &'a Coord<Self::T>
     where
         Self: 'b;
-
-    fn dim(&self) -> Dimensions {
-        Dimensions::Xy
-    }
 
     fn start(&self) -> Self::CoordType<'_> {
         &self.start
@@ -82,15 +71,10 @@ impl<'a, T: CoordNum> LineTrait for &'a Line<T> {
 pub struct UnimplementedLine<T>(PhantomData<T>);
 
 impl<T> LineTrait for UnimplementedLine<T> {
-    type T = T;
     type CoordType<'a>
         = UnimplementedCoord<Self::T>
     where
         Self: 'a;
-
-    fn dim(&self) -> Dimensions {
-        unimplemented!()
-    }
 
     fn start(&self) -> Self::CoordType<'_> {
         unimplemented!()
@@ -98,5 +82,71 @@ impl<T> LineTrait for UnimplementedLine<T> {
 
     fn end(&self) -> Self::CoordType<'_> {
         unimplemented!()
+    }
+}
+
+impl<T> GeometryTrait for UnimplementedLine<T> {
+    type T = T;
+    type PointType<'b>
+        = UnimplementedPoint<Self::T>
+    where
+        Self: 'b;
+    type LineStringType<'b>
+        = UnimplementedLineString<Self::T>
+    where
+        Self: 'b;
+    type PolygonType<'b>
+        = UnimplementedPolygon<Self::T>
+    where
+        Self: 'b;
+    type MultiPointType<'b>
+        = UnimplementedMultiPoint<Self::T>
+    where
+        Self: 'b;
+    type MultiLineStringType<'b>
+        = UnimplementedMultiLineString<Self::T>
+    where
+        Self: 'b;
+    type MultiPolygonType<'b>
+        = UnimplementedMultiPolygon<Self::T>
+    where
+        Self: 'b;
+    type GeometryCollectionType<'b>
+        = UnimplementedGeometryCollection<Self::T>
+    where
+        Self: 'b;
+    type RectType<'b>
+        = UnimplementedRect<Self::T>
+    where
+        Self: 'b;
+    type TriangleType<'b>
+        = UnimplementedTriangle<Self::T>
+    where
+        Self: 'b;
+    type LineType<'b>
+        = UnimplementedLine<Self::T>
+    where
+        Self: 'b;
+
+    fn dim(&self) -> Dimensions {
+        unimplemented!()
+    }
+
+    fn as_type(
+        &self,
+    ) -> GeometryType<
+        '_,
+        Self::PointType<'_>,
+        Self::LineStringType<'_>,
+        Self::PolygonType<'_>,
+        Self::MultiPointType<'_>,
+        Self::MultiLineStringType<'_>,
+        Self::MultiPolygonType<'_>,
+        Self::GeometryCollectionType<'_>,
+        Self::RectType<'_>,
+        Self::TriangleType<'_>,
+        Self::LineType<'_>,
+    > {
+        GeometryType::Line(self)
     }
 }

--- a/geo-traits/src/line.rs
+++ b/geo-traits/src/line.rs
@@ -1,11 +1,6 @@
 use std::marker::PhantomData;
 
-use crate::{
-    CoordTrait, Dimensions, GeometryTrait, GeometryType, UnimplementedCoord,
-    UnimplementedGeometryCollection, UnimplementedLineString, UnimplementedMultiLineString,
-    UnimplementedMultiPoint, UnimplementedMultiPolygon, UnimplementedPoint, UnimplementedPolygon,
-    UnimplementedRect, UnimplementedTriangle,
-};
+use crate::{CoordTrait, GeometryTrait, UnimplementedCoord};
 #[cfg(feature = "geo-types")]
 use geo_types::{Coord, CoordNum, Line};
 
@@ -82,71 +77,5 @@ impl<T> LineTrait for UnimplementedLine<T> {
 
     fn end(&self) -> Self::CoordType<'_> {
         unimplemented!()
-    }
-}
-
-impl<T> GeometryTrait for UnimplementedLine<T> {
-    type T = T;
-    type PointType<'b>
-        = UnimplementedPoint<Self::T>
-    where
-        Self: 'b;
-    type LineStringType<'b>
-        = UnimplementedLineString<Self::T>
-    where
-        Self: 'b;
-    type PolygonType<'b>
-        = UnimplementedPolygon<Self::T>
-    where
-        Self: 'b;
-    type MultiPointType<'b>
-        = UnimplementedMultiPoint<Self::T>
-    where
-        Self: 'b;
-    type MultiLineStringType<'b>
-        = UnimplementedMultiLineString<Self::T>
-    where
-        Self: 'b;
-    type MultiPolygonType<'b>
-        = UnimplementedMultiPolygon<Self::T>
-    where
-        Self: 'b;
-    type GeometryCollectionType<'b>
-        = UnimplementedGeometryCollection<Self::T>
-    where
-        Self: 'b;
-    type RectType<'b>
-        = UnimplementedRect<Self::T>
-    where
-        Self: 'b;
-    type TriangleType<'b>
-        = UnimplementedTriangle<Self::T>
-    where
-        Self: 'b;
-    type LineType<'b>
-        = UnimplementedLine<Self::T>
-    where
-        Self: 'b;
-
-    fn dim(&self) -> Dimensions {
-        unimplemented!()
-    }
-
-    fn as_type(
-        &self,
-    ) -> GeometryType<
-        '_,
-        Self::PointType<'_>,
-        Self::LineStringType<'_>,
-        Self::PolygonType<'_>,
-        Self::MultiPointType<'_>,
-        Self::MultiLineStringType<'_>,
-        Self::MultiPolygonType<'_>,
-        Self::GeometryCollectionType<'_>,
-        Self::RectType<'_>,
-        Self::TriangleType<'_>,
-        Self::LineType<'_>,
-    > {
-        GeometryType::Line(self)
     }
 }

--- a/geo-traits/src/line_string.rs
+++ b/geo-traits/src/line_string.rs
@@ -1,12 +1,7 @@
 use std::marker::PhantomData;
 
 use crate::iterator::LineStringIterator;
-use crate::{
-    CoordTrait, Dimensions, GeometryTrait, GeometryType, UnimplementedCoord,
-    UnimplementedGeometryCollection, UnimplementedLine, UnimplementedMultiLineString,
-    UnimplementedMultiPoint, UnimplementedMultiPolygon, UnimplementedPoint, UnimplementedPolygon,
-    UnimplementedRect, UnimplementedTriangle,
-};
+use crate::{CoordTrait, GeometryTrait, UnimplementedCoord};
 #[cfg(feature = "geo-types")]
 use geo_types::{Coord, CoordNum, LineString};
 
@@ -99,71 +94,5 @@ impl<T> LineStringTrait for UnimplementedLineString<T> {
 
     unsafe fn coord_unchecked(&self, _i: usize) -> Self::CoordType<'_> {
         unimplemented!()
-    }
-}
-
-impl<T> GeometryTrait for UnimplementedLineString<T> {
-    type T = T;
-    type PointType<'b>
-        = UnimplementedPoint<Self::T>
-    where
-        Self: 'b;
-    type LineStringType<'b>
-        = UnimplementedLineString<Self::T>
-    where
-        Self: 'b;
-    type PolygonType<'b>
-        = UnimplementedPolygon<Self::T>
-    where
-        Self: 'b;
-    type MultiPointType<'b>
-        = UnimplementedMultiPoint<Self::T>
-    where
-        Self: 'b;
-    type MultiLineStringType<'b>
-        = UnimplementedMultiLineString<Self::T>
-    where
-        Self: 'b;
-    type MultiPolygonType<'b>
-        = UnimplementedMultiPolygon<Self::T>
-    where
-        Self: 'b;
-    type GeometryCollectionType<'b>
-        = UnimplementedGeometryCollection<Self::T>
-    where
-        Self: 'b;
-    type RectType<'b>
-        = UnimplementedRect<Self::T>
-    where
-        Self: 'b;
-    type TriangleType<'b>
-        = UnimplementedTriangle<Self::T>
-    where
-        Self: 'b;
-    type LineType<'b>
-        = UnimplementedLine<Self::T>
-    where
-        Self: 'b;
-
-    fn dim(&self) -> Dimensions {
-        unimplemented!()
-    }
-
-    fn as_type(
-        &self,
-    ) -> GeometryType<
-        '_,
-        Self::PointType<'_>,
-        Self::LineStringType<'_>,
-        Self::PolygonType<'_>,
-        Self::MultiPointType<'_>,
-        Self::MultiLineStringType<'_>,
-        Self::MultiPolygonType<'_>,
-        Self::GeometryCollectionType<'_>,
-        Self::RectType<'_>,
-        Self::TriangleType<'_>,
-        Self::LineType<'_>,
-    > {
-        GeometryType::LineString(self)
     }
 }

--- a/geo-traits/src/line_string.rs
+++ b/geo-traits/src/line_string.rs
@@ -1,7 +1,12 @@
 use std::marker::PhantomData;
 
 use crate::iterator::LineStringIterator;
-use crate::{CoordTrait, Dimensions, UnimplementedCoord};
+use crate::{
+    CoordTrait, Dimensions, GeometryTrait, GeometryType, UnimplementedCoord,
+    UnimplementedGeometryCollection, UnimplementedLine, UnimplementedMultiLineString,
+    UnimplementedMultiPoint, UnimplementedMultiPolygon, UnimplementedPoint, UnimplementedPolygon,
+    UnimplementedRect, UnimplementedTriangle,
+};
 #[cfg(feature = "geo-types")]
 use geo_types::{Coord, CoordNum, LineString};
 
@@ -11,17 +16,11 @@ use geo_types::{Coord, CoordNum, LineString};
 /// between locations.
 ///
 /// Refer to [geo_types::LineString] for information about semantics and validity.
-pub trait LineStringTrait: Sized {
-    /// The coordinate type of this geometry
-    type T;
-
+pub trait LineStringTrait: Sized + GeometryTrait {
     /// The type of each underlying coordinate, which implements [CoordTrait]
     type CoordType<'a>: 'a + CoordTrait<T = Self::T>
     where
         Self: 'a;
-
-    /// The dimension of this geometry
-    fn dim(&self) -> Dimensions;
 
     /// An iterator over the coordinates in this LineString
     fn coords(&self) -> impl DoubleEndedIterator + ExactSizeIterator<Item = Self::CoordType<'_>> {
@@ -52,15 +51,10 @@ pub trait LineStringTrait: Sized {
 
 #[cfg(feature = "geo-types")]
 impl<T: CoordNum> LineStringTrait for LineString<T> {
-    type T = T;
     type CoordType<'a>
         = &'a Coord<Self::T>
     where
         Self: 'a;
-
-    fn dim(&self) -> Dimensions {
-        Dimensions::Xy
-    }
 
     fn num_coords(&self) -> usize {
         self.0.len()
@@ -73,15 +67,10 @@ impl<T: CoordNum> LineStringTrait for LineString<T> {
 
 #[cfg(feature = "geo-types")]
 impl<'a, T: CoordNum> LineStringTrait for &'a LineString<T> {
-    type T = T;
     type CoordType<'b>
         = &'a Coord<Self::T>
     where
         Self: 'b;
-
-    fn dim(&self) -> Dimensions {
-        Dimensions::Xy
-    }
 
     fn num_coords(&self) -> usize {
         self.0.len()
@@ -99,15 +88,10 @@ impl<'a, T: CoordNum> LineStringTrait for &'a LineString<T> {
 pub struct UnimplementedLineString<T>(PhantomData<T>);
 
 impl<T> LineStringTrait for UnimplementedLineString<T> {
-    type T = T;
     type CoordType<'a>
         = UnimplementedCoord<Self::T>
     where
         Self: 'a;
-
-    fn dim(&self) -> Dimensions {
-        unimplemented!()
-    }
 
     fn num_coords(&self) -> usize {
         unimplemented!()
@@ -115,5 +99,71 @@ impl<T> LineStringTrait for UnimplementedLineString<T> {
 
     unsafe fn coord_unchecked(&self, _i: usize) -> Self::CoordType<'_> {
         unimplemented!()
+    }
+}
+
+impl<T> GeometryTrait for UnimplementedLineString<T> {
+    type T = T;
+    type PointType<'b>
+        = UnimplementedPoint<Self::T>
+    where
+        Self: 'b;
+    type LineStringType<'b>
+        = UnimplementedLineString<Self::T>
+    where
+        Self: 'b;
+    type PolygonType<'b>
+        = UnimplementedPolygon<Self::T>
+    where
+        Self: 'b;
+    type MultiPointType<'b>
+        = UnimplementedMultiPoint<Self::T>
+    where
+        Self: 'b;
+    type MultiLineStringType<'b>
+        = UnimplementedMultiLineString<Self::T>
+    where
+        Self: 'b;
+    type MultiPolygonType<'b>
+        = UnimplementedMultiPolygon<Self::T>
+    where
+        Self: 'b;
+    type GeometryCollectionType<'b>
+        = UnimplementedGeometryCollection<Self::T>
+    where
+        Self: 'b;
+    type RectType<'b>
+        = UnimplementedRect<Self::T>
+    where
+        Self: 'b;
+    type TriangleType<'b>
+        = UnimplementedTriangle<Self::T>
+    where
+        Self: 'b;
+    type LineType<'b>
+        = UnimplementedLine<Self::T>
+    where
+        Self: 'b;
+
+    fn dim(&self) -> Dimensions {
+        unimplemented!()
+    }
+
+    fn as_type(
+        &self,
+    ) -> GeometryType<
+        '_,
+        Self::PointType<'_>,
+        Self::LineStringType<'_>,
+        Self::PolygonType<'_>,
+        Self::MultiPointType<'_>,
+        Self::MultiLineStringType<'_>,
+        Self::MultiPolygonType<'_>,
+        Self::GeometryCollectionType<'_>,
+        Self::RectType<'_>,
+        Self::TriangleType<'_>,
+        Self::LineType<'_>,
+    > {
+        GeometryType::LineString(self)
     }
 }

--- a/geo-traits/src/multi_line_string.rs
+++ b/geo-traits/src/multi_line_string.rs
@@ -2,11 +2,7 @@ use std::marker::PhantomData;
 
 use crate::iterator::MultiLineStringIterator;
 use crate::line_string::UnimplementedLineString;
-use crate::{
-    Dimensions, GeometryTrait, GeometryType, LineStringTrait, UnimplementedGeometryCollection,
-    UnimplementedLine, UnimplementedMultiPoint, UnimplementedMultiPolygon, UnimplementedPoint,
-    UnimplementedPolygon, UnimplementedRect, UnimplementedTriangle,
-};
+use crate::{GeometryTrait, LineStringTrait};
 #[cfg(feature = "geo-types")]
 use geo_types::{CoordNum, LineString, MultiLineString};
 
@@ -99,71 +95,5 @@ impl<T> MultiLineStringTrait for UnimplementedMultiLineString<T> {
 
     unsafe fn line_string_unchecked(&self, _i: usize) -> Self::InnerLineStringType<'_> {
         unimplemented!()
-    }
-}
-
-impl<T> GeometryTrait for UnimplementedMultiLineString<T> {
-    type T = T;
-    type PointType<'b>
-        = UnimplementedPoint<Self::T>
-    where
-        Self: 'b;
-    type LineStringType<'b>
-        = UnimplementedLineString<Self::T>
-    where
-        Self: 'b;
-    type PolygonType<'b>
-        = UnimplementedPolygon<Self::T>
-    where
-        Self: 'b;
-    type MultiPointType<'b>
-        = UnimplementedMultiPoint<Self::T>
-    where
-        Self: 'b;
-    type MultiLineStringType<'b>
-        = UnimplementedMultiLineString<Self::T>
-    where
-        Self: 'b;
-    type MultiPolygonType<'b>
-        = UnimplementedMultiPolygon<Self::T>
-    where
-        Self: 'b;
-    type GeometryCollectionType<'b>
-        = UnimplementedGeometryCollection<Self::T>
-    where
-        Self: 'b;
-    type RectType<'b>
-        = UnimplementedRect<Self::T>
-    where
-        Self: 'b;
-    type TriangleType<'b>
-        = UnimplementedTriangle<Self::T>
-    where
-        Self: 'b;
-    type LineType<'b>
-        = UnimplementedLine<Self::T>
-    where
-        Self: 'b;
-
-    fn dim(&self) -> Dimensions {
-        unimplemented!()
-    }
-
-    fn as_type(
-        &self,
-    ) -> GeometryType<
-        '_,
-        Self::PointType<'_>,
-        Self::LineStringType<'_>,
-        Self::PolygonType<'_>,
-        Self::MultiPointType<'_>,
-        Self::MultiLineStringType<'_>,
-        Self::MultiPolygonType<'_>,
-        Self::GeometryCollectionType<'_>,
-        Self::RectType<'_>,
-        Self::TriangleType<'_>,
-        Self::LineType<'_>,
-    > {
-        GeometryType::MultiLineString(self)
     }
 }

--- a/geo-traits/src/multi_line_string.rs
+++ b/geo-traits/src/multi_line_string.rs
@@ -2,7 +2,11 @@ use std::marker::PhantomData;
 
 use crate::iterator::MultiLineStringIterator;
 use crate::line_string::UnimplementedLineString;
-use crate::{Dimensions, LineStringTrait};
+use crate::{
+    Dimensions, GeometryTrait, GeometryType, LineStringTrait, UnimplementedGeometryCollection,
+    UnimplementedLine, UnimplementedMultiPoint, UnimplementedMultiPolygon, UnimplementedPoint,
+    UnimplementedPolygon, UnimplementedRect, UnimplementedTriangle,
+};
 #[cfg(feature = "geo-types")]
 use geo_types::{CoordNum, LineString, MultiLineString};
 
@@ -11,22 +15,16 @@ use geo_types::{CoordNum, LineString, MultiLineString};
 /// A MultiLineString is a collection of [`LineString`s][LineStringTrait].
 ///
 /// Refer to [geo_types::MultiLineString] for information about semantics and validity.
-pub trait MultiLineStringTrait: Sized {
-    /// The coordinate type of this geometry
-    type T;
-
+pub trait MultiLineStringTrait: Sized + GeometryTrait {
     /// The type of each underlying LineString, which implements [LineStringTrait]
-    type LineStringType<'a>: 'a + LineStringTrait<T = Self::T>
+    type InnerLineStringType<'a>: 'a + LineStringTrait<T = Self::T>
     where
         Self: 'a;
-
-    /// The dimension of this geometry
-    fn dim(&self) -> Dimensions;
 
     /// An iterator over the LineStrings in this MultiLineString
     fn line_strings(
         &self,
-    ) -> impl DoubleEndedIterator + ExactSizeIterator<Item = Self::LineStringType<'_>> {
+    ) -> impl DoubleEndedIterator + ExactSizeIterator<Item = Self::InnerLineStringType<'_>> {
         MultiLineStringIterator::new(self, 0, self.num_line_strings())
     }
 
@@ -35,7 +33,7 @@ pub trait MultiLineStringTrait: Sized {
 
     /// Access to a specified line_string in this MultiLineString
     /// Will return None if the provided index is out of bounds
-    fn line_string(&self, i: usize) -> Option<Self::LineStringType<'_>> {
+    fn line_string(&self, i: usize) -> Option<Self::InnerLineStringType<'_>> {
         if i >= self.num_line_strings() {
             None
         } else {
@@ -48,47 +46,37 @@ pub trait MultiLineStringTrait: Sized {
     /// # Safety
     ///
     /// Accessing an index out of bounds is UB.
-    unsafe fn line_string_unchecked(&self, i: usize) -> Self::LineStringType<'_>;
+    unsafe fn line_string_unchecked(&self, i: usize) -> Self::InnerLineStringType<'_>;
 }
 
 #[cfg(feature = "geo-types")]
 impl<T: CoordNum> MultiLineStringTrait for MultiLineString<T> {
-    type T = T;
-    type LineStringType<'a>
+    type InnerLineStringType<'a>
         = &'a LineString<Self::T>
     where
         Self: 'a;
-
-    fn dim(&self) -> Dimensions {
-        Dimensions::Xy
-    }
 
     fn num_line_strings(&self) -> usize {
         self.0.len()
     }
 
-    unsafe fn line_string_unchecked(&self, i: usize) -> Self::LineStringType<'_> {
+    unsafe fn line_string_unchecked(&self, i: usize) -> Self::InnerLineStringType<'_> {
         self.0.get_unchecked(i)
     }
 }
 
 #[cfg(feature = "geo-types")]
 impl<'a, T: CoordNum> MultiLineStringTrait for &'a MultiLineString<T> {
-    type T = T;
-    type LineStringType<'b>
+    type InnerLineStringType<'b>
         = &'a LineString<Self::T>
     where
         Self: 'b;
-
-    fn dim(&self) -> Dimensions {
-        Dimensions::Xy
-    }
 
     fn num_line_strings(&self) -> usize {
         self.0.len()
     }
 
-    unsafe fn line_string_unchecked(&self, i: usize) -> Self::LineStringType<'_> {
+    unsafe fn line_string_unchecked(&self, i: usize) -> Self::InnerLineStringType<'_> {
         self.0.get_unchecked(i)
     }
 }
@@ -100,21 +88,82 @@ impl<'a, T: CoordNum> MultiLineStringTrait for &'a MultiLineString<T> {
 pub struct UnimplementedMultiLineString<T>(PhantomData<T>);
 
 impl<T> MultiLineStringTrait for UnimplementedMultiLineString<T> {
-    type T = T;
-    type LineStringType<'a>
+    type InnerLineStringType<'a>
         = UnimplementedLineString<Self::T>
     where
         Self: 'a;
-
-    fn dim(&self) -> Dimensions {
-        unimplemented!()
-    }
 
     fn num_line_strings(&self) -> usize {
         unimplemented!()
     }
 
-    unsafe fn line_string_unchecked(&self, _i: usize) -> Self::LineStringType<'_> {
+    unsafe fn line_string_unchecked(&self, _i: usize) -> Self::InnerLineStringType<'_> {
         unimplemented!()
+    }
+}
+
+impl<T> GeometryTrait for UnimplementedMultiLineString<T> {
+    type T = T;
+    type PointType<'b>
+        = UnimplementedPoint<Self::T>
+    where
+        Self: 'b;
+    type LineStringType<'b>
+        = UnimplementedLineString<Self::T>
+    where
+        Self: 'b;
+    type PolygonType<'b>
+        = UnimplementedPolygon<Self::T>
+    where
+        Self: 'b;
+    type MultiPointType<'b>
+        = UnimplementedMultiPoint<Self::T>
+    where
+        Self: 'b;
+    type MultiLineStringType<'b>
+        = UnimplementedMultiLineString<Self::T>
+    where
+        Self: 'b;
+    type MultiPolygonType<'b>
+        = UnimplementedMultiPolygon<Self::T>
+    where
+        Self: 'b;
+    type GeometryCollectionType<'b>
+        = UnimplementedGeometryCollection<Self::T>
+    where
+        Self: 'b;
+    type RectType<'b>
+        = UnimplementedRect<Self::T>
+    where
+        Self: 'b;
+    type TriangleType<'b>
+        = UnimplementedTriangle<Self::T>
+    where
+        Self: 'b;
+    type LineType<'b>
+        = UnimplementedLine<Self::T>
+    where
+        Self: 'b;
+
+    fn dim(&self) -> Dimensions {
+        unimplemented!()
+    }
+
+    fn as_type(
+        &self,
+    ) -> GeometryType<
+        '_,
+        Self::PointType<'_>,
+        Self::LineStringType<'_>,
+        Self::PolygonType<'_>,
+        Self::MultiPointType<'_>,
+        Self::MultiLineStringType<'_>,
+        Self::MultiPolygonType<'_>,
+        Self::GeometryCollectionType<'_>,
+        Self::RectType<'_>,
+        Self::TriangleType<'_>,
+        Self::LineType<'_>,
+    > {
+        GeometryType::MultiLineString(self)
     }
 }

--- a/geo-traits/src/multi_point.rs
+++ b/geo-traits/src/multi_point.rs
@@ -1,7 +1,12 @@
 use std::marker::PhantomData;
 
 use crate::iterator::MultiPointIterator;
-use crate::{Dimensions, PointTrait, UnimplementedPoint};
+use crate::{
+    Dimensions, GeometryTrait, GeometryType, PointTrait, UnimplementedGeometryCollection,
+    UnimplementedLine, UnimplementedLineString, UnimplementedMultiLineString,
+    UnimplementedMultiPolygon, UnimplementedPoint, UnimplementedPolygon, UnimplementedRect,
+    UnimplementedTriangle,
+};
 #[cfg(feature = "geo-types")]
 use geo_types::{CoordNum, MultiPoint, Point};
 
@@ -10,20 +15,16 @@ use geo_types::{CoordNum, MultiPoint, Point};
 /// A MultiPoint is a collection of [`Point`s][PointTrait].
 ///
 /// Refer to [geo_types::MultiPoint] for information about semantics and validity.
-pub trait MultiPointTrait: Sized {
-    /// The coordinate type of this geometry
-    type T;
-
+pub trait MultiPointTrait: Sized + GeometryTrait {
     /// The type of each underlying Point, which implements [PointTrait]
-    type PointType<'a>: 'a + PointTrait<T = Self::T>
+    type InnerPointType<'a>: 'a + PointTrait<T = Self::T>
     where
         Self: 'a;
 
-    /// The dimension of this geometry
-    fn dim(&self) -> Dimensions;
-
     /// An iterator over the points in this MultiPoint
-    fn points(&self) -> impl DoubleEndedIterator + ExactSizeIterator<Item = Self::PointType<'_>> {
+    fn points(
+        &self,
+    ) -> impl DoubleEndedIterator + ExactSizeIterator<Item = Self::InnerPointType<'_>> {
         MultiPointIterator::new(self, 0, self.num_points())
     }
 
@@ -32,7 +33,7 @@ pub trait MultiPointTrait: Sized {
 
     /// Access to a specified point in this MultiPoint
     /// Will return None if the provided index is out of bounds
-    fn point(&self, i: usize) -> Option<Self::PointType<'_>> {
+    fn point(&self, i: usize) -> Option<Self::InnerPointType<'_>> {
         if i >= self.num_points() {
             None
         } else {
@@ -45,47 +46,37 @@ pub trait MultiPointTrait: Sized {
     /// # Safety
     ///
     /// Accessing an index out of bounds is UB.
-    unsafe fn point_unchecked(&self, i: usize) -> Self::PointType<'_>;
+    unsafe fn point_unchecked(&self, i: usize) -> Self::InnerPointType<'_>;
 }
 
 #[cfg(feature = "geo-types")]
 impl<T: CoordNum> MultiPointTrait for MultiPoint<T> {
-    type T = T;
-    type PointType<'a>
+    type InnerPointType<'a>
         = &'a Point<Self::T>
     where
         Self: 'a;
-
-    fn dim(&self) -> Dimensions {
-        Dimensions::Xy
-    }
 
     fn num_points(&self) -> usize {
         self.0.len()
     }
 
-    unsafe fn point_unchecked(&self, i: usize) -> Self::PointType<'_> {
+    unsafe fn point_unchecked(&self, i: usize) -> Self::InnerPointType<'_> {
         self.0.get_unchecked(i)
     }
 }
 
 #[cfg(feature = "geo-types")]
 impl<'a, T: CoordNum> MultiPointTrait for &'a MultiPoint<T> {
-    type T = T;
-    type PointType<'b>
+    type InnerPointType<'b>
         = &'a Point<Self::T>
     where
         Self: 'b;
-
-    fn dim(&self) -> Dimensions {
-        Dimensions::Xy
-    }
 
     fn num_points(&self) -> usize {
         self.0.len()
     }
 
-    unsafe fn point_unchecked(&self, i: usize) -> Self::PointType<'_> {
+    unsafe fn point_unchecked(&self, i: usize) -> Self::InnerPointType<'_> {
         self.0.get_unchecked(i)
     }
 }
@@ -97,21 +88,82 @@ impl<'a, T: CoordNum> MultiPointTrait for &'a MultiPoint<T> {
 pub struct UnimplementedMultiPoint<T>(PhantomData<T>);
 
 impl<T> MultiPointTrait for UnimplementedMultiPoint<T> {
-    type T = T;
-    type PointType<'a>
+    type InnerPointType<'a>
         = UnimplementedPoint<Self::T>
     where
         Self: 'a;
-
-    fn dim(&self) -> Dimensions {
-        unimplemented!()
-    }
 
     fn num_points(&self) -> usize {
         unimplemented!()
     }
 
-    unsafe fn point_unchecked(&self, _i: usize) -> Self::PointType<'_> {
+    unsafe fn point_unchecked(&self, _i: usize) -> Self::InnerPointType<'_> {
         unimplemented!()
+    }
+}
+
+impl<T> GeometryTrait for UnimplementedMultiPoint<T> {
+    type T = T;
+    type PointType<'b>
+        = UnimplementedPoint<Self::T>
+    where
+        Self: 'b;
+    type LineStringType<'b>
+        = UnimplementedLineString<Self::T>
+    where
+        Self: 'b;
+    type PolygonType<'b>
+        = UnimplementedPolygon<Self::T>
+    where
+        Self: 'b;
+    type MultiPointType<'b>
+        = UnimplementedMultiPoint<Self::T>
+    where
+        Self: 'b;
+    type MultiLineStringType<'b>
+        = UnimplementedMultiLineString<Self::T>
+    where
+        Self: 'b;
+    type MultiPolygonType<'b>
+        = UnimplementedMultiPolygon<Self::T>
+    where
+        Self: 'b;
+    type GeometryCollectionType<'b>
+        = UnimplementedGeometryCollection<Self::T>
+    where
+        Self: 'b;
+    type RectType<'b>
+        = UnimplementedRect<Self::T>
+    where
+        Self: 'b;
+    type TriangleType<'b>
+        = UnimplementedTriangle<Self::T>
+    where
+        Self: 'b;
+    type LineType<'b>
+        = UnimplementedLine<Self::T>
+    where
+        Self: 'b;
+
+    fn dim(&self) -> Dimensions {
+        unimplemented!()
+    }
+
+    fn as_type(
+        &self,
+    ) -> GeometryType<
+        '_,
+        Self::PointType<'_>,
+        Self::LineStringType<'_>,
+        Self::PolygonType<'_>,
+        Self::MultiPointType<'_>,
+        Self::MultiLineStringType<'_>,
+        Self::MultiPolygonType<'_>,
+        Self::GeometryCollectionType<'_>,
+        Self::RectType<'_>,
+        Self::TriangleType<'_>,
+        Self::LineType<'_>,
+    > {
+        GeometryType::MultiPoint(self)
     }
 }

--- a/geo-traits/src/multi_point.rs
+++ b/geo-traits/src/multi_point.rs
@@ -1,12 +1,7 @@
 use std::marker::PhantomData;
 
 use crate::iterator::MultiPointIterator;
-use crate::{
-    Dimensions, GeometryTrait, GeometryType, PointTrait, UnimplementedGeometryCollection,
-    UnimplementedLine, UnimplementedLineString, UnimplementedMultiLineString,
-    UnimplementedMultiPolygon, UnimplementedPoint, UnimplementedPolygon, UnimplementedRect,
-    UnimplementedTriangle,
-};
+use crate::{GeometryTrait, PointTrait, UnimplementedPoint};
 #[cfg(feature = "geo-types")]
 use geo_types::{CoordNum, MultiPoint, Point};
 
@@ -99,71 +94,5 @@ impl<T> MultiPointTrait for UnimplementedMultiPoint<T> {
 
     unsafe fn point_unchecked(&self, _i: usize) -> Self::InnerPointType<'_> {
         unimplemented!()
-    }
-}
-
-impl<T> GeometryTrait for UnimplementedMultiPoint<T> {
-    type T = T;
-    type PointType<'b>
-        = UnimplementedPoint<Self::T>
-    where
-        Self: 'b;
-    type LineStringType<'b>
-        = UnimplementedLineString<Self::T>
-    where
-        Self: 'b;
-    type PolygonType<'b>
-        = UnimplementedPolygon<Self::T>
-    where
-        Self: 'b;
-    type MultiPointType<'b>
-        = UnimplementedMultiPoint<Self::T>
-    where
-        Self: 'b;
-    type MultiLineStringType<'b>
-        = UnimplementedMultiLineString<Self::T>
-    where
-        Self: 'b;
-    type MultiPolygonType<'b>
-        = UnimplementedMultiPolygon<Self::T>
-    where
-        Self: 'b;
-    type GeometryCollectionType<'b>
-        = UnimplementedGeometryCollection<Self::T>
-    where
-        Self: 'b;
-    type RectType<'b>
-        = UnimplementedRect<Self::T>
-    where
-        Self: 'b;
-    type TriangleType<'b>
-        = UnimplementedTriangle<Self::T>
-    where
-        Self: 'b;
-    type LineType<'b>
-        = UnimplementedLine<Self::T>
-    where
-        Self: 'b;
-
-    fn dim(&self) -> Dimensions {
-        unimplemented!()
-    }
-
-    fn as_type(
-        &self,
-    ) -> GeometryType<
-        '_,
-        Self::PointType<'_>,
-        Self::LineStringType<'_>,
-        Self::PolygonType<'_>,
-        Self::MultiPointType<'_>,
-        Self::MultiLineStringType<'_>,
-        Self::MultiPolygonType<'_>,
-        Self::GeometryCollectionType<'_>,
-        Self::RectType<'_>,
-        Self::TriangleType<'_>,
-        Self::LineType<'_>,
-    > {
-        GeometryType::MultiPoint(self)
     }
 }

--- a/geo-traits/src/multi_polygon.rs
+++ b/geo-traits/src/multi_polygon.rs
@@ -2,29 +2,27 @@ use std::marker::PhantomData;
 
 use crate::iterator::MultiPolygonIterator;
 use crate::polygon::UnimplementedPolygon;
-use crate::{Dimensions, PolygonTrait};
+use crate::{
+    Dimensions, GeometryTrait, GeometryType, PolygonTrait, UnimplementedGeometryCollection,
+    UnimplementedLine, UnimplementedLineString, UnimplementedMultiLineString,
+    UnimplementedMultiPoint, UnimplementedPoint, UnimplementedRect, UnimplementedTriangle,
+};
 #[cfg(feature = "geo-types")]
 use geo_types::{CoordNum, MultiPolygon, Polygon};
 
 /// A trait for accessing data from a generic MultiPolygon.
 ///
 /// Refer to [geo_types::MultiPolygon] for information about semantics and validity.
-pub trait MultiPolygonTrait: Sized {
-    /// The coordinate type of this geometry
-    type T;
-
+pub trait MultiPolygonTrait: Sized + GeometryTrait {
     /// The type of each underlying Polygon, which implements [PolygonTrait]
-    type PolygonType<'a>: 'a + PolygonTrait<T = Self::T>
+    type InnerPolygonType<'a>: 'a + PolygonTrait<T = Self::T>
     where
         Self: 'a;
-
-    /// The dimension of this geometry
-    fn dim(&self) -> Dimensions;
 
     /// An iterator over the Polygons in this MultiPolygon
     fn polygons(
         &self,
-    ) -> impl DoubleEndedIterator + ExactSizeIterator<Item = Self::PolygonType<'_>> {
+    ) -> impl DoubleEndedIterator + ExactSizeIterator<Item = Self::InnerPolygonType<'_>> {
         MultiPolygonIterator::new(self, 0, self.num_polygons())
     }
 
@@ -33,7 +31,7 @@ pub trait MultiPolygonTrait: Sized {
 
     /// Access to a specified polygon in this MultiPolygon
     /// Will return None if the provided index is out of bounds
-    fn polygon(&self, i: usize) -> Option<Self::PolygonType<'_>> {
+    fn polygon(&self, i: usize) -> Option<Self::InnerPolygonType<'_>> {
         if i >= self.num_polygons() {
             None
         } else {
@@ -46,47 +44,37 @@ pub trait MultiPolygonTrait: Sized {
     /// # Safety
     ///
     /// Accessing an index out of bounds is UB.
-    unsafe fn polygon_unchecked(&self, i: usize) -> Self::PolygonType<'_>;
+    unsafe fn polygon_unchecked(&self, i: usize) -> Self::InnerPolygonType<'_>;
 }
 
 #[cfg(feature = "geo-types")]
 impl<T: CoordNum> MultiPolygonTrait for MultiPolygon<T> {
-    type T = T;
-    type PolygonType<'a>
+    type InnerPolygonType<'a>
         = &'a Polygon<Self::T>
     where
         Self: 'a;
-
-    fn dim(&self) -> Dimensions {
-        Dimensions::Xy
-    }
 
     fn num_polygons(&self) -> usize {
         self.0.len()
     }
 
-    unsafe fn polygon_unchecked(&self, i: usize) -> Self::PolygonType<'_> {
+    unsafe fn polygon_unchecked(&self, i: usize) -> Self::InnerPolygonType<'_> {
         self.0.get_unchecked(i)
     }
 }
 
 #[cfg(feature = "geo-types")]
 impl<'a, T: CoordNum> MultiPolygonTrait for &'a MultiPolygon<T> {
-    type T = T;
-    type PolygonType<'b>
+    type InnerPolygonType<'b>
         = &'a Polygon<Self::T>
     where
         Self: 'b;
-
-    fn dim(&self) -> Dimensions {
-        Dimensions::Xy
-    }
 
     fn num_polygons(&self) -> usize {
         self.0.len()
     }
 
-    unsafe fn polygon_unchecked(&self, i: usize) -> Self::PolygonType<'_> {
+    unsafe fn polygon_unchecked(&self, i: usize) -> Self::InnerPolygonType<'_> {
         self.0.get_unchecked(i)
     }
 }
@@ -97,22 +85,83 @@ impl<'a, T: CoordNum> MultiPolygonTrait for &'a MultiPolygon<T> {
 /// have a MultiPolygon concept
 pub struct UnimplementedMultiPolygon<T>(PhantomData<T>);
 
-impl<T> MultiPolygonTrait for UnimplementedMultiPolygon<T> {
+impl<T> GeometryTrait for UnimplementedMultiPolygon<T> {
     type T = T;
-    type PolygonType<'a>
+    type PointType<'b>
+        = UnimplementedPoint<Self::T>
+    where
+        Self: 'b;
+    type LineStringType<'b>
+        = UnimplementedLineString<Self::T>
+    where
+        Self: 'b;
+    type PolygonType<'b>
         = UnimplementedPolygon<Self::T>
     where
-        Self: 'a;
+        Self: 'b;
+    type MultiPointType<'b>
+        = UnimplementedMultiPoint<Self::T>
+    where
+        Self: 'b;
+    type MultiLineStringType<'b>
+        = UnimplementedMultiLineString<Self::T>
+    where
+        Self: 'b;
+    type MultiPolygonType<'b>
+        = UnimplementedMultiPolygon<Self::T>
+    where
+        Self: 'b;
+    type GeometryCollectionType<'b>
+        = UnimplementedGeometryCollection<Self::T>
+    where
+        Self: 'b;
+    type RectType<'b>
+        = UnimplementedRect<Self::T>
+    where
+        Self: 'b;
+    type TriangleType<'b>
+        = UnimplementedTriangle<Self::T>
+    where
+        Self: 'b;
+    type LineType<'b>
+        = UnimplementedLine<Self::T>
+    where
+        Self: 'b;
 
     fn dim(&self) -> Dimensions {
         unimplemented!()
     }
 
+    fn as_type(
+        &self,
+    ) -> GeometryType<
+        '_,
+        Self::PointType<'_>,
+        Self::LineStringType<'_>,
+        Self::PolygonType<'_>,
+        Self::MultiPointType<'_>,
+        Self::MultiLineStringType<'_>,
+        Self::MultiPolygonType<'_>,
+        Self::GeometryCollectionType<'_>,
+        Self::RectType<'_>,
+        Self::TriangleType<'_>,
+        Self::LineType<'_>,
+    > {
+        GeometryType::MultiPolygon(self)
+    }
+}
+
+impl<T> MultiPolygonTrait for UnimplementedMultiPolygon<T> {
+    type InnerPolygonType<'a>
+        = UnimplementedPolygon<Self::T>
+    where
+        Self: 'a;
+
     fn num_polygons(&self) -> usize {
         unimplemented!()
     }
 
-    unsafe fn polygon_unchecked(&self, _i: usize) -> Self::PolygonType<'_> {
+    unsafe fn polygon_unchecked(&self, _i: usize) -> Self::InnerPolygonType<'_> {
         unimplemented!()
     }
 }

--- a/geo-traits/src/multi_polygon.rs
+++ b/geo-traits/src/multi_polygon.rs
@@ -2,11 +2,7 @@ use std::marker::PhantomData;
 
 use crate::iterator::MultiPolygonIterator;
 use crate::polygon::UnimplementedPolygon;
-use crate::{
-    Dimensions, GeometryTrait, GeometryType, PolygonTrait, UnimplementedGeometryCollection,
-    UnimplementedLine, UnimplementedLineString, UnimplementedMultiLineString,
-    UnimplementedMultiPoint, UnimplementedPoint, UnimplementedRect, UnimplementedTriangle,
-};
+use crate::{GeometryTrait, PolygonTrait};
 #[cfg(feature = "geo-types")]
 use geo_types::{CoordNum, MultiPolygon, Polygon};
 
@@ -84,72 +80,6 @@ impl<'a, T: CoordNum> MultiPolygonTrait for &'a MultiPolygon<T> {
 /// This can be used as the `MultiPolygonType` of the `GeometryTrait` by implementations that don't
 /// have a MultiPolygon concept
 pub struct UnimplementedMultiPolygon<T>(PhantomData<T>);
-
-impl<T> GeometryTrait for UnimplementedMultiPolygon<T> {
-    type T = T;
-    type PointType<'b>
-        = UnimplementedPoint<Self::T>
-    where
-        Self: 'b;
-    type LineStringType<'b>
-        = UnimplementedLineString<Self::T>
-    where
-        Self: 'b;
-    type PolygonType<'b>
-        = UnimplementedPolygon<Self::T>
-    where
-        Self: 'b;
-    type MultiPointType<'b>
-        = UnimplementedMultiPoint<Self::T>
-    where
-        Self: 'b;
-    type MultiLineStringType<'b>
-        = UnimplementedMultiLineString<Self::T>
-    where
-        Self: 'b;
-    type MultiPolygonType<'b>
-        = UnimplementedMultiPolygon<Self::T>
-    where
-        Self: 'b;
-    type GeometryCollectionType<'b>
-        = UnimplementedGeometryCollection<Self::T>
-    where
-        Self: 'b;
-    type RectType<'b>
-        = UnimplementedRect<Self::T>
-    where
-        Self: 'b;
-    type TriangleType<'b>
-        = UnimplementedTriangle<Self::T>
-    where
-        Self: 'b;
-    type LineType<'b>
-        = UnimplementedLine<Self::T>
-    where
-        Self: 'b;
-
-    fn dim(&self) -> Dimensions {
-        unimplemented!()
-    }
-
-    fn as_type(
-        &self,
-    ) -> GeometryType<
-        '_,
-        Self::PointType<'_>,
-        Self::LineStringType<'_>,
-        Self::PolygonType<'_>,
-        Self::MultiPointType<'_>,
-        Self::MultiLineStringType<'_>,
-        Self::MultiPolygonType<'_>,
-        Self::GeometryCollectionType<'_>,
-        Self::RectType<'_>,
-        Self::TriangleType<'_>,
-        Self::LineType<'_>,
-    > {
-        GeometryType::MultiPolygon(self)
-    }
-}
 
 impl<T> MultiPolygonTrait for UnimplementedMultiPolygon<T> {
     type InnerPolygonType<'a>

--- a/geo-traits/src/point.rs
+++ b/geo-traits/src/point.rs
@@ -3,22 +3,22 @@ use std::marker::PhantomData;
 #[cfg(feature = "geo-types")]
 use geo_types::{Coord, CoordNum, Point};
 
-use crate::{CoordTrait, Dimensions, UnimplementedCoord};
+use crate::{
+    CoordTrait, Dimensions, GeometryTrait, GeometryType, UnimplementedCoord,
+    UnimplementedGeometryCollection, UnimplementedLine, UnimplementedLineString,
+    UnimplementedMultiLineString, UnimplementedMultiPoint, UnimplementedMultiPolygon,
+    UnimplementedPolygon, UnimplementedRect, UnimplementedTriangle,
+};
 
 /// A trait for accessing data from a generic Point.
 ///
 /// Refer to [geo_types::Point] for information about semantics and validity.
-pub trait PointTrait {
+pub trait PointTrait: Sized + GeometryTrait {
     /// The coordinate type of this geometry
-    type T;
-
     /// The type of the underlying coordinate, which implements [CoordTrait]
-    type CoordType<'a>: 'a + CoordTrait<T = Self::T>
+    type CoordType<'a>: 'a + CoordTrait<T = <Self as GeometryTrait>::T>
     where
         Self: 'a;
-
-    /// Dimensions of the coordinate tuple
-    fn dim(&self) -> Dimensions;
 
     /// The location of this 0-dimensional geometry.
     ///
@@ -28,35 +28,25 @@ pub trait PointTrait {
 
 #[cfg(feature = "geo-types")]
 impl<T: CoordNum> PointTrait for Point<T> {
-    type T = T;
     type CoordType<'a>
-        = &'a Coord<Self::T>
+        = &'a Coord<<Self as GeometryTrait>::T>
     where
         Self: 'a;
 
     fn coord(&self) -> Option<Self::CoordType<'_>> {
         Some(&self.0)
-    }
-
-    fn dim(&self) -> Dimensions {
-        Dimensions::Xy
     }
 }
 
 #[cfg(feature = "geo-types")]
 impl<T: CoordNum> PointTrait for &Point<T> {
-    type T = T;
     type CoordType<'a>
-        = &'a Coord<Self::T>
+        = &'a Coord<<Self as GeometryTrait>::T>
     where
         Self: 'a;
 
     fn coord(&self) -> Option<Self::CoordType<'_>> {
         Some(&self.0)
-    }
-
-    fn dim(&self) -> Dimensions {
-        Dimensions::Xy
     }
 }
 
@@ -67,17 +57,78 @@ impl<T: CoordNum> PointTrait for &Point<T> {
 pub struct UnimplementedPoint<T>(PhantomData<T>);
 
 impl<T> PointTrait for UnimplementedPoint<T> {
-    type T = T;
     type CoordType<'a>
-        = UnimplementedCoord<Self::T>
+        = UnimplementedCoord<<Self as GeometryTrait>::T>
     where
         Self: 'a;
 
     fn coord(&self) -> Option<Self::CoordType<'_>> {
         unimplemented!()
     }
+}
+
+impl<T> GeometryTrait for UnimplementedPoint<T> {
+    type T = T;
+    type PointType<'b>
+        = UnimplementedPoint<Self::T>
+    where
+        Self: 'b;
+    type LineStringType<'b>
+        = UnimplementedLineString<Self::T>
+    where
+        Self: 'b;
+    type PolygonType<'b>
+        = UnimplementedPolygon<Self::T>
+    where
+        Self: 'b;
+    type MultiPointType<'b>
+        = UnimplementedMultiPoint<Self::T>
+    where
+        Self: 'b;
+    type MultiLineStringType<'b>
+        = UnimplementedMultiLineString<Self::T>
+    where
+        Self: 'b;
+    type MultiPolygonType<'b>
+        = UnimplementedMultiPolygon<Self::T>
+    where
+        Self: 'b;
+    type GeometryCollectionType<'b>
+        = UnimplementedGeometryCollection<Self::T>
+    where
+        Self: 'b;
+    type RectType<'b>
+        = UnimplementedRect<Self::T>
+    where
+        Self: 'b;
+    type TriangleType<'b>
+        = UnimplementedTriangle<Self::T>
+    where
+        Self: 'b;
+    type LineType<'b>
+        = UnimplementedLine<Self::T>
+    where
+        Self: 'b;
 
     fn dim(&self) -> Dimensions {
         unimplemented!()
+    }
+
+    fn as_type(
+        &self,
+    ) -> GeometryType<
+        '_,
+        Self::PointType<'_>,
+        Self::LineStringType<'_>,
+        Self::PolygonType<'_>,
+        Self::MultiPointType<'_>,
+        Self::MultiLineStringType<'_>,
+        Self::MultiPolygonType<'_>,
+        Self::GeometryCollectionType<'_>,
+        Self::RectType<'_>,
+        Self::TriangleType<'_>,
+        Self::LineType<'_>,
+    > {
+        GeometryType::Point(self)
     }
 }

--- a/geo-traits/src/point.rs
+++ b/geo-traits/src/point.rs
@@ -3,12 +3,7 @@ use std::marker::PhantomData;
 #[cfg(feature = "geo-types")]
 use geo_types::{Coord, CoordNum, Point};
 
-use crate::{
-    CoordTrait, Dimensions, GeometryTrait, GeometryType, UnimplementedCoord,
-    UnimplementedGeometryCollection, UnimplementedLine, UnimplementedLineString,
-    UnimplementedMultiLineString, UnimplementedMultiPoint, UnimplementedMultiPolygon,
-    UnimplementedPolygon, UnimplementedRect, UnimplementedTriangle,
-};
+use crate::{CoordTrait, GeometryTrait, UnimplementedCoord};
 
 /// A trait for accessing data from a generic Point.
 ///
@@ -64,71 +59,5 @@ impl<T> PointTrait for UnimplementedPoint<T> {
 
     fn coord(&self) -> Option<Self::CoordType<'_>> {
         unimplemented!()
-    }
-}
-
-impl<T> GeometryTrait for UnimplementedPoint<T> {
-    type T = T;
-    type PointType<'b>
-        = UnimplementedPoint<Self::T>
-    where
-        Self: 'b;
-    type LineStringType<'b>
-        = UnimplementedLineString<Self::T>
-    where
-        Self: 'b;
-    type PolygonType<'b>
-        = UnimplementedPolygon<Self::T>
-    where
-        Self: 'b;
-    type MultiPointType<'b>
-        = UnimplementedMultiPoint<Self::T>
-    where
-        Self: 'b;
-    type MultiLineStringType<'b>
-        = UnimplementedMultiLineString<Self::T>
-    where
-        Self: 'b;
-    type MultiPolygonType<'b>
-        = UnimplementedMultiPolygon<Self::T>
-    where
-        Self: 'b;
-    type GeometryCollectionType<'b>
-        = UnimplementedGeometryCollection<Self::T>
-    where
-        Self: 'b;
-    type RectType<'b>
-        = UnimplementedRect<Self::T>
-    where
-        Self: 'b;
-    type TriangleType<'b>
-        = UnimplementedTriangle<Self::T>
-    where
-        Self: 'b;
-    type LineType<'b>
-        = UnimplementedLine<Self::T>
-    where
-        Self: 'b;
-
-    fn dim(&self) -> Dimensions {
-        unimplemented!()
-    }
-
-    fn as_type(
-        &self,
-    ) -> GeometryType<
-        '_,
-        Self::PointType<'_>,
-        Self::LineStringType<'_>,
-        Self::PolygonType<'_>,
-        Self::MultiPointType<'_>,
-        Self::MultiLineStringType<'_>,
-        Self::MultiPolygonType<'_>,
-        Self::GeometryCollectionType<'_>,
-        Self::RectType<'_>,
-        Self::TriangleType<'_>,
-        Self::LineType<'_>,
-    > {
-        GeometryType::Point(self)
     }
 }

--- a/geo-traits/src/polygon.rs
+++ b/geo-traits/src/polygon.rs
@@ -1,15 +1,9 @@
 use std::marker::PhantomData;
 
-use crate::geometry::{GeometryTrait, GeometryType};
+use crate::geometry::GeometryTrait;
 use crate::iterator::PolygonInteriorIterator;
 use crate::line_string::UnimplementedLineString;
-use crate::{Dimensions, LineStringTrait};
-#[cfg(feature = "geo-types")]
-use crate::{
-    UnimplementedGeometryCollection, UnimplementedLine, UnimplementedMultiLineString,
-    UnimplementedMultiPoint, UnimplementedMultiPolygon, UnimplementedPoint, UnimplementedRect,
-    UnimplementedTriangle,
-};
+use crate::LineStringTrait;
 #[cfg(feature = "geo-types")]
 use geo_types::{CoordNum, LineString, Polygon};
 
@@ -128,71 +122,5 @@ impl<T> PolygonTrait for UnimplementedPolygon<T> {
 
     unsafe fn interior_unchecked(&self, _i: usize) -> Self::RingType<'_> {
         unimplemented!()
-    }
-}
-
-impl<T> GeometryTrait for UnimplementedPolygon<T> {
-    type T = T;
-    type PointType<'b>
-        = UnimplementedPoint<Self::T>
-    where
-        Self: 'b;
-    type LineStringType<'b>
-        = UnimplementedLineString<Self::T>
-    where
-        Self: 'b;
-    type PolygonType<'b>
-        = UnimplementedPolygon<Self::T>
-    where
-        Self: 'b;
-    type MultiPointType<'b>
-        = UnimplementedMultiPoint<Self::T>
-    where
-        Self: 'b;
-    type MultiLineStringType<'b>
-        = UnimplementedMultiLineString<Self::T>
-    where
-        Self: 'b;
-    type MultiPolygonType<'b>
-        = UnimplementedMultiPolygon<Self::T>
-    where
-        Self: 'b;
-    type GeometryCollectionType<'b>
-        = UnimplementedGeometryCollection<Self::T>
-    where
-        Self: 'b;
-    type RectType<'b>
-        = UnimplementedRect<Self::T>
-    where
-        Self: 'b;
-    type TriangleType<'b>
-        = UnimplementedTriangle<Self::T>
-    where
-        Self: 'b;
-    type LineType<'b>
-        = UnimplementedLine<Self::T>
-    where
-        Self: 'b;
-
-    fn dim(&self) -> Dimensions {
-        Dimensions::Xy
-    }
-
-    fn as_type(
-        &self,
-    ) -> GeometryType<
-        '_,
-        Self::PointType<'_>,
-        Self::LineStringType<'_>,
-        Self::PolygonType<'_>,
-        Self::MultiPointType<'_>,
-        Self::MultiLineStringType<'_>,
-        Self::MultiPolygonType<'_>,
-        Self::GeometryCollectionType<'_>,
-        Self::RectType<'_>,
-        Self::TriangleType<'_>,
-        Self::LineType<'_>,
-    > {
-        GeometryType::Polygon(self)
     }
 }

--- a/geo-traits/src/polygon.rs
+++ b/geo-traits/src/polygon.rs
@@ -1,9 +1,8 @@
 use std::marker::PhantomData;
 
-use crate::geometry::GeometryTrait;
 use crate::iterator::PolygonInteriorIterator;
 use crate::line_string::UnimplementedLineString;
-use crate::LineStringTrait;
+use crate::{GeometryTrait, LineStringTrait};
 #[cfg(feature = "geo-types")]
 use geo_types::{CoordNum, LineString, Polygon};
 

--- a/geo-traits/src/polygon.rs
+++ b/geo-traits/src/polygon.rs
@@ -1,8 +1,15 @@
 use std::marker::PhantomData;
 
+use crate::geometry::{GeometryTrait, GeometryType};
 use crate::iterator::PolygonInteriorIterator;
 use crate::line_string::UnimplementedLineString;
 use crate::{Dimensions, LineStringTrait};
+#[cfg(feature = "geo-types")]
+use crate::{
+    UnimplementedGeometryCollection, UnimplementedLine, UnimplementedMultiLineString,
+    UnimplementedMultiPoint, UnimplementedMultiPolygon, UnimplementedPoint, UnimplementedRect,
+    UnimplementedTriangle,
+};
 #[cfg(feature = "geo-types")]
 use geo_types::{CoordNum, LineString, Polygon};
 
@@ -13,17 +20,12 @@ use geo_types::{CoordNum, LineString, Polygon};
 /// represented by `LineString`s.
 ///
 /// Refer to [geo_types::Polygon] for information about semantics and validity.
-pub trait PolygonTrait: Sized {
+pub trait PolygonTrait: Sized + GeometryTrait {
     /// The coordinate type of this geometry
-    type T;
-
     /// The type of each underlying ring, which implements [LineStringTrait]
-    type RingType<'a>: 'a + LineStringTrait<T = Self::T>
+    type RingType<'a>: 'a + LineStringTrait<T = <Self as GeometryTrait>::T>
     where
         Self: 'a;
-
-    /// The dimension of this geometry
-    fn dim(&self) -> Dimensions;
 
     /// The exterior ring of the polygon
     fn exterior(&self) -> Option<Self::RingType<'_>>;
@@ -56,15 +58,10 @@ pub trait PolygonTrait: Sized {
 
 #[cfg(feature = "geo-types")]
 impl<T: CoordNum> PolygonTrait for Polygon<T> {
-    type T = T;
     type RingType<'a>
-        = &'a LineString<Self::T>
+        = &'a LineString<<Self as GeometryTrait>::T>
     where
         Self: 'a;
-
-    fn dim(&self) -> Dimensions {
-        Dimensions::Xy
-    }
 
     fn exterior(&self) -> Option<Self::RingType<'_>> {
         let ext_ring = Polygon::exterior(self);
@@ -86,15 +83,10 @@ impl<T: CoordNum> PolygonTrait for Polygon<T> {
 
 #[cfg(feature = "geo-types")]
 impl<'a, T: CoordNum> PolygonTrait for &'a Polygon<T> {
-    type T = T;
     type RingType<'b>
-        = &'a LineString<Self::T>
+        = &'a LineString<<Self as GeometryTrait>::T>
     where
         Self: 'b;
-
-    fn dim(&self) -> Dimensions {
-        Dimensions::Xy
-    }
 
     fn exterior(&self) -> Option<Self::RingType<'_>> {
         let ext_ring = Polygon::exterior(self);
@@ -121,15 +113,10 @@ impl<'a, T: CoordNum> PolygonTrait for &'a Polygon<T> {
 pub struct UnimplementedPolygon<T>(PhantomData<T>);
 
 impl<T> PolygonTrait for UnimplementedPolygon<T> {
-    type T = T;
     type RingType<'a>
-        = UnimplementedLineString<Self::T>
+        = UnimplementedLineString<<Self as GeometryTrait>::T>
     where
         Self: 'a;
-
-    fn dim(&self) -> Dimensions {
-        unimplemented!()
-    }
 
     fn exterior(&self) -> Option<Self::RingType<'_>> {
         unimplemented!()
@@ -141,5 +128,71 @@ impl<T> PolygonTrait for UnimplementedPolygon<T> {
 
     unsafe fn interior_unchecked(&self, _i: usize) -> Self::RingType<'_> {
         unimplemented!()
+    }
+}
+
+impl<T> GeometryTrait for UnimplementedPolygon<T> {
+    type T = T;
+    type PointType<'b>
+        = UnimplementedPoint<Self::T>
+    where
+        Self: 'b;
+    type LineStringType<'b>
+        = UnimplementedLineString<Self::T>
+    where
+        Self: 'b;
+    type PolygonType<'b>
+        = UnimplementedPolygon<Self::T>
+    where
+        Self: 'b;
+    type MultiPointType<'b>
+        = UnimplementedMultiPoint<Self::T>
+    where
+        Self: 'b;
+    type MultiLineStringType<'b>
+        = UnimplementedMultiLineString<Self::T>
+    where
+        Self: 'b;
+    type MultiPolygonType<'b>
+        = UnimplementedMultiPolygon<Self::T>
+    where
+        Self: 'b;
+    type GeometryCollectionType<'b>
+        = UnimplementedGeometryCollection<Self::T>
+    where
+        Self: 'b;
+    type RectType<'b>
+        = UnimplementedRect<Self::T>
+    where
+        Self: 'b;
+    type TriangleType<'b>
+        = UnimplementedTriangle<Self::T>
+    where
+        Self: 'b;
+    type LineType<'b>
+        = UnimplementedLine<Self::T>
+    where
+        Self: 'b;
+
+    fn dim(&self) -> Dimensions {
+        Dimensions::Xy
+    }
+
+    fn as_type(
+        &self,
+    ) -> GeometryType<
+        '_,
+        Self::PointType<'_>,
+        Self::LineStringType<'_>,
+        Self::PolygonType<'_>,
+        Self::MultiPointType<'_>,
+        Self::MultiLineStringType<'_>,
+        Self::MultiPolygonType<'_>,
+        Self::GeometryCollectionType<'_>,
+        Self::RectType<'_>,
+        Self::TriangleType<'_>,
+        Self::LineType<'_>,
+    > {
+        GeometryType::Polygon(self)
     }
 }

--- a/geo-traits/src/rect.rs
+++ b/geo-traits/src/rect.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 #[cfg(feature = "geo-types")]
 use geo_types::{Coord, CoordNum, Rect};
 
-use crate::{CoordTrait, Dimensions, UnimplementedCoord};
+use crate::{CoordTrait, UnimplementedCoord};
 
 /// A trait for accessing data from a generic Rect.
 ///
@@ -71,72 +71,6 @@ impl<T> RectTrait for UnimplementedRect<T> {
     }
 
     fn max(&self) -> Self::CoordType<'_> {
-        unimplemented!()
-    }
-}
-
-impl<T> crate::GeometryTrait for UnimplementedRect<T> {
-    type T = T;
-    type PointType<'b>
-        = crate::UnimplementedPoint<Self::T>
-    where
-        Self: 'b;
-    type LineStringType<'b>
-        = crate::UnimplementedLineString<Self::T>
-    where
-        Self: 'b;
-    type PolygonType<'b>
-        = crate::UnimplementedPolygon<Self::T>
-    where
-        Self: 'b;
-    type MultiPointType<'b>
-        = crate::UnimplementedMultiPoint<Self::T>
-    where
-        Self: 'b;
-    type MultiLineStringType<'b>
-        = crate::UnimplementedMultiLineString<Self::T>
-    where
-        Self: 'b;
-    type MultiPolygonType<'b>
-        = crate::UnimplementedMultiPolygon<Self::T>
-    where
-        Self: 'b;
-    type GeometryCollectionType<'b>
-        = crate::UnimplementedGeometryCollection<Self::T>
-    where
-        Self: 'b;
-    type RectType<'b>
-        = Self
-    where
-        Self: 'b;
-    type TriangleType<'b>
-        = crate::UnimplementedTriangle<Self::T>
-    where
-        Self: 'b;
-    type LineType<'b>
-        = crate::UnimplementedLine<Self::T>
-    where
-        Self: 'b;
-
-    fn dim(&self) -> Dimensions {
-        unimplemented!()
-    }
-
-    fn as_type(
-        &self,
-    ) -> crate::GeometryType<
-        '_,
-        Self::PointType<'_>,
-        Self::LineStringType<'_>,
-        Self::PolygonType<'_>,
-        Self::MultiPointType<'_>,
-        Self::MultiLineStringType<'_>,
-        Self::MultiPolygonType<'_>,
-        Self::GeometryCollectionType<'_>,
-        Self::RectType<'_>,
-        Self::TriangleType<'_>,
-        Self::LineType<'_>,
-    > {
         unimplemented!()
     }
 }

--- a/geo-traits/src/rect.rs
+++ b/geo-traits/src/rect.rs
@@ -9,17 +9,11 @@ use crate::{CoordTrait, Dimensions, UnimplementedCoord};
 ///
 /// A Rect is an _axis-aligned_ bounded 2D rectangle whose area is
 /// defined by minimum and maximum [`Point`s][CoordTrait].
-pub trait RectTrait {
-    /// The coordinate type of this geometry
-    type T;
-
+pub trait RectTrait: crate::GeometryTrait {
     /// The type of each underlying coordinate, which implements [CoordTrait]
-    type CoordType<'a>: 'a + CoordTrait<T = Self::T>
+    type CoordType<'a>: 'a + CoordTrait<T = <Self as crate::GeometryTrait>::T>
     where
         Self: 'a;
-
-    /// The dimension of this geometry
-    fn dim(&self) -> Dimensions;
 
     /// The minimum coordinate of this Rect
     fn min(&self) -> Self::CoordType<'_>;
@@ -30,15 +24,10 @@ pub trait RectTrait {
 
 #[cfg(feature = "geo-types")]
 impl<T: CoordNum> RectTrait for Rect<T> {
-    type T = T;
     type CoordType<'b>
         = Coord<T>
     where
         Self: 'b;
-
-    fn dim(&self) -> Dimensions {
-        Dimensions::Xy
-    }
 
     fn min(&self) -> Self::CoordType<'_> {
         Rect::min(*self)
@@ -51,15 +40,10 @@ impl<T: CoordNum> RectTrait for Rect<T> {
 
 #[cfg(feature = "geo-types")]
 impl<'a, T: CoordNum + 'a> RectTrait for &'a Rect<T> {
-    type T = T;
     type CoordType<'b>
         = Coord<T>
     where
         Self: 'b;
-
-    fn dim(&self) -> Dimensions {
-        Dimensions::Xy
-    }
 
     fn min(&self) -> Self::CoordType<'_> {
         Rect::min(**self)
@@ -77,21 +61,82 @@ impl<'a, T: CoordNum + 'a> RectTrait for &'a Rect<T> {
 pub struct UnimplementedRect<T>(PhantomData<T>);
 
 impl<T> RectTrait for UnimplementedRect<T> {
-    type T = T;
     type CoordType<'a>
         = UnimplementedCoord<Self::T>
     where
         Self: 'a;
-
-    fn dim(&self) -> Dimensions {
-        unimplemented!()
-    }
 
     fn min(&self) -> Self::CoordType<'_> {
         unimplemented!()
     }
 
     fn max(&self) -> Self::CoordType<'_> {
+        unimplemented!()
+    }
+}
+
+impl<T> crate::GeometryTrait for UnimplementedRect<T> {
+    type T = T;
+    type PointType<'b>
+        = crate::UnimplementedPoint<Self::T>
+    where
+        Self: 'b;
+    type LineStringType<'b>
+        = crate::UnimplementedLineString<Self::T>
+    where
+        Self: 'b;
+    type PolygonType<'b>
+        = crate::UnimplementedPolygon<Self::T>
+    where
+        Self: 'b;
+    type MultiPointType<'b>
+        = crate::UnimplementedMultiPoint<Self::T>
+    where
+        Self: 'b;
+    type MultiLineStringType<'b>
+        = crate::UnimplementedMultiLineString<Self::T>
+    where
+        Self: 'b;
+    type MultiPolygonType<'b>
+        = crate::UnimplementedMultiPolygon<Self::T>
+    where
+        Self: 'b;
+    type GeometryCollectionType<'b>
+        = crate::UnimplementedGeometryCollection<Self::T>
+    where
+        Self: 'b;
+    type RectType<'b>
+        = Self
+    where
+        Self: 'b;
+    type TriangleType<'b>
+        = crate::UnimplementedTriangle<Self::T>
+    where
+        Self: 'b;
+    type LineType<'b>
+        = crate::UnimplementedLine<Self::T>
+    where
+        Self: 'b;
+
+    fn dim(&self) -> Dimensions {
+        unimplemented!()
+    }
+
+    fn as_type(
+        &self,
+    ) -> crate::GeometryType<
+        '_,
+        Self::PointType<'_>,
+        Self::LineStringType<'_>,
+        Self::PolygonType<'_>,
+        Self::MultiPointType<'_>,
+        Self::MultiLineStringType<'_>,
+        Self::MultiPolygonType<'_>,
+        Self::GeometryCollectionType<'_>,
+        Self::RectType<'_>,
+        Self::TriangleType<'_>,
+        Self::LineType<'_>,
+    > {
         unimplemented!()
     }
 }

--- a/geo-traits/src/triangle.rs
+++ b/geo-traits/src/triangle.rs
@@ -1,11 +1,6 @@
 use std::marker::PhantomData;
 
-use crate::{
-    CoordTrait, Dimensions, GeometryTrait, GeometryType, UnimplementedCoord,
-    UnimplementedGeometryCollection, UnimplementedLine, UnimplementedLineString,
-    UnimplementedMultiLineString, UnimplementedMultiPoint, UnimplementedMultiPolygon,
-    UnimplementedPoint, UnimplementedPolygon, UnimplementedRect,
-};
+use crate::{CoordTrait, GeometryTrait, UnimplementedCoord};
 #[cfg(feature = "geo-types")]
 use geo_types::{Coord, CoordNum, Triangle};
 
@@ -97,71 +92,5 @@ impl<T> TriangleTrait for UnimplementedTriangle<T> {
 
     fn third(&self) -> Self::CoordType<'_> {
         unimplemented!()
-    }
-}
-
-impl<T> GeometryTrait for UnimplementedTriangle<T> {
-    type T = T;
-    type PointType<'b>
-        = UnimplementedPoint<Self::T>
-    where
-        Self: 'b;
-    type LineStringType<'b>
-        = UnimplementedLineString<Self::T>
-    where
-        Self: 'b;
-    type PolygonType<'b>
-        = UnimplementedPolygon<Self::T>
-    where
-        Self: 'b;
-    type MultiPointType<'b>
-        = UnimplementedMultiPoint<Self::T>
-    where
-        Self: 'b;
-    type MultiLineStringType<'b>
-        = UnimplementedMultiLineString<Self::T>
-    where
-        Self: 'b;
-    type MultiPolygonType<'b>
-        = UnimplementedMultiPolygon<Self::T>
-    where
-        Self: 'b;
-    type GeometryCollectionType<'b>
-        = UnimplementedGeometryCollection<Self::T>
-    where
-        Self: 'b;
-    type RectType<'b>
-        = UnimplementedRect<Self::T>
-    where
-        Self: 'b;
-    type TriangleType<'b>
-        = UnimplementedTriangle<Self::T>
-    where
-        Self: 'b;
-    type LineType<'b>
-        = UnimplementedLine<Self::T>
-    where
-        Self: 'b;
-
-    fn dim(&self) -> Dimensions {
-        unimplemented!()
-    }
-
-    fn as_type(
-        &self,
-    ) -> GeometryType<
-        '_,
-        Self::PointType<'_>,
-        Self::LineStringType<'_>,
-        Self::PolygonType<'_>,
-        Self::MultiPointType<'_>,
-        Self::MultiLineStringType<'_>,
-        Self::MultiPolygonType<'_>,
-        Self::GeometryCollectionType<'_>,
-        Self::RectType<'_>,
-        Self::TriangleType<'_>,
-        Self::LineType<'_>,
-    > {
-        GeometryType::Triangle(self)
     }
 }

--- a/geo-traits/src/triangle.rs
+++ b/geo-traits/src/triangle.rs
@@ -1,6 +1,11 @@
 use std::marker::PhantomData;
 
-use crate::{CoordTrait, Dimensions, UnimplementedCoord};
+use crate::{
+    CoordTrait, Dimensions, GeometryTrait, GeometryType, UnimplementedCoord,
+    UnimplementedGeometryCollection, UnimplementedLine, UnimplementedLineString,
+    UnimplementedMultiLineString, UnimplementedMultiPoint, UnimplementedMultiPolygon,
+    UnimplementedPoint, UnimplementedPolygon, UnimplementedRect,
+};
 #[cfg(feature = "geo-types")]
 use geo_types::{Coord, CoordNum, Triangle};
 
@@ -9,17 +14,11 @@ use geo_types::{Coord, CoordNum, Triangle};
 /// A triangle is a bounded area whose three vertices are defined by [coordinates][CoordTrait].
 ///
 /// Refer to [geo_types::Triangle] for information about semantics and validity.
-pub trait TriangleTrait: Sized {
-    /// The coordinate type of this geometry
-    type T;
-
+pub trait TriangleTrait: Sized + GeometryTrait {
     /// The type of each underlying coordinate, which implements [CoordTrait]
     type CoordType<'a>: 'a + CoordTrait<T = Self::T>
     where
         Self: 'a;
-
-    /// The dimension of this geometry
-    fn dim(&self) -> Dimensions;
 
     /// Access the first coordinate in this Triangle
     fn first(&self) -> Self::CoordType<'_>;
@@ -38,15 +37,10 @@ pub trait TriangleTrait: Sized {
 
 #[cfg(feature = "geo-types")]
 impl<T: CoordNum> TriangleTrait for Triangle<T> {
-    type T = T;
     type CoordType<'a>
         = &'a Coord<Self::T>
     where
         Self: 'a;
-
-    fn dim(&self) -> Dimensions {
-        Dimensions::Xy
-    }
 
     fn first(&self) -> Self::CoordType<'_> {
         &self.0
@@ -63,15 +57,10 @@ impl<T: CoordNum> TriangleTrait for Triangle<T> {
 
 #[cfg(feature = "geo-types")]
 impl<'a, T: CoordNum> TriangleTrait for &'a Triangle<T> {
-    type T = T;
     type CoordType<'b>
         = &'a Coord<Self::T>
     where
         Self: 'b;
-
-    fn dim(&self) -> Dimensions {
-        Dimensions::Xy
-    }
 
     fn first(&self) -> Self::CoordType<'_> {
         &self.0
@@ -93,15 +82,10 @@ impl<'a, T: CoordNum> TriangleTrait for &'a Triangle<T> {
 pub struct UnimplementedTriangle<T>(PhantomData<T>);
 
 impl<T> TriangleTrait for UnimplementedTriangle<T> {
-    type T = T;
     type CoordType<'a>
         = UnimplementedCoord<Self::T>
     where
         Self: 'a;
-
-    fn dim(&self) -> Dimensions {
-        unimplemented!()
-    }
 
     fn first(&self) -> Self::CoordType<'_> {
         unimplemented!()
@@ -113,5 +97,71 @@ impl<T> TriangleTrait for UnimplementedTriangle<T> {
 
     fn third(&self) -> Self::CoordType<'_> {
         unimplemented!()
+    }
+}
+
+impl<T> GeometryTrait for UnimplementedTriangle<T> {
+    type T = T;
+    type PointType<'b>
+        = UnimplementedPoint<Self::T>
+    where
+        Self: 'b;
+    type LineStringType<'b>
+        = UnimplementedLineString<Self::T>
+    where
+        Self: 'b;
+    type PolygonType<'b>
+        = UnimplementedPolygon<Self::T>
+    where
+        Self: 'b;
+    type MultiPointType<'b>
+        = UnimplementedMultiPoint<Self::T>
+    where
+        Self: 'b;
+    type MultiLineStringType<'b>
+        = UnimplementedMultiLineString<Self::T>
+    where
+        Self: 'b;
+    type MultiPolygonType<'b>
+        = UnimplementedMultiPolygon<Self::T>
+    where
+        Self: 'b;
+    type GeometryCollectionType<'b>
+        = UnimplementedGeometryCollection<Self::T>
+    where
+        Self: 'b;
+    type RectType<'b>
+        = UnimplementedRect<Self::T>
+    where
+        Self: 'b;
+    type TriangleType<'b>
+        = UnimplementedTriangle<Self::T>
+    where
+        Self: 'b;
+    type LineType<'b>
+        = UnimplementedLine<Self::T>
+    where
+        Self: 'b;
+
+    fn dim(&self) -> Dimensions {
+        unimplemented!()
+    }
+
+    fn as_type(
+        &self,
+    ) -> GeometryType<
+        '_,
+        Self::PointType<'_>,
+        Self::LineStringType<'_>,
+        Self::PolygonType<'_>,
+        Self::MultiPointType<'_>,
+        Self::MultiLineStringType<'_>,
+        Self::MultiPolygonType<'_>,
+        Self::GeometryCollectionType<'_>,
+        Self::RectType<'_>,
+        Self::TriangleType<'_>,
+        Self::LineType<'_>,
+    > {
+        GeometryType::Triangle(self)
     }
 }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

By doing this, we'll be able to write algorithms generically for `geo-traits::Geometry` and have the algorithm directly called on geometry types, akin to:

```rust
trait Area {
    fn area(...);
}

impl<G: GeometryTrait> Area for G { ... }

(geo_types::Polygon(...)).area();
```

Prior to this pull request, you would have had to wrap `geo_types::Polygon` in `geo_types::Geometry` before running the algorithm.