### PR TITLE
Simplify tested Rust and proj version spec

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,21 @@ on:
   schedule: [cron: "45 6 * * *"]
 
 name: Run tests
+
 jobs:
+  # Set configurations used throughout the workflow
+  set-matrix:
+    name: Set matrix configuration
+    runs-on: ubuntu-latest
+    outputs:
+      rust-versions: ${{ steps.set-matrix.outputs.rust-versions }}
+      proj-version: ${{ steps.set-matrix.outputs.proj-version }}
+    steps:
+      - id: set-matrix
+        run: |
+          echo 'rust-versions=["1.82", "1.83", "1.84"]' >> $GITHUB_OUTPUT
+          echo "proj-version=9.6.0" >> $GITHUB_OUTPUT
+
   # The `ci-result` job doesn't actually test anything - it just aggregates the
   # overall build status, otherwise the merge queue would need an entry
   # for each individual job produced by the job-matrix.
@@ -23,6 +37,7 @@ jobs:
       - lint
       - geo_types
       - geo
+      - geo_traits
       - geo_postgis
       - geo_fuzz
       - bench
@@ -38,6 +53,7 @@ jobs:
       - lint
       - geo_types
       - geo
+      - geo_traits
       - geo_postgis
       - geo_fuzz
       - bench
@@ -48,24 +64,21 @@ jobs:
 
   lint:
     name: lint
+    needs: set-matrix
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
-    strategy:
-      matrix:
-        container_image:
-          # Use the latest stable version. No need for older versions.
-          - "ghcr.io/georust/geo-ci:proj-9.6.0-rust-1.84"
     container:
-      image: ${{ matrix.container_image }}
+      image: "ghcr.io/georust/geo-ci:proj-${{ needs.set-matrix.outputs.proj-version }}-rust-${{ fromJson(needs.set-matrix.outputs.rust-versions)[2] }}"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - run: rustup component add rustfmt clippy
       - run: cargo fmt --all -- --check
       - run: cargo clippy --all-features --all-targets -- -Dwarnings
 
   geo_types:
     name: geo-types
+    needs: set-matrix
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     defaults:
@@ -73,20 +86,12 @@ jobs:
         working-directory: geo-types
     strategy:
       matrix:
-        container_image:
-          # We aim to support rust-stable plus (at least) the prior 3 releases,
-          # giving us about 6 months of coverage.
-          #
-          # Minimum supported rust version (MSRV)
-          - "ghcr.io/georust/geo-ci:proj-9.6.0-rust-1.82"
-          # Two most recent releases - we omit older ones for expedient CI
-          - "ghcr.io/georust/geo-ci:proj-9.6.0-rust-1.83"
-          - "ghcr.io/georust/geo-ci:proj-9.6.0-rust-1.84"
+        rust_version: ${{ fromJson(needs.set-matrix.outputs.rust-versions) }}
     container:
-      image: ${{ matrix.container_image }}
+      image: "ghcr.io/georust/geo-ci:proj-${{ needs.set-matrix.outputs.proj-version }}-rust-${{ matrix.rust_version }}"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - run: rustup target add thumbv7em-none-eabihf
       - run: cargo check --all-targets --no-default-features
       - run: cargo check --lib --target thumbv7em-none-eabihf --no-default-features -F use-rstar_0_9,serde
@@ -94,6 +99,7 @@ jobs:
 
   geo:
     name: geo
+    needs: set-matrix
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     defaults:
@@ -101,26 +107,19 @@ jobs:
         working-directory: geo
     strategy:
       matrix:
-        container_image:
-          # We aim to support rust-stable plus (at least) the prior 3 releases,
-          # giving us about 6 months of coverage.
-          #
-          # Minimum supported rust version (MSRV)
-          - "ghcr.io/georust/geo-ci:proj-9.6.0-rust-1.82"
-          # Two most recent releases - we omit older ones for expedient CI
-          - "ghcr.io/georust/geo-ci:proj-9.6.0-rust-1.83"
-          - "ghcr.io/georust/geo-ci:proj-9.6.0-rust-1.84"
+        rust_version: ${{ fromJson(needs.set-matrix.outputs.rust-versions) }}
     container:
-      image: ${{ matrix.container_image }}
+      image: "ghcr.io/georust/geo-ci:proj-${{ needs.set-matrix.outputs.proj-version }}-rust-${{ matrix.rust_version }}"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - run: cargo check --all-targets --no-default-features
       # we don't want to test `proj-network` because it only enables the `proj` feature
       - run: cargo test --features "use-proj use-serde earcutr multithreading"
 
   geo_traits:
     name: geo-traits
