### PR TITLE
prepare for 0.7.17 geo-types release

### DIFF
--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -1,6 +1,6 @@
 # Changes
 
-## Unreleased
+## 0.7.17 - 2025-07-25
 
 - Add support to `wkt!` geometry creation macro for `LINE`, `RECT`, and `TRIANGLE` geometries.
   - <https://github.com/georust/geo/pull/1389>

--- a/geo-types/Cargo.toml
+++ b/geo-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geo-types"
-version = "0.7.16"
+version = "0.7.17"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/georust/geo"
 documentation = "https://docs.rs/geo-types/"

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -23,7 +23,7 @@ multithreading = ["i_overlay/allow_multithreading", "geo-types/multithreading"]
 earcutr = { version = "0.4.2", optional = true }
 spade = { version = "2.10.0", optional = true }
 float_next_after = "1.0.0"
-geo-types = { version = "0.7.16", features = ["approx", "use-rstar_0_12"] }
+geo-types = { version = "0.7.17", features = ["approx", "use-rstar_0_12"] }
 geographiclib-rs = { version = "0.2.3", default-features = false }
 log = "0.4.11"
 num-traits = "0.2"


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Not much in this release, but I'd like to take advantage of some of the improved `geo-types` ergonomics in `geo` and elsewhere.