### PR TITLE
Add ContainsProperly relate predicate + custom polygon operation

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -4,6 +4,7 @@
 
 - Move `PreparedGeometry` into a new `indexed` module intended to provide index-backed geometries. `relate::PreparedGeometry` has been deprecated.
 - Use an interval tree for faster (Multi)Point in MultiPolygon checks
+- Add `ContainsProperly` trait to relate and as a standalone operation
 
 ## 0.31.0 - 2025-09-01
 

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -57,6 +57,10 @@ name = "contains"
 harness = false
 
 [[bench]]
+name = "contains_properly"
+harness = false
+
+[[bench]]
 name = "convex_hull"
 harness = false
 

--- a/geo/benches/contains_properly.rs
+++ b/geo/benches/contains_properly.rs
@@ -1,0 +1,90 @@
+use criterion::{Criterion, criterion_group, criterion_main};
+use geo::PreparedGeometry;
+use geo::algorithm::{ContainsProperly, Convert, Relate};
+use geo::geometry::*;
+use geo::wkt;
+
+fn compare_poly_in_poly(c: &mut Criterion) {
+    use geo::algorithm::Contains;
+    let poly1: Polygon<f64> = wkt! {POLYGON((9 0,9 9,0 9,0 0,9 0),(6 3,6 6,3 6,3 3,6 3))}.convert();
+    let poly2: Polygon<f64> = wkt! {POLYGON((8 1,8 8,1 8,1 1,8 1),(7 2,7 7,2 7,2 2,7 2))}.convert();
+
+    let multipoly1: MultiPolygon<f64> =
+        wkt! {MULTIPOLYGON(((9 0,9 9,0 9,0 0,9 0),(8 1,8 8,1 8,1 1,8 1)),((7 2,7 7,2 7,2 2,7 2)))}
+            .convert();
+    let multipoly2: MultiPolygon<f64> = wkt! {MULTIPOLYGON(((6 3,6 6,3 6,3 3,6 3)))}.convert();
+
+    c.bench_function("contains_properly poly poly", |bencher| {
+        bencher.iter(|| {
+            assert!(criterion::black_box(&poly1).contains_properly(criterion::black_box(&poly2)));
+        });
+    });
+
+    c.bench_function("relate prepared poly poly", |bencher| {
+        let p1 = PreparedGeometry::from(poly1.clone());
+        let p2 = PreparedGeometry::from(poly2.clone());
+        bencher.iter(|| {
+            assert!(
+                criterion::black_box(&p1)
+                    .relate(criterion::black_box(&p2))
+                    .is_contains_properly()
+            );
+        });
+    });
+
+    c.bench_function("contains poly poly", |bencher| {
+        bencher.iter(|| {
+            assert!(criterion::black_box(&poly1).contains(criterion::black_box(&poly2)));
+        });
+    });
+
+    c.bench_function("relate poly poly", |bencher| {
+        bencher.iter(|| {
+            assert!(
+                criterion::black_box(&poly1)
+                    .relate(criterion::black_box(&poly2))
+                    .is_contains_properly()
+            );
+        });
+    });
+
+    c.bench_function("contains_properly multipoly multipoly", |bencher| {
+        bencher.iter(|| {
+            assert!(
+                criterion::black_box(&multipoly1)
+                    .contains_properly(criterion::black_box(&multipoly2))
+            );
+        });
+    });
+
+    c.bench_function("relate prepared multipoly multipoly", |bencher| {
+        let p1 = PreparedGeometry::from(multipoly1.clone());
+        let p2 = PreparedGeometry::from(multipoly2.clone());
+        bencher.iter(|| {
+            assert!(
+                criterion::black_box(&p1)
+                    .relate(criterion::black_box(&p2))
+                    .is_contains_properly()
+            );
+        });
+    });
+
+    c.bench_function("contains multipoly multipoly", |bencher| {
+        bencher.iter(|| {
+            assert!(criterion::black_box(&multipoly1).contains(criterion::black_box(&multipoly2)));
+        });
+    });
+
+    c.bench_function("relate multipoly multipoly", |bencher| {
+        bencher.iter(|| {
+            assert!(
+                criterion::black_box(&multipoly1)
+                    .relate(criterion::black_box(&multipoly2))
+                    .is_contains_properly()
+            );
+        });
+    });
+}
+
+criterion_group!(benches, compare_poly_in_poly,);
+criterion_main!(benches);

--- a/geo/src/algorithm/contains_properly/coordinate.rs
+++ b/geo/src/algorithm/contains_properly/coordinate.rs
@@ -1,0 +1,2 @@
+// use super::impl_contains_properly_from_relate;
+

--- a/geo/src/algorithm/contains_properly/coordinate.rs
+++ b/geo/src/algorithm/contains_properly/coordinate.rs
@@ -1,2 +1,1 @@
 // use super::impl_contains_properly_from_relate;
-

--- a/geo/src/algorithm/contains_properly/geometry.rs
+++ b/geo/src/algorithm/contains_properly/geometry.rs
@@ -1,11 +1,10 @@
-use crate::geometry::*;
-use super::{ContainsProperly};
-use crate::{GeoFloat};
-use crate::geometry_delegate_impl;
+use super::ContainsProperly;
 use super::impl_contains_properly_geometry_for;
+use crate::GeoFloat;
+use crate::geometry::*;
+use crate::geometry_delegate_impl;
 
-
-impl<T,G> ContainsProperly<G> for Geometry<T>
+impl<T, G> ContainsProperly<G> for Geometry<T>
 where
     T: GeoFloat,
     Point<T>: ContainsProperly<G>,
@@ -19,13 +18,11 @@ where
     MultiPolygon<T>: ContainsProperly<G>,
     GeometryCollection<T>: ContainsProperly<G>,
     // G: BoundingRect<T>,
-
 {
     geometry_delegate_impl! {
         fn contains_properly(&self, rhs: &G) -> bool;
     }
 }
