### PR TITLE
Covers base

### DIFF
--- a/geo-benches/Cargo.toml
+++ b/geo-benches/Cargo.toml
@@ -56,6 +56,11 @@ path = "src/contains_properly.rs"
 harness = false
 
 [[bench]]
+name = "covers"
+path = "src/covers.rs"
+harness = false
+
+[[bench]]
 name = "convex_hull"
 path = "src/convex_hull.rs"
 harness = false

--- a/geo-benches/src/covers.rs
+++ b/geo-benches/src/covers.rs
@@ -1,0 +1,89 @@
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use geo::algorithm::{Contains, Covers};
+use geo::{Convert, wkt};
+use geo::{coord, geometry::*};
+
+fn rect_covers(c: &mut Criterion) {
+    c.bench_function("rect covers line", |bencher| {
+        let rect = Rect::new(coord! { x: 0., y: 0. }, coord! { x: 10., y: 10. });
+        let line = Line::new(coord! { x: 5., y: 5. }, coord! { x: 7., y: 7. });
+        bencher.iter(|| {
+            assert!(criterion::black_box(&rect).covers(criterion::black_box(&line)));
+        });
+    });
+
+    c.bench_function("rect contains line", |bencher| {
+        let rect = Rect::new(coord! { x: 0., y: 0. }, coord! { x: 10., y: 10. });
+        let line = Line::new(coord! { x: 5., y: 5. }, coord! { x: 7., y: 7. });
+        bencher.iter(|| {
+            assert!(criterion::black_box(&rect).contains(criterion::black_box(&line)));
+        });
+    });
+}
+
+fn linestring_covers_point(c: &mut Criterion) {
+    c.bench_function("linestring covers point", |bencher| {
+        let ls: LineString<f64> = wkt! {LINESTRING(0 0, 10 0, 10 10, 0 10)}.convert();
+        let pt: Point<f64> = wkt! {POINT(5 10)}.convert();
+        bencher.iter(|| {
+            assert!(criterion::black_box(&ls).covers(criterion::black_box(&pt)));
+        });
+    });
+
+    c.bench_function("linestring contains point", |bencher| {
+        let ls: LineString<f64> = wkt! {LINESTRING(0 0, 10 0, 10 10, 0 10)}.convert();
+        let pt: Point<f64> = wkt! {POINT(5 10)}.convert();
+        bencher.iter(|| {
+            assert!(criterion::black_box(&ls).contains(criterion::black_box(&pt)));
+        });
+    });
+}
+
+// bench a method derived from intersects
+fn rect_linestring_scaling(c: &mut Criterion) {
+    fn make_outer_rect(n: i32) -> Rect<f64> {
+        Rect::new(coord! {x:0,y:0}, coord! {x:n,y:3}).convert()
+    }
+    fn make_inner_ls(n: i32) -> LineString<f64> {
+        LineString::new((1..n).map(|i: i32| coord! {x:i,y:(1+i%2)}).collect()).convert()
+    }
+
+    {
+        // create two polygons, both of  of n+2 sides and no holes
+        let mut group = c.benchmark_group("covers rect linestring scaling");
+
+        // trait is faster for small polygons, but relate overtakes from around 700*700 boundary segment checks
+        for i in [10, 1_000, 100_000] {
+            group.throughput(Throughput::Elements(i as u64));
+
+            let inner_poly = make_inner_ls(i);
+            let outer_poly = make_outer_rect(i);
+
+            group.bench_with_input(
+                BenchmarkId::new("covers trait", i),
+                &(&outer_poly, &inner_poly),
+                |bencher, &(a, b)| {
+                    bencher.iter(|| assert!(a.covers(b)));
+                },
+            );
+
+            // contains delegates this to relate
+            group.bench_with_input(
+                BenchmarkId::new("contains trait", i),
+                &(&outer_poly, &inner_poly),
+                |bencher, &(a, b)| {
+                    bencher.iter(|| assert!(a.contains(b)));
+                },
+            );
+        }
+        group.finish();
+    }
+}
+
+criterion_group!(
+    benches,
+    rect_covers,
+    linestring_covers_point,
+    rect_linestring_scaling
+);
+criterion_main!(benches);

--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -19,6 +19,9 @@
   - BREAKING: The `concave_hull` method now has no `concavity` parameter.  
   - Add `concave_hull_with_options` method which requires `ConcaveHullOptions` as a parameter with `concavity` and `length_threshold` options.
   - <https://github.com/georust/geo/pull/1442>
+- Add `Covers` trait to relate and as a standalone operation
+  - custom implementations for checking Geometries covered by `Rect`, `Triangle`, `Line`, `Point`, `Coord`
+  - custom implementations for checking Geometries covering `Point` and `MultiPoint`
 
 ## 0.31.0 - 2025-09-01
 

--- a/geo/src/algorithm/covers/coord.rs
+++ b/geo/src/algorithm/covers/coord.rs
@@ -1,0 +1,41 @@
+use super::{Covers, impl_covers_from_intersects};
+use crate::GeoNum;
+use crate::Intersects;
+use crate::geometry::*;
+
+impl<T, G> Covers<Coord<T>> for G
+where
+    T: GeoNum,
+    G: Intersects<Coord<T>>,
+{
+    fn covers(&self, rhs: &Coord<T>) -> bool {
+        self.intersects(rhs)
+    }
+}
+
+// valid because self is convex geometry
+// all exterior pts of RHS intersecting self means self covers RHS
+impl_covers_from_intersects!(Coord<T>, [
+Point<T>, MultiPoint<T>,
+Line<T>,
+LineString<T>, MultiLineString<T>,
+Rect<T>, Triangle<T>,
+Polygon<T>,  MultiPolygon<T>,
+Geometry<T>, GeometryCollection<T>
+]);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rhs_empty() {
+        let s: Coord<f64> = Coord::zero();
+        assert!(!s.covers(&LineString::empty()));
+        assert!(!s.covers(&Polygon::empty()));
+        assert!(!s.covers(&MultiPoint::empty()));
+        assert!(!s.covers(&MultiLineString::empty()));
+        assert!(!s.covers(&MultiPolygon::empty()));
+        assert!(!s.covers(&GeometryCollection::empty()));
+    }
+}

