### PR TITLE
Convex contains speedups

### DIFF
--- a/geo/Rect-contains-multipoint.md
+++ b/geo/Rect-contains-multipoint.md
@@ -1,0 +1,51 @@
+
+all points must intersect rectangle, at least one must be within
+
+rect contains multipoint 100 (Contains Trait)
+                        time:   [4.7941 µs 4.8059 µs 4.8187 µs]
+                        change: [-99.687% -99.685% -99.684%] (p = 0.00 < 0.05)
+                        Performance has improved.
+Found 10 outliers among 100 measurements (10.00%)
+  3 (3.00%) low mild
+  6 (6.00%) high mild
+  1 (1.00%) high severe
+
+rect contains multipoint 100 (Relates Trait)
+                        time:   [1.5162 ms 1.5248 ms 1.5339 ms]
+                        change: [-0.4346% +0.1214% +0.6936%] (p = 0.66 > 0.05)
+                        No change in performance detected.
+Found 5 outliers among 100 measurements (5.00%)
+  4 (4.00%) high mild
+  1 (1.00%) high severe
+
+rect contains multipoint 1k (Contains Trait)
+                        time:   [483.31 µs 483.95 µs 484.64 µs]
+                        change: [-99.764% -99.762% -99.760%] (p = 0.00 < 0.05)
+                        Performance has improved.
+Found 13 outliers among 100 measurements (13.00%)
+  1 (1.00%) low mild
+  3 (3.00%) high mild
+  9 (9.00%) high severe
+
+rect contains multipoint 1k (Relates Trait)
+                        time:   [206.84 ms 207.71 ms 208.62 ms]
+                        change: [-1.3311% -0.7899% -0.1755%] (p = 0.01 < 0.05)
+                        Change within noise threshold.
+Found 2 outliers among 100 measurements (2.00%)
+  2 (2.00%) high mild
+
+rect not contains multipoint (Contains Trait)
+                        time:   [487.76 µs 489.14 µs 490.75 µs]
+                        change: [-99.761% -99.758% -99.755%] (p = 0.00 < 0.05)
+                        Performance has improved.
+Found 8 outliers among 100 measurements (8.00%)
+  4 (4.00%) high mild
+  4 (4.00%) high severe
+
+rect not contains multipoint (Relates Trait)
+                        time:   [209.42 ms 210.45 ms 211.53 ms]
+                        change: [+1.4876% +1.9958% +2.5719%] (p = 0.00 < 0.05)
+                        Performance has regressed.
+Found 1 outliers among 100 measurements (1.00%)
+  1 (1.00%) high mild
+

--- a/geo/benches/contains.rs
+++ b/geo/benches/contains.rs
@@ -1102,6 +1102,89 @@ fn triangle_contains_triangle(c: &mut Criterion) {
     );
 }
 
+fn rect_contains_multipoint(c: &mut Criterion) {
+    c.bench_function("rect contains multipoint 100 (Contains Trait)", |bencher| {
+        let rect = Rect::new(Point::new(0., 0.), Point::new(10., 10.));
+        let pts: Vec<Point> = (0..10_0)
+            .flat_map(|x| (0..10_0).map(move |y| Point::new(x as f64 / 1_0., y as f64 / 1_0.)))
+            .collect();
+        let mp = MultiPoint::new(pts);
+        bencher.iter(|| {
+            assert!(criterion::black_box(&rect).contains(&mp));
+        });
+    });
+    c.bench_function("rect contains multipoint 100 (Relates Trait)", |bencher| {
+        let rect = Rect::new(Point::new(0., 0.), Point::new(10., 10.));
+        let pts: Vec<Point> = (0..10_0)
+            .flat_map(|x| (0..10_0).map(move |y| Point::new(x as f64 / 1_0., y as f64 / 1_0.)))
+            .collect();
+        let mp = MultiPoint::new(pts);
+        bencher.iter(|| {
+            assert!(criterion::black_box(&rect).relate(&mp).is_contains());
+        });
+    });
+
+    c.bench_function("rect contains multipoint 1k (Contains Trait)", |bencher| {
+        let rect = Rect::new(Point::new(0., 0.), Point::new(10., 10.));
+        let pts: Vec<Point> = (0..10_00)
+            .flat_map(|x| {
+                (0..10_00).map(move |y| Point::new(x as f64 / 1_00., y as f64 / 1_00.))
+            })
+            .collect();
+        let mp = MultiPoint::new(pts);
+        bencher.iter(|| {
+            assert!(criterion::black_box(&rect).contains(&mp));
+        });
+    });
+    c.bench_function("rect contains multipoint 1k (Relates Trait)", |bencher| {
+        let rect = Rect::new(Point::new(0., 0.), Point::new(10., 10.));
+        let pts: Vec<Point> = (0..10_00)
+            .flat_map(|x| {
+                (0..10_00).map(move |y| Point::new(x as f64 / 1_00., y as f64 / 1_00.))
+            })
+            .collect();
+        let mp = MultiPoint::new(pts);
+        bencher.iter(|| {
+            assert!(criterion::black_box(&rect).relate(&mp).is_contains());
+        });
+    });
+
+    c.bench_function(
+        "rect not contains multipoint (Contains Trait)",
+        // worst case scenario where outlier is last point in array
+        |bencher| {
+            let rect = Rect::new(Point::new(0., 0.), Point::new(10., 10.));
+            let mut pts: Vec<Point> = (0..10_00)
+                .flat_map(|x| {
+                    (0..10_00).map(move |y| Point::new(x as f64 / 1_00., y as f64 / 1_00.))
+                })
+                .collect();
+            pts.push(Point::new(11., 11.));
+            let mp = MultiPoint::new(pts);
+            bencher.iter(|| {
+                assert!(!criterion::black_box(&rect).contains(&mp));
+            });
+        },
+    );
+    c.bench_function(
+        "rect not contains multipoint (Relates Trait)",
+        // worst case scenario where outlier is last point in array
+        |bencher| {
+            let rect = Rect::new(Point::new(0., 0.), Point::new(10., 10.));
+            let mut pts: Vec<Point> = (0..10_00)
+                .flat_map(|x| {
+                    (0..10_00).map(move |y| Point::new(x as f64 / 1_00., y as f64 / 1_00.))
+                })
+                .collect();
+            pts.push(Point::new(11., 11.));
+            let mp = MultiPoint::new(pts);
+            bencher.iter(|| {
+                assert!(!criterion::black_box(&rect).relate(&mp).is_contains());
+            });
+        },
+    );
+}
+
 criterion_group!(benches, criterion_benchmark);
 criterion_group!(bench_line_contains_multi_point, line_contains_multi_point);
 criterion_group!(bench_rect_contains_line, rect_contains_line);
@@ -1121,6 +1204,7 @@ criterion_group!(
     triangle_contains_linestring
 );
 criterion_group!(bench_triangle_contains_triangle, triangle_contains_triangle);
+criterion_group!(bench_rect_contains_multipoint, rect_contains_multipoint);
 
 criterion_main!(
     benches,
@@ -1133,4 +1217,5 @@ criterion_main!(
     bench_rect_contains_linestring,
     bench_triangle_contains_linestring,
     bench_triangle_contains_triangle,
+    bench_rect_contains_multipoint
 );

--- a/geo/benches/contains.rs
+++ b/geo/benches/contains.rs
@@ -682,6 +682,116 @@ fn triangle_contains_line(c: &mut Criterion) {
     });
 }
 
