### PR TITLE
Some `Contains` implementations

### DIFF
--- a/geo/benches/contains.rs
+++ b/geo/benches/contains.rs
@@ -384,6 +384,46 @@ fn bench_multipoint_contains_multipoint(c: &mut Criterion) {
             });
         },
     );
+
+    c.bench_function(
+        "Multipoint not contains multipoint 10000 best case (Contains trait)",
+        |bencher| {
+            let base: Vec<Point> = (0..10000)
+                .map(|val| point! {x: f64::from(val)/10., y: f64::from(val)/10.})
+                .collect();
+            let mut comp = base.clone();
+
+            comp.reverse();
+            comp.push(point! {x: f64::from(-1000), y: f64::from(-1000)});
+
+            let base: MultiPoint<f64> = geo::MultiPoint::new(base).convert();
+            let comp: MultiPoint<f64> = geo::MultiPoint::new(comp).convert();
+
+            bencher.iter(|| {
+                assert!(!base.contains(&comp));
+            });
+        },
+    );
+
+    c.bench_function(
+        "Multipoint not contains multipoint 10000 best case (Relate trait)",
+        |bencher| {
+            let base: Vec<Point> = (0..10000)
+                .map(|val| point! {x: f64::from(val)/10., y: f64::from(val)/10.})
+                .collect();
+            let mut comp = base.clone();
+
+            comp.reverse();
+            comp.push(point! {x: f64::from(-1000), y: f64::from(-1000)});
+
+            let base: MultiPoint<f64> = geo::MultiPoint::new(base).convert();
+            let comp: MultiPoint<f64> = geo::MultiPoint::new(comp).convert();
+
+            bencher.iter(|| {
+                assert!(!base.relate(&comp).is_contains());
+            });
+        },
+    );
 }
 
 fn bench_polygon_contains_multipoint(c: &mut Criterion) {

--- a/geo/benches/contains.rs
+++ b/geo/benches/contains.rs
@@ -502,7 +502,7 @@ fn bench_polygon_contains_multipoint(c: &mut Criterion) {
 
 criterion_group!(
     benches,
-    // criterion_benchmark,
+    criterion_benchmark,
     bench_line_contains_multi_point,
     bench_multipoint_contains_multipoint,
     bench_polygon_contains_multipoint,

--- a/geo/src/algorithm/contains/line.rs
+++ b/geo/src/algorithm/contains/line.rs
@@ -89,6 +89,7 @@ where
 {
     fn contains(&self, multi_point: &MultiPoint<T>) -> bool {
         // at least one point must not be equal to one of the vertices
+
         multi_point.iter().any(|point| self.contains(&point.0))
             && multi_point.iter().all(|point| self.intersects(&point.0))
     }
@@ -108,5 +109,40 @@ mod test {
 
         assert!(!line.contains(&empty));
         assert!(!line.relate(&empty).is_contains());
+    }
+
+    #[test]
+    fn test_line_contains_multipoint() {
+        let start = coord! {x: 0., y: 0.};
+        let mid = coord! {x: 50., y: 50.};
+        let end = coord! {x: 100., y: 100.};
+        let out = coord! {x: 101., y: 101.};
+
+        let line = Line::new(start, end);
+
+        let mp_ends = MultiPoint::from(vec![start, end]);
+        let mp_within = MultiPoint::from(vec![mid]);
+        let mp_merged = MultiPoint::from(vec![start, mid, end]);
+
+        let mp_out = MultiPoint::from(vec![out]);
+        let mp_all = MultiPoint::from(vec![start, mid, end, out]);
+
+        // false if all points lie on the boundary of the line (start and end points)
+        assert!(!line.contains(&mp_ends));
+
+        // at least one point must be
+        assert!(line.contains(&mp_within));
+        assert!(line.contains(&mp_merged));
+
+        // return false if any point is not on the line
+        assert!(!line.contains(&mp_out));
+        assert!(!line.contains(&mp_all));
+
+        // multipoint containing duplicates
+        let start_dupe = MultiPoint::from(vec![start, start]);
+        let start_dupe_within = MultiPoint::from(vec![start, start, mid]);
+
+        assert!(!line.contains(&start_dupe));
+        assert!(line.contains(&start_dupe_within));
     }
 }

--- a/geo/src/algorithm/contains/line.rs
+++ b/geo/src/algorithm/contains/line.rs
@@ -83,5 +83,15 @@ where
     }
 }
 
-impl_contains_from_relate!(Line<T>, [Polygon<T>, MultiPoint<T>, MultiLineString<T>, MultiPolygon<T>, GeometryCollection<T>, Rect<T>, Triangle<T>]);
+impl<T> Contains<MultiPoint<T>> for Line<T>
+where
+    T: GeoNum,
+{
+    fn contains(&self, multi_point: &MultiPoint<T>) -> bool {
+        // at least one point must not be equal to one of the vertices
+        multi_point.iter().any(|point| self.contains(&point.0))
+            && multi_point.iter().all(|point| self.intersects(&point.0))
+    }
+}
+impl_contains_from_relate!(Line<T>, [Polygon<T>, MultiLineString<T>, MultiPolygon<T>, GeometryCollection<T>, Rect<T>, Triangle<T>]);
 impl_contains_geometry_for!(Line<T>);

--- a/geo/src/algorithm/contains/line.rs
+++ b/geo/src/algorithm/contains/line.rs
@@ -95,3 +95,18 @@ where
 }
 impl_contains_from_relate!(Line<T>, [Polygon<T>, MultiLineString<T>, MultiPolygon<T>, GeometryCollection<T>, Rect<T>, Triangle<T>]);
 impl_contains_geometry_for!(Line<T>);
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{coord, MultiPoint, Relate};
+
+    #[test]
+    fn test_line_contains_empty_multipoint() {
+        let line = Line::new(coord! {x:0.,y:0.}, coord! {x:100., y:100.});
+        let empty: MultiPoint<f64> = MultiPoint::new(Vec::new());
+
+        assert!(!line.contains(&empty));
+        assert!(!line.relate(&empty).is_contains());
+    }
+}

