### PR TITLE
test(frechet): reduce long-linestring tests from 10k to 1k

### DIFF
--- a/geo/src/algorithm/line_measures/frechet_distance.rs
+++ b/geo/src/algorithm/line_measures/frechet_distance.rs
@@ -160,7 +160,7 @@ mod test {
         let ls: LineString = {
             let delta = 0.01;
 
-            let mut ls = vec![(0.0, 0.0); 10_000];
+            let mut ls = vec![(0.0, 0.0); 1_000];
             for i in 1..ls.len() {
                 let (lat, lon) = ls[i - 1];
                 ls[i] = (lat - delta, lon + delta);
@@ -209,7 +209,7 @@ mod test {
         let ls: LineString = {
             let delta = 0.01;
 
-            let mut ls = vec![(0.0, 0.0); 10_000];
+            let mut ls = vec![(0.0, 0.0); 1_000];
             for i in 1..ls.len() {
                 let (lat, lon) = ls[i - 1];
                 ls[i] = (lat - delta, lon + delta);


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Reduce the size of the two long-linestring Fréchet tests from 10000 to 1000 points to speed up the test suite while preserving coverage. 

Context in #1415.