-
 
 impl_contains_properly_geometry_for!(Point<T>);
 impl_contains_properly_geometry_for!(MultiPoint<T>);
@@ -40,8 +37,6 @@ impl_contains_properly_geometry_for!(MultiPolygon<T>);
 impl_contains_properly_geometry_for!(GeometryCollection<T>);
 impl_contains_properly_geometry_for!(Rect<T>);
 impl_contains_properly_geometry_for!(Triangle<T>);
-
-
 
 // impl<T> ContainsProperly<Geometry<T>> for Geometry<T>
 // where

--- a/geo/src/algorithm/contains_properly/geometry.rs
+++ b/geo/src/algorithm/contains_properly/geometry.rs
@@ -1,0 +1,64 @@
+use crate::geometry::*;
+use super::{ContainsProperly};
+use crate::{GeoFloat};
+use crate::geometry_delegate_impl;
+use super::impl_contains_properly_geometry_for;
+
+
+impl<T,G> ContainsProperly<G> for Geometry<T>
+where
+    T: GeoFloat,
+    Point<T>: ContainsProperly<G>,
+    MultiPoint<T>: ContainsProperly<G>,
+    Line<T>: ContainsProperly<G>,
+    LineString<T>: ContainsProperly<G>,
+    MultiLineString<T>: ContainsProperly<G>,
+    Triangle<T>: ContainsProperly<G>,
+    Rect<T>: ContainsProperly<G>,
+    Polygon<T>: ContainsProperly<G>,
+    MultiPolygon<T>: ContainsProperly<G>,
+    GeometryCollection<T>: ContainsProperly<G>,
+    // G: BoundingRect<T>,
+
+{
+    geometry_delegate_impl! {
+        fn contains_properly(&self, rhs: &G) -> bool;
+    }
+}
+
+
+impl_contains_properly_geometry_for!(Point<T>);
+impl_contains_properly_geometry_for!(MultiPoint<T>);
+
+impl_contains_properly_geometry_for!(Line<T>);
+impl_contains_properly_geometry_for!(LineString<T>);
+impl_contains_properly_geometry_for!(MultiLineString<T>);
+
+impl_contains_properly_geometry_for!(Polygon<T>);
+impl_contains_properly_geometry_for!(MultiPolygon<T>);
+
+impl_contains_properly_geometry_for!(GeometryCollection<T>);
+impl_contains_properly_geometry_for!(Rect<T>);
+impl_contains_properly_geometry_for!(Triangle<T>);
+
+
+
+// impl<T> ContainsProperly<Geometry<T>> for Geometry<T>
+// where
+//     T: GeoFloat,
+// {
+//     fn contains_properly(&self, other: &Geometry<T>) -> bool {
+//         match other {
+//             Geometry::Point(geom) => self.contains_properly(geom),
+//             Geometry::Line(geom) => self.contains_properly(geom),
+//             Geometry::LineString(geom) => self.contains_properly(geom),
+//             Geometry::Polygon(geom) => self.contains_properly(geom),
+//             Geometry::MultiPoint(geom) => self.contains_properly(geom),
+//             Geometry::MultiLineString(geom) => self.contains_properly(geom),
+//             Geometry::MultiPolygon(geom) => self.contains_properly(geom),
+//             Geometry::GeometryCollection(geom) => self.contains_properly(geom),
+//             Geometry::Rect(geom) => self.contains_properly(geom),
+//             Geometry::Triangle(geom) => self.contains_properly(geom),
+//         }
+//     }
+// }

--- a/geo/src/algorithm/contains_properly/geometry_collection.rs
+++ b/geo/src/algorithm/contains_properly/geometry_collection.rs
@@ -1,6 +1,6 @@
 use crate::geometry::*;
 // use crate::relate::Relate;
 use super::{ContainsProperly, impl_contains_properly_from_relate};
-use crate::{GeoFloat};
+use crate::GeoFloat;
 
 impl_contains_properly_from_relate!(GeometryCollection<T>, [Point<T>,Line<T>, LineString<T>, Polygon<T>, MultiPoint<T>, MultiLineString<T>, MultiPolygon<T>, GeometryCollection<T>, Rect<T>, Triangle<T>]);

--- a/geo/src/algorithm/contains_properly/geometry_collection.rs
+++ b/geo/src/algorithm/contains_properly/geometry_collection.rs
@@ -1,0 +1,6 @@
+use crate::geometry::*;
+// use crate::relate::Relate;
+use super::{ContainsProperly, impl_contains_properly_from_relate};
+use crate::{GeoFloat};
+
+impl_contains_properly_from_relate!(GeometryCollection<T>, [Point<T>,Line<T>, LineString<T>, Polygon<T>, MultiPoint<T>, MultiLineString<T>, MultiPolygon<T>, GeometryCollection<T>, Rect<T>, Triangle<T>]);

--- a/geo/src/algorithm/contains_properly/line.rs
+++ b/geo/src/algorithm/contains_properly/line.rs
@@ -1,11 +1,11 @@
-use crate::geometry::*;
 use super::{ContainsProperly, impl_contains_properly_from_relate};
-use crate::{GeoFloat};
+use crate::GeoFloat;
+use crate::geometry::*;
 
 impl_contains_properly_from_relate!(Line<T>, [
-    Point<T>,MultiPoint<T>, 
-    Line<T>, LineString<T>, MultiLineString<T>,
-    Polygon<T>,MultiPolygon<T>,
-    GeometryCollection<T>,
-    Rect<T>,Triangle<T>
-    ]);
+Point<T>,MultiPoint<T>,
+Line<T>, LineString<T>, MultiLineString<T>,
+Polygon<T>,MultiPolygon<T>,
+GeometryCollection<T>,
+Rect<T>,Triangle<T>
+]);

