### PR TITLE
dedupe graham hull and convex

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -27,6 +27,11 @@
   - <https://github.com/georust/geo/pull/1387>
   - <https://github.com/georust/geo/pull/1359>
 
+- Fix `is_convex` to correctly handle duplicate points
+- Fix`graham_hull` to correctly handle duplicate points when `on_hull` is set to true
+  - `graham_hull` now always returns a boundary with no duplicated points
+  - <https://github.com/georust/geo/issues/1383>
+
 ## 0.30.0 - 2025-03-24
 
 - Bump `geo` MSRV to 1.81

--- a/geo/src/algorithm/convex_hull/graham.rs
+++ b/geo/src/algorithm/convex_hull/graham.rs
@@ -5,7 +5,7 @@ use crate::{Coord, GeoNum, LineString};
 /// The [Graham's scan] algorithm to compute the convex hull
 /// of a collection of points. This algorithm is less
 /// performant than the quick hull, but allows computing all
-/// the points on the convex hull, as opposed to a strict
+/// the unique points on the convex hull, as opposed to a strict
 /// convex hull that does not include collinear points.
 ///
 /// # References

--- a/geo/src/algorithm/is_convex.rs
+++ b/geo/src/algorithm/is_convex.rs
@@ -289,7 +289,7 @@ mod tests {
     #[test]
     fn test_single_point() {
         // single point is closed
-        // will panic if is_empyt check in `is_convex_shaped` is removed
+        // will panic if is_empty check in `is_convex_shaped` is removed
         let ls: LineString<f64> = wkt! (LINESTRING (0 0)).convert();
         assert!(ls.is_strictly_convex());
     }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Fix for #1383 by de-duplicating adjacent points in the inputs  

Is there a better way to write the dedupe in `is_convex` without using itertools?