--- a/geo/src/algorithm/covers/geometry.rs
+++ b/geo/src/algorithm/covers/geometry.rs
@@ -1,0 +1,103 @@
+use super::Covers;
+use crate::GeoFloat;
+use crate::geometry::*;
+use crate::geometry_delegate_impl;
+
+impl<T> Covers<Point<T>> for Geometry<T>
+where
+    T: GeoFloat,
+{
+    geometry_delegate_impl! {
+        fn covers(&self, point: &Point<T>) -> bool;
+    }
+}
+
+impl<T> Covers<Line<T>> for Geometry<T>
+where
+    T: GeoFloat,
+{
+    geometry_delegate_impl! {
+        fn covers(&self, line: &Line<T>) -> bool;
+    }
+}
+
+impl<T> Covers<LineString<T>> for Geometry<T>
+where
+    T: GeoFloat,
+{
+    geometry_delegate_impl! {
+        fn covers(&self, line_string: &LineString<T>) -> bool;
+    }
+}
+
+impl<T> Covers<Polygon<T>> for Geometry<T>
+where
+    T: GeoFloat,
+{
+    geometry_delegate_impl! {
+        fn covers(&self, polygon: &Polygon<T>) -> bool;
+    }
+}
+
+impl<T> Covers<MultiPoint<T>> for Geometry<T>
+where
+    T: GeoFloat,
+{
+    geometry_delegate_impl! {
+        fn covers(&self, multi_point: &MultiPoint<T>) -> bool;
+    }
+}
+
+impl<T> Covers<MultiLineString<T>> for Geometry<T>
+where
+    T: GeoFloat,
+{
+    geometry_delegate_impl! {
+        fn covers(&self, multi_line_string: &MultiLineString<T>) -> bool;
+    }
+}
+
+impl<T> Covers<MultiPolygon<T>> for Geometry<T>
+where
+    T: GeoFloat,
+{
+    geometry_delegate_impl! {
+        fn covers(&self, multi_line_string: &MultiPolygon<T>) -> bool;
+    }
+}
+
+impl<T> Covers<GeometryCollection<T>> for Geometry<T>
+where
+    T: GeoFloat,
+{
+    geometry_delegate_impl! {
+        fn covers(&self, geometry_collection: &GeometryCollection<T>) -> bool;
+    }
+}
+
+impl<T> Covers<Rect<T>> for Geometry<T>
+where
+    T: GeoFloat,
+{
+    geometry_delegate_impl! {
+        fn covers(&self, rect: &Rect<T>) -> bool;
+    }
+}
+
+impl<T> Covers<Triangle<T>> for Geometry<T>
+where
+    T: GeoFloat,
+{
+    geometry_delegate_impl! {
+        fn covers(&self, triangle: &Triangle<T>) -> bool;
+    }
+}
+
+impl<T> Covers<Geometry<T>> for Geometry<T>
+where
+    T: GeoFloat,
+{
+    geometry_delegate_impl! {
+        fn covers(&self, other: &Geometry<T>) -> bool;
+    }
+}

--- a/geo/src/algorithm/covers/geometry_collection.rs
+++ b/geo/src/algorithm/covers/geometry_collection.rs
@@ -1,0 +1,52 @@
+use super::{Covers, impl_covers_from_relate, impl_covers_geometry_for};
+use crate::covers::impl_covers_from_intersects;
+use crate::geometry::*;
+use crate::{GeoFloat, GeoNum};
+
+impl_covers_from_intersects!(GeometryCollection<T>,[Point<T>,MultiPoint<T>]);
+impl_covers_from_relate!(GeometryCollection<T>, [
+Line<T>,
+LineString<T>, MultiLineString<T>,
+Rect<T>, Triangle<T>,
+Polygon<T>, MultiPolygon<T>,
+GeometryCollection<T>
+]);
+impl_covers_geometry_for!(GeometryCollection<T>);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::algorithm::convert::Convert;
+    use crate::wkt;
+
+    #[test]
+    fn test_rhs_empty() {
+        let s: GeometryCollection<f64> = wkt!(GEOMETRYCOLLECTION(POINT(0 0))).convert();
+        assert!(!s.covers(&LineString::empty()));
+        assert!(!s.covers(&Polygon::empty()));
+        assert!(!s.covers(&MultiPoint::empty()));
+        assert!(!s.covers(&MultiLineString::empty()));
+        assert!(!s.covers(&MultiPolygon::empty()));
+        assert!(!s.covers(&GeometryCollection::empty()));
+    }
+
+    #[test]
+    fn test_lhs_empty() {
+        let s: GeometryCollection<f64> = GeometryCollection::empty();
+
+        assert!(!s.covers(&wkt!(POINT(0 0)).convert()));
+        assert!(!s.covers(&wkt!(MULTIPOINT(0 0,1 1)).convert()));
+
+        assert!(!s.covers(&wkt!(LINE(0 0,1 1)).convert()));
+        assert!(!s.covers(&wkt!(LINESTRING(0 0,1 1)).convert()));
+        assert!(!s.covers(&wkt!(MULTILINESTRING((0 0,1 1),(2 2,3 3))).convert()));
+
+        assert!(!s.covers(&wkt!(POLYGON((0 0,1 1,1 0,0 0))).convert()));
+        assert!(!s.covers(&wkt!(MULTIPOLYGON(((0 0,1 0, 1 1,0 1, 0 0)))).convert()));
+        assert!(!s.covers(&wkt!(RECT(0 0, 1 1)).convert()));
+        assert!(!s.covers(&wkt!(TRIANGLE(0 0, 0 1, 1 1)).convert()));
+
+        assert!(!s.covers(&Into::<Geometry>::into(wkt!(POINT(0 0)).convert())));
+        assert!(!s.covers(&wkt!(GEOMETRYCOLLECTION(POINT(0 0))).convert()));
+    }
+}

--- a/geo/src/algorithm/covers/line.rs
+++ b/geo/src/algorithm/covers/line.rs
@@ -1,0 +1,32 @@
+use super::{Covers, impl_covers_from_intersects};
+use crate::GeoNum;
+use crate::geometry::*;
+
+// valid because self is convex geometry
+// all exterior pts of RHS intersecting self means self covers RHS
+impl_covers_from_intersects!(Line<T>, [
+Point<T>, MultiPoint<T>,
+Line<T>,
+LineString<T>, MultiLineString<T>,
+Rect<T>, Triangle<T>,
+Polygon<T>,  MultiPolygon<T> ,
+Geometry<T>, GeometryCollection<T>
+]);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::algorithm::convert::Convert;
+    use crate::wkt;
+
+    #[test]
+    fn test_rhs_empty() {
+        let s: Line<f64> = wkt!(LINE(0 0,1 1)).convert();
+        assert!(!s.covers(&LineString::empty()));
+        assert!(!s.covers(&Polygon::empty()));
+        assert!(!s.covers(&MultiPoint::empty()));
+        assert!(!s.covers(&MultiLineString::empty()));
+        assert!(!s.covers(&MultiPolygon::empty()));
+        assert!(!s.covers(&GeometryCollection::empty()));
+    }
+}

