### PR TITLE
sweep line perf

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -2,6 +2,23 @@
 
 # Unreleased
 
+- BREAKING: `Intersections` no longer implements `Iterator` directly.
+  Before:
+  ```rust
+  for intersection in Intersections::from_iter(lines) {
+      foo(intersection)
+  }
+  ```
+
+  After:
+  ```rust
+  for intersection in Intersections::from_iter(lines).iter() {
+      foo(intersection)
+  }
+  ```
+- `Intersections` no longer `panic`'s when given pathological input (and it's typically much faster!)
+  - <https://github.com/georust/geo/pull/1387>
+  - <https://github.com/georust/geo/pull/1358>
 - Added: Geometry buffering to "grow" or "shrink" a geometry by creating a buffer whose boundary is the specified offset from the input.
   - <https://github.com/georust/geo/pull/1365>
 - BREAKING: `BoolOpsNum` must now implement GeoFloat, not just GeoNum. In practice, this shouldn't break for any concrete types (like f32, f64).

--- a/geo/benches/sweep_line_intersection.rs
+++ b/geo/benches/sweep_line_intersection.rs
@@ -11,20 +11,18 @@
 //!
 //! To run specific benchmark groups:
 //! ```
-//! cargo bench --bench sweep_line_intersection "Performance Comparison"
-//! cargo bench --bench sweep_line_intersection "Dense Line Intersections"
-//! cargo bench --bench sweep_line_intersection "Sparse Large Dataset"
+//! cargo bench --bench sweep_line_intersection "Random Dense Lines"
+//! cargo bench --bench sweep_line_intersection "Random Sparse Lines"
 //! cargo bench --bench sweep_line_intersection "Essential Edge Cases"
 //! cargo bench --bench sweep_line_intersection "Realistic Patterns"
 //! ```
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use geo::algorithm::line_intersection::line_intersection;
-use geo::algorithm::sweep::Intersections as NewSweepIntersections;
+use geo::algorithm::sweep::Intersections;
 use geo::{Destination, Euclidean, Line};
 use geo_types::Point;
 use rand::prelude::*;
-use std::iter::FromIterator;
 
 /// Generate a set of random lines
 ///
