### PR TITLE
Fix CoordinatePosition for Triangle

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## Unreleased
+
+- Fix `CoordinatePosition` for `Triangle` to correctly return `CoordPos::OnBoundary` for coordinates sharing the same x as two corners on the triangle.
+
 ## 0.32.0 - 2025-12-05
 
 - Move `PreparedGeometry` into a new `indexed` module intended to provide index-backed geometries. `relate::PreparedGeometry` has been deprecated.

--- a/geo/src/algorithm/coordinate_position.rs
+++ b/geo/src/algorithm/coordinate_position.rs
@@ -190,11 +190,8 @@ where
             .to_lines()
             .map(|l| {
                 let orientation = T::Ker::orient2d(l.start, l.end, *coord);
-                if orientation == Orientation::Collinear
-                    && point_in_rect(*coord, l.start, l.end)
-                    && coord.x != l.end.x
-                {
-                    *boundary_count += 1;
+                if orientation == Orientation::Collinear && point_in_rect(*coord, l.start, l.end) {
+                    *boundary_count = 1;
                 }
                 orientation
             })


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

See #1468 
### Fix
- Remove the x coordinate check (this was used to ensure if a corner point was used the `boundary_count` would only go to 1).
- Instead set `boundary_count` = 1 if one is present, so if multiple are found (if a corner coord is provided) still accepted as on boundary