### PR TITLE
More consistent sweep benches

### DIFF
--- a/geo/benches/sweep_line_intersection.rs
+++ b/geo/benches/sweep_line_intersection.rs
@@ -59,11 +59,11 @@ fn bench_performance_comparison(c: &mut Criterion) {
     let mut rng = StdRng::seed_from_u64(42);
 
     // Test key sizes: crossover point, medium, and large datasets
-    for (n, sample_size) in [
-        (10, None),
-        (100, None),
-        (1_000, Some(100)),
-        (10_000, Some(10)),
+    for (n, sample_size, expected_intersections) in [
+        (10, None, 7),
+        (100, None, 1328),
+        (1_000, Some(100), 130_050),
+        (10_000, Some(10), 11_689_383),
     ] {
         let mut group = c.benchmark_group(&format!("Performance Comparison ({n} lines)"));
         if let Some(sample_size) = sample_size {
@@ -75,7 +75,8 @@ fn bench_performance_comparison(c: &mut Criterion) {
         // Brute force approach
         group.bench_function("brute_force", |b| {
             b.iter(|| {
-                black_box(brute_force_intersections(&lines));
+                let intersections = black_box(brute_force_intersections(&lines));
+                assert_eq!(intersections.len(), expected_intersections);
             });
         });
 
@@ -84,7 +85,7 @@ fn bench_performance_comparison(c: &mut Criterion) {
             b.iter(|| {
                 let intersections: Vec<_> =
                     NewSweepIntersections::<_>::from_iter(lines.iter().cloned()).collect();
-                black_box(intersections);
+                assert_eq!(intersections.len(), expected_intersections);
             });
         });
 

--- a/geo/benches/sweep_line_intersection.rs
+++ b/geo/benches/sweep_line_intersection.rs
@@ -62,7 +62,7 @@ fn bench_performance_comparison(c: &mut Criterion) {
     let mut rng = StdRng::seed_from_u64(42);
 
     // Test key sizes: crossover point, medium, and large datasets
-    for &n in &[1000, 5000, 10000] {
+    for &n in &[10, 100, 1000, 10000] {
         let lines = generate_random_lines(n, &mut rng);
 
         // Brute force approach

--- a/geo/benches/sweep_line_intersection.rs
+++ b/geo/benches/sweep_line_intersection.rs
@@ -21,22 +21,31 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use geo::algorithm::line_intersection::line_intersection;
 use geo::algorithm::sweep::Intersections as NewSweepIntersections;
-use geo::Line;
+use geo::{Destination, Euclidean, Line};
+use geo_types::Point;
 use rand::prelude::*;
 use std::iter::FromIterator;
 
-// Generate a set of random lines
-fn generate_random_lines(count: usize, rng: &mut impl Rng) -> Vec<Line<f64>> {
+/// Generate a set of random lines
+///
+/// The units of `density` aren't very meaningful, but a higher value will increase the likelihood of
+/// intersections between lines.
+/// For example
+///   - 0.1 will create relatively short lines, leading to fewer intersections
+///   - 4.0 will create relatively long lines, leading to more intersections
+fn generate_random_lines(count: usize, density: f64, rng: &mut impl Rng) -> Vec<Line<f64>> {
     let mut lines = Vec::with_capacity(count);
     for _ in 0..count {
         // Generate random coordinates within a bounded area
         // Using a bounded area increases the likelihood of intersections
         let x1 = rng.gen_range(-100.0..100.0);
         let y1 = rng.gen_range(-100.0..100.0);
-        let x2 = rng.gen_range(-100.0..100.0);
-        let y2 = rng.gen_range(-100.0..100.0);
+        let p1 = Point::new(x1, y1);
 
-        lines.push(Line::from([(x1, y1), (x2, y2)]));
+        let length = 200.0 * density * rng.gen_range(0.0..1.0);
+        let p2 = Euclidean.destination(p1, rng.gen_range(0.0..360.0), length);
+
+        lines.push(Line::new(p1, p2))
     }
     lines
 }
@@ -54,23 +63,21 @@ fn brute_force_intersections(lines: &[Line<f64>]) -> Vec<(Line<f64>, Line<f64>)>
     result
 }
 
-// Benchmark performance comparison across different dataset sizes
-fn bench_performance_comparison(c: &mut Criterion) {
+// Benchmark with "dense" case - lines with many intersections.
+// When intersections are dense, the sweep algorithm has less of an advantage vs. brute force.
+fn bench_dense_line_intersections(c: &mut Criterion) {
     let mut rng = StdRng::seed_from_u64(42);
-
-    // Test key sizes: crossover point, medium, and large datasets
     for (n, sample_size, expected_intersections) in [
         (10, None, 7),
-        (100, None, 1328),
-        (1_000, Some(100), 130_050),
-        (10_000, Some(10), 11_689_383),
+        (100, None, 861),
+        (1_000, Some(50), 91_898),
+        (10_000, Some(10), 8_570_900),
     ] {
-        let mut group = c.benchmark_group(&format!("Performance Comparison ({n} lines)"));
+        let mut group = c.benchmark_group(format!("Random dense lines ({n} lines)"));
         if let Some(sample_size) = sample_size {
             group.sample_size(sample_size);
         }
-
-        let lines = generate_random_lines(n, &mut rng);
+        let lines = generate_random_lines(n, 4.0, &mut rng);
 
         // Brute force approach
         group.bench_function("brute_force", |b| {
@@ -93,85 +100,41 @@ fn bench_performance_comparison(c: &mut Criterion) {
     }
 }
 
-// Benchmark with "dense" case - many lines in small area
-// The new algorithm should be faster here
-fn bench_dense_line_intersections(c: &mut Criterion) {
-    let mut group = c.benchmark_group("Dense Line Intersections");
-    group.sample_size(10);
-
-    // Create a grid of lines that will have many intersections
-    // expected intersections = (n / 2) * (n / 2);
-    let n = 1000;
-    let mut lines = Vec::with_capacity(n);
-
-    // Add horizontal and vertical lines (grid-like pattern guarantees many intersections)
-    for i in 0..n / 2 {
-        let pos = (i as f64) * 2.0 - (n as f64 / 2.0);
-        // Horizontal line
-        lines.push(Line::from([(-50.0, pos), (50.0, pos)]));
-        // Vertical line
-        lines.push(Line::from([(pos, -50.0), (pos, 50.0)]));
-    }
-
-    // Brute force approach
-    group.bench_function("brute_force_dense", |b| {
-        b.iter(|| {
-            black_box(brute_force_intersections(&lines));
-        });
-    });
-
-    group.bench_function("sweep_dense", |b| {
-        b.iter(|| {
-            let intersections: Vec<_> =
-                NewSweepIntersections::<_>::from_iter(lines.iter().cloned()).collect();
-            black_box(intersections);
-        });
-    });
-
-    group.finish();
-}
-
-// Benchmark with sparse large dataset: should be faster
-fn bench_sparse_large_dataset(c: &mut Criterion) {
-    let mut group = c.benchmark_group("Sparse Large Dataset");
-    group.sample_size(10);
-
+// Benchmark with "sparse" case - lines with few intersections.
+// When intersections are sparse, the sweep algorithm tends to perform much better than brute force.
+fn bench_sparse_line_intersections(c: &mut Criterion) {
     let mut rng = StdRng::seed_from_u64(42);
+    for (n, sample_size, expected_intersections) in [
+        (10, None, 0),
+        (100, None, 0),
+        (1_000, Some(50), 10),
+        (10_000, Some(10), 796),
+    ] {
+        let mut group = c.benchmark_group(format!("Random sparse lines ({n} lines)"));
+        if let Some(sample_size) = sample_size {
+            group.sample_size(sample_size);
+        }
+        let lines = generate_random_lines(n, 0.01, &mut rng);
 
-    // Generate 10,000 lines with few intersections
-    let n = 10_000;
-    let mut lines = Vec::with_capacity(n);
+        // Brute force approach
+        group.bench_function("brute_force", |b| {
+            b.iter(|| {
+                let intersections = black_box(brute_force_intersections(&lines));
+                assert_eq!(intersections.len(), expected_intersections);
+            });
+        });
 
-    // Create mostly parallel lines with small variations
-    for i in 0..n {
-        let stripe = i / 100;
-        let base_x = (stripe % 20) as f64 * 10.0;
-        let base_y = (stripe / 20) as f64 * 10.0;
-        let angle = (i % 100) as f64 * 0.005;
+        // Sweep line algorithm
+        group.bench_function("sweep", |b| {
+            b.iter(|| {
+                let intersections: Vec<_> =
+                    NewSweepIntersections::<_>::from_iter(lines.iter().cloned()).collect();
+                assert_eq!(intersections.len(), expected_intersections);
+            });
+        });
 
-        let x1 = base_x + rng.gen_range(-1.0..1.0);
-        let y1 = base_y + rng.gen_range(-1.0..1.0);
-        let x2 = x1 + 5.0 * angle.cos();
-        let y2 = y1 + 5.0 * angle.sin();
-
-        lines.push(Line::from([(x1, y1), (x2, y2)]));
+        group.finish();
     }
-
-    group.bench_function("sparse_sweep_10000", |b| {
-        b.iter(|| {
-            let intersections: Vec<_> =
-                NewSweepIntersections::<_>::from_iter(lines.iter().cloned()).collect();
-            black_box(intersections);
-        });
-    });
-
-    group.bench_function("sparse_brute_force_10000", |b| {
-        b.iter(|| {
-            black_box(brute_force_intersections(&lines));
-        });
-    });
-
-    group.finish();
 }
 
 fn generate_random_line(rng: &mut impl Rng) -> Line<f64> {
@@ -185,7 +148,6 @@ fn generate_random_line(rng: &mut impl Rng) -> Line<f64> {
 // Benchmark edge cases
 fn bench_essential_edge_cases(c: &mut Criterion) {
     let mut group = c.benchmark_group("Essential Edge Cases");
-    group.sample_size(10);
 
     let mut rng = StdRng::seed_from_u64(42);
 
@@ -309,8 +271,6 @@ fn bench_essential_edge_cases(c: &mut Criterion) {
 // Additional benchmark for real-world-like patterns
 fn bench_realistic_patterns(c: &mut Criterion) {
     let mut group = c.benchmark_group("Realistic Patterns");
-    group.sample_size(10);
-
     let mut rng = StdRng::seed_from_u64(42);
 
     // Pattern 1: Road network simulation (mostly non-intersecting with some crossings)
@@ -410,9 +370,8 @@ fn bench_realistic_patterns(c: &mut Criterion) {
 
 criterion_group!(
     benches,
-    bench_performance_comparison,
     bench_dense_line_intersections,
-    bench_sparse_large_dataset,
+    bench_sparse_line_intersections,
     bench_essential_edge_cases,
     bench_realistic_patterns
 );


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [n/a] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Inspired by #1358, I had some ideas to further improve the intersection calculations.

I was seeing some pretty large oscillations in the benchmarks, and so wanted to start by first making these particular benchmarks a little more robust.