--- a/geo/src/algorithm/contains_properly/line.rs
+++ b/geo/src/algorithm/contains_properly/line.rs
@@ -1,0 +1,11 @@
+use crate::geometry::*;
+use super::{ContainsProperly, impl_contains_properly_from_relate};
+use crate::{GeoFloat};
+
+impl_contains_properly_from_relate!(Line<T>, [
+    Point<T>,MultiPoint<T>, 
+    Line<T>, LineString<T>, MultiLineString<T>,
+    Polygon<T>,MultiPolygon<T>,
+    GeometryCollection<T>,
+    Rect<T>,Triangle<T>
+    ]);

--- a/geo/src/algorithm/contains_properly/line_string.rs
+++ b/geo/src/algorithm/contains_properly/line_string.rs
@@ -1,19 +1,19 @@
-use crate::geometry::*;
 use super::{ContainsProperly, impl_contains_properly_from_relate};
-use crate::{GeoFloat};
+use crate::GeoFloat;
+use crate::geometry::*;
 
 impl_contains_properly_from_relate!(LineString<T>, [
-    Point<T>,MultiPoint<T>, 
-    Line<T>, LineString<T>, MultiLineString<T>,
-    Polygon<T>,MultiPolygon<T>,
-    GeometryCollection<T>,
-    Rect<T>,Triangle<T>
-    ]);
+Point<T>,MultiPoint<T>,
+Line<T>, LineString<T>, MultiLineString<T>,
+Polygon<T>,MultiPolygon<T>,
+GeometryCollection<T>,
+Rect<T>,Triangle<T>
+]);
 
 impl_contains_properly_from_relate!(MultiLineString<T>, [
-    Point<T>,MultiPoint<T>, 
-    Line<T>, LineString<T>, MultiLineString<T>,
-    Polygon<T>,MultiPolygon<T>,
-    GeometryCollection<T>,
-    Rect<T>,Triangle<T>
-    ]);
+Point<T>,MultiPoint<T>,
+Line<T>, LineString<T>, MultiLineString<T>,
+Polygon<T>,MultiPolygon<T>,
+GeometryCollection<T>,
+Rect<T>,Triangle<T>
+]);

--- a/geo/src/algorithm/contains_properly/line_string.rs
+++ b/geo/src/algorithm/contains_properly/line_string.rs
@@ -1,0 +1,19 @@
+use crate::geometry::*;
+use super::{ContainsProperly, impl_contains_properly_from_relate};
+use crate::{GeoFloat};
+
+impl_contains_properly_from_relate!(LineString<T>, [
+    Point<T>,MultiPoint<T>, 
+    Line<T>, LineString<T>, MultiLineString<T>,
+    Polygon<T>,MultiPolygon<T>,
+    GeometryCollection<T>,
+    Rect<T>,Triangle<T>
+    ]);
+
+impl_contains_properly_from_relate!(MultiLineString<T>, [
+    Point<T>,MultiPoint<T>, 
+    Line<T>, LineString<T>, MultiLineString<T>,
+    Polygon<T>,MultiPolygon<T>,
+    GeometryCollection<T>,
+    Rect<T>,Triangle<T>
+    ]);

--- a/geo/src/algorithm/contains_properly/mod.rs
+++ b/geo/src/algorithm/contains_properly/mod.rs
@@ -29,7 +29,6 @@ macro_rules! impl_contains_properly_from_relate {
 }
 use impl_contains_properly_from_relate;
 
