### PR TITLE
Fix the lifetime annotation of PointTrait implemented for geo_types::Point

### DIFF
--- a/geo-traits/CHANGES.md
+++ b/geo-traits/CHANGES.md
@@ -4,6 +4,8 @@
 
 - BREAKING: All traits now extend `GeometryTrait`.
   - <https://github.com/georust/geo/pull/1346>
+- Fix the lifetime annotation of `PointTrait` implemented for `geo_types::Point`.
+  - <https://github.com/georust/geo/pull/1348>
 
 ## 0.2.0 - 2024.11.06
 

--- a/geo-traits/src/point.rs
+++ b/geo-traits/src/point.rs
@@ -34,11 +34,11 @@ impl<T: CoordNum> PointTrait for Point<T> {
 }
 
 #[cfg(feature = "geo-types")]
-impl<T: CoordNum> PointTrait for &Point<T> {
-    type CoordType<'a>
+impl<'a, T: CoordNum> PointTrait for &'a Point<T> {
+    type CoordType<'b>
         = &'a Coord<<Self as GeometryTrait>::T>
     where
-        Self: 'a;
+        Self: 'b;
 
     fn coord(&self) -> Option<Self::CoordType<'_>> {
         Some(&self.0)

--- a/geo-traits/src/point.rs
+++ b/geo-traits/src/point.rs
@@ -61,3 +61,29 @@ impl<T> PointTrait for UnimplementedPoint<T> {
         unimplemented!()
     }
 }
+
+#[test]
+fn test_point_trait_lifetime() {
+    // This is a regression test for https://github.com/georust/geo/pull/1348
+
+    // let's say point has lifetime 'a
+    let point = Point::new(1.0, 2.0);
+    // as long as coord_ref references a part of point, it should be valid.
+    let coord_ref: &Coord<f64>;
+
+    {
+        // point_ref has lifetime 'b, it references a point which has lifetime 'a
+        let point_ref: &Point<f64> = &point;
+        {
+            let point_ref_ref: &&Point<f64> = &point_ref;
+            // the lifetime of coord it references should be 'a, since it references
+            // a inner part of point which has lifetime 'a
+            coord_ref = point_ref_ref.coord().unwrap();
+        }
+    }
+
+    // Using coord_ref here, it should be valid. Without https://github.com/georust/geo/pull/1348
+    // there would be a compile error here.
+    assert_eq!(coord_ref.x(), 1.0);
+    assert_eq!(coord_ref.y(), 2.0);
+}


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

I found this lifetime problem when building layers of generic abstractions over geo-traits and geo-types. The fix makes the lifetime of `CoordType` of `Point` consistent with other types in geo-types.