### PR TITLE
Intersects op

### DIFF
--- a/geo/benches/intersection.rs
+++ b/geo/benches/intersection.rs
@@ -1,6 +1,6 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use geo::intersects::Intersects;
-use geo::{CoordsIter, MultiPolygon};
+use geo::{CoordsIter, MultiPolygon, Polygon};
 
 fn multi_polygon_intersection(c: &mut Criterion) {
     let plot_polygons: MultiPolygon = geo_test_fixtures::nl_plots_wgs84();
@@ -168,7 +168,27 @@ fn rect_triangle_intersection(c: &mut Criterion) {
             assert!(criterion::black_box(&rect).intersects(criterion::black_box(&triangle)));
         });
     });
-
+    c.bench_function("intersects edge intersections as polygon", |bencher| {
+        let rect = Rect::new(coord! { x: 0., y: 0. }, coord! { x: 10., y: 10. });
+        let triangle: Polygon = Triangle::from([(5., -2.), (4., 11.), (6., 11.)]).into();
+        bencher.iter(|| {
+            assert!(criterion::black_box(&rect).intersects(criterion::black_box(&triangle)));
+        });
+    });
+    c.bench_function("triangle within rect", |bencher| {
+        let rect = Rect::new(coord! { x: 0., y: 0. }, coord! { x: 10., y: 10. });
+        let triangle = Triangle::from([(1., 1.), (1., 2.), (2., 1.)]);
+        bencher.iter(|| {
+            assert!(criterion::black_box(&rect).intersects(criterion::black_box(&triangle)));
+        });
+    });
+    c.bench_function("rect within triangle", |bencher| {
+        let rect = Rect::new(coord! { x: 1., y: 1. }, coord! { x: 2., y: 2. });
+        let triangle = Triangle::from([(0., 10.), (10., 0.), (0., 0.)]);
+        bencher.iter(|| {
+            assert!(criterion::black_box(&rect).intersects(criterion::black_box(&triangle)));
+        });
+    });
     c.bench_function("disjoint", |bencher| {
         let rect = Rect::new(coord! { x: 0., y: 0. }, coord! { x: 10., y: 10. });
         let triangle = Triangle::from([(0., 11.), (1., 11.), (1., 12.)]);
@@ -261,7 +281,6 @@ fn poly_rect_intersection(c: &mut Criterion) {
         });
     });
 }
-
 
 criterion_group! {
     name = bench_multi_polygons;

--- a/geo/benches/intersection.rs
+++ b/geo/benches/intersection.rs
@@ -144,6 +144,40 @@ fn point_triangle_intersection(c: &mut Criterion) {
     });
 }
 
+fn rect_triangle_intersection(c: &mut Criterion) {
+    use geo::{coord, Intersects, Rect, Triangle};
+
+    c.bench_function("intersects triangle pt in rect", |bencher| {
+        let rect = Rect::new(coord! { x: 0., y: 0. }, coord! { x: 10., y: 10. });
+        let triangle = Triangle::from([(5., 5.), (11., 0.), (11., 10.)]);
+        bencher.iter(|| {
+            assert!(criterion::black_box(&rect).intersects(criterion::black_box(&triangle)));
+        });
+    });
+    c.bench_function("intersects rect pt in triangle", |bencher| {
+        let rect = Rect::new(coord! { x: 0., y: 0. }, coord! { x: 10., y: 10. });
+        let triangle = Triangle::from([(-1., 5.), (-1., -5.), (1., -1.)]);
+        bencher.iter(|| {
+            assert!(criterion::black_box(&rect).intersects(criterion::black_box(&triangle)));
+        });
+    });
+    c.bench_function("intersects edge intersections", |bencher| {
+        let rect = Rect::new(coord! { x: 0., y: 0. }, coord! { x: 10., y: 10. });
+        let triangle = Triangle::from([(-1., 2.), (2., -1.), (-10., -10.)]);
+        bencher.iter(|| {
+            assert!(criterion::black_box(&rect).intersects(criterion::black_box(&triangle)));
+        });
+    });
+
+    c.bench_function("disjoint", |bencher| {
+        let rect = Rect::new(coord! { x: 0., y: 0. }, coord! { x: 10., y: 10. });
+        let triangle = Triangle::from([(0., 11.), (1., 11.), (1., 12.)]);
+        bencher.iter(|| {
+            assert!(!criterion::black_box(&rect).intersects(criterion::black_box(&triangle)));
+        });
+    });
+}
+
 criterion_group! {
     name = bench_multi_polygons;
     config = Criterion::default().sample_size(10);
@@ -160,10 +194,12 @@ criterion_group! {
     config = Criterion::default().sample_size(50);
     targets = point_triangle_intersection
 }
+criterion_group!(bench_rect_triangle, rect_triangle_intersection);
 
 criterion_main!(
     bench_multi_polygons,
     bench_rects,
     bench_point_rect,
-    bench_point_triangle
+    bench_point_triangle,
+    bench_rect_triangle
 );

--- a/geo/benches/intersection.rs
+++ b/geo/benches/intersection.rs
@@ -250,6 +250,16 @@ fn poly_rect_intersection(c: &mut Criterion) {
             assert!(!criterion::black_box(&rect).intersects(criterion::black_box(&polygon)));
         });
     });