--- a/geo/src/algorithm/covers/line_string.rs
+++ b/geo/src/algorithm/covers/line_string.rs
@@ -1,0 +1,135 @@
+use super::{Covers, impl_covers_from_intersects, impl_covers_from_relate};
+use crate::{Contains, HasDimensions, geometry::*};
+use crate::{GeoFloat, GeoNum};
+
+// valid because RHS is point or multipoint
+// all exterior pts of RHS intersecting self means self covers RHS
+impl_covers_from_intersects!(LineString<T>, [Point<T>, MultiPoint<T>]);
+
+impl<T> Covers<Line<T>> for LineString<T>
+where
+    T: GeoNum,
+{
+    fn covers(&self, rhs: &Line<T>) -> bool {
+        if rhs.start == rhs.end {
+            // handle edge case where line might sit within a linestring's boundary
+            self.covers(&rhs.start)
+        } else {
+            // remaining scenarios are eqivalent to contains
+            self.contains(rhs)
+        }
+    }
+}
+
+impl<T> Covers<LineString<T>> for LineString<T>
+where
+    T: GeoNum,
+{
+    fn covers(&self, rhs: &LineString<T>) -> bool {
+        if self.is_empty() || rhs.is_empty() {
+            return false;
+        }
+        rhs.lines().all(|l| self.covers(&l))
+    }
+}
+
+impl_covers_from_relate!(LineString<T>, [
+MultiLineString<T>,
+Rect<T>, Triangle<T>,
+Polygon<T>,  MultiPolygon<T>,
+Geometry<T>, GeometryCollection<T>
+]);
+
+// valid because RHS is point or multipoint
+// all exterior pts of RHS intersecting self means self covers RHS
+impl_covers_from_intersects!(MultiLineString<T>, [Point<T>, MultiPoint<T>]);
+
+impl_covers_from_relate!(MultiLineString<T>, [
+Line<T>,
+LineString<T>,  MultiLineString<T>,
+Rect<T>, Triangle<T>,
+Polygon<T>,  MultiPolygon<T>,
+Geometry<T>, GeometryCollection<T>
+]);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::algorithm::convert::Convert;
+    use crate::wkt;
+
+    #[test]
+    fn test_rhs_empty() {
+        let s: LineString<f64> = wkt!(LINESTRING(0 0,1 1)).convert();
+        assert!(!s.covers(&LineString::empty()));
+        assert!(!s.covers(&Polygon::empty()));
+        assert!(!s.covers(&MultiPoint::empty()));
+        assert!(!s.covers(&MultiLineString::empty()));
+        assert!(!s.covers(&MultiPolygon::empty()));
+        assert!(!s.covers(&GeometryCollection::empty()));
+
+        let s: MultiLineString<f64> = wkt!(MULTILINESTRING((0 0,1 1))).convert();
+        assert!(!s.covers(&LineString::empty()));
+        assert!(!s.covers(&Polygon::empty()));
+        assert!(!s.covers(&MultiPoint::empty()));
+        assert!(!s.covers(&MultiLineString::empty()));
+        assert!(!s.covers(&MultiPolygon::empty()));
+        assert!(!s.covers(&GeometryCollection::empty()));
+    }
+
+    #[test]
+    fn test_lhs_empty() {
+        let s: LineString<f64> = LineString::empty();
+        assert!(!s.covers(&wkt!(POINT(0 0)).convert()));
+        assert!(!s.covers(&wkt!(MULTIPOINT(0 0,1 1)).convert()));
+        assert!(!s.covers(&wkt!(LINE(0 0,1 1)).convert()));
+        assert!(!s.covers(&wkt!(LINESTRING(0 0,1 1)).convert()));
+        assert!(!s.covers(&wkt!(MULTILINESTRING((0 0,1 1),(2 2,3 3))).convert()));
+        assert!(!s.covers(&wkt!(POLYGON((0 0,1 1,1 0,0 0))).convert()));
+        assert!(!s.covers(&wkt!(MULTIPOLYGON(((0 0,1 0, 1 1,0 1, 0 0)))).convert()));
+        assert!(!s.covers(&wkt!(RECT(0 0, 1 1)).convert()));
+        assert!(!s.covers(&wkt!(TRIANGLE(0 0, 0 1, 1 1)).convert()));
+        assert!(!s.covers(&Into::<Geometry>::into(wkt!(POINT(0 0)).convert())));
+        assert!(!s.covers(&wkt!(GEOMETRYCOLLECTION(POINT(0 0))).convert()));
+
+        let s: MultiLineString<f64> = MultiLineString::empty();
+        assert!(!s.covers(&wkt!(POINT(0 0)).convert()));
+        assert!(!s.covers(&wkt!(MULTIPOINT(0 0,1 1)).convert()));
+        assert!(!s.covers(&wkt!(LINE(0 0,1 1)).convert()));
+        assert!(!s.covers(&wkt!(LINESTRING(0 0,1 1)).convert()));
+        assert!(!s.covers(&wkt!(MULTILINESTRING((0 0,1 1),(2 2,3 3))).convert()));
+        assert!(!s.covers(&wkt!(POLYGON((0 0,1 1,1 0,0 0))).convert()));
+        assert!(!s.covers(&wkt!(MULTIPOLYGON(((0 0,1 0, 1 1,0 1, 0 0)))).convert()));
+        assert!(!s.covers(&wkt!(RECT(0 0, 1 1)).convert()));
+        assert!(!s.covers(&wkt!(TRIANGLE(0 0, 0 1, 1 1)).convert()));
+        assert!(!s.covers(&Into::<Geometry>::into(wkt!(POINT(0 0)).convert())));
+        assert!(!s.covers(&wkt!(GEOMETRYCOLLECTION(POINT(0 0))).convert()));
+    }
+
+    #[test]
+    fn differ_from_contains() {
+        // test that the edge case is covered by custom implementation
+
+        let ls: LineString<f64> = wkt!(LINESTRING(0 0, 1 1)).convert();
+        let ls_s: LineString<f64> = wkt!(LINESTRING(0 0, 0 0)).convert();
+        let ls_e: LineString<f64> = wkt!(LINESTRING(1 1, 1 1)).convert();
+        let ln_s: Line<f64> = wkt!(LINE(0 0, 0 0)).convert();
+        let ln_e: Line<f64> = wkt!(LINE(1 1, 1 1)).convert();
+        let pt_s: Point<f64> = wkt!(POINT(0 0)).convert();
+        let pt_e: Point<f64> = wkt!(POINT(1 1)).convert();
+
+        assert!(ls.covers(&ls_s));
+        assert!(ls.covers(&ls_e));
+        assert!(ls.covers(&ln_s));
+        assert!(ls.covers(&ln_e));
+        assert!(ls.covers(&pt_s));
+        assert!(ls.covers(&pt_e));
+
+        assert!(!ls.contains(&ls_s));
+        assert!(!ls.contains(&ls_e));
+        assert!(!ls.contains(&ln_s));
+        assert!(!ls.contains(&ln_e));
+        assert!(!ls.contains(&pt_s));
+        assert!(!ls.contains(&pt_e));
+    }
+}

