### PR TITLE
Derive clone, copy and eq on `TriangulationError`

### DIFF
--- a/geo/src/algorithm/triangulate_delaunay.rs
+++ b/geo/src/algorithm/triangulate_delaunay.rs
@@ -35,7 +35,7 @@ where
 
 // ====== Error ========
 
-#[derive(Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum TriangulationError {
     SpadeError(spade::InsertionError),
     LoopTrap,


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
### Purpose
I'm working on an error enum that includes `TriangulationError` and I want to derive clone, copy and eq for better user experience so in my use-case `TriangulationError` needs to implement them.