--- a/geo/src/algorithm/contains/point.rs
+++ b/geo/src/algorithm/contains/point.rs
@@ -233,3 +233,20 @@ fn cmp_pts<T: CoordNum>(a: &Point<T>, b: &Point<T>) -> std::cmp::Ordering {
         None => std::cmp::Ordering::Equal,
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{point, MultiPoint, Relate};
+
+    #[test]
+    fn test_empty_multipoint_contains_multipoint() {
+        let empty: MultiPoint<f64> = MultiPoint::new(Vec::new());
+        let non_empty: MultiPoint<f64> = MultiPoint::new(vec![point!(x: 0.0, y: 0.0)]);
+        assert!(!empty.contains(&non_empty));
+        assert!(!non_empty.contains(&empty));
+
+        assert!(!empty.relate(&non_empty).is_contains());
+        assert!(!non_empty.relate(&empty).is_contains());
+    }
+}

--- a/geo/src/algorithm/contains/point.rs
+++ b/geo/src/algorithm/contains/point.rs
@@ -237,16 +237,53 @@ fn cmp_pts<T: CoordNum>(a: &Point<T>, b: &Point<T>) -> std::cmp::Ordering {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{point, MultiPoint, Relate};
+    use crate::{coord, point, MultiPoint, Relate};
 
     #[test]
+    /**
+     * tests for empty multipoint
+     * behaviour follows `Relate` Trait
+     */
     fn test_empty_multipoint_contains_multipoint() {
         let empty: MultiPoint<f64> = MultiPoint::new(Vec::new());
-        let non_empty: MultiPoint<f64> = MultiPoint::new(vec![point!(x: 0.0, y: 0.0)]);
-        assert!(!empty.contains(&non_empty));
-        assert!(!non_empty.contains(&empty));
+        let non_empty: MultiPoint<f64> = MultiPoint::new(vec![point! {x: 0.0, y: 0.0}]);
 
+        // empty multipoint does not contains empty multipoint
+        assert!(!empty.contains(&non_empty));
         assert!(!empty.relate(&non_empty).is_contains());
+
+        // non-empty multipoint does not contain empty multipoint
+        assert!(!non_empty.contains(&empty));
         assert!(!non_empty.relate(&empty).is_contains());
+
+        // empty multipoint does not contain empty multipoint
+        assert!(!empty.contains(&empty));
+        assert!(!empty.relate(&empty).is_contains());
+    }
+
+    #[test]
+    fn test_multipoint_contains_multipoint() {
+        let pt_a = coord! {x: 0., y: 0.};
+        let pt_b = coord! {x: 10., y: 10.};
+        let pt_c = coord! {x: 20., y: 20.};
+        let pt_d = coord! {x: 30., y: 30.};
+
+        let mp_a = MultiPoint::from(vec![pt_a]);
+        let mp_bc = MultiPoint::from(vec![pt_a, pt_b]);
+        let mp_abc = MultiPoint::from(vec![pt_a, pt_b, pt_c]);
+        let mp_bcd = MultiPoint::from(vec![pt_b, pt_c, pt_d]);
+
+        // multipoint contains itself
+        assert!(mp_a.contains(&mp_a));
+        assert!(mp_bc.contains(&mp_bc));
+        assert!(mp_abc.contains(&mp_abc));
+        assert!(mp_bcd.contains(&mp_bcd));
+
+        // multipoint contains subsets
+        assert!(mp_abc.contains(&mp_a));
+        assert!(mp_abc.contains(&mp_bc));
+
+        // overlapping multipoints do not contain each other
+        assert!(!mp_abc.contains(&mp_bcd));
     }
 }

