### PR TITLE
`wkt!` macro for creating geometries gets support for non-standard variants: LINE/RECT/TRIANGLE

### DIFF
--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add support to `wkt!` geometry creation macro for `LINE`, `RECT`, and `TRIANGLE` geometries.
+  - <https://github.com/georust/geo/pull/1389>
 - Add `empty` convenience initializer for constructing empty geometries
   - <https://github.com/georust/geo/pull/1363>
 


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Note these are non-standard wkt - they wouldn't be parsable by an external parser. Maybe this is controversial...

I think they'll be easier to transform into valid wkt than the current representations, and it's a nice symmetry with the Debug representation, which already prints this format for Line, Rect, Triangle.
