### PR TITLE
Make new sweep generic (intersect your own types)

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -2,23 +2,6 @@
 
 # Unreleased
 
-- BREAKING: `Intersections` no longer implements `Iterator` directly.
-  Before:
-  ```rust
-  for intersection in Intersections::from_iter(lines) {
-      foo(intersection)
-  }
-  ```
-
-  After:
-  ```rust
-  for intersection in Intersections::from_iter(lines).iter() {
-      foo(intersection)
-  }
-  ```
-- `Intersections` no longer `panic`'s when given pathological input (and it's typically much faster!)
-  - <https://github.com/georust/geo/pull/1387>
-  - <https://github.com/georust/geo/pull/1358>
 - Added: Geometry buffering to "grow" or "shrink" a geometry by creating a buffer whose boundary is the specified offset from the input.
   - <https://github.com/georust/geo/pull/1365>
 - BREAKING: `BoolOpsNum` must now implement GeoFloat, not just GeoNum. In practice, this shouldn't break for any concrete types (like f32, f64).
@@ -33,8 +16,16 @@
 - Add `Bearing` and `Destination` trait implementations for `Euclidean`
 - Add `FillRule`-configurable boolean operations to `BooleanOps` trait
   - <https://github.com/georust/geo/pull/1382>
-- Add new implementation of the Bentley-Ottmann sweep-line algorithm to efficiently find sparse intersections between groups of lines.
+
+##  Update `Intersections` with new implementation of the Bentley-Ottmann sweep-line algorithm to efficiently find sparse intersections between groups of lines.
+
+- no longer `panic`'s when given pathological input
+- BREAKING: `Intersections` now computes intersections lazily
+- BREAKING: The `Crosses` trait used by `Intersections` now returns a `Line`, not a `LineOrPoint`.
+- BREAKING: The `Crosses` trait no longer needs to implement Clone
   - <https://github.com/georust/geo/pull/1358>
+  - <https://github.com/georust/geo/pull/1387>
+  - <https://github.com/georust/geo/pull/1359>
 
 ## 0.30.0 - 2025-03-24
 

--- a/geo/benches/sweep_line_intersection.rs
+++ b/geo/benches/sweep_line_intersection.rs
@@ -49,16 +49,13 @@ fn generate_random_lines(count: usize, density: f64, rng: &mut impl Rng) -> Vec<
 }
 
 // Benchmark the brute force approach (O(n²))
-fn brute_force_intersections(lines: &[Line<f64>]) -> Vec<(Line<f64>, Line<f64>)> {
-    let mut result = Vec::new();
-    for i in 0..lines.len() {
-        for j in (i + 1)..lines.len() {
-            if line_intersection(lines[i], lines[j]).is_some() {
-                result.push((lines[i], lines[j]));
-            }
-        }
-    }
-    result
+fn brute_force_intersections(
+    lines: &[Line<f64>],
+) -> impl Iterator<Item = (Line<f64>, Line<f64>)> + '_ {
+    (0..lines.len()).flat_map(move |i| {
+        ((i + 1)..lines.len())
+            .flat_map(move |j| line_intersection(lines[i], lines[j]).map(|_| (lines[i], lines[j])))
+    })
 }
 
 // Benchmark with "dense" case - lines with many intersections.
