### PR TITLE
Intersects Polygon Polygon

### DIFF
--- a/geo/src/algorithm/intersects/polygon.rs
+++ b/geo/src/algorithm/intersects/polygon.rs
@@ -42,26 +42,43 @@ where
             return false;
         }
 
-        // if there are no line intersections,
+        // if there are no line intersections among exteriors and interiors,
         // then either one fully contains the other
         // or they are disjoint
 
-        // exterior exterior
-        // using lines_iter() skips the bounds check for ls intersections gives a ~33% speedup
-        // we already know that exteriors are not disjoint
-        // and avoid recalcuating bounds of self.exterior() for every linestring-line itersects check
-        self.exterior().lines_iter().any(|line| polygon.exterior().lines_iter().any(|other_line| line.intersects(&other_line)))
-
-        // exterior inner
-        || self.interiors().iter().any(|inner_line_string| polygon.exterior().lines_iter().any(|other_line| inner_line_string.intersects(&other_line)))
-        || polygon.interiors().iter().any(|inner_line_string| self.exterior().lines_iter().any(|other_line| inner_line_string.intersects(&other_line)))
-
-        // inner inner 
-        || self.interiors().iter().any(|inner_line_string| polygon.interiors().iter().any(|other_line_string| inner_line_string.intersects(other_line_string)))
-
         // check 1 point of each polygon being within the other
-        || self.exterior().coords_iter().take(1).any(|p|polygon.intersects(&p))
+        self.exterior().coords_iter().take(1).any(|p|polygon.intersects(&p))
         || polygon.exterior().coords_iter().take(1).any(|p|self.intersects(&p))
+        // exterior exterior
+        || self.exterior().lines_iter().any(|self_line| polygon.exterior().lines_iter().any(|poly_line| self_line.intersects(&poly_line)))
+        // exterior interior
+        ||self.interiors().iter().any(|inner_line_string| polygon.exterior().intersects(inner_line_string))
+        ||polygon.interiors().iter().any(|inner_line_string| self.exterior().intersects(inner_line_string))
+
+        // interior interior (not needed)
+        /*
+           suppose interior-interior is a required check
+           this requires that there are no ext-ext intersections
+           and that there are no ext-int intersections
+           and that self-ext[0] not intersects other
+           and other-ext[0] not intersects self
+           and there is some intersection between self and other
+
+           if ext-ext disjoint, then one ext ring must be within the other ext ring
+
+           suppose self-ext is within other-ext and self-ext[0] is not intersects other
+           then self-ext[0] must be within an interior hole of other-ext
+           if self-ext does not intersect the interior ring which contains self-ext[0],
+           then self is contained within other interior hole
+           and hence self and other cannot intersect
+           therefore for self to intersect other, some part of the self-ext must intersect the other-int ring
+           However, this is a contradiction because one of the premises for requiring this check is that self-ext ring does not intersect any other-int ring
+
+           By symmetry, the mirror case of other-ext ring within self-ext ring is also true
+
+           therefore, if there cannot exist and int-int intersection when all the prior checks are false
+           and so we can skip the interior-interior check
+        */
     }
 }
 


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

built on top of #1376 

Concept: if there are no line intersections between two polygons, then either one fully contains the other or they are disjoint.  
So after checking for line crossing, we only need to check one point within the other to check for intersection  

Not totally sure how performance characteristics might compare on significantly more complex geometries, but I don't think it would change much>?
 
Additionally, I noticed while implementing this that the recursive `LineString instersects LineString` implementation from blanket implementation recalculates the bounding box of the LineString on every recursion. Eg. `LS1.intersects(LS2)` calculates bounding box of LS2 (1+no. of segments in LS1) times due to `LS1.iter().any(LS2)` calling `LineString intersects Line` blanket implementation  

In the benchmark, using `LineString intersect LineString` as the polygon boundary check is ~33% slower than decomposing and running `Line intersects Line` The current blanket implementation might be a bit over eager in the bounding box checks