+
+    c.bench_function("intersects rect within polygon", |bencher| {
+        let rect: Rect = Rect::new(coord! { x: 0., y: 0. }, coord! { x: 10., y: 10. }).into();
+        let polygon: Polygon =
+            Rect::new(coord! { x: -1., y: -1. }, coord! { x: 11., y: 11. }).into();
+
+        bencher.iter(|| {
+            assert!(criterion::black_box(&rect).intersects(criterion::black_box(&polygon)));
+        });
+    });
 }
 
 

--- a/geo/benches/intersection.rs
+++ b/geo/benches/intersection.rs
@@ -276,10 +276,9 @@ fn poly_rect_intersection(c: &mut Criterion) {
             assert!(criterion::black_box(&rect).intersects(criterion::black_box(&polygon)));
         });
     });
-     c.bench_function("intersects polygon within rect", |bencher| {
+    c.bench_function("intersects polygon within rect", |bencher| {
         let rect: Rect = Rect::new(coord! { x: 0., y: 0. }, coord! { x: 10., y: 10. }).into();
-        let polygon: Polygon =
-            Rect::new(coord! { x: 1., y: 1. }, coord! { x: 9., y: 9. }).into();
+        let polygon: Polygon = Rect::new(coord! { x: 1., y: 1. }, coord! { x: 9., y: 9. }).into();
 
         bencher.iter(|| {
             assert!(criterion::black_box(&rect).intersects(criterion::black_box(&polygon)));

--- a/geo/benches/intersection.rs
+++ b/geo/benches/intersection.rs
@@ -1,6 +1,6 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use geo::intersects::Intersects;
-use geo::MultiPolygon;
+use geo::{CoordsIter, MultiPolygon};
 
 fn multi_polygon_intersection(c: &mut Criterion) {
     let plot_polygons: MultiPolygon = geo_test_fixtures::nl_plots_wgs84();
@@ -149,21 +149,21 @@ fn rect_triangle_intersection(c: &mut Criterion) {
 
     c.bench_function("intersects triangle pt in rect", |bencher| {
         let rect = Rect::new(coord! { x: 0., y: 0. }, coord! { x: 10., y: 10. });
-        let triangle = Triangle::from([(5., 5.), (11., 0.), (11., 10.)]);
+        let triangle = Triangle::from([(5., 5.), (11., 4.), (11., 6.)]);
         bencher.iter(|| {
             assert!(criterion::black_box(&rect).intersects(criterion::black_box(&triangle)));
         });
     });
     c.bench_function("intersects rect pt in triangle", |bencher| {
         let rect = Rect::new(coord! { x: 0., y: 0. }, coord! { x: 10., y: 10. });
-        let triangle = Triangle::from([(-1., 5.), (-1., -5.), (1., -1.)]);
+        let triangle = Triangle::from([(-2., 4.), (4., -2.), (-2., -2.)]);
         bencher.iter(|| {
             assert!(criterion::black_box(&rect).intersects(criterion::black_box(&triangle)));
         });
     });
     c.bench_function("intersects edge intersections", |bencher| {
         let rect = Rect::new(coord! { x: 0., y: 0. }, coord! { x: 10., y: 10. });
-        let triangle = Triangle::from([(-1., 2.), (2., -1.), (-10., -10.)]);
+        let triangle = Triangle::from([(5., -2.), (4., 11.), (6., 11.)]);
         bencher.iter(|| {
             assert!(criterion::black_box(&rect).intersects(criterion::black_box(&triangle)));
         });
@@ -177,6 +177,81 @@ fn rect_triangle_intersection(c: &mut Criterion) {
         });
     });
 }
+
+fn poly_rect_intersection(c: &mut Criterion) {
+    use geo::{coord, polygon, Intersects, LineString, Polygon, Rect};
+
+    fn get_rect() -> Rect<f64> {
+        Rect::new(coord! { x: 0., y: 0. }, coord! { x: 10., y: 10. })
+    }
+
+    c.bench_function("intersects polygon pt in rect", |bencher| {
+        let rect = get_rect();
+        let polygon = polygon![(x:5.,y:5.),(x:4.,y:11.),(x:5.,y:11.),(x:6.,y:11.),(x:5.,y:5.)];
+        bencher.iter(|| {
+            assert!(criterion::black_box(&rect).intersects(criterion::black_box(&polygon)));
+        });
+    });
+    c.bench_function("intersects rect pt in polygon", |bencher| {
+        let rect = get_rect();
+        let polygon = polygon![(x:-2.,y:-2.),(x:-2.,y:-1.),(x:4.,y:-2.),(x:-2.,y:4.),(x:-1.,y:-2.),(x:-2.,y:-2.)];
+        bencher.iter(|| {
+            assert!(criterion::black_box(&rect).intersects(criterion::black_box(&polygon)));
+        });
+    });
+    c.bench_function("intersects edge intersections", |bencher| {
+        let rect = get_rect();
+        let polygon =
+            polygon![(x:5., y:-2.), (x:4., y:11.),(x:5., y:11.), (x:6., y:11.),(x:5., y:-2.)];
+        bencher.iter(|| {
+            assert!(criterion::black_box(&rect).intersects(criterion::black_box(&polygon)));
+        });
+    });
+
+    c.bench_function("not intersects disjoint", |bencher| {
+        let rect = get_rect();
+        let polygon: Polygon =
+            Rect::new(coord! { x: 11., y: 11. }, coord! { x: 12., y: 12. }).into();
+
+        bencher.iter(|| {
+            assert!(!criterion::black_box(&rect).intersects(criterion::black_box(&polygon)));
+        });
+    });
+
+    c.bench_function("intersects rect equals polygon gap", |bencher| {
+        let rect = get_rect();
+        let ls = LineString::new(
+            Rect::new(coord! {x:-1.,y:-1.}, coord! {x:11.,y:11.})
+                .exterior_coords_iter()
+                .collect(),
+        );
+        let polygon = Polygon::new(ls, vec![rect.exterior_coords_iter().collect()]);
+
+        bencher.iter(|| {
+            assert!(criterion::black_box(&rect).intersects(criterion::black_box(&polygon)));
+        });
+    });
+
+    c.bench_function("intersects rect within polygon gap", |bencher| {
+        let rect = get_rect();
+        let ls = LineString::new(
+            Rect::new(coord! {x:-1.,y:-1.}, coord! {x:11.,y:11.})
+                .exterior_coords_iter()
+                .collect(),
+        );
+        let inner = LineString::new(
+            Rect::new(coord! {x:-0.1,y:-0.1}, coord! {x:10.1,y:10.1})
+                .exterior_coords_iter()
+                .collect(),
+        );
+        let polygon = Polygon::new(ls, vec![inner]);
+
+        bencher.iter(|| {
+            assert!(!criterion::black_box(&rect).intersects(criterion::black_box(&polygon)));
+        });
+    });
+}
+
 
 criterion_group! {
     name = bench_multi_polygons;
@@ -195,11 +270,13 @@ criterion_group! {
     targets = point_triangle_intersection
 }
 criterion_group!(bench_rect_triangle, rect_triangle_intersection);
+criterion_group!(bench_poly_rect, poly_rect_intersection);
 
 criterion_main!(
     bench_multi_polygons,
     bench_rects,
     bench_point_rect,
     bench_point_triangle,
-    bench_rect_triangle
+    bench_rect_triangle,
+    bench_poly_rect,
 );

--- a/geo/benches/intersection.rs
+++ b/geo/benches/intersection.rs
@@ -227,7 +227,6 @@ fn poly_rect_intersection(c: &mut Criterion) {
             assert!(criterion::black_box(&rect).intersects(criterion::black_box(&polygon)));
         });
     });
-
     c.bench_function("not intersects disjoint", |bencher| {
         let rect = get_rect();
         let polygon: Polygon =
@@ -237,7 +236,6 @@ fn poly_rect_intersection(c: &mut Criterion) {
             assert!(!criterion::black_box(&rect).intersects(criterion::black_box(&polygon)));
         });
     });
-
     c.bench_function("intersects rect equals polygon gap", |bencher| {
         let rect = get_rect();
         let ls = LineString::new(
@@ -251,7 +249,6 @@ fn poly_rect_intersection(c: &mut Criterion) {
             assert!(criterion::black_box(&rect).intersects(criterion::black_box(&polygon)));
         });
     });
-
     c.bench_function("intersects rect within polygon gap", |bencher| {
         let rect = get_rect();
         let ls = LineString::new(
@@ -270,11 +267,19 @@ fn poly_rect_intersection(c: &mut Criterion) {
             assert!(!criterion::black_box(&rect).intersects(criterion::black_box(&polygon)));
         });
     });
-
     c.bench_function("intersects rect within polygon", |bencher| {
         let rect: Rect = Rect::new(coord! { x: 0., y: 0. }, coord! { x: 10., y: 10. }).into();
         let polygon: Polygon =
             Rect::new(coord! { x: -1., y: -1. }, coord! { x: 11., y: 11. }).into();
+
+        bencher.iter(|| {
+            assert!(criterion::black_box(&rect).intersects(criterion::black_box(&polygon)));
+        });
+    });
+     c.bench_function("intersects polygon within rect", |bencher| {
+        let rect: Rect = Rect::new(coord! { x: 0., y: 0. }, coord! { x: 10., y: 10. }).into();
+        let polygon: Polygon =
+            Rect::new(coord! { x: 1., y: 1. }, coord! { x: 9., y: 9. }).into();
 
         bencher.iter(|| {
             assert!(criterion::black_box(&rect).intersects(criterion::black_box(&polygon)));

--- a/geo/src/algorithm/intersects/coordinate.rs
+++ b/geo/src/algorithm/intersects/coordinate.rs
@@ -10,6 +10,11 @@ where
     }
 }
 
+symmetric_intersects_impl!(Coord<T>, LineString<T>);
+symmetric_intersects_impl!(Coord<T>, MultiLineString<T>);
+
+symmetric_intersects_impl!(Coord<T>, Line<T>);
+
 // The other side of this is handled via a blanket impl.
 impl<T> Intersects<Point<T>> for Coord<T>
 where
@@ -19,3 +24,11 @@ where
         self == &rhs.0
     }
 }
+symmetric_intersects_impl!(Coord<T>, MultiPoint<T>);
+
+symmetric_intersects_impl!(Coord<T>, Polygon<T>);
+symmetric_intersects_impl!(Coord<T>, MultiPolygon<T>);
+
+symmetric_intersects_impl!(Coord<T>, Rect<T>);
+
+symmetric_intersects_impl!(Coord<T>, Triangle<T>);

--- a/geo/src/algorithm/intersects/line.rs
+++ b/geo/src/algorithm/intersects/line.rs
@@ -13,8 +13,9 @@ where
             && point_in_rect(*rhs, self.start, self.end)
     }
 }
-symmetric_intersects_impl!(Coord<T>, Line<T>);
-symmetric_intersects_impl!(Line<T>, Point<T>);
+
+symmetric_intersects_impl!(Line<T>, LineString<T>);
+symmetric_intersects_impl!(Line<T>, MultiLineString<T>);
 
 impl<T> Intersects<Line<T>> for Line<T>
 where
@@ -68,6 +69,14 @@ where
     }
 }
 