--- a/geo/src/algorithm/covers/mod.rs
+++ b/geo/src/algorithm/covers/mod.rs
@@ -1,0 +1,333 @@
+/// Checks if every point in `rhs` lies inside `self`.
+/// (i.e. intersects the interior or boundary of) `self`.
+/// Equivalently, tests that no point of `other` lies outside (in the exterior of) `self`
+/// In other words, the [DE-9IM] intersection matrix
+/// of `(rhs, self)` matches one of the following patterns:
+/// `[T*****FF*], [*T****FF*], [***T**FF*], [****T*FF*]`
+///
+/// [DE-9IM]: https://en.wikipedia.org/wiki/DE-9IM
+///
+/// # Examples
+///
+/// ```
+/// use geo::Covers;
+/// use geo::{line_string, point, Polygon};
+///
+/// let line_string = line_string![
+///     (x: 0., y: 0.),
+///     (x: 2., y: 0.),
+///     (x: 2., y: 2.),
+///     (x: 0., y: 2.),
+///     (x: 0., y: 0.),
+/// ];
+///
+/// let polygon = Polygon::new(line_string.clone(), vec![]);
+///
+/// // Point in Point
+/// assert!(point!(x: 2., y: 0.).covers(&point!(x: 2., y: 0.)));
+///
+/// // Point in Linestring
+/// assert!(line_string.covers(&point!(x: 2., y: 0.)));
+///
+/// // Point in Polygon
+/// assert!(polygon.covers(&point!(x: 1., y: 1.)));
+/// ```
+///
+/// # Performance Note
+///
+/// Much of this trait is currently implemented by delegating to the [`Relate`](crate::algorithm::Relate) trait - see
+/// [`IntersectionMatrix::is_covers`](crate::algorithm::relate::IntersectionMatrix::is_covers);
+/// However, [`Covers`] may be faster for checking if geometries are covered by `Point`, `Line`, `Rect` and `Triangle`
+///
+pub trait Covers<Rhs = Self> {
+    fn covers(&self, rhs: &Rhs) -> bool;
+}
+
+pub(crate) mod coord;
+pub(crate) mod line_string;
+pub(crate) mod point;
+pub(crate) mod polygon;
+
+pub(crate) mod line;
+pub(crate) mod rect;
+pub(crate) mod triangle;
+
+pub(crate) mod geometry;
+pub(crate) mod geometry_collection;
+
+macro_rules! impl_covers_from_relate {
+    ($for:ty,  [$($target:ty),*]) => {
+        $(
+            impl<T> Covers<$target> for $for
+            where
+                T: GeoFloat
+            {
+                fn covers(&self, target: &$target) -> bool {
+                    use $crate::algorithm::Relate;
+                    self.relate(target).is_covers()
+                }
+            }
+        )*
+    };
+}
+pub(crate) use impl_covers_from_relate;
+
+// returns true if all coords of rhs intersects with self
+// always valid if self is Point, Line or Convex Polygon (Rect/Triangle)
+// always valid if other is Point or MultiPoint
+macro_rules! impl_covers_from_intersects {
+
+    (Coord<T>,  [$($target:ty),*]) => {
+
+        $(
+            impl<T> Covers<$target> for Coord<T>
+            where
+                T: GeoNum,
+                Self: $crate::algorithm::Intersects<Coord<T>>,
+            {
+                fn covers(&self, target: &$target) -> bool {
+                    use $crate::CoordsIter;
+                    use $crate::algorithm::Intersects;
+                    use $crate::algorithm::HasDimensions;
+                    if HasDimensions::is_empty(target) {
+                        return false;
+                    }
+                    target.exterior_coords_iter().all(|pt| self.intersects(&pt))
+                }
+            }
+        )*
+    };
+
+    ($for:ty,  [$($target:ty),*]) => {
+
+        $(
+            impl<T> Covers<$target> for $for
+            where
+                T: GeoNum,
+                Self: $crate::algorithm::Intersects<Coord<T>>,
+            {
+                fn covers(&self, target: &$target) -> bool {
+                    use $crate::CoordsIter;
+                    use $crate::algorithm::Intersects;
+                    use $crate::algorithm::HasDimensions;
+                    if HasDimensions::is_empty(self) || HasDimensions::is_empty(target){
+                        return false;
+                    }
+                    target.exterior_coords_iter().all(|pt| self.intersects(&pt))
+                }
+            }
+        )*
+    };
+}
+pub(crate) use impl_covers_from_intersects;
+
+macro_rules! impl_covers_geometry_for {
+    ($geom_type: ty) => {
+        impl<T> Covers<Geometry<T>> for $geom_type
+        where
+            T: GeoFloat,
+        {
+            fn covers(&self, geometry: &Geometry<T>) -> bool {
+                match geometry {
+                    Geometry::Point(g) => self.covers(g),
+                    Geometry::Line(g) => self.covers(g),
+                    Geometry::LineString(g) => self.covers(g),
+                    Geometry::Polygon(g) => self.covers(g),
+                    Geometry::MultiPoint(g) => self.covers(g),
+                    Geometry::MultiLineString(g) => self.covers(g),
+                    Geometry::MultiPolygon(g) => self.covers(g),
+                    Geometry::GeometryCollection(g) => self.covers(g),
+                    Geometry::Rect(g) => self.covers(g),
+                    Geometry::Triangle(g) => self.covers(g),
+                }
+            }
+        }
+    };
+}
+pub(crate) use impl_covers_geometry_for;
+
+// ┌───────┐
+// │ Tests │
+// └───────┘
+
+#[cfg(test)]
+mod test {
+    use crate::Covers;
+    use crate::line_string;
+    use crate::*;
+
+    #[test]
+    fn exhaustive_compile_test() {
+        use geo_types::{GeometryCollection, Triangle};
+        let c: Coord = Coord::zero();
+        let pt: Point = Point::new(0., 0.);
+        let ln: Line = Line::new((0., 0.), (1., 1.));
+        let ls = line_string![(0., 0.).into(), (1., 1.).into()];
+        let poly = Polygon::new(LineString::from(vec![(0., 0.), (1., 1.), (1., 0.)]), vec![]);
+        let rect = Rect::new(coord! { x: 10., y: 20. }, coord! { x: 30., y: 10. });
+        let tri = Triangle::new(
+            coord! { x: 0., y: 0. },
+            coord! { x: 10., y: 20. },
+            coord! { x: 20., y: -10. },
+        );
+        let geom = Geometry::Point(pt);
+        let gc = GeometryCollection::new_from(vec![geom.clone()]);
+        let multi_point = MultiPoint::new(vec![pt]);
+        let multi_ls = MultiLineString::new(vec![ls.clone()]);
+        let multi_poly = MultiPolygon::new(vec![poly.clone()]);
+
+        let _ = c.covers(&c);
+        let _ = c.covers(&pt);
+        let _ = c.covers(&ln);
+        let _ = c.covers(&ls);
+        let _ = c.covers(&poly);
+        let _ = c.covers(&rect);
+        let _ = c.covers(&tri);
+        let _ = c.covers(&geom);
+        let _ = c.covers(&gc);
+        let _ = c.covers(&multi_point);
+        let _ = c.covers(&multi_ls);
+        let _ = c.covers(&multi_poly);
+
+        let _ = pt.covers(&c);
+        let _ = pt.covers(&pt);
+        let _ = pt.covers(&ln);
+        let _ = pt.covers(&ls);
+        let _ = pt.covers(&poly);
+        let _ = pt.covers(&rect);
+        let _ = pt.covers(&tri);
+        let _ = pt.covers(&geom);
+        let _ = pt.covers(&gc);
+        let _ = pt.covers(&multi_point);
+        let _ = pt.covers(&multi_ls);
+        let _ = pt.covers(&multi_poly);
+
+        let _ = ln.covers(&c);
+        let _ = ln.covers(&pt);
+        let _ = ln.covers(&ln);
+        let _ = ln.covers(&ls);
+        let _ = ln.covers(&poly);
+        let _ = ln.covers(&rect);
+        let _ = ln.covers(&tri);
+        let _ = ln.covers(&geom);
+        let _ = ln.covers(&gc);
+        let _ = ln.covers(&multi_point);
+        let _ = ln.covers(&multi_ls);
+        let _ = ln.covers(&multi_poly);
+
+        let _ = ls.covers(&c);
+        let _ = ls.covers(&pt);
+        let _ = ls.covers(&ln);
+        let _ = ls.covers(&ls);
+        let _ = ls.covers(&poly);
+        let _ = ls.covers(&rect);
+        let _ = ls.covers(&tri);
+        let _ = ls.covers(&geom);
+        let _ = ls.covers(&gc);
+        let _ = ls.covers(&multi_point);
+        let _ = ls.covers(&multi_ls);
+        let _ = ls.covers(&multi_poly);
+
+        let _ = poly.covers(&c);
+        let _ = poly.covers(&pt);
+        let _ = poly.covers(&ln);
+        let _ = poly.covers(&ls);
+        let _ = poly.covers(&poly);
+        let _ = poly.covers(&rect);
+        let _ = poly.covers(&tri);
+        let _ = poly.covers(&geom);
+        let _ = poly.covers(&gc);
+        let _ = poly.covers(&multi_point);
+        let _ = poly.covers(&multi_ls);
+        let _ = poly.covers(&multi_poly);
+        let _ = rect.covers(&pt);
+        let _ = rect.covers(&ln);
+        let _ = rect.covers(&ls);
+        let _ = rect.covers(&poly);
+        let _ = rect.covers(&rect);
+        let _ = rect.covers(&tri);
+        let _ = rect.covers(&geom);
+        let _ = rect.covers(&gc);
+        let _ = rect.covers(&multi_point);
+        let _ = rect.covers(&multi_ls);
+        let _ = rect.covers(&multi_poly);
+
+        let _ = tri.covers(&c);
+        let _ = tri.covers(&pt);
+        let _ = tri.covers(&ln);
+        let _ = tri.covers(&ls);
+        let _ = tri.covers(&poly);
+        let _ = tri.covers(&rect);
+        let _ = tri.covers(&tri);
+        let _ = tri.covers(&geom);
+        let _ = tri.covers(&gc);
+        let _ = tri.covers(&multi_point);
+        let _ = tri.covers(&multi_ls);
+        let _ = tri.covers(&multi_poly);
+
+        let _ = geom.covers(&c);
+        let _ = geom.covers(&pt);
+        let _ = geom.covers(&ln);
+        let _ = geom.covers(&ls);
+        let _ = geom.covers(&poly);
+        let _ = geom.covers(&rect);
+        let _ = geom.covers(&tri);
+        let _ = geom.covers(&geom);
+        let _ = geom.covers(&gc);
+        let _ = geom.covers(&multi_point);
+        let _ = geom.covers(&multi_ls);
+        let _ = geom.covers(&multi_poly);
+
+        let _ = gc.covers(&c);
+        let _ = gc.covers(&pt);
+        let _ = gc.covers(&ln);
+        let _ = gc.covers(&ls);
+        let _ = gc.covers(&poly);
+        let _ = gc.covers(&rect);
+        let _ = gc.covers(&tri);
+        let _ = gc.covers(&geom);
+        let _ = gc.covers(&gc);
+        let _ = gc.covers(&multi_point);
+        let _ = gc.covers(&multi_ls);
+        let _ = gc.covers(&multi_poly);
+
+        let _ = multi_point.covers(&c);
+        let _ = multi_point.covers(&pt);
+        let _ = multi_point.covers(&ln);
+        let _ = multi_point.covers(&ls);
+        let _ = multi_point.covers(&poly);
+        let _ = multi_point.covers(&rect);
+        let _ = multi_point.covers(&tri);
+        let _ = multi_point.covers(&geom);
+        let _ = multi_point.covers(&gc);
+        let _ = multi_point.covers(&multi_point);
+        let _ = multi_point.covers(&multi_ls);
+        let _ = multi_point.covers(&multi_poly);
+
+        let _ = multi_ls.covers(&c);
+        let _ = multi_ls.covers(&pt);
+        let _ = multi_ls.covers(&ln);
+        let _ = multi_ls.covers(&ls);
+        let _ = multi_ls.covers(&poly);
+        let _ = multi_ls.covers(&rect);
+        let _ = multi_ls.covers(&tri);
+        let _ = multi_ls.covers(&geom);
+        let _ = multi_ls.covers(&gc);
+        let _ = multi_ls.covers(&multi_point);
+        let _ = multi_ls.covers(&multi_ls);
+        let _ = multi_ls.covers(&multi_poly);
+
+        let _ = multi_poly.covers(&c);
+        let _ = multi_poly.covers(&pt);
+        let _ = multi_poly.covers(&ln);
+        let _ = multi_poly.covers(&ls);
+        let _ = multi_poly.covers(&poly);
+        let _ = multi_poly.covers(&rect);
+        let _ = multi_poly.covers(&tri);
+        let _ = multi_poly.covers(&geom);
+        let _ = multi_poly.covers(&gc);
+        let _ = multi_poly.covers(&multi_point);
+        let _ = multi_poly.covers(&multi_ls);
+        let _ = multi_poly.covers(&multi_poly);
+    }
+}