+fn triangle_contains_rect(c: &mut Criterion) {
+    c.bench_function("rect within triangle (Contains Trait)", |bencher| {
+        let tri = Triangle::new(
+            coord! {x:0., y:0.},
+            coord! {x:10., y:0.},
+            coord! {x:10., y:10.},
+        );
+        let rect = Rect::new(Point::new(5., 5.), Point::new(9., 1.));
+
+        bencher.iter(|| {
+            assert!(criterion::black_box(&tri).contains(criterion::black_box(&rect)));
+        });
+    });
+    c.bench_function("rect within triangle (Relate Trait)", |bencher| {
+        let tri = Triangle::new(
+            coord! {x:0., y:0.},
+            coord! {x:10., y:0.},
+            coord! {x:10., y:10.},
+        );
+        let rect = Rect::new(Point::new(5., 5.), Point::new(9., 1.));
+
+        bencher.iter(|| {
+            assert!(criterion::black_box(&tri)
+                .relate(criterion::black_box(&rect))
+                .is_contains());
+        });
+    });
+
+    c.bench_function("triangle within rect (Contains Trait)", |bencher| {
+        let tri = Triangle::new(
+            coord! {x:0., y:0.},
+            coord! {x:10., y:0.},
+            coord! {x:10., y:10.},
+        );
+        let rect = Rect::new(Point::new(0., 0.), Point::new(10., 10.));
+
+        bencher.iter(|| {
+            assert!(criterion::black_box(&rect).contains(criterion::black_box(&tri)));
+        });
+    });
+    c.bench_function("triangle within rect (Relate Trait)", |bencher| {
+        let tri = Triangle::new(
+            coord! {x:0., y:0.},
+            coord! {x:10., y:0.},
+            coord! {x:10., y:10.},
+        );
+        let rect = Rect::new(Point::new(0., 0.), Point::new(10., 10.));
+
+        bencher.iter(|| {
+            assert!(criterion::black_box(&rect)
+                .relate(criterion::black_box(&tri))
+                .is_contains());
+        });
+    });
+
+    c.bench_function("rect disjoint triangle (Contains Trait)", |bencher| {
+        let tri = Triangle::new(
+            coord! {x:0., y:0.},
+            coord! {x:10., y:0.},
+            coord! {x:10., y:10.},
+        );
+        let rect = Rect::new(Point::new(-1., -1.), Point::new(-10., -10.));
+
+        bencher.iter(|| {
+            assert!(!criterion::black_box(&rect).contains(criterion::black_box(&tri)));
+        });
+    });
+    c.bench_function("rect disjoint triangle (Relate Trait)", |bencher| {
+        let tri = Triangle::new(
+            coord! {x:0., y:0.},
+            coord! {x:10., y:0.},
+            coord! {x:10., y:10.},
+        );
+        let rect = Rect::new(Point::new(-1., -1.), Point::new(-10., -10.));
+
+        bencher.iter(|| {
+            assert!(!criterion::black_box(&rect)
+                .relate(criterion::black_box(&tri))
+                .is_contains());
+        });
+    });
+
+    c.bench_function("triangle disjoint rect (Contains Trait)", |bencher| {
+        let tri = Triangle::new(
+            coord! {x:0., y:0.},
+            coord! {x:10., y:0.},
+            coord! {x:10., y:10.},
+        );
+        let rect = Rect::new(Point::new(-1., -1.), Point::new(-10., -10.));
+
+        bencher.iter(|| {
+            assert!(!criterion::black_box(&tri).contains(criterion::black_box(&rect)));
+        });
+    });
+    c.bench_function("triangle disjoint rect (Relate Trait)", |bencher| {
+        let tri = Triangle::new(
+            coord! {x:0., y:0.},
+            coord! {x:10., y:0.},
+            coord! {x:10., y:10.},
+        );
+        let rect = Rect::new(Point::new(-1., -1.), Point::new(-10., -10.));
+
+        bencher.iter(|| {
+            assert!(!criterion::black_box(&tri)
+                .relate(criterion::black_box(&rect))
+                .is_contains());
+        });
+    });
+}
+
 criterion_group!(benches, criterion_benchmark);
 criterion_group!(bench_line_contains_multi_point, line_contains_multi_point);
 criterion_group!(bench_rect_contains_line, rect_contains_line);
@@ -693,11 +803,8 @@ criterion_group!(
     bench_polygon_contains_multipoint,
     polygon_contains_multipoint
 );
-criterion_group!(
-    bench_triangle_contains_line,
-    triangle_contains_line,
-    rect_contains_line
-);
+criterion_group!(bench_triangle_contains_line, triangle_contains_line);
+criterion_group!(bench_triangle_contains_rect, triangle_contains_rect);
 
 criterion_main!(
     benches,
@@ -706,4 +813,5 @@ criterion_main!(
     bench_multipoint_contains_multipoint,
     bench_polygon_contains_multipoint,
     bench_triangle_contains_line,
+    bench_triangle_contains_rect,
 );

--- a/geo/benches/contains.rs
+++ b/geo/benches/contains.rs
@@ -239,7 +239,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     });
 }
 