+symmetric_intersects_impl!(Line<T>, Point<T>);
+symmetric_intersects_impl!(Line<T>, MultiPoint<T>);
+
+symmetric_intersects_impl!(Line<T>, Polygon<T>);
+symmetric_intersects_impl!(Line<T>, MultiPolygon<T>);
+
+symmetric_intersects_impl!(Line<T>, Rect<T>);
+
 impl<T> Intersects<Triangle<T>> for Line<T>
 where
     T: GeoNum,
@@ -76,4 +85,3 @@ where
         self.intersects(&rhs.to_polygon())
     }
 }
-symmetric_intersects_impl!(Triangle<T>, Line<T>);

--- a/geo/src/algorithm/intersects/line_string.rs
+++ b/geo/src/algorithm/intersects/line_string.rs
@@ -31,4 +31,3 @@ where
         self.iter().any(|p| p.intersects(rhs))
     }
 }
-

--- a/geo/src/algorithm/intersects/line_string.rs
+++ b/geo/src/algorithm/intersects/line_string.rs
@@ -16,10 +16,6 @@ where
         self.lines().any(|l| l.intersects(geom))
     }
 }
-symmetric_intersects_impl!(Coord<T>, LineString<T>);
-symmetric_intersects_impl!(Line<T>, LineString<T>);
-symmetric_intersects_impl!(Rect<T>, LineString<T>);
-symmetric_intersects_impl!(Triangle<T>, LineString<T>);
 
 // Blanket implementation from LineString<T>
 impl<T, G> Intersects<G> for MultiLineString<T>