--- a/geo/src/algorithm/covers/point.rs
+++ b/geo/src/algorithm/covers/point.rs
@@ -1,0 +1,78 @@
+use super::{Covers, impl_covers_from_intersects, impl_covers_from_relate};
+use crate::{Contains, geometry::*};
+use crate::{GeoFloat, GeoNum};
+
+// valid because self is convex geometry
+// all exterior pts of RHS intersecting self means self covers RHS
+impl_covers_from_intersects!(Point<T>, [
+Point<T>, MultiPoint<T>,
+Line<T>,
+LineString<T>,  MultiLineString<T>,
+Rect<T>, Triangle<T>,
+Polygon<T>,  MultiPolygon<T>,
+Geometry<T>, GeometryCollection<T>
+]);
+
+// valid because RHS is point
+impl_covers_from_intersects!(MultiPoint<T>, [Point<T>]);
+
+// use the sliding window comparison implementation of contains
+// multipoint has no boundary so they are equivalent
+impl<T> Covers<MultiPoint<T>> for MultiPoint<T>
+where
+    T: GeoNum,
+{
+    fn covers(&self, rhs: &MultiPoint<T>) -> bool {
+        self.contains(rhs)
+    }
+}
+
+impl_covers_from_relate!(MultiPoint<T>, [
+Line<T>,
+LineString<T>,  MultiLineString<T>,
+Rect<T>, Triangle<T>,
+Polygon<T>,  MultiPolygon<T>,
+Geometry<T>, GeometryCollection<T>
+]);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::algorithm::convert::Convert;
+    use crate::wkt;
+
+    #[test]
+    fn test_rhs_empty() {
+        let s: Point<f64> = wkt!(POINT(0 0)).convert();
+        assert!(!s.covers(&LineString::empty()));
+        assert!(!s.covers(&Polygon::empty()));
+        assert!(!s.covers(&MultiPoint::empty()));
+        assert!(!s.covers(&MultiLineString::empty()));
+        assert!(!s.covers(&MultiPolygon::empty()));
+        assert!(!s.covers(&GeometryCollection::empty()));
+
+        let s: MultiPoint<f64> = wkt!(MULTIPOINT(0 0, 1 1)).convert();
+        assert!(!s.covers(&LineString::empty()));
+        assert!(!s.covers(&Polygon::empty()));
+        assert!(!s.covers(&MultiPoint::empty()));
+        assert!(!s.covers(&MultiLineString::empty()));
+        assert!(!s.covers(&MultiPolygon::empty()));
+        assert!(!s.covers(&GeometryCollection::empty()));
+    }
+
+    #[test]
+    fn test_lhs_empty() {
+        let s: MultiPoint<f64> = MultiPoint::empty();
+        assert!(!s.covers(&wkt!(POINT(0 0)).convert()));
+        assert!(!s.covers(&wkt!(MULTIPOINT(0 0,1 1)).convert()));
+        assert!(!s.covers(&wkt!(LINE(0 0,1 1)).convert()));
+        assert!(!s.covers(&wkt!(LINESTRING(0 0,1 1)).convert()));
+        assert!(!s.covers(&wkt!(MULTILINESTRING((0 0,1 1),(2 2,3 3))).convert()));
+        assert!(!s.covers(&wkt!(POLYGON((0 0,1 1,1 0,0 0))).convert()));
+        assert!(!s.covers(&wkt!(MULTIPOLYGON(((0 0,1 0, 1 1,0 1, 0 0)))).convert()));
+        assert!(!s.covers(&wkt!(RECT(0 0, 1 1)).convert()));
+        assert!(!s.covers(&wkt!(TRIANGLE(0 0, 0 1, 1 1)).convert()));
+        assert!(!s.covers(&Into::<Geometry>::into(wkt!(POINT(0 0)).convert())));
+        assert!(!s.covers(&wkt!(GEOMETRYCOLLECTION(POINT(0 0))).convert()));
+    }
+}