-
 macro_rules! impl_contains_properly_geometry_for {
     ($geom_type: ty) => {
         impl<T> ContainsProperly<Geometry<T>> for $geom_type

--- a/geo/src/algorithm/contains_properly/mod.rs
+++ b/geo/src/algorithm/contains_properly/mod.rs
@@ -1,0 +1,239 @@
+mod coordinate;
+mod geometry;
+mod geometry_collection;
+mod line;
+mod line_string;
+mod point;
+mod polygon;
+mod rect;
+mod triangle;
+
+pub trait ContainsProperly<Rhs = Self> {
+    fn contains_properly(&self, rhs: &Rhs) -> bool;
+}
+
+macro_rules! impl_contains_properly_from_relate {
+    ($for:ty,  [$($target:ty),*]) => {
+        $(
+            impl<T> ContainsProperly<$target> for $for
+            where
+                T: GeoFloat
+            {
+                fn contains_properly(&self, target: &$target) -> bool {
+                    use $crate::algorithm::Relate;
+                    self.relate(target).is_contains_properly()
+                }
+            }
+        )*
+    };
+}
+use impl_contains_properly_from_relate;
+
+
+macro_rules! impl_contains_properly_geometry_for {
+    ($geom_type: ty) => {
+        impl<T> ContainsProperly<Geometry<T>> for $geom_type
+        where
+            T: GeoFloat,
+        {
+            fn contains_properly(&self, geometry: &Geometry<T>) -> bool {
+                match geometry {
+                    Geometry::Point(g) => self.contains_properly(g),
+                    Geometry::Line(g) => self.contains_properly(g),
+                    Geometry::LineString(g) => self.contains_properly(g),
+                    Geometry::Polygon(g) => self.contains_properly(g),
+                    Geometry::MultiPoint(g) => self.contains_properly(g),
+                    Geometry::MultiLineString(g) => self.contains_properly(g),
+                    Geometry::MultiPolygon(g) => self.contains_properly(g),
+                    Geometry::GeometryCollection(g) => self.contains_properly(g),
+                    Geometry::Rect(g) => self.contains_properly(g),
+                    Geometry::Triangle(g) => self.contains_properly(g),
+                }
+            }
+        }
+    };
+}
+use impl_contains_properly_geometry_for;
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn exhaustive_compile_test() {
+        use geo_types::*;
+        // let c = Coord { x: 0., y: 0. };
+        let pt: Point = Point::new(0., 0.);
+        let ls = line_string![(0., 0.).into(), (1., 1.).into()];
+        let multi_ls = MultiLineString::new(vec![ls.clone()]);
+        let ln: Line = Line::new((0., 0.), (1., 1.));
+
+        let poly = Polygon::new(LineString::from(vec![(0., 0.), (1., 1.), (1., 0.)]), vec![]);
+        let rect = Rect::new(coord! { x: 10., y: 20. }, coord! { x: 30., y: 10. });
+        let tri = Triangle::new(
+            coord! { x: 0., y: 0. },
+            coord! { x: 10., y: 20. },
+            coord! { x: 20., y: -10. },
+        );
+        let geom = Geometry::Point(pt);
+        let gc = GeometryCollection::new_from(vec![geom.clone()]);
+        let multi_point = MultiPoint::new(vec![pt]);
+        let multi_poly = MultiPolygon::new(vec![poly.clone()]);
+
+        // let _ = c.contains_properly(&c);
+        // let _ = c.contains_properly(&pt);
+        // let _ = c.contains_properly(&ln);
+        // let _ = c.contains_properly(&ls);
+        // let _ = c.contains_properly(&poly);
+        // let _ = c.contains_properly(&rect);
+        // let _ = c.contains_properly(&tri);
+        // let _ = c.contains_properly(&geom);
+        // let _ = c.contains_properly(&gc);
+        // let _ = c.contains_properly(&multi_point);
+        // let _ = c.contains_properly(&multi_ls);
+        // let _ = c.contains_properly(&multi_poly);
+
+        // let _ = pt.contains_properly(&c);
+        let _ = pt.contains_properly(&pt);
+        let _ = pt.contains_properly(&ln);
+        let _ = pt.contains_properly(&ls);
+        let _ = pt.contains_properly(&poly);
+        let _ = pt.contains_properly(&rect);
+        let _ = pt.contains_properly(&tri);
+        let _ = pt.contains_properly(&geom);
+        let _ = pt.contains_properly(&gc);
+        let _ = pt.contains_properly(&multi_point);
+        let _ = pt.contains_properly(&multi_ls);
+        let _ = pt.contains_properly(&multi_poly);
+
+        // let _ = ln.contains_properly(&c);
+        let _ = ln.contains_properly(&pt);
+        let _ = ln.contains_properly(&ln);
+        let _ = ln.contains_properly(&ls);
+        let _ = ln.contains_properly(&poly);
+        let _ = ln.contains_properly(&rect);
+        let _ = ln.contains_properly(&tri);
+        let _ = ln.contains_properly(&geom);
+        let _ = ln.contains_properly(&gc);
+        let _ = ln.contains_properly(&multi_point);
+        let _ = ln.contains_properly(&multi_ls);
+        let _ = ln.contains_properly(&multi_poly);
+
+        // let _ = ls.contains_properly(&c);
+        let _ = ls.contains_properly(&pt);
+        let _ = ls.contains_properly(&ln);
+        let _ = ls.contains_properly(&ls);
+        let _ = ls.contains_properly(&poly);
+        let _ = ls.contains_properly(&rect);
+        let _ = ls.contains_properly(&tri);
+        let _ = ls.contains_properly(&geom);
+        let _ = ls.contains_properly(&gc);
+        let _ = ls.contains_properly(&multi_point);
+        let _ = ls.contains_properly(&multi_ls);
+        let _ = ls.contains_properly(&multi_poly);
+
+        // let _ = poly.contains_properly(&c);
+        let _ = poly.contains_properly(&pt);
+        let _ = poly.contains_properly(&ln);
+        let _ = poly.contains_properly(&ls);
+        let _ = poly.contains_properly(&poly);
+        let _ = poly.contains_properly(&rect);
+        let _ = poly.contains_properly(&tri);
+        let _ = poly.contains_properly(&geom);
+        let _ = poly.contains_properly(&gc);
+        let _ = poly.contains_properly(&multi_point);
+        let _ = poly.contains_properly(&multi_ls);
+        let _ = poly.contains_properly(&multi_poly);
+
+        // let _ = rect.contains_properly(&c);
+        let _ = rect.contains_properly(&pt);
+        let _ = rect.contains_properly(&ln);
+        let _ = rect.contains_properly(&ls);
+        let _ = rect.contains_properly(&poly);
+        let _ = rect.contains_properly(&rect);
+        let _ = rect.contains_properly(&tri);
+        let _ = rect.contains_properly(&geom);
+        let _ = rect.contains_properly(&gc);
+        let _ = rect.contains_properly(&multi_point);
+        let _ = rect.contains_properly(&multi_ls);
+        let _ = rect.contains_properly(&multi_poly);
+
+        // let _ = tri.contains_properly(&c);
+        let _ = tri.contains_properly(&pt);
+        let _ = tri.contains_properly(&ln);
+        let _ = tri.contains_properly(&ls);
+        let _ = tri.contains_properly(&poly);
+        let _ = tri.contains_properly(&rect);
+        let _ = tri.contains_properly(&tri);
+        let _ = tri.contains_properly(&geom);
+        let _ = tri.contains_properly(&gc);
+        let _ = tri.contains_properly(&multi_point);
+        let _ = tri.contains_properly(&multi_ls);
+        let _ = tri.contains_properly(&multi_poly);
+
+        // let _ = geom.contains_properly(&c);
+        let _ = geom.contains_properly(&pt);
+        let _ = geom.contains_properly(&ln);
+        let _ = geom.contains_properly(&ls);
+        let _ = geom.contains_properly(&poly);
+        let _ = geom.contains_properly(&rect);
+        let _ = geom.contains_properly(&tri);
+        let _ = geom.contains_properly(&geom);
+        let _ = geom.contains_properly(&gc);
+        let _ = geom.contains_properly(&multi_point);
+        let _ = geom.contains_properly(&multi_ls);
+        let _ = geom.contains_properly(&multi_poly);
+
+        // let _ = gc.contains_properly(&c);
+        let _ = gc.contains_properly(&pt);
+        let _ = gc.contains_properly(&ln);
+        let _ = gc.contains_properly(&ls);
+        let _ = gc.contains_properly(&poly);
+        let _ = gc.contains_properly(&rect);
+        let _ = gc.contains_properly(&tri);
+        let _ = gc.contains_properly(&geom);
+        let _ = gc.contains_properly(&gc);
+        let _ = gc.contains_properly(&multi_point);
+        let _ = gc.contains_properly(&multi_ls);
+        let _ = gc.contains_properly(&multi_poly);
+
+        // let _ = multi_point.contains_properly(&c);
+        let _ = multi_point.contains_properly(&pt);
+        let _ = multi_point.contains_properly(&ln);
+        let _ = multi_point.contains_properly(&ls);
+        let _ = multi_point.contains_properly(&poly);
+        let _ = multi_point.contains_properly(&rect);
+        let _ = multi_point.contains_properly(&tri);
+        let _ = multi_point.contains_properly(&geom);
+        let _ = multi_point.contains_properly(&gc);
+        let _ = multi_point.contains_properly(&multi_point);
+        let _ = multi_point.contains_properly(&multi_ls);
+        let _ = multi_point.contains_properly(&multi_poly);
+
+        // let _ = multi_ls.contains_properly(&c);
+        let _ = multi_ls.contains_properly(&pt);
+        let _ = multi_ls.contains_properly(&ln);
+        let _ = multi_ls.contains_properly(&ls);
+        let _ = multi_ls.contains_properly(&poly);
+        let _ = multi_ls.contains_properly(&rect);
+        let _ = multi_ls.contains_properly(&tri);
+        let _ = multi_ls.contains_properly(&geom);
+        let _ = multi_ls.contains_properly(&gc);
+        let _ = multi_ls.contains_properly(&multi_point);
+        let _ = multi_ls.contains_properly(&multi_ls);
+        let _ = multi_ls.contains_properly(&multi_poly);
+
+        // let _ = multi_poly.contains_properly(&c);
+        let _ = multi_poly.contains_properly(&pt);
+        let _ = multi_poly.contains_properly(&ln);
+        let _ = multi_poly.contains_properly(&ls);
+        let _ = multi_poly.contains_properly(&poly);
+        let _ = multi_poly.contains_properly(&rect);
+        let _ = multi_poly.contains_properly(&tri);
+        let _ = multi_poly.contains_properly(&geom);
+        let _ = multi_poly.contains_properly(&gc);
+        let _ = multi_poly.contains_properly(&multi_point);
+        let _ = multi_poly.contains_properly(&multi_ls);
+        let _ = multi_poly.contains_properly(&multi_poly);
+    }
+}

--- a/geo/src/algorithm/contains_properly/point.rs
+++ b/geo/src/algorithm/contains_properly/point.rs
@@ -1,19 +1,19 @@
-use crate::geometry::*;
 use super::{ContainsProperly, impl_contains_properly_from_relate};
-use crate::{GeoFloat};
+use crate::GeoFloat;
+use crate::geometry::*;
 
 impl_contains_properly_from_relate!(Point<T>, [
-    Point<T>,MultiPoint<T>, 
-    Line<T>, LineString<T>, MultiLineString<T>,
-    Polygon<T>,MultiPolygon<T>,
-    GeometryCollection<T>,
-    Rect<T>,Triangle<T>
-    ]);
+Point<T>,MultiPoint<T>,
+Line<T>, LineString<T>, MultiLineString<T>,
+Polygon<T>,MultiPolygon<T>,
+GeometryCollection<T>,
+Rect<T>,Triangle<T>
+]);
 
 impl_contains_properly_from_relate!(MultiPoint<T>, [
-    Point<T>,MultiPoint<T>, 
-    Line<T>, LineString<T>, MultiLineString<T>,
-    Polygon<T>,MultiPolygon<T>,
-    GeometryCollection<T>,
-    Rect<T>,Triangle<T>
-    ]);
+Point<T>,MultiPoint<T>,
+Line<T>, LineString<T>, MultiLineString<T>,
+Polygon<T>,MultiPolygon<T>,
+GeometryCollection<T>,
+Rect<T>,Triangle<T>
+]);