--- a/geo/src/algorithm/contains/point.rs
+++ b/geo/src/algorithm/contains/point.rs
@@ -248,7 +248,7 @@ mod test {
         let empty: MultiPoint<f64> = MultiPoint::new(Vec::new());
         let non_empty: MultiPoint<f64> = MultiPoint::new(vec![point! {x: 0.0, y: 0.0}]);
 
-        // empty multipoint does not contains empty multipoint
+        // empty multipoint does not contains non-empty multipoint
         assert!(!empty.contains(&non_empty));
         assert!(!empty.relate(&non_empty).is_contains());
 
@@ -283,7 +283,7 @@ mod test {
         assert!(mp_abc.contains(&mp_a));
         assert!(mp_abc.contains(&mp_bc));
 
-        // overlapping multipoints do not contain each other
+        // partially overlapping multipoints do not contain each other
         assert!(!mp_abc.contains(&mp_bcd));
     }
 }

--- a/geo/src/algorithm/contains/polygon.rs
+++ b/geo/src/algorithm/contains/polygon.rs
@@ -26,7 +26,22 @@ where
     }
 }
 
-impl_contains_from_relate!(Polygon<T>, [Line<T>, LineString<T>, Polygon<T>, MultiPoint<T>, MultiLineString<T>, MultiPolygon<T>, GeometryCollection<T>, Rect<T>, Triangle<T>]);
+impl<T> Contains<MultiPoint<T>> for Polygon<T>
+where
+    T: GeoNum,
+{
+    fn contains(&self, mp: &MultiPoint<T>) -> bool {
+        use crate::coordinate_position::{CoordPos, CoordinatePosition};
+        // at least one point must be fully within
+        // others can be on the boundary
+        mp.iter().any(|p| self.contains(p))
+            && mp
+                .iter()
+                .all(|p| self.coordinate_position(&p.0) != CoordPos::Outside)
+    }
+}
+
+impl_contains_from_relate!(Polygon<T>, [Line<T>, LineString<T>, Polygon<T>, MultiLineString<T>, MultiPolygon<T>, GeometryCollection<T>, Rect<T>, Triangle<T>]);
 impl_contains_geometry_for!(Polygon<T>);
 
 // ┌──────────────────────────────────┐

--- a/geo/src/algorithm/contains/polygon.rs
+++ b/geo/src/algorithm/contains/polygon.rs
@@ -146,3 +146,24 @@ where
         rhs.relate(self).is_within()
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{polygon, MultiPoint, Relate};
+
+    #[test]
+    fn test_polygon_contains_empty_multipoint() {
+        let poly = polygon![
+            (x: 0.0, y: 0.0),
+            (x: 10.0, y: 0.0),
+            (x: 10.0, y: 10.0),
+            (x: 0.0, y: 10.0),
+            (x: 0.0, y: 0.0),
+        ];
+        let empty: MultiPoint<f64> = MultiPoint::new(Vec::new());
+
+        assert!(!poly.contains(&empty));
+        assert!(!poly.relate(&empty).is_contains());
+    }
+}