@@ -36,7 +32,3 @@ where
     }
 }
 
-symmetric_intersects_impl!(Point<T>, MultiLineString<T>);
-symmetric_intersects_impl!(Line<T>, MultiLineString<T>);
-symmetric_intersects_impl!(Rect<T>, MultiLineString<T>);
-symmetric_intersects_impl!(Triangle<T>, MultiLineString<T>);

--- a/geo/src/algorithm/intersects/mod.rs
+++ b/geo/src/algorithm/intersects/mod.rs
@@ -549,10 +549,13 @@ mod test {
 
     #[test]
     fn exhaustive_compile_test() {
-        use geo_types::{GeometryCollection, Triangle};
+        use geo_types::{GeometryCollection, Triangle,Coord};
+        let c = Coord{x:0., y:0.};
         let pt: Point = Point::new(0., 0.);
-        let ln: Line = Line::new((0., 0.), (1., 1.));
         let ls = line_string![(0., 0.).into(), (1., 1.).into()];
+        let multi_ls = MultiLineString::new(vec![ls.clone()]);
+        let ln: Line = Line::new((0., 0.), (1., 1.));
+
         let poly = Polygon::new(LineString::from(vec![(0., 0.), (1., 1.), (1., 0.)]), vec![]);
         let rect = Rect::new(coord! { x: 10., y: 20. }, coord! { x: 30., y: 10. });
         let tri = Triangle::new(
@@ -563,9 +566,22 @@ mod test {
         let geom = Geometry::Point(pt);
         let gc = GeometryCollection::new_from(vec![geom.clone()]);
         let multi_point = MultiPoint::new(vec![pt]);
-        let multi_ls = MultiLineString::new(vec![ls.clone()]);
         let multi_poly = MultiPolygon::new(vec![poly.clone()]);
 
+        let _ = c.intersects(&c);
+        let _ = c.intersects(&pt);
+        let _ = c.intersects(&ln);
+        let _ = c.intersects(&ls);
+        let _ = c.intersects(&poly);
+        let _ = c.intersects(&rect);
+        let _ = c.intersects(&tri);
+        let _ = c.intersects(&geom);
+        let _ = c.intersects(&gc);
+        let _ = c.intersects(&multi_point);
+        let _ = c.intersects(&multi_ls);
+        let _ = c.intersects(&multi_poly);
+
+        let _ = pt.intersects(&c);
         let _ = pt.intersects(&pt);
         let _ = pt.intersects(&ln);
         let _ = pt.intersects(&ls);
@@ -577,6 +593,8 @@ mod test {
         let _ = pt.intersects(&multi_point);
         let _ = pt.intersects(&multi_ls);
         let _ = pt.intersects(&multi_poly);
+
+        let _ = ln.intersects(&c);
         let _ = ln.intersects(&pt);
         let _ = ln.intersects(&ln);
         let _ = ln.intersects(&ls);
@@ -588,6 +606,8 @@ mod test {
         let _ = ln.intersects(&multi_point);
         let _ = ln.intersects(&multi_ls);
         let _ = ln.intersects(&multi_poly);
+
+        let _ = ls.intersects(&c);
         let _ = ls.intersects(&pt);
         let _ = ls.intersects(&ln);
         let _ = ls.intersects(&ls);
@@ -599,6 +619,8 @@ mod test {
         let _ = ls.intersects(&multi_point);
         let _ = ls.intersects(&multi_ls);
         let _ = ls.intersects(&multi_poly);
+
+        let _ = poly.intersects(&c);
         let _ = poly.intersects(&pt);
         let _ = poly.intersects(&ln);
         let _ = poly.intersects(&ls);
@@ -610,6 +632,8 @@ mod test {
         let _ = poly.intersects(&multi_point);
         let _ = poly.intersects(&multi_ls);
         let _ = poly.intersects(&multi_poly);
+
+        let _ = rect.intersects(&c);
         let _ = rect.intersects(&pt);
         let _ = rect.intersects(&ln);
         let _ = rect.intersects(&ls);
@@ -621,6 +645,8 @@ mod test {
         let _ = rect.intersects(&multi_point);
         let _ = rect.intersects(&multi_ls);
         let _ = rect.intersects(&multi_poly);
+
+        let _ = tri.intersects(&c);
         let _ = tri.intersects(&pt);
         let _ = tri.intersects(&ln);
         let _ = tri.intersects(&ls);
@@ -632,6 +658,8 @@ mod test {
         let _ = tri.intersects(&multi_point);
         let _ = tri.intersects(&multi_ls);
         let _ = tri.intersects(&multi_poly);
+
+        let _ = geom.intersects(&c);
         let _ = geom.intersects(&pt);
         let _ = geom.intersects(&ln);
         let _ = geom.intersects(&ls);
@@ -643,6 +671,8 @@ mod test {
         let _ = geom.intersects(&multi_point);
         let _ = geom.intersects(&multi_ls);
         let _ = geom.intersects(&multi_poly);
+
+        let _ = gc.intersects(&c);
         let _ = gc.intersects(&pt);
         let _ = gc.intersects(&ln);
         let _ = gc.intersects(&ls);
@@ -654,6 +684,8 @@ mod test {
         let _ = gc.intersects(&multi_point);
         let _ = gc.intersects(&multi_ls);
         let _ = gc.intersects(&multi_poly);
+
+        let _ = multi_point.intersects(&c);
         let _ = multi_point.intersects(&pt);
         let _ = multi_point.intersects(&ln);
         let _ = multi_point.intersects(&ls);
@@ -665,6 +697,8 @@ mod test {
         let _ = multi_point.intersects(&multi_point);
         let _ = multi_point.intersects(&multi_ls);
         let _ = multi_point.intersects(&multi_poly);
+
+        let _ = multi_ls.intersects(&c);
         let _ = multi_ls.intersects(&pt);
         let _ = multi_ls.intersects(&ln);
         let _ = multi_ls.intersects(&ls);
@@ -676,6 +710,8 @@ mod test {
         let _ = multi_ls.intersects(&multi_point);
         let _ = multi_ls.intersects(&multi_ls);
         let _ = multi_ls.intersects(&multi_poly);
+
+        let _ = multi_poly.intersects(&c);
         let _ = multi_poly.intersects(&pt);
         let _ = multi_poly.intersects(&ln);
         let _ = multi_poly.intersects(&ls);

--- a/geo/src/algorithm/intersects/mod.rs
+++ b/geo/src/algorithm/intersects/mod.rs
@@ -549,8 +549,8 @@ mod test {
 
     #[test]
     fn exhaustive_compile_test() {
-        use geo_types::{GeometryCollection, Triangle,Coord};
-        let c = Coord{x:0., y:0.};
+        use geo_types::{Coord, GeometryCollection, Triangle};
+        let c = Coord { x: 0., y: 0. };
         let pt: Point = Point::new(0., 0.);
         let ls = line_string![(0., 0.).into(), (1., 1.).into()];
         let multi_ls = MultiLineString::new(vec![ls.clone()]);

--- a/geo/src/algorithm/intersects/point.rs
+++ b/geo/src/algorithm/intersects/point.rs
@@ -22,8 +22,3 @@ where
         self.iter().any(|p| p.intersects(rhs))
     }
 }
-
-symmetric_intersects_impl!(Coord<T>, MultiPoint<T>);
-symmetric_intersects_impl!(Line<T>, MultiPoint<T>);
-symmetric_intersects_impl!(Triangle<T>, MultiPoint<T>);
-symmetric_intersects_impl!(Polygon<T>, MultiPoint<T>);

--- a/geo/src/algorithm/intersects/polygon.rs
+++ b/geo/src/algorithm/intersects/polygon.rs
@@ -52,23 +52,9 @@ where
 
 symmetric_intersects_impl!(Polygon<T>, MultiPolygon<T>);
 
-impl<T> Intersects<Rect<T>> for Polygon<T>
-where
-    T: GeoNum,
-{
-    fn intersects(&self, rect: &Rect<T>) -> bool {
-        self.intersects(&rect.to_polygon())
-    }
-}
+symmetric_intersects_impl!(Polygon<T>, Rect<T>);
 
-impl<T> Intersects<Triangle<T>> for Polygon<T>
-where
-    T: GeoNum,
-{
-    fn intersects(&self, rect: &Triangle<T>) -> bool {
-        self.intersects(&rect.to_polygon())
-    }
-}
+symmetric_intersects_impl!(Polygon<T>, Triangle<T>);
 
 // Blanket implementation for MultiPolygon
 impl<G, T> Intersects<G> for MultiPolygon<T>

--- a/geo/src/algorithm/intersects/polygon.rs
+++ b/geo/src/algorithm/intersects/polygon.rs
@@ -2,8 +2,8 @@ use super::{has_disjoint_bboxes, Intersects};
 use crate::coordinate_position::CoordPos;
 use crate::{BoundingRect, CoordinatePosition};
 use crate::{
-    Coord, CoordNum, GeoNum, Line, LineString, MultiLineString, MultiPolygon, Point, Polygon, Rect,
-    Triangle,MultiPoint
+    Coord, CoordNum, GeoNum, Line, LineString, MultiLineString, MultiPoint, MultiPolygon, Point,
+    Polygon, Rect, Triangle,
 };
 
 impl<T> Intersects<Coord<T>> for Polygon<T>
@@ -70,8 +70,7 @@ where
     }
 }
 
-// Implementations for MultiPolygon
-
+// Blanket implementation for MultiPolygon
 impl<G, T> Intersects<G> for MultiPolygon<T>
 where
     T: GeoNum,
@@ -85,7 +84,6 @@ where
         self.iter().any(|p| p.intersects(rhs))
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/geo/src/algorithm/intersects/polygon.rs
+++ b/geo/src/algorithm/intersects/polygon.rs
@@ -3,7 +3,7 @@ use crate::coordinate_position::CoordPos;
 use crate::{BoundingRect, CoordinatePosition};
 use crate::{
     Coord, CoordNum, GeoNum, Line, LineString, MultiLineString, MultiPolygon, Point, Polygon, Rect,
-    Triangle,
+    Triangle,MultiPoint
 };
 
 impl<T> Intersects<Coord<T>> for Polygon<T>
@@ -14,8 +14,9 @@ where
         self.coordinate_position(p) != CoordPos::Outside
     }
 }
-symmetric_intersects_impl!(Coord<T>, Polygon<T>);
-symmetric_intersects_impl!(Polygon<T>, Point<T>);
+
+symmetric_intersects_impl!(Polygon<T>, LineString<T>);
+symmetric_intersects_impl!(Polygon<T>, MultiLineString<T>);
 
 impl<T> Intersects<Line<T>> for Polygon<T>
 where
@@ -28,29 +29,9 @@ where
             || self.intersects(&line.end)
     }
 }
-symmetric_intersects_impl!(Line<T>, Polygon<T>);
-symmetric_intersects_impl!(Polygon<T>, LineString<T>);
-symmetric_intersects_impl!(Polygon<T>, MultiLineString<T>);
 
-impl<T> Intersects<Rect<T>> for Polygon<T>
-where
-    T: GeoNum,
-{
-    fn intersects(&self, rect: &Rect<T>) -> bool {
-        self.intersects(&rect.to_polygon())
-    }
-}
-symmetric_intersects_impl!(Rect<T>, Polygon<T>);
-
-impl<T> Intersects<Triangle<T>> for Polygon<T>
-where
-    T: GeoNum,
-{
-    fn intersects(&self, rect: &Triangle<T>) -> bool {
-        self.intersects(&rect.to_polygon())
-    }
-}
-symmetric_intersects_impl!(Triangle<T>, Polygon<T>);
+symmetric_intersects_impl!(Polygon<T>, Point<T>);
+symmetric_intersects_impl!(Polygon<T>, MultiPoint<T>);
 
 impl<T> Intersects<Polygon<T>> for Polygon<T>
 where
@@ -66,6 +47,26 @@ where
             polygon.interiors().iter().any(|inner_line_string| self.intersects(inner_line_string)) ||
             // self is contained inside polygon
             polygon.intersects(self.exterior())
+    }
+}
+
+symmetric_intersects_impl!(Polygon<T>, MultiPolygon<T>);
+
+impl<T> Intersects<Rect<T>> for Polygon<T>
+where
+    T: GeoNum,
+{
+    fn intersects(&self, rect: &Rect<T>) -> bool {
+        self.intersects(&rect.to_polygon())
+    }
+}
+
+impl<T> Intersects<Triangle<T>> for Polygon<T>
+where
+    T: GeoNum,
+{
+    fn intersects(&self, rect: &Triangle<T>) -> bool {
+        self.intersects(&rect.to_polygon())
     }
 }
 
@@ -85,11 +86,6 @@ where
     }
 }
 
-symmetric_intersects_impl!(Point<T>, MultiPolygon<T>);
-symmetric_intersects_impl!(Line<T>, MultiPolygon<T>);
-symmetric_intersects_impl!(Rect<T>, MultiPolygon<T>);
-symmetric_intersects_impl!(Triangle<T>, MultiPolygon<T>);
-symmetric_intersects_impl!(Polygon<T>, MultiPolygon<T>);
 
 #[cfg(test)]
 mod tests {

--- a/geo/src/algorithm/intersects/rect.rs
+++ b/geo/src/algorithm/intersects/rect.rs
@@ -1,4 +1,4 @@
-use super::Intersects;
+use super::{has_disjoint_bboxes, Intersects};
 use crate::*;
 
 impl<T> Intersects<Coord<T>> for Rect<T>
@@ -73,6 +73,17 @@ where
     T: GeoNum,
 {
     fn intersects(&self, rhs: &Triangle<T>) -> bool {
-        self.intersects(&rhs.to_polygon())
+        // sufficient to show that any of these are true:
+        // some corner of the triangle intersects the rectangle
+        // some corner of the rectangle intersects the triangle
+        // some edge of triangle intersects edge of rectangle
+
+        if has_disjoint_bboxes(self, rhs) {
+            return false;
+        }
+
+        rhs.coords_iter().any(|p| self.intersects(&p))
+            || self.coords_iter().any(|p| rhs.intersects(&p))
+            || rhs.lines_iter().any(|l| self.intersects(&l))
     }
 }

--- a/geo/src/algorithm/intersects/rect.rs
+++ b/geo/src/algorithm/intersects/rect.rs
@@ -106,7 +106,7 @@ where
         }
 
         rhs.coords_iter().any(|p| self.intersects(&p))
-            || self.coords_iter().any(|p| rhs.intersects(&p))
             || rhs.lines_iter().any(|l| self.intersects(&l))
+            || self.coords_iter().any(|p| rhs.intersects(&p))
     }
 }

--- a/geo/src/algorithm/intersects/rect.rs
+++ b/geo/src/algorithm/intersects/rect.rs
@@ -12,9 +12,36 @@ where
             && rhs.y <= self.max().y
     }
 }
