### PR TITLE
faster upper bound for line-rect intersection

### DIFF
--- a/geo-benches/src/intersection.rs
+++ b/geo-benches/src/intersection.rs
@@ -2,6 +2,46 @@ use criterion::{Criterion, criterion_group, criterion_main};
 use geo::intersects::Intersects;
 use geo::{MultiPolygon, Triangle};
 
+fn line_rect_intersection(c: &mut Criterion) {
+    use geo::{Line, Rect, coord};
+
+    c.bench_function("Line intersects Rect (end intersect)", |bencher| {
+        let line = Line::new(coord! {x:0., y:0.}, coord! {x:10., y:10.});
+        let rect = Rect::new(coord! {x:0., y:0.}, coord! {x:10., y:10.});
+
+        bencher.iter(|| {
+            assert!(criterion::black_box(&line).intersects(criterion::black_box(&rect)));
+        });
+    });
+
+    c.bench_function("Line intersects Rect cross", |bencher| {
+        let line = Line::new(coord! {x:-1., y:5.}, coord! {x:11., y:16.});
+        let rect = Rect::new(coord! {x:0., y:0.}, coord! {x:10., y:10.});
+
+        bencher.iter(|| {
+            assert!(criterion::black_box(&line).intersects(criterion::black_box(&rect)));
+        });
+    });
+
+    c.bench_function("Line disjoint Rect bbox disjoint", |bencher| {
+        let line = Line::new(coord! {x:0., y:0.}, coord! {x:10., y:10.});
+        let rect = Rect::new(coord! {x:11., y:11.}, coord! {x:12., y:12.});
+
+        bencher.iter(|| {
+            assert!(!criterion::black_box(&line).intersects(criterion::black_box(&rect)));
+        });
+    });
+
+    c.bench_function("Line disjoint Rect bbox overlap", |bencher| {
+        let line = Line::new(coord! {x:0., y:0.}, coord! {x:10., y:10.});
+        let rect = Rect::new(coord! {x:6., y:4.}, coord! {x:10., y:0.});
+
+        bencher.iter(|| {
+            assert!(!criterion::black_box(&line).intersects(criterion::black_box(&rect)));
+        });
+    });
+}
+
 fn multi_polygon_intersection(c: &mut Criterion) {
     let plot_polygons: MultiPolygon = geo_test_fixtures::nl_plots_wgs84();
     let zone_polygons: MultiPolygon = geo_test_fixtures::nl_zones();
@@ -253,8 +293,10 @@ criterion_group! {
 }
 
 criterion_group! { bench_linestring_poly,linestring_polygon_intersection}
+criterion_group! { bench_line_rect_intersection,line_rect_intersection}
 
 criterion_main!(
+    bench_line_rect_intersection,
     bench_linestring_poly,
     bench_multi_polygons,
     bench_point_rect,

--- a/geo/src/algorithm/intersects/line_string.rs
+++ b/geo/src/algorithm/intersects/line_string.rs
@@ -63,7 +63,19 @@ where
     }
 }
 
-intersects_line_string_impl!(area: Rect<T>);
+impl<T> Intersects<Rect<T>> for LineString<T>
+where
+    T: GeoNum,
+{
+    fn intersects(&self, rhs: &Rect<T>) -> bool {
+        if has_disjoint_bboxes(self, rhs) {
+            return false;
+        }
+        // splitting into `Line` intersects `Rect`
+        self.lines_iter().any(|ln| ln.intersects(rhs))
+    }
+}
+
 intersects_line_string_impl!(area: Triangle<T>);
 
 // Blanket implementation from LineString<T>


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

## Description
Flatten the performance of Line-Rect intersection checks to ~ 4ns 
The old best case scenario of Line Start being inside the Rect is slower (was ~ 2ns)
- The short circuit option exists, but it adds to the worst case timing so...

But the worst case of disjoint geoms drops dramatically (was ~ 15ns)

## Approach
1. if corners of the `Rect` are all to the left or all to the right of the infinitely extended `Line`, the `Rect` cannot intersect the `Line`
2. Since there is some part of the `Rect` which intersects or crosses the infinitely extended `Line`, then the `Line` must be pointing "toward" the `Rect`
3. Due to this direction, the corner of the `Line`'s bounding box which is closest to the `Rect` is one of the terminals of the `Line`
4. Therefore if the `Line`'s bounding box intersects the `Rect`, the `Line` must also intersect the `Rect`

using explicit variables instead of coords_iter because iter-map-collect approach benches at ~26ns 

## Benches
```
Line intersects Rect (end intersect)
                        time:   [3.9922 ns 3.9990 ns 4.0059 ns]
                        change: [+95.373% +96.046% +96.690%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) low severe

Line intersects Rect cross
                        time:   [4.0872 ns 4.1004 ns 4.1158 ns]
                        change: [-11.778% -11.384% -10.968%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) low mild
  3 (3.00%) high mild
  2 (2.00%) high severe

Line disjoint Rect bbox disjoint
                        time:   [2.0466 ns 2.0495 ns 2.0525 ns]
                        change: [-83.383% -83.317% -83.262%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  1 (1.00%) high severe

Line disjoint Rect bbox overlap
                        time:   [4.1009 ns 4.1096 ns 4.1192 ns]
                        change: [-73.490% -73.423% -73.351%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe
```

