### PR TITLE
Reduce numerical errors in triangle area calculation

### DIFF
--- a/geo/benches/area.rs
+++ b/geo/benches/area.rs
@@ -1,6 +1,7 @@
 use criterion::{Criterion, criterion_group, criterion_main};
 use geo::Area;
 use geo::Polygon;
+use geo::TriangulateEarcut;
 
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("area", |bencher| {
@@ -10,6 +11,26 @@ fn criterion_benchmark(c: &mut Criterion) {
         bencher.iter(|| {
             criterion::black_box(criterion::black_box(&polygon).signed_area());
         });
+    });
+
+    c.bench_function("triangle area", |bencher| {
+        let norway = geo_test_fixtures::norway_main::<f32>();
+        let polygon = Polygon::new(norway, vec![]);
+        let triangles = polygon.earcut_triangles();
+
+        bencher.iter(|| {
+            criterion::black_box(
+                criterion::black_box(&triangles)
+                    .iter()
+                    .fold(0.0, |area, tri| area + tri.signed_area()),
+            );
+        })
+    });
+
+    c.bench_function("multipolygon area", |bencher| {
+        let nl_plots = geo_test_fixtures::nl_plots_wgs84::<f32>();
+
+        bencher.iter(|| criterion::black_box(criterion::black_box(&nl_plots).signed_area()))
     });
 }
 


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

# Problem
The calculation of a triangle area is quite sensitive to the location of that triangle, meaning even small triangles have a very imprecise area if they're far away from the origin.

This is especially noticeable when working in f32, e.g. the triangle `(-2722.4326 7536.2935,-2721.9543 7535.4424,-2721.2642 7534.726,-2722.4326 7536.2935)` computes an area of `0` instead of `0.12`. For single triangles this is easily avoided by shifting it near the origin but this also makes simplifying a large geometry(-collection) with the Visvalingam-Whyatt algorithm either very rough or quite complex.

All other geometry types (except triangles) already compensate this error leading to the quite confusing behavior of `triangle.unsigned_area() != triangle.to_polygon().unsigned_area()`. In a lot of cases this is not even close to the same area (e.g. sample above).

# Solution
Shift triangles close to the origin (subtracting the first coordinate from each coordinate) before calculating the area. This is the same behavior as the polygon area calculation already uses.

# Notes
- Because the intended/expected behavior of the calculation doesn't change (it only makes it more precise), i didn't add an entry to `CHANGES.md`.
- ~~There is a negative performance impact (although small), possibly making heavy triangle computations slower. Should this be noted in `CHANGES.md`?~~ There is a small **positive** performance impact on polygon (especially triangle) area calculations (see [comment below](https://github.com/georust/geo/pull/1438#issuecomment-3462590368)).
- There are now a few small functions (`twice_signed_ring_area`, `get_linestring_area`, `twice_polygon_area` and `sum_line_determinants`) which do very little on their own and possibly should be consolidated. I didn't do it because I tried to avoid touching too much of the existing code.