### PR TITLE
improve linestring contain coord perf

### DIFF
--- a/geo/src/algorithm/contains/line_string.rs
+++ b/geo/src/algorithm/contains/line_string.rs
@@ -1,8 +1,7 @@
 use super::{Contains, impl_contains_from_relate, impl_contains_geometry_for};
-use crate::Orientation;
 use crate::algorithm::kernels::Kernel;
 use crate::geometry::*;
-use crate::{CoordNum, GeoFloat, GeoNum, HasDimensions};
+use crate::{CoordNum, GeoFloat, GeoNum, HasDimensions, Intersects, Orientation};
 
 // ┌────────────────────────────────┐
 // │ Implementations for LineString │
@@ -21,9 +20,9 @@ where
             return self.is_closed();
         }
 
-        self.lines()
-            .enumerate()
-            .any(|(i, line)| line.contains(coord) || (i > 0 && coord == &line.start))
+        // since it is already known that coord != linestring start or end
+        // it is sufficient to check if the coord intersects any line,
+        self.lines().any(|ln| ln.intersects(coord))
     }
 }
 


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Removed necessary enumerate and check in the LineString.contains(Coord) implementation  

benched using boundary of `point in simple polygon` bench
```
point in simple linestring time:   [2.9182 ns 2.9279 ns 2.9396 ns]
                        change: [-28.259% -27.484% -26.754%] (p = 0.00 < 0.05)
                        Performance has improved.
```