### PR TITLE
add Trait operation tests into Relate

### DIFF
--- a/jts-test-runner/src/lib.rs
+++ b/jts-test-runner/src/lib.rs
@@ -136,7 +136,7 @@ mod tests {
         //
         // We'll need to increase this number as more tests are added, but it should never be
         // decreased.
-        let expected_test_count: usize = 3911;
+        let expected_test_count: usize = 5720;
         let actual_test_count = runner.unexpected_failures().len() + runner.successes().len();
         match actual_test_count.cmp(&expected_test_count) {
             Ordering::Less => {

--- a/jts-test-runner/src/runner.rs
+++ b/jts-test-runner/src/runner.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeSet;
 
 use approx::relative_eq;
+use geo::relate::IntersectionMatrix;
 use include_dir::{include_dir, Dir, DirEntry};
 use log::{debug, info};
 use wkt::ToWkt;
@@ -364,15 +365,59 @@ impl TestRunner {
                     let actual = a.relate(b);
                     if actual == *expected {
                         debug!("Relate success: actual == expected");
-                        self.successes.push(test_case);
+                        self.successes.push(test_case.clone());
                     } else {
                         debug!("Relate failure: actual != expected");
                         let error_description =
                             format!("expected {expected:?}, actual: {actual:?}");
                         self.add_failure(TestFailure {
-                            test_case,
+                            test_case: test_case.clone(),
                             error_description,
                         });
+                    }
+
+                    #[allow(clippy::type_complexity)]
+                    let op_pairs: Vec<(
+                        &str,
+                        Box<dyn Fn(&IntersectionMatrix) -> bool>,
+                        Box<dyn Fn(&Geometry, &Geometry) -> bool>,
+                    )> = vec![
+                        (
+                            "Contains",
+                            Box::new(IntersectionMatrix::is_contains),
+                            Box::new(|a: &Geometry, b: &Geometry| a.contains(b)),
+                        ),
+                        (
+                            "Within",
+                            Box::new(IntersectionMatrix::is_within),
+                            Box::new(|a: &Geometry, b: &Geometry| a.is_within(b)),
+                        ),
+                        (
+                            "Intersects",
+                            Box::new(IntersectionMatrix::is_intersects),
+                            Box::new(|a: &Geometry, b: &Geometry| a.intersects(b)),
+                        ),
+                        // add more here as required
+                    ];
+
+                    for (op_name, relate_fn, trait_fn) in op_pairs {
+                        let actual_result = relate_fn(&actual);
+                        let trait_result = trait_fn(a, b);
+                        if actual_result == trait_result {
+                            debug!(
+                                "{op_name} sucess: Relate matches {op_name} trait implementation"
+                            );
+                            self.successes.push(test_case.clone());
+                        } else {
+                            debug!("{op_name} failure: Relate doesn't match {op_name} trait implementation");
+                            let error_description = format!(
+                            "{op_name} failure: Relate: {actual_result:?}, {op_name} trait: {trait_result:?}"
+                        );
+                            self.add_failure(TestFailure {
+                                test_case: test_case.clone(),
+                                error_description,
+                            });
+                        }
                     }
                 }
                 Operation::BooleanOp { a, b, op, expected } => {


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Add a way to more generally test `Trait` implementation against `Relate` equivalents for test data in jts-test-runner  

while working on #1427 , I realized that the jts-test-runner xml files are limited in that they only run the predicates explicitly spelled out in the xml file (and ContainsProperly isn't one of these). 

I'm thinking we could add these as a baseline test set which checks that the Trait implementation matches the Relate results for test data in jts-test-runner

Thoughts and ideas?
1. it does end up running the test case which are explicitly stated in the xml file twice 
1. should be it bi-directional? ie test both A.predicate(B) and B.predicate(A)?