--- a/geo/src/algorithm/covers/polygon.rs
+++ b/geo/src/algorithm/covers/polygon.rs
@@ -1,0 +1,82 @@
+use super::{Covers, impl_covers_from_intersects, impl_covers_from_relate};
+use crate::geometry::*;
+use crate::{GeoFloat, GeoNum};
+
+// valid because RHS is point or multipoint
+// all exterior pts of RHS intersecting self means self covers RHS
+impl_covers_from_intersects!(Polygon<T>, [Point<T>, MultiPoint<T>]);
+
+impl_covers_from_relate!(Polygon<T>, [
+Line<T>,
+LineString<T>,  MultiLineString<T>,
+Rect<T>, Triangle<T>,
+Polygon<T>,  MultiPolygon<T>,
+Geometry<T>, GeometryCollection<T>
+]);
+
+// valid because RHS is point or multipoint
+// all exterior pts of RHS intersecting self means self covers RHS
+impl_covers_from_intersects!(MultiPolygon<T>, [Point<T>, MultiPoint<T>]);
+
+impl_covers_from_relate!(MultiPolygon<T>, [
+Line<T>,
+LineString<T>,  MultiLineString<T>,
+Rect<T>, Triangle<T>,
+Polygon<T>,  MultiPolygon<T>,
+Geometry<T>, GeometryCollection<T>
+]);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::algorithm::convert::Convert;
+    use crate::wkt;
+
+    #[test]
+    fn test_rhs_empty() {
+        let s: Polygon<f64> = wkt!(POLYGON((0 0,1 0, 1 1,0 1, 0 0))).convert();
+        assert!(!s.covers(&LineString::empty()));
+        assert!(!s.covers(&Polygon::empty()));
+        assert!(!s.covers(&MultiPoint::empty()));
+        assert!(!s.covers(&MultiLineString::empty()));
+        assert!(!s.covers(&MultiPolygon::empty()));
+        assert!(!s.covers(&GeometryCollection::empty()));
+
+        let s: MultiPolygon<f64> = wkt!(MULTIPOLYGON(((0 0,1 0, 1 1,0 1, 0 0)))).convert();
+        assert!(!s.covers(&LineString::empty()));
+        assert!(!s.covers(&Polygon::empty()));
+        assert!(!s.covers(&MultiPoint::empty()));
+        assert!(!s.covers(&MultiLineString::empty()));
+        assert!(!s.covers(&MultiPolygon::empty()));
+        assert!(!s.covers(&GeometryCollection::empty()));
+    }
+
+    #[test]
+    fn test_lhs_empty() {
+        let s: Polygon<f64> = Polygon::empty();
+        assert!(!s.covers(&wkt!(POINT(0 0)).convert()));
+        assert!(!s.covers(&wkt!(MULTIPOINT(0 0,1 1)).convert()));
+        assert!(!s.covers(&wkt!(LINE(0 0,1 1)).convert()));
+        assert!(!s.covers(&wkt!(LINESTRING(0 0,1 1)).convert()));
+        assert!(!s.covers(&wkt!(MULTILINESTRING((0 0,1 1),(2 2,3 3))).convert()));
+        assert!(!s.covers(&wkt!(POLYGON((0 0,1 1,1 0,0 0))).convert()));
+        assert!(!s.covers(&wkt!(MULTIPOLYGON(((0 0,1 0, 1 1,0 1, 0 0)))).convert()));
+        assert!(!s.covers(&wkt!(RECT(0 0, 1 1)).convert()));
+        assert!(!s.covers(&wkt!(TRIANGLE(0 0, 0 1, 1 1)).convert()));
+        assert!(!s.covers(&Into::<Geometry>::into(wkt!(POINT(0 0)).convert())));
+        assert!(!s.covers(&wkt!(GEOMETRYCOLLECTION(POINT(0 0))).convert()));
+
+        let s: MultiPolygon<f64> = MultiPolygon::empty();
+        assert!(!s.covers(&wkt!(POINT(0 0)).convert()));
+        assert!(!s.covers(&wkt!(MULTIPOINT(0 0,1 1)).convert()));
+        assert!(!s.covers(&wkt!(LINE(0 0,1 1)).convert()));
+        assert!(!s.covers(&wkt!(LINESTRING(0 0,1 1)).convert()));
+        assert!(!s.covers(&wkt!(MULTILINESTRING((0 0,1 1),(2 2,3 3))).convert()));
+        assert!(!s.covers(&wkt!(POLYGON((0 0,1 1,1 0,0 0))).convert()));
+        assert!(!s.covers(&wkt!(MULTIPOLYGON(((0 0,1 0, 1 1,0 1, 0 0)))).convert()));
+        assert!(!s.covers(&wkt!(RECT(0 0, 1 1)).convert()));
+        assert!(!s.covers(&wkt!(TRIANGLE(0 0, 0 1, 1 1)).convert()));
+        assert!(!s.covers(&Into::<Geometry>::into(wkt!(POINT(0 0)).convert())));
+        assert!(!s.covers(&wkt!(GEOMETRYCOLLECTION(POINT(0 0))).convert()));
+    }
+}

