### PR TITLE
Add macro for benchmarks to compare Traits against Relate

### DIFF
--- a/geo-benches/src/utils/compare_impl.rs
+++ b/geo-benches/src/utils/compare_impl.rs
@@ -1,0 +1,44 @@
+/// Macro to run Trait and Relate benchmarks against the same input
+/// set up a benchmark group so that Criteron can plot the comparisons
+#[macro_export]
+macro_rules! trait_vs_relate {
+    (
+        $c:ident,
+        $group_name:expr,
+        $arg_a:expr,
+        $arg_b:expr,
+        $trait_fn:expr,
+        $relate_fn:expr,
+        $result:expr
+    ) => {{
+        let mut group = $c.benchmark_group($group_name);
+
+        group.bench_with_input(
+            "trait",
+            &($arg_a.clone(), $arg_b.clone()),
+            |bencher, (arg_a, arg_b)| {
+                bencher.iter(|| {
+                    assert_eq!(
+                        $result,
+                        $trait_fn(criterion::black_box(arg_a), criterion::black_box(arg_b))
+                    );
+                });
+            },
+        );
+
+        group.bench_with_input(
+            "relate",
+            &($arg_a.clone(), $arg_b.clone()),
+            |bencher, (arg_a, arg_b)| {
+                bencher.iter(|| {
+                    assert_eq!(
+                        $result,
+                        $relate_fn(
+                            &criterion::black_box(arg_a).relate(criterion::black_box(arg_b))
+                        )
+                    );
+                });
+            },
+        );
+    }};
+}


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Added a macro in benches to do head to head comparisons of Trait and Relate  
Has the nice additional effect of ensuring that the bench inputs are identical  

Also lets Criterion create a nice violin graph for results in the same group at  
`/geo/target/criterion/<group name>/report/index.html`
<img width="1018" height="342" alt="Screenshot 2025-10-25 at 00 13 49" src="https://github.com/user-attachments/assets/d2016127-3889-40e7-b415-eade26b406eb" />
