### PR TITLE
Fix useless use of vec! Clippy warning in Rust 1.91

### DIFF
--- a/geo/src/algorithm/old_sweep/segment.rs
+++ b/geo/src/algorithm/old_sweep/segment.rs
@@ -221,7 +221,7 @@ mod tests {
             }
         }
 
-        let test_cases = vec![
+        let test_cases = [
             TestCase {
                 a: 0,
                 b: 0,


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

This warning isn't currently causing CI to fail, but it will if / when we start testing on Rust 1.91+