### PR TITLE
Bump i_overlay dependency to 3.4.1

### DIFF
--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -31,7 +31,7 @@ proj = { version = "0.30.0", optional = true }
 robust = "1.1.0"
 rstar = "0.12.0"
 serde = { version = "1.0", optional = true, features = ["derive"] }
-i_overlay = { version = "2.0.0, < 2.1.0", default-features = false }
+i_overlay = { version = "3.4.1", default-features = false }
 
 [dev-dependencies]
 approx = ">= 0.4.0, < 0.6.0"

--- a/geo/src/algorithm/bool_ops/i_overlay_integration.rs
+++ b/geo/src/algorithm/bool_ops/i_overlay_integration.rs
@@ -47,11 +47,8 @@ pub(super) mod convert {
 
     pub fn polygon_from_shape<T: BoolOpsNum>(shape: Vec<Vec<BoolOpsCoord<T>>>) -> Polygon<T> {
         let mut rings = shape.into_iter().map(|path| {
-            // From i_overlay: > Note: Outer boundary paths have a clockwise order, and holes have a counterclockwise order.
-            // Which is the opposite convention we use.
             let mut line_string = line_string_from_path(path);
             line_string.close();
-            line_string.0.reverse();
             line_string
         });
         let exterior = rings.next().unwrap_or(LineString::new(vec![]));

--- a/geo/src/algorithm/bool_ops/mod.rs
+++ b/geo/src/algorithm/bool_ops/mod.rs
@@ -184,9 +184,9 @@ pub fn unary_union<'a, B: BooleanOps + 'a>(
         .collect::<Vec<_>>();
 
     let fill_rule = if winding_order == Some(WindingOrder::Clockwise) {
-        FillRule::Positive
-    } else {
         FillRule::Negative
+    } else {
+        FillRule::Positive
     };
 
     let shapes = FloatOverlay::with_subj(&subject).overlay(OverlayRule::Subject, fill_rule);


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Since v3.0.0 iOverlay has changed the winding order of polygon rings to match the one in use in geo so I thought it could be a good thing to update iOverlay (I also wanted to update it because I was starting to look at how much work was needed to use iOverlay's path offsetting for a buffering function for geo)

However there is now two tests that fails:

1)

```
thread 'algorithm::bool_ops::i_overlay_integration::tests::one_empty_polygon' panicked at geo/src/algorithm/bool_ops/i_overlay_integration.rs:158:9:
assertion `left == right` failed
  left: MULTIPOLYGON(((0.0 1.0,0.0 0.0,1.0 0.0,1.0 1.0,0.0 1.0)))
 right: MULTIPOLYGON(((0.0 0.0,1.0 0.0,1.0 1.0,0.0 1.0,0.0 0.0)))
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

So when we union `POLYGON((0.0 0.0,1.0 0.0,1.0 1.0,0.0 1.0,0.0 0.0)` with `POLYGON EMPTY`, it returns the correct polygon, but the order of coordinates is not preserved. In practical terms, this doesn't change the polygon in question, but it would have been nice if it hadn't changed the order of the coordinates...

2)

```
thread 'algorithm::bool_ops::tests::gh_issues::gh_issue_1193' panicked at geo/src/algorithm/bool_ops/tests.rs:367:9:
assertion `left == right` failed
  left: MULTIPOLYGON(((-19.458324 -3.623188,-22.058823 -3.623188,-19.064932 -6.57369,-19.458324 -3.623188)),((-14.705883 -7.649791,-17.60358 -8.013862,-17.60358 -8.013863,-14.705883 -7.6497912,-14.705883 -7.649791)))
 right: MULTIPOLYGON(((-22.058823 -3.623188,-19.064932 -6.57369,-19.458324 -3.623188,-22.058823 -3.623188)),((-17.60358 -8.013862,-17.60358 -8.013863,-14.705883 -7.6497912,-14.705883 -7.649791,-17.60358 -8.013862)))
```

Again, it's a question of the order of the coordinates (I think I can just modify the expected value since there was no expected result in the issue from which this test case came).