--- a/geo/src/algorithm/contains_properly/point.rs
+++ b/geo/src/algorithm/contains_properly/point.rs
@@ -1,0 +1,19 @@
+use crate::geometry::*;
+use super::{ContainsProperly, impl_contains_properly_from_relate};
+use crate::{GeoFloat};
+
+impl_contains_properly_from_relate!(Point<T>, [
+    Point<T>,MultiPoint<T>, 
+    Line<T>, LineString<T>, MultiLineString<T>,
+    Polygon<T>,MultiPolygon<T>,
+    GeometryCollection<T>,
+    Rect<T>,Triangle<T>
+    ]);
+
+impl_contains_properly_from_relate!(MultiPoint<T>, [
+    Point<T>,MultiPoint<T>, 
+    Line<T>, LineString<T>, MultiLineString<T>,
+    Polygon<T>,MultiPolygon<T>,
+    GeometryCollection<T>,
+    Rect<T>,Triangle<T>
+    ]);

--- a/geo/src/algorithm/contains_properly/polygon.rs
+++ b/geo/src/algorithm/contains_properly/polygon.rs
@@ -1,18 +1,303 @@
-use crate::geometry::*;
 use super::{ContainsProperly, impl_contains_properly_from_relate};
-use crate::{GeoFloat};
+use crate::CoordsIter;
+use crate::HasDimensions;
+use crate::Intersects;
+use crate::LinesIter;
+use crate::coordinate_position::{CoordPos, CoordinatePosition, coord_pos_relative_to_ring};
+use crate::geometry::*;
+use crate::{GeoFloat, GeoNum};
 