@@ -66,14 +64,14 @@ fn brute_force_intersections(lines: &[Line<f64>]) -> Vec<(Line<f64>, Line<f64>)>
 // Benchmark with "dense" case - lines with many intersections.
 // When intersections are dense, the sweep algorithm has less of an advantage vs. brute force.
 fn bench_dense_line_intersections(c: &mut Criterion) {
-    let mut rng = StdRng::seed_from_u64(42);
     for (n, sample_size, expected_intersections) in [
         (10, None, 7),
-        (100, None, 861),
-        (1_000, Some(50), 91_898),
-        (10_000, Some(10), 8_570_900),
+        (100, None, 827),
+        (1_000, Some(50), 90_438),
+        (10_000, Some(10), 8_604_894),
     ] {
-        let mut group = c.benchmark_group(format!("Random dense lines ({n} lines)"));
+        let mut rng = StdRng::seed_from_u64(42);
+        let mut group = c.benchmark_group(format!("Random Dense Lines ({n} lines)"));
         if let Some(sample_size) = sample_size {
             group.sample_size(sample_size);
         }
@@ -90,8 +88,9 @@ fn bench_dense_line_intersections(c: &mut Criterion) {
         // Sweep line algorithm
         group.bench_function("sweep", |b| {
             b.iter(|| {
-                let intersections: Vec<_> =
-                    NewSweepIntersections::<_>::from_iter(lines.iter().cloned()).collect();
+                let intersections: Vec<_> = Intersections::from_iter(lines.iter().cloned())
+                    .iter()
+                    .collect();
                 assert_eq!(intersections.len(), expected_intersections);
             });
         });
@@ -103,14 +102,14 @@ fn bench_dense_line_intersections(c: &mut Criterion) {
 // Benchmark with "sparse" case - lines with few intersections.
 // When intersections are sparse, the sweep algorithm tends to perform much better than brute force.
 fn bench_sparse_line_intersections(c: &mut Criterion) {
-    let mut rng = StdRng::seed_from_u64(42);
     for (n, sample_size, expected_intersections) in [
         (10, None, 0),
         (100, None, 0),
-        (1_000, Some(50), 10),
-        (10_000, Some(10), 796),
+        (1_000, Some(50), 11),
+        (10_000, Some(10), 798),
     ] {
-        let mut group = c.benchmark_group(format!("Random sparse lines ({n} lines)"));
+        let mut rng = StdRng::seed_from_u64(42);
+        let mut group = c.benchmark_group(format!("Random Sparse Lines ({n} lines)"));
         if let Some(sample_size) = sample_size {
             group.sample_size(sample_size);
         }
@@ -127,8 +126,9 @@ fn bench_sparse_line_intersections(c: &mut Criterion) {
         // Sweep line algorithm
         group.bench_function("sweep", |b| {
             b.iter(|| {
-                let intersections: Vec<_> =
-                    NewSweepIntersections::<_>::from_iter(lines.iter().cloned()).collect();
+                let intersections: Vec<_> = Intersections::from_iter(lines.iter().cloned())
+                    .iter()
+                    .collect();
                 assert_eq!(intersections.len(), expected_intersections);
             });
         });
@@ -174,8 +174,9 @@ fn bench_essential_edge_cases(c: &mut Criterion) {
 
         group.bench_function("collinear_segments_sweep", |b| {
             b.iter(|| {
-                let intersections: Vec<_> =
-                    NewSweepIntersections::<_>::from_iter(lines.iter().cloned()).collect();
+                let intersections: Vec<_> = Intersections::from_iter(lines.iter().cloned())
+                    .iter()
+                    .collect();
                 black_box(intersections);
             });
         });
@@ -252,8 +253,9 @@ fn bench_essential_edge_cases(c: &mut Criterion) {
 
         group.bench_function("numerical_precision_sweep", |b| {
             b.iter(|| {
-                let intersections: Vec<_> =
-                    NewSweepIntersections::<_>::from_iter(lines.iter().cloned()).collect();
+                let intersections: Vec<_> = Intersections::from_iter(lines.iter().cloned())
+                    .iter()
+                    .collect();
                 black_box(intersections);
             });
         });
@@ -311,8 +313,9 @@ fn bench_realistic_patterns(c: &mut Criterion) {
 
         group.bench_function("road_network_sweep", |b| {
             b.iter(|| {
-                let intersections: Vec<_> =
-                    NewSweepIntersections::<_>::from_iter(lines.iter().cloned()).collect();
+                let intersections: Vec<_> = Intersections::from_iter(lines.iter().cloned())
+                    .iter()
+                    .collect();
                 black_box(intersections);
             });
         });
@@ -352,8 +355,9 @@ fn bench_realistic_patterns(c: &mut Criterion) {
 
         group.bench_function("polygon_boundaries_sweep", |b| {
             b.iter(|| {
-                let intersections: Vec<_> =
-                    NewSweepIntersections::<_>::from_iter(lines.iter().cloned()).collect();
+                let intersections: Vec<_> = Intersections::from_iter(lines.iter().cloned())
+                    .iter()
+                    .collect();
                 black_box(intersections);
             });
         });

--- a/geo/benches/utils/crossings.rs
+++ b/geo/benches/utils/crossings.rs
@@ -1,14 +1,12 @@
 #![allow(dead_code)]
 
-use std::iter::FromIterator;
-
 use geo::algorithm::sweep::Intersections;
 use geo::{line_intersection::line_intersection, Line};
 
 use rstar::{primitives::GeomWithData, RTree};
 
 pub fn count_bo(lines: Vec<Line<f64>>) -> usize {
-    Intersections::from_iter(lines).count()
+    Intersections::from_iter(lines).iter().count()
 }
 
 pub fn count_brute(lines: &[Line<f64>]) -> usize {

--- a/geo/src/algorithm/interior_point.rs
+++ b/geo/src/algorithm/interior_point.rs
@@ -193,7 +193,7 @@ fn polygon_interior_point_with_segment_length<T: GeoFloat>(
     let lines = polygon.lines_iter().chain(std::iter::once(scan_line));
 
     let mut intersections: Vec<Point<T>> = Vec::new();
-    for (l1, l2, inter) in Intersections::from_iter(lines) {
+    for (l1, l2, inter) in Intersections::from_iter(lines).iter() {
         if !(l1 == scan_line || l2 == scan_line) {
             continue;
         }

--- a/geo/src/algorithm/old_sweep/iter.rs
+++ b/geo/src/algorithm/old_sweep/iter.rs
@@ -180,7 +180,7 @@ where
 /// See the trait documentation for more information on usage with
 /// custom types.
 ///
-/// ```rust
+/// ```rust,ignore
 /// use geo::Line;
 /// use geo::sweep::Intersections;
 /// use std::iter::FromIterator;

--- a/geo/src/algorithm/sweep/tests.rs
+++ b/geo/src/algorithm/sweep/tests.rs
@@ -1,6 +1,5 @@
 use super::*;
 use crate::algorithm::line_intersection::line_intersection;
-use std::iter::FromIterator;
 
 fn compute_brute_force_intersections<T: GeoFloat>(
     lines: &[Line<T>],
@@ -19,8 +18,9 @@ fn compute_brute_force_intersections<T: GeoFloat>(
 /// Helper function to verify that sweep line and brute force find the same intersections
 fn verify_intersections(lines: &[Line<f64>]) {
     // Get intersections using both algorithms
-    let sweep_intersections: Vec<_> =
-        Intersections::<_>::from_iter(lines.iter().cloned()).collect();
+    let sweep_intersections: Vec<_> = Intersections::<_>::new(lines.iter().cloned())
+        .iter()
+        .collect();
     let brute_force_intersections = compute_brute_force_intersections(lines);
 
     // Check for same count
@@ -151,7 +151,7 @@ fn test_iterator_behavior() {
     ];
 
     // They intersect at (0.5, 0.5)
-    let intersections: Vec<_> = Intersections::<_>::from_iter(input).collect();
+    let intersections: Vec<_> = Intersections::<_>::new(input).iter().collect();
 
     // There should be one intersection
     assert_eq!(intersections.len(), 1);
@@ -224,7 +224,9 @@ fn test_debug_grid_algorithm() {
         // Expected number of intersections in grid
         let expected_intersections = size * size;
 
-        let sweep_results: Vec<_> = Intersections::<_>::from_iter(lines.iter().cloned()).collect();
+        let sweep_results: Vec<_> = Intersections::<_>::new(lines.iter().cloned())
+            .iter()
+            .collect();
         assert_eq!(
             sweep_results.len(),
             expected_intersections,


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [n/a] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
  -  Since we haven't released the new Sweep, it seems redundant to add another changelog entry. 
---

While studying the new BO implementation, I kept finding little pieces that I could strip off, which lead to multiple rounds of simplification until what remains is (subjectively) essential, and (less subjectively) faster.

First the benches: I'm finding them pretty noisy, even after #1386, but there are clearly some improvements. I'd be curious to see if others get similar results when running the bench vs. main.

## benches

**Random dense lines**

Sweep does best with sparse intersections, but it's decent for reasonably dense ones too! Only on the very small line sets did Sweep perform worse than brute-force, and on the very large sets it did significantly better than brute-force.

```
$ cargo bench --bench="sweep_line_intersection" -- --baseline=main
   Compiling geo v0.30.0 (/Users/mkirk/src/georust/geo/geo)
   Compiling jts-test-runner v0.1.0 (/Users/mkirk/src/georust/geo/jts-test-runner)
    Finished `bench` profile [optimized] target(s) in 5.81s
     Running benches/sweep_line_intersection.rs (target/release/deps/sweep_line_intersection-05f43c36d3715a21)
Gnuplot not found, using plotters backend
Random dense lines (10 lines)/brute_force
                        time:   [362.70 ns 364.29 ns 365.95 ns]
                        change: [-0.7102% -0.2557% +0.1699%] (p = 0.25 > 0.05)
                        No change in performance detected.
Random dense lines (10 lines)/sweep
                        time:   [528.17 ns 528.89 ns 529.69 ns]
                        change: [-32.666% -31.880% -31.208%] (p = 0.00 < 0.05)👍👍👍
                        Performance has improved.

Random dense lines (100 lines)/brute_force
                        time:   [56.225 µs 57.503 µs 58.815 µs]
                        change: [-3.1780% -0.9382% +1.3174%] (p = 0.43 > 0.05)
                        No change in performance detected.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild
Random dense lines (100 lines)/sweep
                        time:   [53.443 µs 54.006 µs 54.617 µs]
                        change: [-1.1526% +0.5026% +2.2079%] (p = 0.54 > 0.05) 🤷
                        No change in performance detected.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild

Random dense lines (1000 lines)/brute_force
                        time:   [9.7531 ms 9.8292 ms 9.9045 ms]
                        change: [+0.7552% +1.8500% +2.8884%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 50 measurements (2.00%)
  1 (2.00%) high mild
Random dense lines (1000 lines)/sweep
                        time:   [8.3380 ms 8.4277 ms 8.5149 ms]
                        change: [-14.630% -13.278% -11.909%] (p = 0.00 < 0.05)👍
                        Performance has improved.

Benchmarking Random dense lines (10000 lines)/brute_force: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 9.2s.
Random dense lines (10000 lines)/brute_force
                        time:   [928.95 ms 931.58 ms 934.19 ms]
                        change: [+0.9622% +1.3817% +1.7846%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Benchmarking Random dense lines (10000 lines)/sweep: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 7.9s.
Random dense lines (10000 lines)/sweep
                        time:   [783.34 ms 783.93 ms 784.55 ms]
                        change: [-10.387% -9.7930% -9.2555%] (p = 0.00 < 0.05)👍
                        Performance has improved.
Found 3 outliers among 10 measurements (30.00%)
  1 (10.00%) low mild
  2 (20.00%) high mild
```

**random sparse lines**

Sweep does best with sparse intersections. These benches saw similar improvement (maybe even slightly better) than the dense case, further widening the gap between Sweep and brute-force.

```
Random sparse lines (10 lines)/brute_force
                        time:   [178.51 ns 178.60 ns 178.69 ns]
                        change: [-0.4702% -0.3432% -0.2204%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 13 outliers among 100 measurements (13.00%)
  3 (3.00%) low severe
  4 (4.00%) low mild
  6 (6.00%) high mild
Random sparse lines (10 lines)/sweep
                        time:   [160.37 ns 160.76 ns 161.19 ns]
                        change: [-52.347% -52.190% -52.039%] (p = 0.00 < 0.05)👍👍👍
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  10 (10.00%) high mild
  1 (1.00%) high severe

Random sparse lines (100 lines)/brute_force
                        time:   [19.197 µs 19.212 µs 19.231 µs]
                        change: [-0.1152% -0.0119% +0.0959%] (p = 0.83 > 0.05)
                        No change in performance detected.
Found 10 outliers among 100 measurements (10.00%)
  2 (2.00%) low mild
  3 (3.00%) high mild
  5 (5.00%) high severe
Random sparse lines (100 lines)/sweep
                        time:   [1.6400 µs 1.6449 µs 1.6501 µs]
                        change: [-54.479% -54.130% -53.832%] (p = 0.00 < 0.05)👍👍👍
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  6 (6.00%) high mild

Random sparse lines (1000 lines)/brute_force
                        time:   [1.9031 ms 1.9051 ms 1.9076 ms]
                        change: [-0.2159% +0.0024% +0.2208%] (p = 0.99 > 0.05)
                        No change in performance detected.
Found 8 outliers among 50 measurements (16.00%)
  5 (10.00%) high mild
  3 (6.00%) high severe
Random sparse lines (1000 lines)/sweep
                        time:   [63.467 µs 65.359 µs 67.189 µs]
                        change: [-37.712% -35.861% -33.825%] (p = 0.00 < 0.05)👍👍👍
                        Performance has improved.

Random sparse lines (10000 lines)/brute_force
                        time:   [190.13 ms 190.35 ms 190.60 ms]
                        change: [-0.0380% +0.0959% +0.2384%] (p = 0.22 > 0.05)
                        No change in performance detected.
Random sparse lines (10000 lines)/sweep
                        time:   [2.0398 ms 2.0425 ms 2.0456 ms]
                        change: [-13.212% -12.363% -11.619%] (p = 0.00 < 0.05)👍
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
```

The "edge cases and realistic" benches saw mixed changes, but mostly positive. 

```
Essential Edge Cases/collinear_segments_sweep
                        time:   [195.72 µs 198.49 µs 201.20 µs]
                        change: [-5.7581% -4.6444% -3.5904%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  6 (6.00%) low mild
Benchmarking Essential Edge Cases/collinear_segments_brute_force: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 9.6s, enable flat sampling, or reduce sample count to 50.
Essential Edge Cases/collinear_segments_brute_force
                        time:   [1.9052 ms 1.9104 ms 1.9196 ms]
                        change: [-0.1599% +0.0469% +0.2813%] (p = 0.69 > 0.05)
                        No change in performance detected.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe
Essential Edge Cases/numerical_precision_sweep
                        time:   [270.04 µs 272.16 µs 274.30 µs]
                        change: [-19.604% -18.756% -17.879%] (p = 0.00 < 0.05)👍👍
                        Performance has improved.
Benchmarking Essential Edge Cases/numerical_precision_brute_force: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 7.0s, enable flat sampling, or reduce sample count to 50.
Essential Edge Cases/numerical_precision_brute_force
                        time:   [1.3782 ms 1.3813 ms 1.3846 ms]
                        change: [-3.0719% -2.4662% -1.8839%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe

Realistic Patterns/road_network_sweep
                        time:   [2.1498 ms 2.1618 ms 2.1769 ms]
                        change: [+1.7014% +2.5660% +3.4966%] (p = 0.00 < 0.05) 🤷
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
Realistic Patterns/road_network_brute_force
                        time:   [47.600 ms 48.501 ms 49.572 ms]
                        change: [+3.0720% +4.7734% +7.2299%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 14 outliers among 100 measurements (14.00%)
  4 (4.00%) high mild
  10 (10.00%) high severe
Realistic Patterns/polygon_boundaries_sweep
                        time:   [257.92 µs 265.27 µs 272.30 µs]
                        change: [-20.730% -18.010% -15.211%] (p = 0.00 < 0.05) 👍
                        Performance has improved.
Realistic Patterns/polygon_boundaries_brute_force
                        time:   [5.2464 ms 5.3689 ms 5.5107 ms]
                        change: [+4.5549% +7.3895% +10.453%] (p = 0.00 < 0.05) 🤷
                        Performance has regressed.  
Found 12 outliers among 100 measurements (12.00%)
  1 (1.00%) high mild
  11 (11.00%) high severe
```

## Draft?

If we are going to merge this - I'd like to overhaul the docs to better match the implementation.

Even though the core algorithm flow is essentially the same old BO sweep, I've simplified it to the point that I'm not sure how recognizable it is - in particular I feel like talking about "events" sort of muddies the waters. It no longer coincides with the implementation, even though they are a part of the "spiritual" predecessor of this implementation. 

I'm currently leaning towards a top level doc, something like:

> If two segments intersect, their x values must overlap. Thus, to efficiently find all intersections between segments, we first narrow down the candidates to check for intersection by considering only segment pairs whose x-intersections overlap.
>
> To find overlapping x segments:
> 1. Take all segments and sort them by their minimum_x.
> 2. For each segment (the "current segment"), take all subsequent segments (those that start after the current segment), stopping once you find a segment that starts after the end of the current segment. All segments until then, are overlapping with the current segment.
> 3. These overlapping segments can then be checked for intersection

What do you think @urschrei? I imagine you spent a fair amount of effort writing up the current documentation, which explains the more classical translation of BO. Do you think it would be helpful to retain that language, even if only in the documentation?