+    needs: set-matrix
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     defaults:
@@ -128,25 +127,18 @@ jobs:
         working-directory: geo-traits
     strategy:
       matrix:
-        container_image:
-          # We aim to support rust-stable plus (at least) the prior 3 releases,
-          # giving us about 6 months of coverage.
-          #
-          # Minimum supported rust version (MSRV)
-          - "ghcr.io/georust/geo-ci:proj-9.6.0-rust-1.82"
-          # Two most recent releases - we omit older ones for expedient CI
-          - "ghcr.io/georust/geo-ci:proj-9.6.0-rust-1.83"
-          - "ghcr.io/georust/geo-ci:proj-9.6.0-rust-1.84"
+        rust_version: ${{ fromJson(needs.set-matrix.outputs.rust-versions) }}
     container:
-      image: ${{ matrix.container_image }}
+      image: "ghcr.io/georust/geo-ci:proj-${{ needs.set-matrix.outputs.proj-version }}-rust-${{ matrix.rust_version }}"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - run: cargo check --all-targets
       - run: cargo test
 
   geo_postgis:
     name: geo-postgis
+    needs: set-matrix
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     defaults:
@@ -154,60 +146,50 @@ jobs:
         working-directory: geo-postgis
     strategy:
       matrix:
-        container_image:
-          # We aim to support rust-stable plus (at least) the prior 3 releases,
-          # giving us about 6 months of coverage.
-          #
-          # Minimum supported rust version (MSRV)
-          - "ghcr.io/georust/geo-ci:proj-9.6.0-rust-1.82"
-          # Two most recent releases - we omit older ones for expedient CI
-          - "ghcr.io/georust/geo-ci:proj-9.6.0-rust-1.83"
-          - "ghcr.io/georust/geo-ci:proj-9.6.0-rust-1.84"
+        rust_version: ${{ fromJson(needs.set-matrix.outputs.rust-versions) }}
     container:
-      image: ${{ matrix.container_image }}
+      image: "ghcr.io/georust/geo-ci:proj-${{ needs.set-matrix.outputs.proj-version }}-rust-${{ matrix.rust_version }}"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - run: cargo check --all-targets
       - run: cargo test
 
   geo_fuzz:
     name: geo-fuzz
+    needs: set-matrix
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     defaults:
       run:
         working-directory: geo/fuzz
-    strategy:
-      matrix:
-        container_image:
-          # Fuzz only on latest
-          - "ghcr.io/georust/geo-ci:proj-9.6.0-rust-1.84"
     container:
-      image: ${{ matrix.container_image }}
+      image: "ghcr.io/georust/geo-ci:proj-${{ needs.set-matrix.outputs.proj-version }}-rust-${{ fromJson(needs.set-matrix.outputs.rust-versions)[2] }}"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - run: cargo build --bins
 
   bench:
     name: bench
+    needs: set-matrix
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     container:
-      image: ghcr.io/georust/geo-ci:proj-9.6.0-rust-1.84
+      image: "ghcr.io/georust/geo-ci:proj-${{ needs.set-matrix.outputs.proj-version }}-rust-${{ fromJson(needs.set-matrix.outputs.rust-versions)[2] }}"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - run: cargo bench --no-run
 
   docs:
     name: build documentation
+    needs: set-matrix
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     container:
-      image: ghcr.io/georust/geo-ci:proj-9.6.0-rust-1.84
+      image: "ghcr.io/georust/geo-ci:proj-${{ needs.set-matrix.outputs.proj-version }}-rust-${{ fromJson(needs.set-matrix.outputs.rust-versions)[2] }}"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - run: RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps

--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -5,6 +5,7 @@
 - BREAKING: The `Simplify`, `SimplifyVw`, and `SimplifyVwIdx` traits no longer require a borrowed `epsilon` parameter as these are `Copy` types
 - BREAKING: update proj dependency to 0.30.0 (libproj 9.6.0)
 - Bump geo MSRV to 1.82
+- Simplify test rustc and libproj version specification in CI
 
 ## 0.30.0 - 2025-03-24
 


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Draft as it's a slightly speculative, but this reduces the number of places we have to define our testable rustc and proj versions to 1, at the expense of some more complex variable shuffling in the form of the `rust-matrix` test, which only exists to make the correct variables available to all other workflows.

Also took the opportunity to update our checkout actions versions, and add `geo-traits` to the success/failure matrices.