### PR TITLE
LOF efficiency improvements

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -4,6 +4,7 @@
 
 - Move `PreparedGeometry` into a new `indexed` module intended to provide index-backed geometries. `relate::PreparedGeometry` has been deprecated.
 - Use an interval tree for faster (Multi)Point in MultiPolygon checks
+- LOF algorithm efficiency improvements due to caching kth distance
 
 ## 0.31.0 - 2025-09-01
 


### PR DESCRIPTION
No need to re-calculate kth distance several times

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

While working on #1429 I revisited our LOF implementation. This eliminates one pass over the input to calculate kth distances for point neighbours.
