### PR TITLE
Apply `empty` constructor to other crates.

### DIFF
--- a/geo-traits/src/to_geo.rs
+++ b/geo-traits/src/to_geo.rs
@@ -81,7 +81,7 @@ impl<T: CoordNum, G: PolygonTrait<T = T>> ToGeoPolygon<T> for G {
         let exterior = if let Some(exterior) = self.exterior() {
             exterior.to_line_string()
         } else {
-            LineString::new(vec![])
+            LineString::empty()
         };
         let interiors = self
             .interiors()

--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## Unreleased
+
+- Add `empty` convenience initializer for constructing empty geometries
+  - <https://github.com/georust/geo/pull/1363>
+
 ## 0.7.16 - 2025-03-24
 
 - Add `LineString::rev_lines` to iterate segments from end to start

--- a/geo-types/src/debug.rs
+++ b/geo-types/src/debug.rs
@@ -221,7 +221,7 @@ mod tests {
     }
     #[test]
     fn empty_line_string() {
-        let line_string = LineString::<i32>::new(vec![]);
+        let line_string = LineString::<i32>::empty();
         assert_eq!("LINESTRING EMPTY", format!("{line_string:?}"));
     }
     #[test]
@@ -256,7 +256,7 @@ mod tests {
     fn invalid_polygon_interior_but_no_exterior() {
         // Not a valid polygon, but we should still have reasonable debug output - note this is *not* valid WKT
         let interior = LineString::new(vec![(1, 2).into()]);
-        let polygon = Polygon::new(LineString::new(vec![]), vec![interior]);
+        let polygon = Polygon::new(LineString::empty(), vec![interior]);
         assert_eq!("POLYGON(EMPTY,(1 2))", format!("{polygon:?}"));
     }
     #[test]
@@ -455,7 +455,7 @@ mod tests {
     fn geometry_collection_with_no_coordinates() {
         let geometry_collection: GeometryCollection<f64> = GeometryCollection::from(vec![
             Geometry::Point(Point::new(0.0, 0.0)),
-            Geometry::Polygon(Polygon::new(LineString::new(vec![]), vec![])),
+            Geometry::Polygon(Polygon::empty()),
         ]);
 
         assert_eq!(

--- a/geo-types/src/geometry/geometry_collection.rs
+++ b/geo-types/src/geometry/geometry_collection.rs
@@ -84,7 +84,7 @@ impl<T: CoordNum> Default for GeometryCollection<T> {
 impl<T: CoordNum> GeometryCollection<T> {
     /// Return an empty GeometryCollection
     #[deprecated(
-        note = "Will be replaced with a parametrized version in upcoming version. Use GeometryCollection::default() instead"
+        note = "Will be replaced with a parametrized version in upcoming version. Use GeometryCollection::empty() instead"
     )]
     pub fn new() -> Self {
         GeometryCollection::default()
@@ -95,6 +95,11 @@ impl<T: CoordNum> GeometryCollection<T> {
     /// This fn is not marked as deprecated because it would require extensive refactoring of the geo code.
     pub fn new_from(value: Vec<Geometry<T>>) -> Self {
         Self(value)
+    }
+
+    /// Returns an empty GeometryCollection
+    pub fn empty() -> Self {
+        Self(Vec::new())
     }
 
     /// Number of geometries in this GeometryCollection
@@ -348,12 +353,19 @@ mod approx_integration {
 mod tests {
     use alloc::vec;
 
-    use crate::{GeometryCollection, Point};
+    use crate::{wkt, GeometryCollection, Point};
 
     #[test]
     fn from_vec() {
         let gc = GeometryCollection::from(vec![Point::new(1i32, 2)]);
         let p = Point::try_from(gc[0].clone()).unwrap();
         assert_eq!(p.y(), 2);
+    }
+
+    #[test]
+    fn empty() {
+        let empty = GeometryCollection::<f64>::empty();
+        let empty_2 = wkt! { GEOMETRYCOLLECTION EMPTY };
+        assert_eq!(empty, empty_2);
     }
 }

--- a/geo-types/src/geometry/line_string.rs
+++ b/geo-types/src/geometry/line_string.rs
@@ -190,9 +190,14 @@ impl<T: CoordNum> DoubleEndedIterator for CoordinatesIter<'_, T> {
 }
 
 impl<T: CoordNum> LineString<T> {
-    /// Instantiate Self from the raw content value
+    /// Returns a LineString with the given coordinates
     pub fn new(value: Vec<Coord<T>>) -> Self {
         Self(value)
+    }
+
+    /// Returns an empty LineString
+    pub fn empty() -> Self {
+        Self::new(Vec::new())
     }
 
     /// Return an iterator yielding the coordinates of a [`LineString`] as [`Point`]s
@@ -596,7 +601,7 @@ impl_rstar_line_string!(rstar_0_12);
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::coord;
+    use crate::{coord, wkt};
     use approx::{AbsDiffEq, RelativeEq};
 
     #[test]
@@ -685,5 +690,12 @@ mod test {
         let expected = LineString::new(vec![start, end]);
 
         assert_eq!(expected, LineString::from(line));
+    }
+
+    #[test]
+    fn empty() {
+        let empty = LineString::<f64>::empty();
+        let empty_2 = wkt! { LINESTRING EMPTY };
+        assert_eq!(empty, empty_2);
     }
 }

--- a/geo-types/src/geometry/multi_line_string.rs
+++ b/geo-types/src/geometry/multi_line_string.rs
@@ -39,9 +39,14 @@ use rayon::prelude::*;
 pub struct MultiLineString<T: CoordNum = f64>(pub Vec<LineString<T>>);
 
 impl<T: CoordNum> MultiLineString<T> {
-    /// Instantiate Self from the raw content value
+    /// Returns a MultiLineString with the given LineStrings as elements
     pub fn new(value: Vec<LineString<T>>) -> Self {
         Self(value)
+    }
+
+    /// Returns an empty MultiLineString
+    pub fn empty() -> Self {
+        Self::new(Vec::new())
     }
 
     /// True if the MultiLineString is empty or if all of its LineStrings are closed - see
@@ -62,7 +67,7 @@ impl<T: CoordNum> MultiLineString<T> {
     /// assert!(!MultiLineString::new(vec![open_line_string, closed_line_string]).is_closed());
     ///
     /// // An empty MultiLineString is closed
-    /// assert!(MultiLineString::<f32>::new(vec![]).is_closed());
+    /// assert!(MultiLineString::<f32>::empty().is_closed());
     /// ```
     pub fn is_closed(&self) -> bool {
         // Note: Unlike JTS et al, we consider an empty MultiLineString as closed.
@@ -331,5 +336,12 @@ mod test {
                 );
             }
         }
+    }
+
+    #[test]
+    fn empty() {
+        let empty = MultiLineString::<f64>::empty();
+        let empty_2 = wkt! { MULTILINESTRING EMPTY };
+        assert_eq!(empty, empty_2);
     }
 }

--- a/geo-types/src/geometry/multi_point.rs
+++ b/geo-types/src/geometry/multi_point.rs
@@ -115,8 +115,14 @@ impl<'a, T: CoordNum + Send + Sync> IntoParallelIterator for &'a mut MultiPoint<
 }
 
 impl<T: CoordNum> MultiPoint<T> {
+    /// Returns a MultiPoint with the given Points as elements
     pub fn new(value: Vec<Point<T>>) -> Self {
         Self(value)
+    }
+
+    /// Returns an empty MultiPoint
+    pub fn empty() -> Self {
+        Self::new(Vec::new())
     }
 
     pub fn len(&self) -> usize {
@@ -234,6 +240,7 @@ mod approx_integration {
 
 #[cfg(test)]
 mod test {
+    use super::*;
     use crate::{point, wkt};
     use approx::{AbsDiffEq, RelativeEq};
 
@@ -337,5 +344,12 @@ mod test {
         // Over-sized but otherwise equal.
         let multi_oversized = wkt! { MULTIPOINT(0. 0.,10. 10.,10. 100.) };
         assert!(multi.abs_diff_ne(&multi_oversized, 1.));
+    }
+
+    #[test]
+    fn empty() {
+        let empty = MultiPoint::<f64>::empty();
+        let empty_2 = wkt! { MULTIPOINT EMPTY };
+        assert_eq!(empty, empty_2);
     }
 }

--- a/geo-types/src/geometry/multi_polygon.rs
+++ b/geo-types/src/geometry/multi_polygon.rs
@@ -107,9 +107,14 @@ impl<'a, T: CoordNum + Send + Sync> IntoParallelIterator for &'a mut MultiPolygo
 }
 
 impl<T: CoordNum> MultiPolygon<T> {
-    /// Instantiate Self from the raw content value
+    /// Returns a MultiPolygon with the given Polygons as elements
     pub fn new(value: Vec<Polygon<T>>) -> Self {
         Self(value)
+    }
+
+    /// Returns an empty MultiPolygon
+    pub fn empty() -> Self {
+        Self(Vec::new())
     }
 
     pub fn iter(&self) -> impl Iterator<Item = &Polygon<T>> {
@@ -258,7 +263,7 @@ impl_rstar_multi_polygon!(rstar_0_12);
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::polygon;
+    use crate::{polygon, wkt};
 
     #[test]
     fn test_iter() {
@@ -357,5 +362,12 @@ mod test {
                 );
             }
         }
+    }
+
+    #[test]
+    fn empty() {
+        let empty = MultiPolygon::<f64>::empty();
+        let empty_2 = wkt! { MULTIPOLYGON EMPTY };
+        assert_eq!(empty, empty_2);
     }
 }

--- a/geo-types/src/geometry/polygon.rs
+++ b/geo-types/src/geometry/polygon.rs
@@ -132,6 +132,13 @@ impl<T: CoordNum> Polygon<T> {
         }
     }
 
+    /// Returns an empty Polygon.
+    ///
+    /// `geo` represents an empty Polygon as one whose exterior is an empty LineString
+    pub fn empty() -> Self {
+        Self::new(LineString::empty(), vec![])
+    }
+
     /// Consume the `Polygon`, returning the exterior `LineString` ring and
     /// a vector of the interior `LineString` rings.
     ///
@@ -677,3 +684,16 @@ impl_rstar_polygon!(rstar_0_11);
 
 #[cfg(feature = "rstar_0_12")]
 impl_rstar_polygon!(rstar_0_12);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::wkt;
+
+    #[test]
+    fn empty() {
+        let empty = Polygon::<f64>::empty();
+        let empty_2 = wkt! { POLYGON EMPTY };
+        assert_eq!(empty, empty_2);
+    }
+}

--- a/geo-types/src/macros.rs
+++ b/geo-types/src/macros.rs
@@ -123,7 +123,7 @@ macro_rules! coord {
 /// [`LineString`]: ./line_string/struct.LineString.html
 #[macro_export]
 macro_rules! line_string {
-    () => { $crate::LineString::new($crate::_alloc::vec![]) };
+    () => { $crate::LineString::empty() };
     (
         $(( $($tag:tt : $val:expr),* $(,)? )),*
         $(,)?
@@ -214,7 +214,7 @@ macro_rules! line_string {
 /// [`Polygon`]: ./struct.Polygon.html
 #[macro_export]
 macro_rules! polygon {
-    () => { $crate::Polygon::new($crate::line_string![], $crate::_alloc::vec![]) };
+    () => { $crate::Polygon::empty() };
     (
         exterior: [
             $(( $($exterior_tag:tt : $exterior_val:expr),* $(,)? )),*

--- a/geo-types/src/wkt_macro.rs
+++ b/geo-types/src/wkt_macro.rs
@@ -44,7 +44,7 @@ macro_rules! wkt_internal {
         compile_error!("Invalid POINT wkt");
     };
     (LINESTRING EMPTY) => {
-        $crate::line_string![]
+        $crate::LineString::empty()
     };
     (LINESTRING ($($x: literal $y: literal),+)) => {
         $crate::line_string![
@@ -58,7 +58,7 @@ macro_rules! wkt_internal {
         compile_error!("Invalid LINESTRING wkt");
     };
     (POLYGON EMPTY) => {
-        $crate::polygon![]
+        $crate::Polygon::empty()
     };
     (POLYGON ( $exterior_tt: tt )) => {
         $crate::Polygon::new($crate::wkt!(LINESTRING $exterior_tt), $crate::_alloc::vec![])
@@ -78,7 +78,7 @@ macro_rules! wkt_internal {
         compile_error!("Invalid POLYGON wkt");
     };
     (MULTIPOINT EMPTY) => {
-        $crate::MultiPoint($crate::_alloc::vec![])
+        $crate::MultiPoint::empty()
     };
     (MULTIPOINT ()) => {
         compile_error!("use `EMPTY` instead of () for an empty collection")
@@ -92,7 +92,7 @@ macro_rules! wkt_internal {
         compile_error!("Invalid MULTIPOINT wkt");
     };
     (MULTILINESTRING EMPTY) => {
-        $crate::MultiLineString($crate::_alloc::vec![])
+        $crate::MultiLineString::empty()
     };
     (MULTILINESTRING ()) => {
         compile_error!("use `EMPTY` instead of () for an empty collection")
@@ -106,7 +106,7 @@ macro_rules! wkt_internal {
         compile_error!("Invalid MULTILINESTRING wkt");
     };
     (MULTIPOLYGON EMPTY) => {
-        $crate::MultiPolygon($crate::_alloc::vec![])
+        $crate::MultiPolygon::empty()
     };
     (MULTIPOLYGON ()) => {
         compile_error!("use `EMPTY` instead of () for an empty collection")
@@ -120,7 +120,7 @@ macro_rules! wkt_internal {
         compile_error!("Invalid MULTIPOLYGON wkt");
     };
     (GEOMETRYCOLLECTION EMPTY) => {
-        $crate::GeometryCollection($crate::_alloc::vec![])
+        $crate::GeometryCollection::empty()
     };
     (GEOMETRYCOLLECTION ()) => {
         compile_error!("use `EMPTY` instead of () for an empty collection")

--- a/geo/src/algorithm/bool_ops/i_overlay_integration.rs
+++ b/geo/src/algorithm/bool_ops/i_overlay_integration.rs
@@ -54,7 +54,7 @@ pub(super) mod convert {
             line_string.0.reverse();
             line_string
         });
-        let exterior = rings.next().unwrap_or(LineString::new(vec![]));
+        let exterior = rings.next().unwrap_or(LineString::empty());
 
         Polygon::new(exterior, rings.collect())
     }

--- a/geo/src/algorithm/bool_ops/tests.rs
+++ b/geo/src/algorithm/bool_ops/tests.rs
@@ -31,7 +31,7 @@ fn test_unary_union_errors() {
 
     let naive_union = {
         let start = Instant::now();
-        let mut output = MultiPolygon::new(Vec::new());
+        let mut output = MultiPolygon::empty();
         for poly in input.iter() {
             output = output.union(poly);
         }
@@ -279,7 +279,7 @@ mod gh_issues {
             wkt!(POLYGON((3.3493652 -55.80127,171.22443 -300.,195.83728 -300.,-46.650635 30.80127,3.3493652 -55.80127))),
         ];
 
-        let mut multi: MultiPolygon<f32> = MultiPolygon::new(Vec::new());
+        let mut multi: MultiPolygon<f32> = MultiPolygon::empty();
         for poly in polygons {
             multi = multi.union(&MultiPolygon::new(vec![poly]));
         }

--- a/geo/src/algorithm/centroid.rs
+++ b/geo/src/algorithm/centroid.rs
@@ -745,7 +745,7 @@ mod test {
     // Tests: Centroid of MultiLineString
     #[test]
     fn empty_multilinestring_test() {
-        let mls: MultiLineString = MultiLineString::new(vec![]);
+        let mls: MultiLineString = MultiLineString::empty();
         let centroid = mls.centroid();
         assert!(centroid.is_none());
     }
@@ -924,7 +924,7 @@ mod test {
     fn empty_interior_polygon_test() {
         let poly = Polygon::new(
             LineString::from(vec![p(0., 0.), p(0., 1.), p(1., 1.), p(1., 0.), p(0., 0.)]),
-            vec![LineString::new(vec![])],
+            vec![LineString::empty()],
         );
         assert_eq!(poly.centroid(), Some(p(0.5, 0.5)));
     }
@@ -947,7 +947,7 @@ mod test {
     // Tests: Centroid of MultiPolygon
     #[test]
     fn empty_multipolygon_polygon_test() {
-        assert!(MultiPolygon::<f64>::new(Vec::new()).centroid().is_none());
+        assert!(MultiPolygon::<f64>::empty().centroid().is_none());
     }
 
     #[test]

--- a/geo/src/algorithm/closest_point.rs
+++ b/geo/src/algorithm/closest_point.rs
@@ -260,7 +260,7 @@ mod tests {
 
     #[test]
     fn empty_line_string_is_indeterminate() {
-        let ls = LineString::new(Vec::new());
+        let ls = LineString::empty();
         let p = Point::new(0.0, 0.0);
 
         let got = ls.closest_point(&p);

--- a/geo/src/algorithm/contains/mod.rs
+++ b/geo/src/algorithm/contains/mod.rs
@@ -176,7 +176,7 @@ mod test {
     /// Tests: Point in LineString
     #[test]
     fn empty_linestring_test() {
-        let linestring = LineString::new(Vec::new());
+        let linestring = LineString::empty();
         assert!(!linestring.contains(&Point::new(2., 1.)));
     }
     #[test]
@@ -196,8 +196,7 @@ mod test {
     /// Tests: Point in Polygon
     #[test]
     fn empty_polygon_test() {
-        let linestring = LineString::new(Vec::new());
-        let poly = Polygon::new(linestring, Vec::new());
+        let poly = Polygon::empty();
         assert!(!poly.contains(&Point::new(2., 1.)));
     }
     #[test]
@@ -275,7 +274,7 @@ mod test {
     /// Tests: Point in MultiPolygon
     #[test]
     fn empty_multipolygon_test() {
-        let multipoly = MultiPolygon::new(Vec::new());
+        let multipoly = MultiPolygon::empty();
         assert!(!multipoly.contains(&Point::new(2., 1.)));
     }
     #[test]
@@ -605,7 +604,7 @@ mod test {
     #[test]
     fn rect_contains_empty_polygon() {
         let rect = Rect::new(coord! { x: 90., y: 150. }, coord! { x: 300., y: 360. });
-        let empty_poly = Polygon::new(line_string![], vec![]);
+        let empty_poly = Polygon::empty();
         assert_eq!(
             rect.contains(&empty_poly),
             rect.relate(&empty_poly).is_contains()

--- a/geo/src/algorithm/coordinate_position.rs
+++ b/geo/src/algorithm/coordinate_position.rs
@@ -452,7 +452,7 @@ mod test {
 
     #[test]
     fn test_empty_poly() {
-        let square_poly: Polygon<f64> = Polygon::new(LineString::new(vec![]), vec![]);
+        let square_poly: Polygon<f64> = Polygon::empty();
         assert_eq!(
             square_poly.coordinate_position(&Coord::zero()),
             CoordPos::Outside

--- a/geo/src/algorithm/densify_haversine.rs
+++ b/geo/src/algorithm/densify_haversine.rs
@@ -221,7 +221,7 @@ mod tests {
 
     #[test]
     fn test_empty_linestring() {
-        let linestring: LineString<f64> = LineString::new(vec![]);
+        let linestring: LineString<f64> = LineString::empty();
         #[allow(deprecated)]
         let dense = linestring.densify_haversine(10.0);
         assert_eq!(0, dense.coords_count());

--- a/geo/src/algorithm/dimensions.rs
+++ b/geo/src/algorithm/dimensions.rs
@@ -50,7 +50,7 @@ pub trait HasDimensions {
     /// ]);
     /// assert!(!line_string.is_empty());
     ///
-    /// let empty_line_string: LineString = LineString::new(vec![]);
+    /// let empty_line_string: LineString = LineString::empty();
     /// assert!(empty_line_string.is_empty());
     ///
     /// let point = Point::new(0.0, 0.0);
@@ -89,7 +89,7 @@ pub trait HasDimensions {
     /// assert_eq!(Dimensions::ZeroDimensional, point.dimensions());
     ///
     /// // An `Empty` dimensionality is distinct from, and less than, being 0-dimensional
-    /// let empty_collection = GeometryCollection::<f32>::new_from(vec![]);
+    /// let empty_collection = GeometryCollection::<f32>::empty();
     /// assert_eq!(Dimensions::Empty, empty_collection.dimensions());
     /// assert!(empty_collection.dimensions() < point.dimensions());
     /// ```

--- a/geo/src/algorithm/euclidean_distance.rs
+++ b/geo/src/algorithm/euclidean_distance.rs
@@ -769,8 +769,7 @@ mod test {
     #[test]
     // Point to LineString, empty LineString
     fn point_linestring_empty_test() {
-        let points = vec![];
-        let ls = LineString::new(points);
+        let ls = LineString::empty();
         let p = Point::new(5.0, 4.0);
         let dist = p.euclidean_distance(&ls);
         assert_relative_eq!(dist, 0.0);

--- a/geo/src/algorithm/extremes.rs
+++ b/geo/src/algorithm/extremes.rs
@@ -122,7 +122,7 @@ mod test {
 
     #[test]
     fn empty() {
-        let multi_point: MultiPoint<f32> = MultiPoint::new(vec![]);
+        let multi_point: MultiPoint<f32> = MultiPoint::empty();
 
         let actual = multi_point.extremes();
 

--- a/geo/src/algorithm/haversine_closest_point.rs
+++ b/geo/src/algorithm/haversine_closest_point.rs
@@ -514,7 +514,7 @@ mod test {
 
     #[test]
     fn point_to_empty_linestring() {
-        let linestring = LineString::new(vec![]);
+        let linestring = LineString::empty();
 
         let p_from = Point::new(17.02374, 10.57037);
 

--- a/geo/src/algorithm/interior_point.rs
+++ b/geo/src/algorithm/interior_point.rs
@@ -429,7 +429,7 @@ mod test {
     // Tests: InteriorPoint of MultiLineString
     #[test]
     fn empty_multilinestring_test() {
-        let mls: MultiLineString = MultiLineString::new(vec![]);
+        let mls: MultiLineString = MultiLineString::empty();
         let interior_point = mls.interior_point();
         assert!(interior_point.is_none());
     }
@@ -636,7 +636,7 @@ mod test {
     fn empty_interior_polygon_test() {
         let poly = Polygon::new(
             LineString::from(vec![p(0., 0.), p(0., 1.), p(1., 1.), p(1., 0.), p(0., 0.)]),
-            vec![LineString::new(vec![])],
+            vec![LineString::empty()],
         );
         assert_eq!(poly.interior_point(), Some(p(0.5, 0.5)));
     }
@@ -664,9 +664,7 @@ mod test {
     // Tests: InteriorPoint of MultiPolygon
     #[test]
     fn empty_multipolygon_polygon_test() {
-        assert!(MultiPolygon::<f64>::new(Vec::new())
-            .interior_point()
-            .is_none());
+        assert!(MultiPolygon::<f64>::empty().interior_point().is_none());
     }
 
     #[test]

--- a/geo/src/algorithm/intersects/mod.rs
+++ b/geo/src/algorithm/intersects/mod.rs
@@ -143,7 +143,7 @@ mod test {
     #[test]
     fn empty_linestring2_test() {
         let linestring = line_string![(x: 3., y: 2.), (x: 7., y: 6.)];
-        assert!(!linestring.intersects(&LineString::new(Vec::new())));
+        assert!(!linestring.intersects(&LineString::empty()));
     }
     #[test]
     fn empty_all_linestring_test() {

--- a/geo/src/algorithm/k_nearest_concave_hull.rs
+++ b/geo/src/algorithm/k_nearest_concave_hull.rs
@@ -398,7 +398,7 @@ mod tests {
     #[test]
     fn empty_hull() {
         let actual: Polygon<f64> = concave_hull([].iter(), 3);
-        let expected = Polygon::new(LineString::new(vec![]), vec![]);
+        let expected = Polygon::new(LineString::empty(), vec![]);
         assert_eq!(actual, expected);
     }
 }

--- a/geo/src/algorithm/line_measures/densify.rs
+++ b/geo/src/algorithm/line_measures/densify.rs
@@ -202,7 +202,7 @@ impl<F: CoordFloat + FromPrimitive> Densifiable<F> for LineString<F> {
         MetricSpace: Distance<F, Point<F>, Point<F>> + InterpolatePoint<F>,
     {
         if self.coords_count() == 0 {
-            return LineString::new(vec![]);
+            return LineString::empty();
         }
 
         let mut points = vec![];
@@ -393,7 +393,7 @@ mod tests {
 
         #[test]
         fn test_empty_linestring_densify() {
-            let linestring = LineString::<f64>::new(vec![]);
+            let linestring = LineString::<f64>::empty();
             let max_dist = 2.0;
             let densified = Euclidean.densify(&linestring, max_dist);
             assert!(densified.0.is_empty());

--- a/geo/src/algorithm/line_measures/interpolate_line.rs
+++ b/geo/src/algorithm/line_measures/interpolate_line.rs
@@ -756,7 +756,7 @@ mod tests {
 
             #[test]
             fn empty_line_string() {
-                let line_string: LineString = LineString::new(vec![]);
+                let line_string: LineString = LineString::empty();
                 assert_eq!(None, Euclidean.point_at_ratio_from_start(&line_string, 0.5));
                 assert_eq!(
                     None,

--- a/geo/src/algorithm/relate/geomgraph/intersection_matrix.rs
+++ b/geo/src/algorithm/relate/geomgraph/intersection_matrix.rs
@@ -763,7 +763,7 @@ mod tests {
 
     #[test]
     fn empty_is_equal_topo() {
-        let empty_polygon = Polygon::<f64>::new(LineString::new(vec![]), vec![]);
+        let empty_polygon = Polygon::<f64>::new(LineString::empty(), vec![]);
         let im = empty_polygon.relate(&empty_polygon);
         assert!(im.is_equal_topo());
     }

--- a/geo/src/algorithm/rotate.rs
+++ b/geo/src/algorithm/rotate.rs
@@ -560,7 +560,7 @@ mod test {
         assert_eq!(empty_linestring, rotated_empty_linestring);
 
         // multi line string
-        let empty_multilinestring: MultiLineString = MultiLineString::new(vec![]);
+        let empty_multilinestring: MultiLineString = MultiLineString::empty();
         let rotated_empty_multilinestring = empty_multilinestring.rotate_around_centroid(90.);
         assert_eq!(empty_multilinestring, rotated_empty_multilinestring);
 


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

This is a draft because it depends on the review/release of https://github.com/georust/geo/pull/1363 first.

We could merge this before releasing geo-types, but it means that the other crates won't be releasable *until* we release geo-types and bump their minimum geo-types req.