--- a/geo/src/algorithm/contains/polygon.rs
+++ b/geo/src/algorithm/contains/polygon.rs
@@ -150,20 +150,77 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{polygon, MultiPoint, Relate};
+    use crate::{coord, polygon, MultiPoint, Relate};
+
+    fn make_test_pts() -> [Coord<f64>; 7] {
+        let pt_a = coord! {x: 0., y: 0.};
+        let pt_b = coord! {x: 10., y: 0.};
+        let pt_c = coord! {x: 10., y: 10.};
+        let pt_d = coord! {x: 0., y: 10.};
+
+        let pt_edge = coord! {x: 0., y: 5.};
+        let pt_mid = coord! {x: 5., y: 5.};
+        let pt_out = coord! {x: 11., y: 11.};
+        [pt_a, pt_b, pt_c, pt_d, pt_edge, pt_mid, pt_out]
+    }
 
     #[test]
-    fn test_polygon_contains_empty_multipoint() {
-        let poly = polygon![
-            (x: 0.0, y: 0.0),
-            (x: 10.0, y: 0.0),
-            (x: 10.0, y: 10.0),
-            (x: 0.0, y: 10.0),
-            (x: 0.0, y: 0.0),
-        ];
+    fn test_polygon_should_never_contain_empty_multipoint() {
+        let [pt_a, pt_b, pt_c, pt_d, _pt_edge, _pt_mid, _pt_out] = make_test_pts();
+
+        let poly = polygon![pt_a, pt_b, pt_c, pt_d, pt_a];
         let empty: MultiPoint<f64> = MultiPoint::new(Vec::new());
 
+        // contains implementation follows `Relate`` trait
         assert!(!poly.contains(&empty));
         assert!(!poly.relate(&empty).is_contains());
+    }
+
+    #[test]
+    fn test_polygon_should_contains_multipoint() {
+        let [pt_a, pt_b, pt_c, pt_d, pt_edge, pt_mid, _pt_out] = make_test_pts();
+
+        let poly = polygon![pt_a, pt_b, pt_c, pt_d, pt_a];
+
+        // contains requires at least one point fully within the polygon
+        let mp_a_mid = MultiPoint::from(vec![pt_a, pt_mid]);
+        let mp_bc_mid = MultiPoint::from(vec![pt_a, pt_b, pt_mid]);
+        let mp_bc_edge_mid = MultiPoint::from(vec![pt_a, pt_b, pt_edge, pt_mid]);
+
+        assert!(poly.contains(&mp_a_mid));
+        assert!(poly.contains(&mp_bc_mid));
+        assert!(poly.contains(&mp_bc_edge_mid));
+    }
+
+    #[test]
+    fn test_polygon_should_not_contains_multipoint_on_edge() {
+        let [pt_a, pt_b, pt_c, pt_d, pt_edge, _pt_mid, _pt_out] = make_test_pts();
+
+        let poly = polygon![pt_a, pt_b, pt_c, pt_d, pt_a];
+
+        // contains should return false if all points lie on the boundary of the polygon
+        let mp_a = MultiPoint::from(vec![pt_a]);
+        let mp_bc = MultiPoint::from(vec![pt_a, pt_b]);
+        let mp_bc_edge = MultiPoint::from(vec![pt_a, pt_b, pt_edge]);
+
+        assert!(!poly.contains(&mp_a));
+        assert!(!poly.contains(&mp_bc));
+        assert!(!poly.contains(&mp_bc_edge));
+    }
+
+    #[test]
+    fn test_polygon_should_not_contains_out_multipoint() {
+        let [pt_a, pt_b, pt_c, pt_d, pt_edge, _pt_mid, pt_out] = make_test_pts();
+
+        let poly = polygon![pt_a, pt_b, pt_c, pt_d, pt_a];
+
+        // contains should return false if any point lies outside the polygon
+        let mp_a_out = MultiPoint::from(vec![pt_a, pt_out]);
+        let mp_bc_out = MultiPoint::from(vec![pt_a, pt_b, pt_out]);
+        let mp_bc_edge_out = MultiPoint::from(vec![pt_a, pt_b, pt_edge, pt_out]);
+
+        assert!(!poly.contains(&mp_a_out));
+        assert!(!poly.contains(&mp_bc_out));
+        assert!(!poly.contains(&mp_bc_edge_out));
     }
 }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Added implementations for some contains operations  
- Line contain Multipoint using iter() 
  - ~8x faster
- Multipoint contain Multipoint using sort + double pointer
  - ~40x faster in worst case 
  - ~120x faster in best case
- Polygon contains Multipoint using iter()
  - ~30x faster

benchmarks ran on a m4 macbook pro  
benchmarks used synthetic data where the outlier in `not-contains` benchmark is the last element checked  