### PR TITLE
add contains<Coord<T>> for MultiLineString

### DIFF
--- a/geo/src/algorithm/contains/line_string.rs
+++ b/geo/src/algorithm/contains/line_string.rs
@@ -127,6 +127,16 @@ impl_contains_geometry_for!(LineString<T>);
 impl_contains_from_relate!(MultiLineString<T>, [Line<T>, LineString<T>, Polygon<T>, MultiPoint<T>, MultiLineString<T>, MultiPolygon<T>, GeometryCollection<T>, Rect<T>, Triangle<T>]);
 impl_contains_geometry_for!(MultiLineString<T>);
 
+impl<T> Contains<Coord<T>> for MultiLineString<T>
+where
+    T: CoordNum,
+    LineString<T>: Contains<Coord<T>>,
+{
+    fn contains(&self, coord: &Coord<T>) -> bool {
+        self.iter().any(|ls| ls.contains(coord))
+    }
+}
+
 impl<T> Contains<Point<T>> for MultiLineString<T>
 where
     T: CoordNum,


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

While working on Contains, I realised that MultiLineString.contains(Coord<T>) wasn't implemented  

Implementation based on MultiLineString.contains(Point<T>)