-fn bench_line_contains_multi_point(c: &mut Criterion) {
+fn line_contains_multi_point(c: &mut Criterion) {
     c.bench_function(
         "Line not contains 1000 MultiPoint within bounding box (Contains trait)",
         |bencher| {
@@ -302,7 +302,66 @@ fn bench_line_contains_multi_point(c: &mut Criterion) {
     });
 }
 
-fn bench_multipoint_contains_multipoint(c: &mut Criterion) {
+fn rect_contains_line(c: &mut Criterion) {
+    c.bench_function("line within rect (Contains Trait)", |bencher| {
+        let rect = Rect::new(Point::new(0., 0.), Point::new(10., 5.));
+        let ln = Line::new(Point::new(1., 1.), Point::new(9., 4.));
+
+        bencher.iter(|| {
+            assert!(criterion::black_box(&rect).contains(criterion::black_box(&ln)));
+        });
+    });
+    c.bench_function("line within rect (Relates Trait)", |bencher| {
+        let rect = Rect::new(Point::new(0., 0.), Point::new(10., 5.));
+        let ln = Line::new(Point::new(1., 1.), Point::new(9., 4.));
+
+        bencher.iter(|| {
+            assert!(criterion::black_box(&rect)
+                .relate(criterion::black_box(&ln))
+                .is_contains());
+        });
+    });
+
+    c.bench_function("line disjoint rect (Contains Trait)", |bencher| {
+        let rect = Rect::new(Point::new(0., 0.), Point::new(10., 5.));
+        let ln = Line::new(Point::new(1., 6.), Point::new(9., 6.));
+
+        bencher.iter(|| {
+            assert!(!criterion::black_box(&rect).contains(criterion::black_box(&ln)));
+        });
+    });
+    c.bench_function("line disjoint rect (Relates Trait)", |bencher| {
+        let rect = Rect::new(Point::new(0., 0.), Point::new(10., 5.));
+        let ln = Line::new(Point::new(1., 6.), Point::new(9., 6.));
+
+        bencher.iter(|| {
+            assert!(!criterion::black_box(&rect)
+                .relate(criterion::black_box(&ln))
+                .is_contains());
+        });
+    });
+
+    c.bench_function("line along rect (Contains Trait)", |bencher| {
+        let rect = Rect::new(Point::new(0., 0.), Point::new(10., 5.));
+        let ln = Line::new(Point::new(1., 0.), Point::new(9., 0.));
+
+        bencher.iter(|| {
+            assert!(!criterion::black_box(&rect).contains(criterion::black_box(&ln)));
+        });
+    });
+    c.bench_function("line along rect (Relates Trait)", |bencher| {
+        let rect = Rect::new(Point::new(0., 0.), Point::new(10., 5.));
+        let ln = Line::new(Point::new(1., 0.), Point::new(9., 0.));
+
+        bencher.iter(|| {
+            assert!(!criterion::black_box(&rect)
+                .relate(criterion::black_box(&ln))
+                .is_contains());
+        });
+    });
+}
+
+fn multipoint_contains_multipoint(c: &mut Criterion) {
     // worst case where the point is at the end of the sorted list
 
     c.bench_function(
@@ -426,7 +485,7 @@ fn bench_multipoint_contains_multipoint(c: &mut Criterion) {
     );
 }
 
-fn bench_polygon_contains_multipoint(c: &mut Criterion) {
+fn polygon_contains_multipoint(c: &mut Criterion) {
     // worst case where the point is at the end of the sorted list
 
     c.bench_function(
@@ -540,11 +599,111 @@ fn bench_polygon_contains_multipoint(c: &mut Criterion) {
     );
 }
 
+fn triangle_contains_line(c: &mut Criterion) {
+    c.bench_function("line within triangle (Contains Trait)", |bencher| {
+        let tri = Triangle::new(
+            coord! {x:0., y:0.},
+            coord! {x:10., y:0.},
+            coord! {x:10., y:5.},
+        );
+        let ln = Line::new(Point::new(3., 1.), Point::new(9., 3.));
+
+        bencher.iter(|| {
+            assert!(criterion::black_box(&tri).contains(criterion::black_box(&ln)));
+        });
+    });
+    c.bench_function("line within triangle (Relates Trait)", |bencher| {
+        let tri = Triangle::new(
+            coord! {x:0., y:0.},
+            coord! {x:10., y:0.},
+            coord! {x:10., y:5.},
+        );
+        let ln = Line::new(Point::new(3., 1.), Point::new(9., 3.));
+
+        bencher.iter(|| {
+            assert!(criterion::black_box(&tri)
+                .relate(criterion::black_box(&ln))
+                .is_contains());
+        });
+    });
+
+    c.bench_function("line disjoint triangle (Contains Trait)", |bencher| {
+        let tri = Triangle::new(
+            coord! {x:0., y:0.},
+            coord! {x:10., y:0.},
+            coord! {x:10., y:5.},
+        );
+        let ln = Line::new(Point::new(1., 6.), Point::new(9., 6.));
+
+        bencher.iter(|| {
+            assert!(!criterion::black_box(&tri).contains(criterion::black_box(&ln)));
+        });
+    });
+    c.bench_function("line disjoint triangle (Relates Trait)", |bencher| {
+        let tri = Triangle::new(
+            coord! {x:0., y:0.},
+            coord! {x:10., y:0.},
+            coord! {x:10., y:5.},
+        );
+        let ln = Line::new(Point::new(1., 6.), Point::new(9., 6.));
+
+        bencher.iter(|| {
+            assert!(!criterion::black_box(&tri)
+                .relate(criterion::black_box(&ln))
+                .is_contains());
+        });
+    });
+
+    c.bench_function("line along triangle (Contains Trait)", |bencher| {
+        let tri = Triangle::new(
+            coord! {x:0., y:0.},
+            coord! {x:10., y:0.},
+            coord! {x:10., y:5.},
+        );
+        let ln = Line::new(Point::new(1., 0.), Point::new(9., 0.));
+
+        bencher.iter(|| {
+            assert!(!criterion::black_box(&tri).contains(criterion::black_box(&ln)));
+        });
+    });
+    c.bench_function("line along triangle (Relates Trait)", |bencher| {
+        let tri = Triangle::new(
+            coord! {x:0., y:0.},
+            coord! {x:10., y:0.},
+            coord! {x:10., y:5.},
+        );
+        let ln = Line::new(Point::new(1., 0.), Point::new(9., 0.));
+
+        bencher.iter(|| {
+            assert!(!criterion::black_box(&tri)
+                .relate(criterion::black_box(&ln))
+                .is_contains());
+        });
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_group!(bench_line_contains_multi_point, line_contains_multi_point);
+criterion_group!(bench_rect_contains_line, rect_contains_line);
 criterion_group!(
+    bench_multipoint_contains_multipoint,
+    multipoint_contains_multipoint
+);
+criterion_group!(
+    bench_polygon_contains_multipoint,
+    polygon_contains_multipoint
+);
+criterion_group!(
+    bench_triangle_contains_line,
+    triangle_contains_line,
+    rect_contains_line
+);
+
+criterion_main!(
     benches,
-    criterion_benchmark,
     bench_line_contains_multi_point,
+    bench_rect_contains_line,
     bench_multipoint_contains_multipoint,
     bench_polygon_contains_multipoint,
+    bench_triangle_contains_line,
 );
-criterion_main!(benches);

--- a/geo/benches/contains.rs
+++ b/geo/benches/contains.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use geo::algorithm::{Contains, Convert, Relate};
-use geo::geometry::*;
-use geo::{coord, point, polygon};
+use geo::{coord, line_string, point, polygon};
+use geo::{geometry::*, CoordsIter};
 
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("point in simple polygon", |bencher| {
@@ -792,6 +792,204 @@ fn triangle_contains_rect(c: &mut Criterion) {
     });
 }
 
+fn rect_contains_linestring(c: &mut Criterion) {
+    c.bench_function(
+        "rect contains linestring 40 on boundary (Contains Trait)",
+        |bencher| {
+            let rect = Rect::new(Point::new(5., 5.), Point::new(9., 1.));
+            let ls = LineString::from_iter(rect.coords_iter().cycle().take(10));
+
+            bencher.iter(|| {
+                assert!(!criterion::black_box(&rect).contains(criterion::black_box(&ls)));
+            });
+        },
+    );
+    c.bench_function(
+        "rect contains linestring 40 on boundary (Relate Trait)",
+        |bencher| {
+            let rect = Rect::new(Point::new(5., 5.), Point::new(9., 1.));
+            let ls = LineString::from_iter(rect.coords_iter().cycle().take(10));
+
+            bencher.iter(|| {
+                assert!(!criterion::black_box(&rect)
+                    .relate(criterion::black_box(&ls))
+                    .is_contains());
+            });
+        },
+    );
+
+    c.bench_function(
+        "rect contains linestring 4000 on boundary (Contains Trait)",
+        |bencher| {
+            let rect = Rect::new(Point::new(5., 5.), Point::new(9., 1.));
+            let ls = LineString::from_iter(rect.coords_iter().cycle().take(1000));
+
+            bencher.iter(|| {
+                assert!(!criterion::black_box(&rect).contains(criterion::black_box(&ls)));
+            });
+        },
+    );
+    c.bench_function(
+        "rect contains linestring 4000 on boundary (Relate Trait)",
+        |bencher| {
+            let rect = Rect::new(Point::new(5., 5.), Point::new(9., 1.));
+            let ls = LineString::from_iter(rect.coords_iter().cycle().take(1000));
+
+            bencher.iter(|| {
+                assert!(!criterion::black_box(&rect)
+                    .relate(criterion::black_box(&ls))
+                    .is_contains());
+            });
+        },
+    );
+
+    c.bench_function(
+        "rect contains linestring disjoint in bb (Contains Trait)",
+        |bencher| {
+            let rect = Rect::new(Point::new(5., 5.), Point::new(9., 1.));
+            let ls = line_string![
+                coord! {x:0.,y:0.},
+                coord! {x:0.,y:10.},
+                coord! {x:10.,y:10.},
+                coord! {x:10.,y:0.}
+            ];
+
+            bencher.iter(|| {
+                assert!(!criterion::black_box(&rect).contains(criterion::black_box(&ls)));
+            });
+        },
+    );
+    c.bench_function(
+        "rect contains linestring disjoint in bb (Relate Trait)",
+        |bencher| {
+            let rect = Rect::new(Point::new(5., 5.), Point::new(9., 1.));
+            let ls = line_string![
+                coord! {x:0.,y:0.},
+                coord! {x:0.,y:10.},
+                coord! {x:10.,y:10.},
+                coord! {x:10.,y:0.}
+            ];
+
+            bencher.iter(|| {
+                assert!(!criterion::black_box(&rect)
+                    .relate(criterion::black_box(&ls))
+                    .is_contains());
+            });
+        },
+    );
+}
+
+fn triangle_contains_linestring(c: &mut Criterion) {
+    c.bench_function(
+        "triangle contains linestring 30 on boundary (Contains Trait)",
+        |bencher| {
+            let tri = Triangle::new(
+                coord! {x:0.,y:0.},
+                coord! {x:10.,y:0.},
+                coord! {x:10.,y:10.},
+            );
+            let ls = LineString::from_iter(tri.coords_iter().cycle().take(10));
+
+            bencher.iter(|| {
+                assert!(!criterion::black_box(&tri).contains(criterion::black_box(&ls)));
+            });
+        },
+    );
+    c.bench_function(
+        "triangle contains linestring 30 on boundary (Relate Trait)",
+        |bencher| {
+            let tri = Triangle::new(
+                coord! {x:0.,y:0.},
+                coord! {x:10.,y:0.},
+                coord! {x:10.,y:10.},
+            );
+            let ls = LineString::from_iter(tri.coords_iter().cycle().take(10));
+
+            bencher.iter(|| {
+                assert!(!criterion::black_box(&tri)
+                    .relate(criterion::black_box(&ls))
+                    .is_contains());
+            });
+        },
+    );
+
+    c.bench_function(
+        "triangle contains linestring 3000 on boundary (Contains Trait)",
+        |bencher| {
+            let tri = Triangle::new(
+                coord! {x:0.,y:0.},
+                coord! {x:10.,y:0.},
+                coord! {x:10.,y:10.},
+            );
+            let ls = LineString::from_iter(tri.coords_iter().cycle().take(1000));
+
+            bencher.iter(|| {
+                assert!(!criterion::black_box(&tri).contains(criterion::black_box(&ls)));
+            });
+        },
+    );
+    c.bench_function(
+        "triangle contains linestring 3000 on boundary (Relate Trait)",
+        |bencher| {
+            let tri = Triangle::new(
+                coord! {x:0.,y:0.},
+                coord! {x:10.,y:0.},
+                coord! {x:10.,y:10.},
+            );
+            let ls = LineString::from_iter(tri.coords_iter().cycle().take(1000));
+
+            bencher.iter(|| {
+                assert!(!criterion::black_box(&tri)
+                    .relate(criterion::black_box(&ls))
+                    .is_contains());
+            });
+        },
+    );
+
+    c.bench_function(
+        "triangle contains linestring disjoint in bounding box (Contains Trait)",
+        |bencher| {
+            let tri = Triangle::new(
+                coord! {x:0.,y:0.},
+                coord! {x:10.,y:0.},
+                coord! {x:10.,y:10.},
+            );
+            let ls = line_string![
+                coord! {x:0.,y:0.},
+                coord! {x:0.,y:10.},
+                coord! {x:10.,y:10.},
+                coord! {x:10.,y:0.}
+            ];
+
+            bencher.iter(|| {
+                assert!(!criterion::black_box(&tri).contains(criterion::black_box(&ls)));
+            });
+        },
+    );
+    c.bench_function(
+        "triangle contains linestring disjoint in bounding box (Relate Trait)",
+        |bencher| {
+            let tri = Triangle::new(
+                coord! {x:0.,y:0.},
+                coord! {x:10.,y:0.},
+                coord! {x:10.,y:10.},
+            );
+            let ls = line_string![
+                coord! {x:0.,y:0.},
+                coord! {x:0.,y:10.},
+                coord! {x:10.,y:10.},
+                coord! {x:10.,y:0.}
+            ];
+
+            bencher.iter(|| {
+                assert!(!criterion::black_box(&tri)
+                    .relate(criterion::black_box(&ls))
+                    .is_contains());
+            });
+        },
+    );
+}
+
 criterion_group!(benches, criterion_benchmark);
 criterion_group!(bench_line_contains_multi_point, line_contains_multi_point);
 criterion_group!(bench_rect_contains_line, rect_contains_line);
@@ -805,6 +1003,11 @@ criterion_group!(
 );
 criterion_group!(bench_triangle_contains_line, triangle_contains_line);
 criterion_group!(bench_triangle_contains_rect, triangle_contains_rect);
+criterion_group!(bench_rect_contains_linestring, rect_contains_linestring);
+criterion_group!(
+    bench_triangle_contains_linestring,
+    triangle_contains_linestring
+);
 
 criterion_main!(
     benches,
@@ -814,4 +1017,6 @@ criterion_main!(
     bench_polygon_contains_multipoint,
     bench_triangle_contains_line,
     bench_triangle_contains_rect,
+    bench_rect_contains_linestring,
+    bench_triangle_contains_linestring,
 );

--- a/geo/benches/contains.rs
+++ b/geo/benches/contains.rs
@@ -990,6 +990,118 @@ fn triangle_contains_linestring(c: &mut Criterion) {
     );
 }
 
+fn triangle_contains_triangle(c: &mut Criterion) {
+    /*
+       contains
+       disjoint
+    */
+
+    c.bench_function("triangle contains triangle (Contains Trait)", |bencher| {
+        let tri = Triangle::new(
+            coord! {x:0.,y:0.},
+            coord! {x:10.,y:0.},
+            coord! {x:10.,y:10.},
+        );
+
+        bencher.iter(|| {
+            assert!(criterion::black_box(&tri).contains(criterion::black_box(&tri)));
+        });
+    });
+    c.bench_function("triangle contains triangle (Relate Trait)", |bencher| {
+        let tri = Triangle::new(
+            coord! {x:0.,y:0.},
+            coord! {x:10.,y:0.},
+            coord! {x:10.,y:10.},
+        );
+
+        bencher.iter(|| {
+            assert!(criterion::black_box(&tri)
+                .relate(criterion::black_box(&tri))
+                .is_contains());
+        });
+    });
+
+    c.bench_function(
+        "triangle disjoint triangle disjoint bounding box(Contains Trait)",
+        |bencher| {
+            let tri = Triangle::new(
+                coord! {x:0.,y:0.},
+                coord! {x:10.,y:0.},
+                coord! {x:10.,y:10.},
+            );
+            let tri2 = Triangle::new(
+                coord! {x:-1.,y:-1.},
+                coord! {x:-10.,y:-1.},
+                coord! {x:-10.,y:-10.},
+            );
+
+            bencher.iter(|| {
+                assert!(!criterion::black_box(&tri).contains(criterion::black_box(&tri2)));
+            });
+        },
+    );
+    c.bench_function(
+        "triangle disjoint triangle  disjoint bounding box (Relate Trait)",
+        |bencher| {
+            let tri = Triangle::new(
+                coord! {x:0.,y:0.},
+                coord! {x:10.,y:0.},
+                coord! {x:10.,y:10.},
+            );
+            let tri2 = Triangle::new(
+                coord! {x:-1.,y:-1.},
+                coord! {x:-10.,y:-1.},
+                coord! {x:-10.,y:-10.},
+            );
+            bencher.iter(|| {
+                assert!(!criterion::black_box(&tri)
+                    .relate(criterion::black_box(&tri2))
+                    .is_contains());
+            });
+        },
+    );
+
+    c.bench_function(
+        "triangle disjoint triangle overlapping bounding box (Contains Trait)",
+        |bencher| {
+            let tri = Triangle::new(
+                coord! {x:0.,y:0.},
+                coord! {x:10.,y:0.},
+                coord! {x:10.,y:10.},
+            );
+            let tri2 = Triangle::new(
+                coord! {x:0.,y:0.},
+                coord! {x:0.,y:10.},
+                coord! {x:10.,y:10.},
+            );
+
+            bencher.iter(|| {
+                assert!(!criterion::black_box(&tri).contains(criterion::black_box(&tri2)));
+            });
+        },
+    );
+    c.bench_function(
+        "triangle disjoint triangle overlapping bounding box (Relate Trait)",
+        |bencher| {
+            let tri = Triangle::new(
+                coord! {x:0.,y:0.},
+                coord! {x:10.,y:0.},
+                coord! {x:10.,y:10.},
+            );
+            let tri2 = Triangle::new(
+                coord! {x:0.,y:0.},
+                coord! {x:0.,y:10.},
+                coord! {x:10.,y:10.},
+            );
+            bencher.iter(|| {
+                assert!(!criterion::black_box(&tri)
+                    .relate(criterion::black_box(&tri2))
+                    .is_contains());
+            });
+        },
+    );
+}
+
 criterion_group!(benches, criterion_benchmark);
 criterion_group!(bench_line_contains_multi_point, line_contains_multi_point);
 criterion_group!(bench_rect_contains_line, rect_contains_line);
@@ -1008,6 +1120,7 @@ criterion_group!(
     bench_triangle_contains_linestring,
     triangle_contains_linestring
 );
+criterion_group!(bench_triangle_contains_triangle, triangle_contains_triangle);
 
 criterion_main!(
     benches,
@@ -1019,4 +1132,5 @@ criterion_main!(
     bench_triangle_contains_rect,
     bench_rect_contains_linestring,
     bench_triangle_contains_linestring,
+    bench_triangle_contains_triangle,
 );

--- a/geo/benches/contains.rs
+++ b/geo/benches/contains.rs
@@ -1105,8 +1105,8 @@ fn triangle_contains_triangle(c: &mut Criterion) {
 fn rect_contains_multipoint(c: &mut Criterion) {
     c.bench_function("rect contains multipoint 100 (Contains Trait)", |bencher| {
         let rect = Rect::new(Point::new(0., 0.), Point::new(10., 10.));
-        let pts: Vec<Point> = (0..10_0)
-            .flat_map(|x| (0..10_0).map(move |y| Point::new(x as f64 / 1_0., y as f64 / 1_0.)))
+        let pts: Vec<Point> = (0..100)
+            .flat_map(|x| (0..100).map(move |y| Point::new(x as f64 / 1_0., y as f64 / 1_0.)))
             .collect();
         let mp = MultiPoint::new(pts);
         bencher.iter(|| {
@@ -1115,8 +1115,8 @@ fn rect_contains_multipoint(c: &mut Criterion) {
     });
     c.bench_function("rect contains multipoint 100 (Relates Trait)", |bencher| {
         let rect = Rect::new(Point::new(0., 0.), Point::new(10., 10.));
-        let pts: Vec<Point> = (0..10_0)
-            .flat_map(|x| (0..10_0).map(move |y| Point::new(x as f64 / 1_0., y as f64 / 1_0.)))
+        let pts: Vec<Point> = (0..100)
+            .flat_map(|x| (0..100).map(move |y| Point::new(x as f64 / 1_0., y as f64 / 1_0.)))
             .collect();
         let mp = MultiPoint::new(pts);
         bencher.iter(|| {

--- a/geo/benches/contains.rs
+++ b/geo/benches/contains.rs
@@ -1127,9 +1127,7 @@ fn rect_contains_multipoint(c: &mut Criterion) {
     c.bench_function("rect contains multipoint 1k (Contains Trait)", |bencher| {
         let rect = Rect::new(Point::new(0., 0.), Point::new(10., 10.));
         let pts: Vec<Point> = (0..10_00)
-            .flat_map(|x| {
-                (0..10_00).map(move |y| Point::new(x as f64 / 1_00., y as f64 / 1_00.))
-            })
+            .flat_map(|x| (0..10_00).map(move |y| Point::new(x as f64 / 1_00., y as f64 / 1_00.)))
             .collect();
         let mp = MultiPoint::new(pts);
         bencher.iter(|| {
@@ -1139,9 +1137,7 @@ fn rect_contains_multipoint(c: &mut Criterion) {
     c.bench_function("rect contains multipoint 1k (Relates Trait)", |bencher| {
         let rect = Rect::new(Point::new(0., 0.), Point::new(10., 10.));
         let pts: Vec<Point> = (0..10_00)
-            .flat_map(|x| {
-                (0..10_00).map(move |y| Point::new(x as f64 / 1_00., y as f64 / 1_00.))
-            })
+            .flat_map(|x| (0..10_00).map(move |y| Point::new(x as f64 / 1_00., y as f64 / 1_00.)))
             .collect();
         let mp = MultiPoint::new(pts);
         bencher.iter(|| {

--- a/geo/convex-contains-convex.md
+++ b/geo/convex-contains-convex.md
@@ -1,0 +1,70 @@
+For Rectangle Contains Triangle, 
+if triangle is not degenerate and all three triangle corners intersect the rectangle, then the rectangle contains the triangle.
+three corners intersecting means that there must be some edge crossing the rectangle, satisfying the within reqirement.  
+
+For Triangle Contains Rectangle, 
+if triangle is not degenerate and all four corners intersect the rectangle, then the triangle contains the rectangle.
+four corners intersecting means that there must be some edge crossing the triangle, satisfying the within reqirement.
+
+```
+rect within triangle (Contains Trait)
+                        time:   [32.047 ns 32.095 ns 32.148 ns]
+                        change: [-99.132% -99.127% -99.122%] (p = 0.00 < 0.05)
+                        Performance has improved.
+Found 1 outliers among 100 measurements (1.00%)
+  1 (1.00%) high mild
+
+rect within triangle (Relate Trait)
+                        time:   [3.3069 µs 3.3172 µs 3.3292 µs]
+                        change: [-3.6471% -2.8156% -1.7563%] (p = 0.00 < 0.05)
+                        Performance has improved.
+Found 4 outliers among 100 measurements (4.00%)
+  2 (2.00%) high mild
+  2 (2.00%) high severe
+```
+
+```
+triangle within rect (Contains Trait)
+                        time:   [3.0131 ns 3.0317 ns 3.0511 ns]
+                        change: [-99.922% -99.921% -99.921%] (p = 0.00 < 0.05)
+                        Performance has improved.
+
+triangle within rect (Relate Trait)
+                        time:   [3.7826 µs 3.7919 µs 3.8013 µs]
+                        change: [-1.5469% -1.1346% -0.7272%] (p = 0.00 < 0.05)
+                        Change within noise threshold.
+Found 3 outliers among 100 measurements (3.00%)
+  1 (1.00%) low mild
+  2 (2.00%) high mild
+```
+
+```
+rect disjoint triangle (Contains Trait)
+                        time:   [2.5148 ns 2.5217 ns 2.5276 ns]
+                        change: [-78.872% -78.789% -78.709%] (p = 0.00 < 0.05)
+                        Performance has improved.
+Found 1 outliers among 100 measurements (1.00%)
+  1 (1.00%) low mild
+
+rect disjoint triangle (Relate Trait)
+                        time:   [10.400 ns 10.423 ns 10.450 ns]
+                        change: [-12.136% -11.714% -11.319%] (p = 0.00 < 0.05)
+                        Performance has improved.
+```
+
+```
+triangle disjoint rect (Contains Trait)
+                        time:   [9.1853 ns 9.1987 ns 9.2132 ns]
+                        change: [-27.199% -26.980% -26.746%] (p = 0.00 < 0.05)
+                        Performance has improved.
+Found 1 outliers among 100 measurements (1.00%)
+  1 (1.00%) low mild
+
+triangle disjoint rect (Relate Trait)
+                        time:   [10.644 ns 10.676 ns 10.707 ns]
+                        change: [-14.999% -14.695% -14.349%] (p = 0.00 < 0.05)
+                        Performance has improved.
+Found 3 outliers among 100 measurements (3.00%)
+  1 (1.00%) low mild
+  2 (2.00%) high mild
+```

--- a/geo/convex-contains-line.md
+++ b/geo/convex-contains-line.md
@@ -1,0 +1,125 @@
+For the `Contains` predicate, the line is contained if all points of the line intersect the shape, and at least one part of the line lies does not lie on the shape's boundary.  
+For a convex shape, if both ends of a line intersect the shape, the shape contains the line.  
+However, if the both ends of the line line on the same segment of the boundary, then it must lie on the shape's boundary.  
+It is not possible for a line to be on more than one segment of the boundary for Rectangle and Triangle.
+- For both these shape, it is impossible for adjacent segments of the boundary to be coliniear.
+- The possible exception is a degerate case where the line is a point or a line.
+- In degenerate cases, the shape becomes a line or a point, and the line is either disjoint, or contained by the boundary.  
+
+Therefore it is sufficient to check that both ends intersect the shape,
+and that they do not intersect the same segment of the boundary.  
+if any end of the line lies within the polygon(i.e not on the boundary), we can short circuit the check
+
+```
+line within rect (Contains Trait)
+                        time:   [2.0043 ns 2.0093 ns 2.0152 ns]
+                        change: [-99.921% -99.920% -99.920%] (p = 0.00 < 0.05)
+                        Performance has improved.
+Found 8 outliers among 100 measurements (8.00%)
+  1 (1.00%) low severe
+  4 (4.00%) high mild
+  3 (3.00%) high severe
+
+line within rect (Relates Trait)
+                        time:   [2.4976 µs 2.5088 µs 2.5205 µs]
+                        change: [-0.2887% +0.1245% +0.5210%] (p = 0.54 > 0.05)
+                        No change in performance detected.
+Found 2 outliers among 100 measurements (2.00%)
+  2 (2.00%) high mild
+```
+
+```
+line disjoint rect (Contains Trait)
+                        time:   [1.9890 ns 1.9913 ns 1.9937 ns]
+                        change: [-78.327% -78.253% -78.182%] (p = 0.00 < 0.05)
+                        Performance has improved.
+Found 6 outliers among 100 measurements (6.00%)
+  1 (1.00%) low severe
+  1 (1.00%) low mild
+  2 (2.00%) high mild
+  2 (2.00%) high severe
+
+line disjoint rect (Relates Trait)
+                        time:   [8.2672 ns 8.2721 ns 8.2774 ns]
+                        change: [-10.612% -10.421% -10.228%] (p = 0.00 < 0.05)
+                        Performance has improved.
+Found 6 outliers among 100 measurements (6.00%)
+  1 (1.00%) low severe
+  3 (3.00%) high mild
+  2 (2.00%) high severe
+```
+
+```
+line along rect (Contains Trait)
+                        time:   [11.960 ns 11.976 ns 11.995 ns]
+                        change: [-99.580% -99.578% -99.577%] (p = 0.00 < 0.05)
+                        Performance has improved.
+Found 8 outliers among 100 measurements (8.00%)
+  1 (1.00%) low severe
+  3 (3.00%) low mild
+  3 (3.00%) high mild
+  1 (1.00%) high severe
+
+line along rect (Relates Trait)
+                        time:   [2.8608 µs 2.8700 µs 2.8829 µs]
+                        change: [-0.1797% +0.2629% +0.7349%] (p = 0.27 > 0.05)
+                        No change in performance detected.
+Found 5 outliers among 100 measurements (5.00%)
+  1 (1.00%) low mild
+  3 (3.00%) high mild
+  1 (1.00%) high severe
+```
+
+```
+line within triangle (Contains Trait)
+                        time:   [13.358 ns 13.371 ns 13.388 ns]
+                        change: [-99.483% -99.481% -99.479%] (p = 0.00 < 0.05)
+                        Performance has improved.
+Found 9 outliers among 100 measurements (9.00%)
+  1 (1.00%) low severe
+  6 (6.00%) high mild
+  2 (2.00%) high severe
+
+line within triangle (Relates Trait)
+                        time:   [2.5793 µs 2.5879 µs 2.5968 µs]
+                        change: [-0.0517% +0.4215% +0.8637%] (p = 0.07 > 0.05)
+                        No change in performance detected.
+Found 2 outliers among 100 measurements (2.00%)
+  1 (1.00%) low mild
+  1 (1.00%) high mild
+```
+
+```
+line disjoint triangle (Contains Trait)
+                        time:   [5.3985 ns 5.4122 ns 5.4268 ns]
+                        change: [-56.951% -56.754% -56.560%] (p = 0.00 < 0.05)
+                        Performance has improved.
+
+line disjoint triangle (Relates Trait)
+                        time:   [10.561 ns 10.613 ns 10.688 ns]
+                        change: [-16.871% -16.486% -16.071%] (p = 0.00 < 0.05)
+                        Performance has improved.
+Found 2 outliers among 100 measurements (2.00%)
+  1 (1.00%) high mild
+  1 (1.00%) high severe
+```
+
+```
+line along triangle (Contains Trait)
+                        time:   [21.239 ns 21.267 ns 21.307 ns]
+                        change: [-99.263% -99.259% -99.256%] (p = 0.00 < 0.05)
+                        Performance has improved.
+Found 10 outliers among 100 measurements (10.00%)
+  2 (2.00%) low severe
+  1 (1.00%) low mild
+  3 (3.00%) high mild
+  4 (4.00%) high severe
+
+line along triangle (Relates Trait)
+                        time:   [2.8540 µs 2.8593 µs 2.8655 µs]
+                        change: [-1.2264% -0.6838% -0.1442%] (p = 0.01 < 0.05)
+                        Change within noise threshold.
+Found 6 outliers among 100 measurements (6.00%)
+  5 (5.00%) high mild
+  1 (1.00%) high severe
+```

--- a/geo/convex-contains-linestring.md
+++ b/geo/convex-contains-linestring.md
@@ -1,0 +1,104 @@
+Extending the concepts from contains `Line` and contains `Convex Polygon` to `LineString`  
+If all `Points` of a LineString intersect a convex polygon, and there exists some `Point` not on the boundary of the polygon, then the `Convex Polygon` contains the `LineString`  
+If all `Points` of a LineString intersect a convex polygon, and there exists some `Line` not on the boundary of the polygon, then part of that line must cross the `Convex Polygon`'s face and the `Convex Polygon` contains the `LineString`  
+
+benchmarks seem to indicate that relative performance gains over `Relate` trait get better as the number of points in the `LineString` increases.  
+
+```
+rect contains linestring 40 on boundary (Contains Trait)
+                        time:   [73.304 ns 74.178 ns 75.137 ns]
+                        change: [-98.946% -98.934% -98.923%] (p = 0.00 < 0.05)
+                        Performance has improved.
+
+rect contains linestring 40 on boundary (Relate Trait)
+                        time:   [7.5039 µs 7.5469 µs 7.5914 µs]
+                        change: [+3.8975% +4.3975% +4.9324%] (p = 0.00 < 0.05)
+                        Performance has regressed.
+Found 3 outliers among 100 measurements (3.00%)
+  1 (1.00%) low mild
+  2 (2.00%) high mild
+```
+
+```
+rect contains linestring 4000 on boundary (Contains Trait)
+                        time:   [8.5126 µs 8.6127 µs 8.7135 µs]
+                        change: [-99.982% -99.982% -99.982%] (p = 0.00 < 0.05)
+                        Performance has improved.
+
+rect contains linestring 4000 on boundary (Relate Trait)
+                        time:   [48.053 ms 48.151 ms 48.261 ms]
+                        change: [+0.6742% +0.9155% +1.1898%] (p = 0.00 < 0.05)
+                        Change within noise threshold.
+Found 7 outliers among 100 measurements (7.00%)
+  6 (6.00%) high mild
+  1 (1.00%) high severe
+```
+
+```
+rect contains linestring disjoint in bb (Contains Trait)
+                        time:   [2.0763 ns 2.0795 ns 2.0829 ns]
+                        change: [-99.921% -99.921% -99.921%] (p = 0.00 < 0.05)
+                        Performance has improved.
+Found 4 outliers among 100 measurements (4.00%)
+  1 (1.00%) high mild
+  3 (3.00%) high severe
+
+rect contains linestring disjoint in bb (Relate Trait)
+                        time:   [2.6528 µs 2.6660 µs 2.6796 µs]
+                        change: [-0.7489% -0.1863% +0.4131%] (p = 0.54 > 0.05)
+                        No change in performance detected.
+Found 6 outliers among 100 measurements (6.00%)
+  6 (6.00%) high mild
+```
+
+```
+triangle contains linestring 30 on boundary (Contains Trait)
+                        time:   [151.67 ns 152.06 ns 152.47 ns]
+                        change: [-97.263% -97.254% -97.244%] (p = 0.00 < 0.05)
+                        Performance has improved.
+Found 1 outliers among 100 measurements (1.00%)
+  1 (1.00%) high mild
+
+triangle contains linestring 30 on boundary (Relate Trait)
+                        time:   [5.5585 µs 5.5719 µs 5.5864 µs]
+                        change: [+0.9877% +1.2700% +1.5679%] (p = 0.00 < 0.05)
+                        Change within noise threshold.
+Found 2 outliers among 100 measurements (2.00%)
+  2 (2.00%) high mild
+```
+
+```
+triangle contains linestring 3000 on boundary (Contains Trait)
+                        time:   [15.151 µs 15.193 µs 15.239 µs]
+                        change: [-99.646% -99.644% -99.643%] (p = 0.00 < 0.05)
+                        Performance has improved.
+Found 1 outliers among 100 measurements (1.00%)
+  1 (1.00%) high severe
+
+triangle contains linestring 3000 on boundary (Relate Trait)
+                        time:   [4.3090 ms 4.3147 ms 4.3210 ms]
+                        change: [+1.1245% +1.4144% +1.6907%] (p = 0.00 < 0.05)
+                        Performance has regressed.
+Found 5 outliers among 100 measurements (5.00%)
+  3 (3.00%) high mild
+  2 (2.00%) high severe
+```
+
+```
+triangle contains linestring disjoint in bounding box (Contains Trait)
+                        time:   [10.973 ns 10.990 ns 11.007 ns]
+                        change: [-99.671% -99.669% -99.666%] (p = 0.00 < 0.05)
+                        Performance has improved.
+Found 5 outliers among 100 measurements (5.00%)
+  3 (3.00%) high mild
+  2 (2.00%) high severe
+
+triangle contains linestring disjoint in bounding box (Relate Trait)
+                        time:   [3.3271 µs 3.3331 µs 3.3393 µs]
+                        change: [-0.9428% -0.6279% -0.3293%] (p = 0.00 < 0.05)
+                        Change within noise threshold.
+Found 3 outliers among 100 measurements (3.00%)
+  1 (1.00%) low mild
+  1 (1.00%) high mild
+  1 (1.00%) high severe
+```

--- a/geo/src/algorithm/contains/rect.rs
+++ b/geo/src/algorithm/contains/rect.rs
@@ -36,7 +36,7 @@ where
 {
     fn contains(&self, other: &Rect<T>) -> bool {
         match (self.dimensions(), other.dimensions()) {
-            (a,b) if a < b => false,
+            (a, b) if a < b => false,
             (Dimensions::TwoDimensional, Dimensions::TwoDimensional) => {
                 // standard case
                 self.min().x <= other.min().x
@@ -109,7 +109,7 @@ where
 {
     fn contains(&self, rhs: &Line<T>) -> bool {
         match (self.dimensions(), rhs.dimensions()) {
-            (a,b) if a < b => false,
+            (a, b) if a < b => false,
             (Dimensions::TwoDimensional, Dimensions::OneDimensional) => {
                 // standard case
                 self.intersects(&rhs.start)
@@ -140,7 +140,7 @@ where
     fn contains(&self, rhs: &Triangle<T>) -> bool {
         // in non-degenerate cases, all three triangle corners intersecting the rectangle implies one edge crosses the rectangle
         match (self.dimensions(), rhs.dimensions()) {
-            (a,b) if a < b => false,
+            (a, b) if a < b => false,
             (Dimensions::TwoDimensional, Dimensions::TwoDimensional) => {
                 // standard case
                 self.intersects(&rhs.0) && self.intersects(&rhs.1) && self.intersects(&rhs.2)
@@ -165,7 +165,7 @@ where
 {
     fn contains(&self, rhs: &LineString<T>) -> bool {
         match (self.dimensions(), rhs.dimensions()) {
-            (a,b) if a < b => false,
+            (a, b) if a < b => false,
             (Dimensions::TwoDimensional, Dimensions::OneDimensional) => {
                 // standard case
                 // self intersects all points
@@ -196,12 +196,11 @@ where
 {
     fn contains(&self, rhs: &MultiPoint<T>) -> bool {
         match (self.dimensions(), rhs.dimensions()) {
-            (a,b) if a < b => false,
+            (a, b) if a < b => false,
             (Dimensions::TwoDimensional, Dimensions::ZeroDimensional) => {
                 // standard case
                 // all intersects and at least one contains
-                rhs.iter().all(|pt| self.intersects(pt)) 
-                && rhs.iter().any(|pt| self.contains(pt))
+                rhs.iter().all(|pt| self.intersects(pt)) && rhs.iter().any(|pt| self.contains(pt))
             }
             (Dimensions::OneDimensional, _) => false,
             (Dimensions::ZeroDimensional, _) => false,
@@ -214,7 +213,6 @@ where
     }
 }
 
-
 impl<T> Contains<MultiLineString<T>> for Rect<T>
 where
     T: GeoFloat,
@@ -224,7 +222,7 @@ where
 {
     fn contains(&self, rhs: &MultiLineString<T>) -> bool {
         match (self.dimensions(), rhs.dimensions()) {
-            (a,b) if a < b => false,
+            (a, b) if a < b => false,
             (Dimensions::TwoDimensional, Dimensions::OneDimensional) => {
                 // standard case
                 // self intersects all points
@@ -247,7 +245,6 @@ where
     }
 }
 
-// impl_contains_from_relate!(Rect<T>, [ MultiLineString<T>]);
 impl_contains_from_relate!(Rect<T>, [ MultiPolygon<T>, GeometryCollection<T> ]);
 impl_contains_geometry_for!(Rect<T>);
 

--- a/geo/src/algorithm/contains/rect.rs
+++ b/geo/src/algorithm/contains/rect.rs
@@ -31,11 +31,11 @@ where
 impl<T> Contains<Rect<T>> for Rect<T>
 where
     T: GeoNum,
-    Line<T> : Contains<Coord<T>>+Contains<Line<T>>,
-    Rect<T> : Contains<Line<T>>+Contains<Coord<T>>,
+    Line<T>: Contains<Coord<T>> + Contains<Line<T>>,
+    Rect<T>: Contains<Line<T>> + Contains<Coord<T>>,
 {
     fn contains(&self, other: &Rect<T>) -> bool {
-        match(self.dimensions(), other.dimensions()) {
+        match (self.dimensions(), other.dimensions()) {
             (Dimensions::TwoDimensional, Dimensions::TwoDimensional) => {
                 // standard case
                 self.min().x <= other.min().x
@@ -44,17 +44,19 @@ where
                     && self.max().y >= other.max().y
             }
             (Dimensions::TwoDimensional, Dimensions::OneDimensional) => {
-               self.contains(&Line::<T>::new(other.min(), other.max()))
+                self.contains(&Line::<T>::new(other.min(), other.max()))
             }
-            (Dimensions::TwoDimensional, Dimensions::ZeroDimensional) => self.contains(&other.min()),
+            (Dimensions::TwoDimensional, Dimensions::ZeroDimensional) => {
+                self.contains(&other.min())
+            }
             // individual cases for OneDimensional because Line contains Rect is currently a Relate Trait impl
-             (Dimensions::OneDimensional, Dimensions::TwoDimensional) => false,
-                 (Dimensions::OneDimensional, Dimensions::OneDimensional) => {
+            (Dimensions::OneDimensional, Dimensions::TwoDimensional) => false,
+            (Dimensions::OneDimensional, Dimensions::OneDimensional) => {
                 Line::new(self.min(), self.max()).contains(&Line::new(other.min(), other.max()))
-                }
+            }
             (Dimensions::OneDimensional, Dimensions::ZeroDimensional) => {
                 Line::<T>::new(self.min(), self.max()).contains(&other.min())
-                }
+            }
             (Dimensions::ZeroDimensional, _) => Point::<T>::from(self.min()).contains(other),
             (Dimensions::Empty, _) => false,
             (_, Dimensions::Empty) => false,
@@ -228,11 +230,10 @@ mod tests_triangle {
     }
 }
 
-
 #[cfg(test)]
 mod tests_rect {
     use super::*;
-    use crate::{ Point, Rect, Relate};
+    use crate::{Point, Rect, Relate};
 
     #[test]
     fn rect2d_contains_line0d() {
@@ -242,13 +243,12 @@ mod tests_rect {
 
         assert!(rect.contains(&rect));
         assert!(rect.relate(&rect).is_contains());
-        
+
         assert!(!rect.contains(&rect_1d));
         assert!(!rect.relate(&rect_1d).is_contains());
-        
+
         assert!(!rect.contains(&rect_0d));
         assert!(!rect.relate(&rect_0d).is_contains());
-
     }
 }
 #[cfg(test)]

--- a/geo/src/algorithm/contains/triangle.rs
+++ b/geo/src/algorithm/contains/triangle.rs
@@ -1,6 +1,6 @@
 use super::{impl_contains_from_relate, impl_contains_geometry_for, Contains};
 use crate::geometry::*;
-use crate::{kernels::Kernel, GeoFloat, GeoNum, Orientation};
+use crate::{kernels::Kernel, GeoFloat, GeoNum, Intersects, LinesIter, Orientation};
 
 // ┌──────────────────────────────┐
 // │ Implementations for Triangle │
@@ -48,5 +48,74 @@ where
     }
 }
 
-impl_contains_from_relate!(Triangle<T>, [Line<T>, LineString<T>, Polygon<T>, MultiPoint<T>, MultiLineString<T>, MultiPolygon<T>, GeometryCollection<T>, Rect<T>, Triangle<T>]);
+impl<T> Contains<Line<T>> for Triangle<T>
+where
+    T: GeoNum,
+    Line<T>: Contains<Line<T>>,
+    Triangle<T>: Intersects<Coord<T>>,
+{
+    fn contains(&self, rhs: &Line<T>) -> bool {
+        // self intersects all points && line does not sit on any of the self's edges
+
+        self.intersects(&rhs.start)
+            && self.intersects(&rhs.end)
+            && (self.contains(&rhs.start)
+                || self.contains(&rhs.end)
+                || !self.lines_iter().any(|edge| edge.contains(rhs)))
+    }
+}
+
+impl_contains_from_relate!(Triangle<T>, [LineString<T>, Polygon<T>, MultiPoint<T>, MultiLineString<T>, MultiPolygon<T>, GeometryCollection<T>, Rect<T>, Triangle<T>]);
 impl_contains_geometry_for!(Triangle<T>);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{coord, Line, Point, Relate, Triangle};
+
+    #[test]
+    fn triangle_contains_line() {
+        let tri = Triangle::new(
+            coord! {x:0., y:0.},
+            coord! {x:10., y:0.},
+            coord! {x:10., y:5.},
+        );
+
+        let ln_within = Line::new(Point::new(3., 1.), Point::new(9., 3.));
+        let ln_in_cross = Line::new(Point::new(0., 0.), Point::new(10., 4.));
+
+        let ln_boundary = Line::new(Point::new(0., 0.), Point::new(10., 0.));
+        let ln_boundary_partial = Line::new(Point::new(1., 0.), Point::new(9., 0.));
+
+        let ln_disjoint = Line::new(Point::new(0., 6.), Point::new(10., 6.));
+        let ln_out_cross = Line::new(Point::new(0., 0.), Point::new(9., 6.));
+
+        assert!(tri.contains(&ln_within));
+        assert!(tri.relate(&ln_within).is_contains());
+
+        assert!(tri.contains(&ln_in_cross));
+        assert!(tri.relate(&ln_in_cross).is_contains());
+
+        assert!(!tri.contains(&ln_boundary));
+        assert!(!tri.relate(&ln_boundary).is_contains());
+
+        assert!(!tri.contains(&ln_boundary_partial));
+        assert!(!tri.relate(&ln_boundary_partial).is_contains());
+
+        assert!(!tri.contains(&ln_disjoint));
+        assert!(!tri.relate(&ln_disjoint).is_contains());
+
+        assert!(!tri.contains(&ln_out_cross));
+        assert!(!tri.relate(&ln_out_cross).is_contains());
+    }
+
+    /**
+     *  Implementation of Triangle contains Line requires line contains self to be true
+     */
+    #[test]
+    fn line_contains_self() {
+        let ln = Line::new(Point::new(0., 0.), Point::new(10., 0.));
+        assert!(ln.contains(&ln));
+        assert!(ln.relate(&ln).is_contains());
+    }
+}

--- a/geo/src/algorithm/contains/triangle.rs
+++ b/geo/src/algorithm/contains/triangle.rs
@@ -1,7 +1,7 @@
 use super::{impl_contains_from_relate, impl_contains_geometry_for, Contains};
 use crate::dimensions::Dimensions;
 use crate::{geometry::*, CoordsIter, HasDimensions};
-use crate::{kernels::Kernel, GeoFloat, GeoNum, Intersects, LinesIter, Orientation, Relate};
+use crate::{kernels::Kernel, GeoFloat, GeoNum, Intersects, LinesIter, Orientation};
 // ┌──────────────────────────────┐
 // │ Implementations for Triangle │
 // └──────────────────────────────┘
@@ -96,18 +96,71 @@ where
             }
             (Dimensions::TwoDimensional, Dimensions::ZeroDimensional) => self.contains(&rhs.min()),
             (Dimensions::OneDimensional, _) => {
-                LineString::from_iter(self.coords_iter()).contains(&rhs)
+                LineString::from_iter(self.coords_iter()).contains(rhs)
             }
             (Dimensions::ZeroDimensional, _) => Point::from(self.0).contains(rhs),
             (Dimensions::Empty, _) => false,
             (_, Dimensions::Empty) => false,
         }
     }
-
 }
 
-impl_contains_from_relate!(Triangle<T>, [LineString<T>, Polygon<T>, MultiPoint<T>, MultiLineString<T>, MultiPolygon<T>, GeometryCollection<T>, Triangle<T>]);
+impl<T> Contains<LineString<T>> for Triangle<T>
+where
+    T: GeoNum,
+    Line<T>: Contains<Line<T>>,
+    Triangle<T>: Intersects<Coord<T>>,
+{
+    fn contains(&self, rhs: &LineString<T>) -> bool {
+        match (self.dimensions(), rhs.dimensions()) {
+            (Dimensions::TwoDimensional, Dimensions::OneDimensional) => {
+                // standard case
+                // self intersects all points
+                rhs.coords_iter().all(|c| self.intersects(&c))
+                // either a point
+                &&( rhs.coords_iter().any(|c| self.contains(&c))
+                // or there exists a line which does not line on any of the self's edges
+                || rhs.lines_iter().any(|rhs_edge| !self.lines_iter().any(|edge| edge.contains(&rhs_edge)))
+            )
+            }
+            (Dimensions::TwoDimensional, Dimensions::ZeroDimensional) => self.contains(&rhs.0[0]),
+            (Dimensions::OneDimensional, _) => {
+                LineString::from_iter(self.coords_iter()).contains(rhs)
+            }
+            (Dimensions::ZeroDimensional, _) => Point::from(self.0).contains(rhs),
+            (Dimensions::Empty, _) => false,
+            (_, Dimensions::Empty) => false,
+            (_, Dimensions::TwoDimensional) => unreachable!("LineString cannot be 2 dimensional"),
+        }
+    }
+}
+
+impl_contains_from_relate!(Triangle<T>, [ Polygon<T>, MultiPoint<T>, MultiLineString<T>, MultiPolygon<T>, GeometryCollection<T>, Triangle<T>]);
 impl_contains_geometry_for!(Triangle<T>);
+
+#[cfg(test)]
+mod tests_linestring {
+    use super::*;
+    use crate::{coord, line_string};
+
+    #[test]
+    fn rect_contains_linestring() {
+        let tri = Triangle::new(
+            coord! {x:0.,y:0.},
+            coord! {x:10.,y:0.},
+            coord! {x:10.,y:10.},
+        );
+        let ls_within = line_string![(x: 3., y: 2.),(x: 5., y: 3.),];
+        let ls_boundary = LineString::from_iter(tri.exterior_coords_iter());
+        let ls_cross_in = line_string![(x: 1., y: 0.),(x:10., y: 1.),];
+        let ls_cross_out = line_string![(x: 0., y: 0.),(x: 10., y: 11.),];
+
+        assert!(tri.contains(&ls_within));
+        assert!(!tri.contains(&ls_boundary));
+        assert!(tri.contains(&ls_cross_in));
+        assert!(!tri.contains(&ls_cross_out));
+    }
+}
 
 #[cfg(test)]
 mod test_triangle {

--- a/geo/src/algorithm/contains/triangle.rs
+++ b/geo/src/algorithm/contains/triangle.rs
@@ -255,7 +255,27 @@ mod test_rect {
 #[cfg(test)]
 mod test_line {
     use super::*;
-    use crate::{coord, Line, Point, Relate, Triangle};
+    use crate::{ coord, Line, Point, Relate, Triangle};
+
+    #[test]
+    fn triangle_i32(){
+        let tri = Triangle::new(
+            coord! {x:0, y:0},
+            coord! {x:10, y:0},
+            coord! {x:10, y:5},
+        );
+        let line_boundary = Line::new(Point::new(2, 1), Point::new(0, 0));
+        let line_within = Line::new(Point::new(0, 0), Point::new(10, 1));
+        let line_disjoint = Line::new(Point::new(0, -1), Point::new(10, -1));
+
+
+        assert!(!tri.contains(&line_boundary));
+        assert!(tri.contains(&line_within));
+        assert!(!tri.contains(&line_disjoint));
+
+    }
+
+
 
     #[test]
     fn triangle2d_contains_line0d() {

--- a/geo/src/algorithm/contains/triangle.rs
+++ b/geo/src/algorithm/contains/triangle.rs
@@ -427,3 +427,12 @@ mod test_line {
         assert!(ln.relate(&ln).is_contains());
     }
 }
+
+#[cfg(test)]
+mod test_multilinestring {}
+
+#[cfg(test)]
+mod test_polygon {}
+
+#[cfg(test)]
+mod test_multipolygon {}

--- a/geo/triangle-contains-triangle.md
+++ b/geo/triangle-contains-triangle.md
@@ -1,0 +1,58 @@
+for two non degenerate convex polygons, if all points of a lie in b, then b contains a
+
+   // bounding box check
+        // bounding box self !contains bounding box rhs iff 
+        // (1) bounding box b is degenerate and lies on bounding box a or (2) some part of b not in a  
+        // if case (1), then there canno be any part of b within a
+        // if case (2), then a cannot contains b
+        // and rect contains rect is cheap
+```
+triangle contains triangle (Contains Trait)
+                        time:   [16.831 ns 16.899 ns 16.968 ns]
+                        change: [-99.548% -99.544% -99.540%] (p = 0.00 < 0.05)
+                        Performance has improved.
+Found 1 outliers among 100 measurements (1.00%)
+  1 (1.00%) high severe
+
+triangle contains triangle (Relate Trait)
+                        time:   [3.7257 µs 3.7362 µs 3.7473 µs]
+                        change: [+3.1596% +3.5874% +4.0676%] (p = 0.00 < 0.05)
+                        Performance has regressed.
+Found 8 outliers among 100 measurements (8.00%)
+  1 (1.00%) low mild
+  6 (6.00%) high mild
+  1 (1.00%) high severe
+```
+
+```
+triangle disjoint triangle disjoint bounding box(Contains Trait)
+                        time:   [3.4483 ns 3.4639 ns 3.4848 ns]
+                        change: [-57.537% -57.185% -56.744%] (p = 0.00 < 0.05)
+                        Performance has improved.
+Found 11 outliers among 100 measurements (11.00%)
+  5 (5.00%) high mild
+  6 (6.00%) high severe
+
+triangle disjoint triangle  disjoint bounding box (Relate Trait)
+                        time:   [12.894 ns 12.927 ns 12.966 ns]
+                        change: [+53.795% +54.311% +54.854%] (p = 0.00 < 0.05)
+                        Performance has regressed.
+Found 4 outliers among 100 measurements (4.00%)
+  2 (2.00%) high mild
+  2 (2.00%) high severe
+```
+
+```
+triangle disjoint triangle overlapping bounding box (Contains Trait)
+                        time:   [12.639 ns 12.684 ns 12.730 ns]
+                        change: [-99.604% -99.603% -99.601%] (p = 0.00 < 0.05)
+                        Performance has improved.
+
+triangle disjoint triangle overlapping bounding box (Relate Trait)
+                        time:   [3.2598 µs 3.2698 µs 3.2807 µs]
+                        change: [+2.4239% +2.8904% +3.3359%] (p = 0.00 < 0.05)
+                        Performance has regressed.
+Found 3 outliers among 100 measurements (3.00%)
+  2 (2.00%) high mild
+  1 (1.00%) high severe
+```


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
1. Handle degenerate cases in Rect contains Rect
1. Exploiting the properties of simple convex polygons to speed up the execution time of `Rect.contains` and `Triangle.contains` methods  

benchmarks and casual proofs in the committed markdown files

Draft as its still only partially complete, looking for challenging integer test cases because these implementations should work for them