-symmetric_intersects_impl!(Coord<T>, Rect<T>);
+
+symmetric_intersects_impl!(Rect<T>, LineString<T>);
+symmetric_intersects_impl!(Rect<T>, MultiLineString<T>);
+
+// Same logic as Polygon<T>: Intersects<Line<T>>, but avoid
+// an allocation.
+impl<T> Intersects<Line<T>> for Rect<T>
+where
+    T: GeoNum,
+{
+    fn intersects(&self, rhs: &Line<T>) -> bool {
+        let lb = self.min();
+        let rt = self.max();
+        let lt = Coord::from((lb.x, rt.y));
+        let rb = Coord::from((rt.x, lb.y));
+        // If either rhs.{start,end} lies inside Rect, then true
+        self.intersects(&rhs.start)
+            || self.intersects(&rhs.end)
+            || Line::new(lt, rt).intersects(rhs)
+            || Line::new(rt, rb).intersects(rhs)
+            || Line::new(lb, rb).intersects(rhs)
+            || Line::new(lt, lb).intersects(rhs)
+    }
+}
+
 symmetric_intersects_impl!(Rect<T>, Point<T>);
 symmetric_intersects_impl!(Rect<T>, MultiPoint<T>);
+
+symmetric_intersects_impl!(Rect<T>, Polygon<T>);
+symmetric_intersects_impl!(Rect<T>, MultiPolygon<T>);
 
 impl<T> Intersects<Rect<T>> for Rect<T>
 where