-impl_contains_properly_from_relate!(Polygon<T>, [
-    Point<T>,MultiPoint<T>, 
-    Line<T>, LineString<T>, MultiLineString<T>,
-    Polygon<T>,MultiPolygon<T>,
-    GeometryCollection<T>,
-    Rect<T>,Triangle<T>
-    ]);
-impl_contains_properly_from_relate!(MultiPolygon<T>, [
-    Point<T>,MultiPoint<T>, 
-    Line<T>, LineString<T>, MultiLineString<T>,
-    Polygon<T>,MultiPolygon<T>,
-    GeometryCollection<T>,
-    Rect<T>,Triangle<T>
-    ]);
+impl<T> ContainsProperly<Coord<T>> for Polygon<T>
+where
+    T: GeoNum,
+{
+    fn contains_properly(&self, rhs: &Coord<T>) -> bool {
+        if self.is_empty() {
+            return false;
+        }
+        self.coordinate_position(rhs) == CoordPos::Inside
+    }
+}
+
+impl<T> ContainsProperly<Point<T>> for Polygon<T>
+where
+    T: GeoNum,
+{
+    fn contains_properly(&self, rhs: &Point<T>) -> bool {
+        if self.is_empty() || rhs.is_empty() {
+            return false;
+        }
+
+        self.contains_properly(&rhs.0)
+    }
+}
+
+impl<T> ContainsProperly<MultiPoint<T>> for Polygon<T>
+where
+    T: GeoNum,
+{
+    fn contains_properly(&self, rhs: &MultiPoint<T>) -> bool {
+        if self.is_empty() || rhs.is_empty() {
+            return false;
+        }
+
+        rhs.coords_iter().all(|p| self.contains_properly(&p))
+    }
+}
+
+impl<T> ContainsProperly<Polygon<T>> for Polygon<T>
+where
+    T: GeoNum,
+{
+    fn contains_properly(&self, rhs: &Polygon<T>) -> bool {
+        if self.is_empty() || rhs.is_empty() {
+            return false;
+        }
+
+        // no boundary intersection
+        if boundary_intersects::<T, Polygon<T>, Polygon<T>>(self, rhs) {
+            return false;
+        }
+        // established that pairwise relation betwwen any two rings is either concentric or disjoint
+
+        // if any point of rhs.exterior lies within self.exterior, then all points of rhs exterior lie within self.exterior
+        let Some(rhs_ext_coord) = rhs.exterior().0.first() else {
+            return false;
+        };
+
+        //check for disjoint
+        if !coord_in_ring(rhs_ext_coord, self.exterior()) {
+            return false;
+        }
+
+        // if there exits a self_hole which is not inside a rhs_hole
+        // then there must be some point of rhs which does not lie on the interior of self
+        // and hence self does not contains_properly rhs
+        for self_hole in self.interiors() {
+            // if self_hole is empty, then it is covered by rhs
+            if !is_covered_hole(self_hole, rhs) {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+impl<T> ContainsProperly<MultiPolygon<T>> for Polygon<T>
+where
+    T: GeoNum,
+{
+    fn contains_properly(&self, rhs: &MultiPolygon<T>) -> bool {
+        if self.is_empty() || rhs.is_empty() {
+            return false;
+        }
+        rhs.iter().all(|poly| self.contains_properly(poly))
+    }
+}
+
+impl<T> ContainsProperly<Rect<T>> for Polygon<T>
+where
+    T: GeoNum,
+{
+    fn contains_properly(&self, rhs: &Rect<T>) -> bool {
+        self.contains_properly(&rhs.to_polygon())
+    }
+}
+impl<T> ContainsProperly<Triangle<T>> for Polygon<T>
+where
+    T: GeoNum,
+{
+    fn contains_properly(&self, rhs: &Triangle<T>) -> bool {
+        self.contains_properly(&rhs.to_polygon())
+    }
+}
+
+impl_contains_properly_from_relate!(Polygon<T>, [Line<T>, LineString<T>, MultiLineString<T>,GeometryCollection<T>]);
+
+impl<T> ContainsProperly<Polygon<T>> for MultiPolygon<T>
+where
+    T: GeoNum,
+{
+    fn contains_properly(&self, rhs: &Polygon<T>) -> bool {
+        if self.is_empty() || rhs.is_empty() {
+            return false;
+        }
+        if boundary_intersects::<T, MultiPolygon<T>, Polygon<T>>(self, rhs) {
+            return false;
+        }
+        // all rings are concentric or disjoint
+
+        let Some(rhs_ext_coord) = rhs.exterior().0.first() else {
+            return false;
+        };
+
+        // check for disjoint within the loop
+        // rhs will lie in at most one polygon of self
+        // filtering by intersects is sufficient to identify this polygon
+        // if there is no intersection, then rhs lies in no polygon of self and is disjoint
+        // if there are multiple intersections, then self must have been self intersecting
+        let mut is_disjoint = true;
+
+        let candidates = self
+            .0
+            .iter()
+            .filter(|poly| poly.contains_properly(rhs_ext_coord));
+
+        // there should at most one candidate
+
+        for self_poly in candidates {
+            is_disjoint = false;
+
+            for self_hole in self_poly.interiors() {
+                if !is_covered_hole(self_hole, rhs) {
+                    return false;
+                }
+            }
+        }
+
+        !is_disjoint
+    }
+}
+impl<T> ContainsProperly<MultiPolygon<T>> for MultiPolygon<T>
+where
+    T: GeoNum,
+{
+    fn contains_properly(&self, rhs: &MultiPolygon<T>) -> bool {
+        if self.is_empty() || rhs.is_empty() {
+            return false;
+        }
+
+        if boundary_intersects::<T, MultiPolygon<T>, MultiPolygon<T>>(self, rhs) {
+            return false;
+        }
+
+        for rhs_poly in rhs.0.iter() {
+            // if any point of rhs exterior lies within self.exterior, then all points of rhs exterior lie within self.exterior
+            let Some(rhs_ext_coord) = rhs_poly.exterior().0.first() else {
+                return false;
+            };
+            // check for disjoint per rhs_poly
+            let mut is_disjoint = true;
+            let candidates = self
+                .0
+                .iter()
+                .filter(|poly| poly.contains_properly(rhs_ext_coord));
+
+            for self_poly in candidates {
+                is_disjoint = false;
+                for self_hole in self_poly.interiors() {
+                    if !is_covered_hole(self_hole, rhs_poly) {
+                        return false;
+                    }
+                }
+            }
+
+            if is_disjoint {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+impl<T> ContainsProperly<Rect<T>> for MultiPolygon<T>
+where
+    T: GeoNum,
+{
+    fn contains_properly(&self, rhs: &Rect<T>) -> bool {
+        self.contains_properly(&rhs.to_polygon())
+    }
+}
+impl<T> ContainsProperly<Triangle<T>> for MultiPolygon<T>
+where
+    T: GeoNum,
+{
+    fn contains_properly(&self, rhs: &Triangle<T>) -> bool {
+        self.contains_properly(&rhs.to_polygon())
+    }
+}
+
+impl_contains_properly_from_relate!(MultiPolygon<T>, [Point<T>,MultiPoint<T>,Line<T>, LineString<T>, MultiLineString<T>,GeometryCollection<T>]);
+
+//------------------------------------------------------------------------------
+// Util functions
+//------------------------------------------------------------------------------
+
+/// Returns true if self_hole is inside an RHS hole
+/// ~ if self_hole is not inside an rhs hole, then part of RHS is outside of self  
+fn is_covered_hole<T>(self_hole: &LineString<T>, rhs: &Polygon<T>) -> bool
+where
+    T: GeoNum,
+{
+    // empty hole is always covered
+    let Some(self_hole_first_coord) = self_hole.0.first() else {
+        return true;
+    };
+    // no hole in rhs means hole is covered
+    if rhs.interiors().is_empty() {
+        return true;
+    }
+
+    // since all rings are either concentric or disjoint, we can check using represenative point
+    rhs.interiors()
+        .iter()
+        .map(|ring| coord_pos_relative_to_ring(*self_hole_first_coord, ring))
+        .any(|pos| pos == CoordPos::Inside)
+}
+
+/// Return true if the boundary of lhs intersects any of the boundaries of rhs
+/// where lhs and rhs are both polygons/multipolygons
+fn boundary_intersects<'a, T, G1, G2>(lhs: &'a G1, rhs: &'a G2) -> bool
+where
+    T: GeoNum,
+    G1: LinesIter<'a, Scalar = T>,
+    G2: LinesIter<'a, Scalar = T>,
+    Line<T>: Intersects<Line<T>>,
+{
+    lhs.lines_iter()
+        .flat_map(|self_l| rhs.lines_iter().map(move |rhs_l| (self_l, rhs_l)))
+        .any(|(self_l, rhs_l)| self_l.intersects(&rhs_l))
+}
+
+fn coord_in_ring<T>(coord: &Coord<T>, ring: &LineString<T>) -> bool
+where
+    T: GeoNum,
+{
+    coord_pos_relative_to_ring(*coord, ring) == CoordPos::Inside
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Convert;
+    use crate::wkt;
+    use crate::{MultiPolygon, Polygon};
+
+    #[test]
+    fn test_contains_properly_donut() {
+        let poly1: Polygon<f64> =
+            wkt! {POLYGON((9 0,9 9,0 9,0 0,9 0),(6 3,6 6,3 6,3 3,6 3))}.convert();
+        let poly2: Polygon<f64> =
+            wkt! {POLYGON((8 1,8 8,1 8,1 1,8 1),(7 2,7 7,2 7,2 2,7 2))}.convert();
+
+        assert!(poly1.contains_properly(&poly2));
+    }
+
+    #[test]
+    fn test_contains_properly_donut_multi_multi() {
+        let poly1: MultiPolygon<f64> =
+            wkt! {MULTIPOLYGON(((9 0,9 9,0 9,0 0,9 0),(6 3,6 6,3 6,3 3,6 3)))}.convert();
+        let poly2: MultiPolygon<f64> =
+            wkt! {MULTIPOLYGON(((8 1,8 8,1 8,1 1,8 1),(7 2,7 7,2 7,2 2,7 2)))}.convert();
+
+        assert!(poly1.contains_properly(&poly2));
+    }
+
+    #[test]
+    fn test_contains_properly_donut_multi_poly() {
+        let mp: MultiPolygon<f64> = wkt!{MULTIPOLYGON(((9 0,9 9,0 9,0 0,9 0),(8 1,8 8,1 8,1 1,8 1)),((7 2,7 7,2 7,2 2,7 2)))}.convert();
+        let poly2: Polygon<f64> = wkt! {POLYGON((6 3,6 6,3 6,3 3,6 3))}.convert();
+
+        assert!(mp.contains_properly(&poly2));
+    }
+}

--- a/geo/src/algorithm/contains_properly/polygon.rs
+++ b/geo/src/algorithm/contains_properly/polygon.rs
@@ -1,0 +1,18 @@
+use crate::geometry::*;
+use super::{ContainsProperly, impl_contains_properly_from_relate};
+use crate::{GeoFloat};
+
+impl_contains_properly_from_relate!(Polygon<T>, [
+    Point<T>,MultiPoint<T>, 
+    Line<T>, LineString<T>, MultiLineString<T>,
+    Polygon<T>,MultiPolygon<T>,
+    GeometryCollection<T>,
+    Rect<T>,Triangle<T>
+    ]);
+impl_contains_properly_from_relate!(MultiPolygon<T>, [
+    Point<T>,MultiPoint<T>, 
+    Line<T>, LineString<T>, MultiLineString<T>,
+    Polygon<T>,MultiPolygon<T>,
+    GeometryCollection<T>,
+    Rect<T>,Triangle<T>
+    ]);

--- a/geo/src/algorithm/contains_properly/rect.rs
+++ b/geo/src/algorithm/contains_properly/rect.rs
@@ -1,11 +1,11 @@
-use crate::geometry::*;
 use super::{ContainsProperly, impl_contains_properly_from_relate};
-use crate::{GeoFloat};
+use crate::GeoFloat;
+use crate::geometry::*;
 
 impl_contains_properly_from_relate!(Rect<T>, [
-    Point<T>,MultiPoint<T>, 
-    Line<T>, LineString<T>, MultiLineString<T>,
-    Polygon<T>,MultiPolygon<T>,
-    GeometryCollection<T>,
-    Rect<T>,Triangle<T>
-    ]);
+Point<T>,MultiPoint<T>,
+Line<T>, LineString<T>, MultiLineString<T>,
+Polygon<T>,MultiPolygon<T>,
+GeometryCollection<T>,
+Rect<T>,Triangle<T>
+]);

--- a/geo/src/algorithm/contains_properly/rect.rs
+++ b/geo/src/algorithm/contains_properly/rect.rs
@@ -1,0 +1,11 @@
+use crate::geometry::*;
+use super::{ContainsProperly, impl_contains_properly_from_relate};
+use crate::{GeoFloat};
+
+impl_contains_properly_from_relate!(Rect<T>, [
+    Point<T>,MultiPoint<T>, 
+    Line<T>, LineString<T>, MultiLineString<T>,
+    Polygon<T>,MultiPolygon<T>,
+    GeometryCollection<T>,
+    Rect<T>,Triangle<T>
+    ]);

--- a/geo/src/algorithm/contains_properly/triangle.rs
+++ b/geo/src/algorithm/contains_properly/triangle.rs
@@ -1,0 +1,11 @@
+use crate::geometry::*;
+use super::{ContainsProperly, impl_contains_properly_from_relate};
+use crate::{GeoFloat};
+
+impl_contains_properly_from_relate!(Triangle<T>, [
+    Point<T>,MultiPoint<T>, 
+    Line<T>, LineString<T>, MultiLineString<T>,
+    Polygon<T>,MultiPolygon<T>,
+    GeometryCollection<T>,
+    Rect<T>,Triangle<T>
+    ]);

--- a/geo/src/algorithm/contains_properly/triangle.rs
+++ b/geo/src/algorithm/contains_properly/triangle.rs
@@ -1,11 +1,11 @@
-use crate::geometry::*;
 use super::{ContainsProperly, impl_contains_properly_from_relate};
-use crate::{GeoFloat};
+use crate::GeoFloat;
+use crate::geometry::*;
 
 impl_contains_properly_from_relate!(Triangle<T>, [
-    Point<T>,MultiPoint<T>, 
-    Line<T>, LineString<T>, MultiLineString<T>,
-    Polygon<T>,MultiPolygon<T>,
-    GeometryCollection<T>,
-    Rect<T>,Triangle<T>
-    ]);
+Point<T>,MultiPoint<T>,
+Line<T>, LineString<T>, MultiLineString<T>,
+Polygon<T>,MultiPolygon<T>,
+GeometryCollection<T>,
+Rect<T>,Triangle<T>
+]);

--- a/geo/src/algorithm/mod.rs
+++ b/geo/src/algorithm/mod.rs
@@ -45,6 +45,9 @@ pub use concave_hull::ConcaveHull;
 pub mod contains;
 pub use contains::Contains;
 
+pub mod contains_properly;
+pub use contains_properly::ContainsProperly;
+
 /// Convert the type of a geometry’s coordinate value.
 pub mod convert;
 pub use convert::{Convert, TryConvert};

--- a/geo/src/algorithm/relate/geomgraph/intersection_matrix.rs
+++ b/geo/src/algorithm/relate/geomgraph/intersection_matrix.rs
@@ -419,6 +419,23 @@ impl IntersectionMatrix {
         && self.0[CoordPos::Outside][CoordPos::OnBoundary] == Dimensions::Empty
     }
 
+    /// Returns `true` if every point in Geometry `b` is a point of Geometry `a` interior.
+    ///
+    /// # Notes
+    /// - If Geometry `b` has any interaction with the boundary of Geometry `a`, then the result is `false`.
+    /// - Geometry`a` will never contains_properly itself.
+    /// - Matches `[T**FF*FF*]`
+    /// - This predicate is **transitive** but not **reflexive**
+    #[allow(clippy::nonminimal_bool)]
+    pub fn is_contains_properly(&self) -> bool {
+        //  [T**FF*FF*]
+        self.0[CoordPos::Inside][CoordPos::Inside] != Dimensions::Empty
+            && self.0[CoordPos::OnBoundary][CoordPos::Inside] == Dimensions::Empty
+            && self.0[CoordPos::OnBoundary][CoordPos::OnBoundary] == Dimensions::Empty
+            && self.0[CoordPos::Outside][CoordPos::Inside] == Dimensions::Empty
+            && self.0[CoordPos::Outside][CoordPos::OnBoundary] == Dimensions::Empty
+    }
+
     /// Returns `true` if `a` touches `b`: they have at least one point in common, but their
     /// interiors do not intersect.
     ///


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---  

# Draft for copywriting and tests

## Context
I run lots of Polygon \~in\~ Polygon checks. The tighter boundary intersection of `ContainsProperly` allows for faster algorithms since other geometry which intersects the boundary in any way can immediately be rejected

## Implementation
1. Added the is_contains_properly method to `Relate` using `[T**FF*FF*]`
2. Added base `ContainsProperly` trait, mostly using the `Relate` method
3. Added custom `ContainsProperly` implementations for combinations of `Polygon` and `MultiPolygon` 

## Documentation
Will be written before undrafting

## Tests
Currently not very comprehensive, but covers some of the edge cases I've encountered  
ContainsProperly also isn't in the JTS `*Relate*.xml` files, which is rather inconvenient

## References:
[JTS](https://locationtech.github.io/jts/javadoc/org/locationtech/jts/geom/prep/PreparedGeometry.html#containsProperly-org.locationtech.jts.geom.Geometry-)
[PostGIS](https://postgis.net/docs/ST_ContainsProperly.html)
