### PR TITLE
Add remaining JTS convex hull tests

### DIFF
--- a/jts-test-runner/src/lib.rs
+++ b/jts-test-runner/src/lib.rs
@@ -136,7 +136,7 @@ mod tests {
         //
         // We'll need to increase this number as more tests are added, but it should never be
         // decreased.
-        let expected_test_count: usize = 9307;
+        let expected_test_count: usize = 9313;
         let actual_test_count = runner.unexpected_failures().len() + runner.successes().len();
         match actual_test_count.cmp(&expected_test_count) {
             Ordering::Less => {


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [n/a] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

JTS::ConvexHull returns Point and Line types when the dimensionality allows it, whereas geo::ConvexHull always returns a Polygon.