@@ -41,27 +68,6 @@ where
     }
 }
 
-// Same logic as Polygon<T>: Intersects<Line<T>>, but avoid
-// an allocation.
-impl<T> Intersects<Line<T>> for Rect<T>
-where
-    T: GeoNum,
-{
-    fn intersects(&self, rhs: &Line<T>) -> bool {
-        let lb = self.min();
-        let rt = self.max();
-        let lt = Coord::from((lb.x, rt.y));
-        let rb = Coord::from((rt.x, lb.y));
-        // If either rhs.{start,end} lies inside Rect, then true
-        self.intersects(&rhs.start)
-            || self.intersects(&rhs.end)
-            || Line::new(lt, rt).intersects(rhs)
-            || Line::new(rt, rb).intersects(rhs)
-            || Line::new(lb, rb).intersects(rhs)
-            || Line::new(lt, lb).intersects(rhs)
-    }
-}
-symmetric_intersects_impl!(Line<T>, Rect<T>);
 
 impl<T> Intersects<Triangle<T>> for Rect<T>
 where
@@ -71,4 +77,3 @@ where
         self.intersects(&rhs.to_polygon())
     }
 }
-symmetric_intersects_impl!(Triangle<T>, Rect<T>);

--- a/geo/src/algorithm/intersects/rect.rs
+++ b/geo/src/algorithm/intersects/rect.rs
@@ -68,7 +68,6 @@ where
     }
 }
 
