### PR TITLE
Fix for Clippy never used / constructed warnings in old_sweep module

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -18,6 +18,7 @@
   - <https://github.com/georust/geo/pull/1382>
 - Fix panic in `algorithm::simplify::compute_rdp` with one point
 - Fix Clippy warning (surfaced in Rust 1.89) related to lifetime elision
+- Silence Clippy warnings related to `old_sweep` module
 
 ## Update `Intersections` with new implementation of the Bentley-Ottmann sweep-line algorithm to efficiently find sparse intersections between groups of lines.
 

--- a/geo/src/algorithm/old_sweep/mod.rs
+++ b/geo/src/algorithm/old_sweep/mod.rs
@@ -1,6 +1,8 @@
 // NOTE: this module is private and for the use of the monotone module only
 // For all other purposes it is DEPRECATED in favour of new_sweep
 
+#![allow(dead_code)]
+
 mod point;
 pub use point::SweepPoint;
 


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

This warning surfaces in Rust 1.89