### PR TITLE
Speed up CI by skipping bench build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,6 @@ jobs:
       - geo_traits
       - geo_postgis
       - geo_fuzz
-      - bench
       - docs
     if: success()
     steps:
@@ -56,7 +55,6 @@ jobs:
       - geo_traits
       - geo_postgis
       - geo_fuzz
-      - bench
     if: failure()
     steps:
       - name: Mark the job as a failure
@@ -175,19 +173,6 @@ jobs:
         uses: actions/checkout@v5
       - uses: Swatinem/rust-cache@v2
       - run: cargo build --bins
-
-  bench:
-    name: bench
-    needs: set-matrix
-    runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
-    container:
-      image: "ghcr.io/georust/geo-ci:proj-${{ needs.set-matrix.outputs.proj-version }}-rust-${{ fromJson(needs.set-matrix.outputs.rust-versions)[2] }}"
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
-      - uses: Swatinem/rust-cache@v2
-      - run: cargo bench --no-run
 
   docs:
     name: build documentation


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [n/a] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

The `bench` build is a "no run" build. So the bench program is built,
but not run. Presumably this was done just to be sure we didn't break
the build.

However this is already largely, and more quickly, accomplished by the
`check --all-targets`.

For context I added the bench build to CI in https://github.com/georust/geo/pull/585