--- a/geo/src/algorithm/covers/rect.rs
+++ b/geo/src/algorithm/covers/rect.rs
@@ -1,0 +1,32 @@
+use super::{Covers, impl_covers_from_intersects};
+use crate::GeoNum;
+use crate::geometry::*;
+
+// valid because self is convex geometry
+// all exterior pts of RHS intersecting self means self covers RHS
+impl_covers_from_intersects!(Rect<T>, [
+Point<T>,MultiPoint<T>,
+Line<T>,
+LineString<T>, MultiLineString<T>,
+Rect<T>, Triangle<T>,
+Polygon<T>,  MultiPolygon<T>,
+Geometry<T>, GeometryCollection<T>
+]);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::algorithm::convert::Convert;
+    use crate::wkt;
+
+    #[test]
+    fn test_rhs_empty() {
+        let s: Rect<f64> = wkt!(RECT(0 0,1 1)).convert();
+        assert!(!s.covers(&LineString::empty()));
+        assert!(!s.covers(&Polygon::empty()));
+        assert!(!s.covers(&MultiPoint::empty()));
+        assert!(!s.covers(&MultiLineString::empty()));
+        assert!(!s.covers(&MultiPolygon::empty()));
+        assert!(!s.covers(&GeometryCollection::empty()));
+    }
+}