-
 impl<T> Intersects<Triangle<T>> for Rect<T>
 where
     T: GeoNum,

--- a/geo/src/algorithm/intersects/rect.rs
+++ b/geo/src/algorithm/intersects/rect.rs
@@ -59,8 +59,8 @@ where
         // rhs.intersects(pt) is the most expensive, so check it last
         // only required if rectangle sits entirely within polygon
         rhs.coords_iter().any(|p| self.intersects(&p))
-            || rhs.lines_iter().any(|l| self.intersects(&l))
-            || self.coords_iter().any(|p| rhs.intersects(&p))
+        || rhs.lines_iter().any(|l| self.lines_iter().any(|other_line| l.intersects(&other_line)))
+        || self.min().intersects(rhs)
     }
 }
 
@@ -106,7 +106,7 @@ where
         }
 
         rhs.coords_iter().any(|p| self.intersects(&p))
-            || rhs.lines_iter().any(|l| self.intersects(&l))
-            || self.coords_iter().any(|p| rhs.intersects(&p))
+        || rhs.lines_iter().any(|l| self.lines_iter().any(|other_line| l.intersects(&other_line)))
+            || self.min().intersects(rhs)
     }
 }

--- a/geo/src/algorithm/intersects/rect.rs
+++ b/geo/src/algorithm/intersects/rect.rs
@@ -59,8 +59,11 @@ where
         // rhs.intersects(pt) is the most expensive, so check it last
         // only required if rectangle sits entirely within polygon
         rhs.coords_iter().any(|p| self.intersects(&p))