@@ -80,18 +77,16 @@ fn bench_dense_line_intersections(c: &mut Criterion) {
         // Brute force approach
         group.bench_function("brute_force", |b| {
             b.iter(|| {
-                let intersections = black_box(brute_force_intersections(&lines));
-                assert_eq!(intersections.len(), expected_intersections);
+                let intersections = black_box(brute_force_intersections(&lines)).count();
+                assert_eq!(intersections, expected_intersections);
             });
         });
 
         // Sweep line algorithm
         group.bench_function("sweep", |b| {
             b.iter(|| {
-                let intersections: Vec<_> = Intersections::from_iter(lines.iter().cloned())
-                    .iter()
-                    .collect();
-                assert_eq!(intersections.len(), expected_intersections);
+                let intersections = Intersections::from_iter(&lines).count();
+                assert_eq!(intersections, expected_intersections);
             });
         });
 
@@ -118,18 +113,16 @@ fn bench_sparse_line_intersections(c: &mut Criterion) {
         // Brute force approach
         group.bench_function("brute_force", |b| {
             b.iter(|| {
-                let intersections = black_box(brute_force_intersections(&lines));
-                assert_eq!(intersections.len(), expected_intersections);
+                let intersections = black_box(brute_force_intersections(&lines)).count();
+                assert_eq!(intersections, expected_intersections);
             });
         });
 
         // Sweep line algorithm
         group.bench_function("sweep", |b| {
             b.iter(|| {
-                let intersections: Vec<_> = Intersections::from_iter(lines.iter().cloned())
-                    .iter()
-                    .collect();
-                assert_eq!(intersections.len(), expected_intersections);
+                let intersections = Intersections::from_iter(&lines).count();
+                assert_eq!(intersections, expected_intersections);
             });
         });
 
@@ -174,16 +167,15 @@ fn bench_essential_edge_cases(c: &mut Criterion) {
 
         group.bench_function("collinear_segments_sweep", |b| {
             b.iter(|| {
-                let intersections: Vec<_> = Intersections::from_iter(lines.iter().cloned())
-                    .iter()
-                    .collect();
+                let intersections = Intersections::from_iter(&lines).count();
                 black_box(intersections);
             });
         });
 
         group.bench_function("collinear_segments_brute_force", |b| {
             b.iter(|| {
-                black_box(brute_force_intersections(&lines));
+                let intersections = brute_force_intersections(&lines).count();
+                black_box(intersections);
             });
         });
     }
@@ -253,16 +245,15 @@ fn bench_essential_edge_cases(c: &mut Criterion) {
 
         group.bench_function("numerical_precision_sweep", |b| {
             b.iter(|| {
-                let intersections: Vec<_> = Intersections::from_iter(lines.iter().cloned())
-                    .iter()
-                    .collect();
+                let intersections = Intersections::from_iter(&lines).count();
                 black_box(intersections);
             });
         });
 
         group.bench_function("numerical_precision_brute_force", |b| {
             b.iter(|| {
-                black_box(brute_force_intersections(&lines));
+                let intersections = brute_force_intersections(&lines).count();
+                black_box(intersections);
             });
         });
     }
@@ -313,16 +304,15 @@ fn bench_realistic_patterns(c: &mut Criterion) {
 
         group.bench_function("road_network_sweep", |b| {
             b.iter(|| {
-                let intersections: Vec<_> = Intersections::from_iter(lines.iter().cloned())
-                    .iter()
-                    .collect();
+                let intersections = Intersections::from_iter(&lines).count();
                 black_box(intersections);
             });
         });
 
         group.bench_function("road_network_brute_force", |b| {
             b.iter(|| {
-                black_box(brute_force_intersections(&lines));
+                let intersections = brute_force_intersections(&lines).count();
+                black_box(intersections);
             });
         });
     }
@@ -355,16 +345,15 @@ fn bench_realistic_patterns(c: &mut Criterion) {
 
         group.bench_function("polygon_boundaries_sweep", |b| {
             b.iter(|| {
-                let intersections: Vec<_> = Intersections::from_iter(lines.iter().cloned())
-                    .iter()
-                    .collect();
+                let intersections = Intersections::from_iter(&lines).count();
                 black_box(intersections);
             });
         });
 
         group.bench_function("polygon_boundaries_brute_force", |b| {
             b.iter(|| {
-                black_box(brute_force_intersections(&lines));
+                let intersections = brute_force_intersections(&lines).count();
+                black_box(intersections);
             });
         });
     }

--- a/geo/benches/utils/crossings.rs
+++ b/geo/benches/utils/crossings.rs
@@ -6,7 +6,7 @@ use geo::{line_intersection::line_intersection, Line};
 use rstar::{primitives::GeomWithData, RTree};
 
 pub fn count_bo(lines: Vec<Line<f64>>) -> usize {
-    Intersections::from_iter(lines).iter().count()
+    Intersections::from_iter(lines).count()
 }
 
 pub fn count_brute(lines: &[Line<f64>]) -> usize {

--- a/geo/src/algorithm/interior_point.rs
+++ b/geo/src/algorithm/interior_point.rs
@@ -193,7 +193,7 @@ fn polygon_interior_point_with_segment_length<T: GeoFloat>(
     let lines = polygon.lines_iter().chain(std::iter::once(scan_line));
 
     let mut intersections: Vec<Point<T>> = Vec::new();
-    for (l1, l2, inter) in Intersections::from_iter(lines).iter() {
+    for (l1, l2, inter) in Intersections::from_iter(lines) {
         if !(l1 == scan_line || l2 == scan_line) {
             continue;
         }

--- a/geo/src/algorithm/sweep/cross.rs
+++ b/geo/src/algorithm/sweep/cross.rs
@@ -1,0 +1,54 @@
+use crate::GeoFloat;
+use geo_types::Line;
+use std::rc::Rc;
+use std::sync::Arc;
+
+/// A 1-dimensional finite line used as input to [`Intersections`](super::Intersections).
+///
+/// This is implemented by [`Line`], but you can implement it on your own
+/// type if you'd like to associate some other data with it.
+///
+/// # Cloning
+///
+/// Note that for usage with the `Intersections` iterator, the type must
+/// also impl. `Clone`. If the custom type is not cheap to clone, use
+/// either a reference to the type, a [`Rc`] or an [`Arc`]. All these
+/// are supported via blanket trait implementations.
+pub trait Cross {
+    /// Scalar used by the line coordinates.
+    type Scalar: GeoFloat;
+
+    /// The geometry associated with this type.
+    fn line(&self) -> Line<Self::Scalar>;
+}
+
+impl<T: GeoFloat> Cross for Line<T> {
+    type Scalar = T;
+
+    fn line(&self) -> Line<Self::Scalar> {
+        *self
+    }
+}
+
+impl<C: Cross> Cross for &C {
+    type Scalar = C::Scalar;
+
+    fn line(&self) -> Line<Self::Scalar> {
+        C::line(*self)
+    }
+}
+
+macro_rules! blanket_impl_smart_pointer {
+    ($ty:ty) => {
+        impl<T: Cross> Cross for $ty {
+            type Scalar = T::Scalar;
+
+            fn line(&self) -> Line<Self::Scalar> {
+                T::line(self)
+            }
+        }
+    };
+}
+blanket_impl_smart_pointer!(Box<T>);
+blanket_impl_smart_pointer!(Rc<T>);
+blanket_impl_smart_pointer!(Arc<T>);

--- a/geo/src/algorithm/sweep/tests.rs
+++ b/geo/src/algorithm/sweep/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::algorithm::line_intersection::line_intersection;
+use crate::{GeoFloat, Line};
 
 fn compute_brute_force_intersections<T: GeoFloat>(
     lines: &[Line<T>],
@@ -18,9 +19,7 @@ fn compute_brute_force_intersections<T: GeoFloat>(
 /// Helper function to verify that sweep line and brute force find the same intersections
 fn verify_intersections(lines: &[Line<f64>]) {
     // Get intersections using both algorithms
-    let sweep_intersections: Vec<_> = Intersections::<_>::new(lines.iter().cloned())
-        .iter()
-        .collect();
+    let sweep_intersections: Vec<_> = Intersections::from_iter(lines).collect();
     let brute_force_intersections = compute_brute_force_intersections(lines);
 
     // Check for same count
@@ -36,8 +35,7 @@ fn verify_intersections(lines: &[Line<f64>]) {
     // and that their intersection details match
     for (bf_line1, bf_line2, bf_intersection) in &brute_force_intersections {
         let matching_intersection = sweep_intersections.iter().find(|(line1, line2, _)| {
-            (*line1 == *bf_line1 && *line2 == *bf_line2)
-                || (*line1 == *bf_line2 && *line2 == *bf_line1)
+            (*line1 == bf_line1 && *line2 == bf_line2) || (*line1 == bf_line2 && *line2 == bf_line1)
         });
 
         assert!(
@@ -94,10 +92,9 @@ fn verify_intersections(lines: &[Line<f64>]) {
     }
 
     // Check that all sweep intersections are found by brute force
-    for (sw_line1, sw_line2, _) in &sweep_intersections {
+    for (sw_line1, sw_line2, _) in sweep_intersections {
         let found = brute_force_intersections.iter().any(|(line1, line2, _)| {
-            (*line1 == *sw_line1 && *line2 == *sw_line2)
-                || (*line1 == *sw_line2 && *line2 == *sw_line1)
+            (line1 == sw_line1 && line2 == sw_line2) || (line1 == sw_line2 && line2 == sw_line1)
         });
 
         assert!(
@@ -151,7 +148,7 @@ fn test_iterator_behavior() {
     ];
 
     // They intersect at (0.5, 0.5)
-    let intersections: Vec<_> = Intersections::<_>::new(input).iter().collect();
+    let intersections: Vec<_> = Intersections::from_iter(&input).collect();
 
     // There should be one intersection
     assert_eq!(intersections.len(), 1);
@@ -224,9 +221,7 @@ fn test_debug_grid_algorithm() {
         // Expected number of intersections in grid
         let expected_intersections = size * size;
 
-        let sweep_results: Vec<_> = Intersections::<_>::new(lines.iter().cloned())
-            .iter()
-            .collect();
+        let sweep_results: Vec<_> = Intersections::from_iter(&lines).collect();
         assert_eq!(
             sweep_results.len(),
             expected_intersections,


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Restores the ability to compute Intersection between foreign types (restores the `Cross` trait) as mentioned in https://github.com/georust/geo/pull/1358#issuecomment-3083898459

You'll note there's more than that in this PR, but it's all related fallout. It's fair to call it "churn", which is a little embarassing. I could undo parts of this if it's controversial. 

Most notably, I restored the original API:

Recall that originally, user code looked like this: 
```
let intersections: Vec<_> = Intersections::from(lines).collect()
```

This API was maintained in #1358.

As of #1387, it became just a little worse:  
```
let intersections: Vec<_> = Intersections::from(lines).iter().collect()
```

Then, with my first attempt at re-introducing the generic `Cross` trait in this branch, the above code started producing an error like "dropping of temporary value". I think because the iterator is returning references to these `Cross`es, but I confess I didn't really nail down my understanding.

This was the fix:
```
let intersections_finder = Intersections::from(lines);
let intersections: Vec<_> = intersections_finder.iter().collect()
```
Which works, but is pretty ugly for user code!

So I bit the bullet: I wrote some iteration logic and re-introduced the Clone requirement. 

The good news is that, as well as restoring the original API, performance has once again improved.

I think the improvements are primarily from:
1. You're no longer required to clone the `Line` input — `&Line` implements `Cross`
2. The new custom iterator replaces a somewhat complicated iterator chain - something like (`FlatMap<FlatMap<Map>>>`). Plus it uses an inner `loop` where possible, rather than recursion. The new code doesn't read quite as nicely IMO, but I imagine it removed some overhead.


<details>
<summary>Benches vs main:</summary>

Note: the brute_force implementations also improved. I changed the brute force impl to *also* use an iterator rather than return a `Vec`, which allows us to have our benchmark spend more time running the interesting `Intersection` code, rather than spending time copying data into a Vec.

Some amount of the improvements in the `sweep` code are also from this change, but as you can see sweep benefitted much more than brute_force, because of the improvements I mentioned earlier.

```
    Finished `bench` profile [optimized] target(s) in 0.05s
     Running benches/sweep_line_intersection.rs (target/release/deps/sweep_line_intersection-05f43c36d3715a21)
Gnuplot not found, using plotters backend
Random Dense Lines (10 lines)/brute_force
                        time:   [286.25 ns 287.77 ns 289.51 ns]
                        change: [-22.159% -21.561% -21.023%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
Random Dense Lines (10 lines)/sweep
                        time:   [327.03 ns 327.76 ns 328.45 ns]
                        change: [-39.748% -39.251% -38.789%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

Random Dense Lines (100 lines)/brute_force
                        time:   [53.014 µs 53.969 µs 54.950 µs]
                        change: [-7.6281% -5.3429% -3.2814%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
Random Dense Lines (100 lines)/sweep
                        time:   [34.019 µs 34.650 µs 35.371 µs]
                        change: [-36.378% -35.258% -34.034%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  4 (4.00%) high mild
  5 (5.00%) high severe

Random Dense Lines (1000 lines)/brute_force
                        time:   [8.8227 ms 8.8378 ms 8.8528 ms]
                        change: [-8.3292% -7.6151% -6.9163%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking Random Dense Lines (1000 lines)/sweep: Warming up for 3.0000 s
Warning: Unable to complete 50 samples in 5.0s. You may wish to increase target time to 8.5s, enable flat sampling, or reduce sample count to 20.
Random Dense Lines (1000 lines)/sweep
                        time:   [6.6567 ms 6.6805 ms 6.7040 ms]
                        change: [-16.116% -15.649% -15.225%] (p = 0.00 < 0.05)
                        Performance has improved.

Benchmarking Random Dense Lines (10000 lines)/brute_force: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 8.6s.
Random Dense Lines (10000 lines)/brute_force
                        time:   [854.74 ms 858.22 ms 861.25 ms]
                        change: [-9.7519% -9.1437% -8.5298%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) low mild
Benchmarking Random Dense Lines (10000 lines)/sweep: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 6.9s.
Random Dense Lines (10000 lines)/sweep
                        time:   [689.08 ms 695.60 ms 704.07 ms]
                        change: [-12.659% -11.577% -10.290%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild

Random Sparse Lines (10 lines)/brute_force
                        time:   [180.09 ns 180.28 ns 180.51 ns]
                        change: [+0.8184% +1.0060% +1.2177%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 17 outliers among 100 measurements (17.00%)
  2 (2.00%) low severe
  3 (3.00%) low mild
  4 (4.00%) high mild
  8 (8.00%) high severe
Random Sparse Lines (10 lines)/sweep
                        time:   [134.07 ns 134.54 ns 135.06 ns]
                        change: [-22.809% -21.206% -19.626%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  10 (10.00%) high mild

Random Sparse Lines (100 lines)/brute_force
                        time:   [19.230 µs 19.244 µs 19.261 µs]
                        change: [+0.0643% +0.2131% +0.3501%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 13 outliers among 100 measurements (13.00%)
  2 (2.00%) low severe
  4 (4.00%) low mild
  3 (3.00%) high mild
  4 (4.00%) high severe
Random Sparse Lines (100 lines)/sweep
                        time:   [1.3980 µs 1.4068 µs 1.4181 µs]
                        change: [-15.741% -15.456% -15.131%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high severe

Random Sparse Lines (1000 lines)/brute_force
                        time:   [1.9014 ms 1.9122 ms 1.9291 ms]
                        change: [-0.4255% +0.0969% +0.5773%] (p = 0.75 > 0.05)
                        No change in performance detected.
Found 5 outliers among 50 measurements (10.00%)
  2 (4.00%) high mild
  3 (6.00%) high severe
Random Sparse Lines (1000 lines)/sweep
                        time:   [29.041 µs 29.212 µs 29.390 µs]
                        change: [-61.431% -60.690% -59.895%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 50 measurements (6.00%)
  2 (4.00%) high mild
  1 (2.00%) high severe

Random Sparse Lines (10000 lines)/brute_force
                        time:   [189.53 ms 189.63 ms 189.78 ms]
                        change: [-0.8628% -0.5596% -0.3286%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Random Sparse Lines (10000 lines)/sweep
                        time:   [1.7295 ms 1.7354 ms 1.7397 ms]
                        change: [-16.682% -15.845% -15.084%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) low mild
```

</details>