--- a/geo/src/algorithm/covers/triangle.rs
+++ b/geo/src/algorithm/covers/triangle.rs
@@ -1,0 +1,32 @@
+use super::{Covers, impl_covers_from_intersects};
+use crate::GeoNum;
+use crate::geometry::*;
+
+// valid because self is convex geometry
+// all exterior pts of RHS intersecting self means self covers RHS
+impl_covers_from_intersects!(Triangle<T>, [
+Point<T>,MultiPoint<T>,
+Line<T>,
+LineString<T>, MultiLineString<T>,
+Rect<T>, Triangle<T>,
+Polygon<T>,  MultiPolygon<T>,
+Geometry<T>, GeometryCollection<T>
+]);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::algorithm::convert::Convert;
+    use crate::wkt;
+
+    #[test]
+    fn test_rhs_empty() {
+        let s: Triangle<f64> = wkt!(TRIANGLE(0 0,0 1,1 1)).convert();
+        assert!(!s.covers(&LineString::empty()));
+        assert!(!s.covers(&Polygon::empty()));
+        assert!(!s.covers(&MultiPoint::empty()));
+        assert!(!s.covers(&MultiLineString::empty()));
+        assert!(!s.covers(&MultiPolygon::empty()));
+        assert!(!s.covers(&GeometryCollection::empty()));
+    }
+}

--- a/geo/src/algorithm/mod.rs
+++ b/geo/src/algorithm/mod.rs
@@ -48,6 +48,9 @@ pub use contains::Contains;
 pub mod contains_properly;
 pub use contains_properly::ContainsProperly;
 
+pub mod covers;
+pub use covers::Covers;
+
 /// Convert the type of a geometry’s coordinate value.
 pub mod convert;
 pub use convert::{Convert, TryConvert};

--- a/geo/src/lib.rs
+++ b/geo/src/lib.rs
@@ -115,6 +115,7 @@
 //!
 //! - **[`Contains`]**: Calculate if a geometry contains another
 //!   geometry
+//! - **[`Covers`]**: Calculate if a geometry covers another geometry
 //! - **[`CoordinatePosition`]**: Calculate
 //!   the position of a coordinate relative to a geometry
 //! - **[`HasDimensions`]**: Determine the dimensions of a geometry

--- a/jts-test-runner/src/input.rs
+++ b/jts-test-runner/src/input.rs
@@ -135,6 +135,15 @@ pub struct ContainsInput {
 }
 
 #[derive(Debug, Deserialize)]
+pub struct CoversInput {
+    pub(crate) arg1: String,
+    pub(crate) arg2: String,
+
+    #[serde(rename = "$value", deserialize_with = "deserialize_from_str")]
+    pub(crate) expected: bool,
+}
+
+#[derive(Debug, Deserialize)]
 pub struct WithinInput {
     pub(crate) arg1: String,
     pub(crate) arg2: String,
@@ -160,6 +169,9 @@ pub(crate) enum OperationInput {
 
     #[serde(rename = "contains")]
     ContainsInput(ContainsInput),
+
+    #[serde(rename = "covers")]
+    CoversInput(CoversInput),
 
     #[serde(rename = "getCentroid")]
     CentroidInput(CentroidInput),
@@ -210,6 +222,11 @@ pub(crate) enum Operation {
         expected: Option<Point>,
     },
     Contains {
+        subject: Geometry,
+        target: Geometry,
+        expected: bool,
+    },
+    Covers {
         subject: Geometry,
         target: Geometry,
         expected: bool,
@@ -330,6 +347,15 @@ impl OperationInput {
                 assert_eq!("A", input.arg1);
                 assert_eq!("B", input.arg2);
                 Ok(Operation::Contains {
+                    subject: geometry.clone(),
+                    target: case.b.clone().expect("no geometry b in case"),
+                    expected: input.expected,
+                })
+            }
+            Self::CoversInput(input) => {
+                assert_eq!("A", input.arg1);
+                assert_eq!("B", input.arg2);
+                Ok(Operation::Covers {
                     subject: geometry.clone(),
                     target: case.b.clone().expect("no geometry b in case"),
                     expected: input.expected,

--- a/jts-test-runner/src/lib.rs
+++ b/jts-test-runner/src/lib.rs
@@ -136,7 +136,7 @@ mod tests {
         //
         // We'll need to increase this number as more tests are added, but it should never be
         // decreased.
-        let expected_test_count: usize = 8735;
+        let expected_test_count: usize = 9307;
         let actual_test_count = runner.unexpected_failures().len() + runner.successes().len();
         match actual_test_count.cmp(&expected_test_count) {
             Ordering::Less => {

--- a/jts-test-runner/src/runner.rs
+++ b/jts-test-runner/src/runner.rs
@@ -9,7 +9,7 @@ use wkt::ToWkt;
 
 use super::{check_buffer_test_case, input, Operation, Result};
 use geo::algorithm::{
-    BooleanOps, Contains, ContainsProperly, HasDimensions, Intersects, Relate, Within,
+    BooleanOps, Contains, ContainsProperly, Covers, HasDimensions, Intersects, Relate, Within,
 };
 use geo::geometry::*;
 use geo::GeoNum;
@@ -194,6 +194,37 @@ impl TestRunner {
                         });
                     } else {
                         debug!("Contains success: actual == expected");
+                        self.successes.push(test_case);
+                    }
+                }
+                Operation::Covers {
+                    subject,
+                    target,
+                    expected,
+                } => {
+                    let relate_actual = subject.relate(target).is_covers();
+                    let direct_actual = subject.covers(target);
+
+                    if relate_actual != *expected {
+                        debug!("Covers failure: Relate doesn't match expected");
+                        let error_description = format!(
+                            "Covers failure: expected {expected:?}, relate: {relate_actual:?}"
+                        );
+                        self.add_failure(TestFailure {
+                            test_case,
+                            error_description,
+                        });
+                    } else if relate_actual != direct_actual {
+                        debug!("Covers failure: Relate doesn't match Covers trait implementation");
+                        let error_description = format!(
+                            "Covers failure - Relate.is_covers: {expected:?} doesn't match Covers trait: {direct_actual:?}"
+                        );
+                        self.add_failure(TestFailure {
+                            test_case,
+                            error_description,
+                        });
+                    } else {
+                        debug!("Covers success: actual == expected");
                         self.successes.push(test_case);
                     }
                 }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Simplification of `Contains` in the opposite direction of #1427 , `Covers` trait allows for simpler Geom in Geom operations because we don't need to be concerned about rhs being inside self's boundary

## Parts implemented
1. New `Covers` Trait 
2. Blanket implementation based on `Relate`
3. Results which can be derived from `intersects`
4. Some results which are equivalent to `Contains`
5. enable jts-tests-runner case for `Covers`

lacking in the test department, but these are the basic derivable implementations