-        || rhs.lines_iter().any(|l| self.lines_iter().any(|other_line| l.intersects(&other_line)))
-        || self.min().intersects(rhs)
+            || rhs.lines_iter().any(|l| {
+                self.lines_iter()
+                    .any(|other_line| l.intersects(&other_line))
+            })
+            || self.min().intersects(rhs)
     }
 }
 
@@ -106,7 +109,10 @@ where
         }
 
         rhs.coords_iter().any(|p| self.intersects(&p))
-        || rhs.lines_iter().any(|l| self.lines_iter().any(|other_line| l.intersects(&other_line)))
+            || rhs.lines_iter().any(|l| {
+                self.lines_iter()
+                    .any(|other_line| l.intersects(&other_line))
+            })
             || self.min().intersects(rhs)
     }
 }

--- a/geo/src/algorithm/intersects/rect.rs
+++ b/geo/src/algorithm/intersects/rect.rs
@@ -56,9 +56,11 @@ where
             return false;
         }
 
+        // rhs.intersects(pt) is the most expensive, so check it last
+        // only required if rectangle sits entirely within polygon
         rhs.coords_iter().any(|p| self.intersects(&p))
-            || self.coords_iter().any(|p| rhs.intersects(&p))
             || rhs.lines_iter().any(|l| self.intersects(&l))
+            || self.coords_iter().any(|p| rhs.intersects(&p))
     }
 }
 

--- a/geo/src/algorithm/intersects/rect.rs
+++ b/geo/src/algorithm/intersects/rect.rs
@@ -40,7 +40,28 @@ where
 symmetric_intersects_impl!(Rect<T>, Point<T>);
 symmetric_intersects_impl!(Rect<T>, MultiPoint<T>);
 
-symmetric_intersects_impl!(Rect<T>, Polygon<T>);
+impl<T> Intersects<Polygon<T>> for Rect<T>
+where
+    T: GeoNum,
+{
+    fn intersects(&self, rhs: &Polygon<T>) -> bool {
+        /*
+        sufficient to show that any of these are true:
+        some corner of the polygon intersects the rectangle
+        some corner of the rectangle intersects the polygon
+        some edge of polygon (interior or exterior) intersects edge of rectangle
+        */
+
+        if has_disjoint_bboxes(self, rhs) {
+            return false;
+        }
+
+        rhs.coords_iter().any(|p| self.intersects(&p))
+            || self.coords_iter().any(|p| rhs.intersects(&p))
+            || rhs.lines_iter().any(|l| self.intersects(&l))
+    }
+}
+
 symmetric_intersects_impl!(Rect<T>, MultiPolygon<T>);
 
 impl<T> Intersects<Rect<T>> for Rect<T>

--- a/geo/src/algorithm/intersects/triangle.rs
+++ b/geo/src/algorithm/intersects/triangle.rs
@@ -47,7 +47,14 @@ symmetric_intersects_impl!(Triangle<T>, Line<T>);
 symmetric_intersects_impl!(Triangle<T>, Point<T>);
 symmetric_intersects_impl!(Triangle<T>, MultiPoint<T>);
 
-symmetric_intersects_impl!(Triangle<T>, Polygon<T>);
+impl<T> Intersects<Polygon<T>> for Triangle<T>
+where
+    T: GeoNum,
+{
+    fn intersects(&self, rhs: &Polygon<T>) -> bool {
+        self.to_polygon().intersects(rhs)
+    }
+}
 symmetric_intersects_impl!(Triangle<T>, MultiPolygon<T>);
 
 symmetric_intersects_impl!(Triangle<T>, Rect<T>);

--- a/geo/src/algorithm/intersects/triangle.rs
+++ b/geo/src/algorithm/intersects/triangle.rs
@@ -39,8 +39,18 @@ where
     }
 }
 
-symmetric_intersects_impl!(Coord<T>, Triangle<T>);
+symmetric_intersects_impl!(Triangle<T>, LineString<T>);
+symmetric_intersects_impl!(Triangle<T>, MultiLineString<T>);
+
+symmetric_intersects_impl!(Triangle<T>, Line<T>);
+
 symmetric_intersects_impl!(Triangle<T>, Point<T>);
+symmetric_intersects_impl!(Triangle<T>, MultiPoint<T>);
+
+symmetric_intersects_impl!(Triangle<T>, Polygon<T>);
+symmetric_intersects_impl!(Triangle<T>, MultiPolygon<T>);
+
+symmetric_intersects_impl!(Triangle<T>, Rect<T>);
 
 impl<T> Intersects<Triangle<T>> for Triangle<T>
 where
@@ -50,3 +60,4 @@ where
         self.to_polygon().intersects(&rhs.to_polygon())
     }
 }
+

--- a/geo/src/algorithm/intersects/triangle.rs
+++ b/geo/src/algorithm/intersects/triangle.rs
@@ -60,4 +60,3 @@ where
         self.to_polygon().intersects(&rhs.to_polygon())
     }
 }
-


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

1. Implement a faster `impl<T> Intersects<Polygon<T>> for Rect<T>`
2. Implement a faster `impl<T> Intersects<Triangle<T>> for Rect<T>`

by using the more optimized methods of `Rect` and `Triangle` instead of the general `Polygon` methods

built on top of changes in #1376 