### PR TITLE
Split TriangulateDelaunay trait to support Point collections

### DIFF
--- a/geo-benches/src/contains.rs
+++ b/geo-benches/src/contains.rs
@@ -284,6 +284,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                         inside += 1
                     }
                 }
+                criterion::black_box(inside);
             });
         },
     );

--- a/geo-benches/src/triangulate.rs
+++ b/geo-benches/src/triangulate.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main};
-use geo::algorithm::{TriangulateDelaunay, TriangulateEarcut};
+use geo::algorithm::{TriangulateDelaunay, TriangulateDelaunayUnconstrained, TriangulateEarcut};
 use geo::geometry::Polygon;
 use geo::triangulate_delaunay::DelaunayTriangulationConfig;
 
@@ -11,7 +11,8 @@ fn criterion_benchmark(c: &mut criterion::Criterion) {
             bencher.iter(|| {
                 for poly in &multi_poly {
                     let triangulation =
-                        TriangulateDelaunay::unconstrained_triangulation(poly).unwrap();
+                        TriangulateDelaunayUnconstrained::unconstrained_triangulation(poly)
+                            .unwrap();
                     assert!(triangulation.len() > 1);
                     criterion::black_box(triangulation);
                 }
@@ -48,7 +49,8 @@ fn criterion_benchmark(c: &mut criterion::Criterion) {
     c.bench_function("TriangulateSpade (unconstrained) - large_poly", |bencher| {
         let poly = Polygon::new(geo_test_fixtures::norway_main::<f64>(), vec![]);
         bencher.iter(|| {
-            let triangulation = TriangulateDelaunay::unconstrained_triangulation(&poly).unwrap();
+            let triangulation =
+                TriangulateDelaunayUnconstrained::unconstrained_triangulation(&poly).unwrap();
             assert!(triangulation.len() > 1);
             criterion::black_box(triangulation);
         });

--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -5,6 +5,8 @@
 - Fix `CoordinatePosition` for `LineString` to handle dimensionally collapsed input  e.g. `LINESTRING(0 0)` is treated like `POINT(0 0)`.
   - <https://github.com/georust/geo/pull/1483>
 - Fix `CoordinatePosition` for `Triangle` to correctly return `CoordPos::OnBoundary` for coordinate within vertical segment.
+- Split `TriangulateDelaunay` trait to support Point collections in addition to existing geometries
+  - <https://github.com/georust/geo/pull/1486>
 
 ## 0.32.0 - 2025-12-05
 

--- a/geo/src/algorithm/mod.rs
+++ b/geo/src/algorithm/mod.rs
@@ -285,7 +285,7 @@ pub use triangulate_earcut::TriangulateEarcut;
 #[cfg(feature = "spade")]
 pub mod triangulate_delaunay;
 #[cfg(feature = "spade")]
-pub use triangulate_delaunay::TriangulateDelaunay;
+pub use triangulate_delaunay::{TriangulateDelaunay, TriangulateDelaunayUnconstrained};
 
 /// Triangulate polygons using an (un)constrained [Delaunay Triangulation](https://en.wikipedia.org/wiki/Delaunay_triangulation) algorithm.
 #[cfg(feature = "spade")]


### PR DESCRIPTION
New trait structure:

- `TriangulateDelaunayUnconstrained`: **new** trait with unconstrained triangulation methods only
- `TriangulateDelaunay`: now **extends** `TriangulateDelaunayUnconstrained`

New:
- `MultiPoint`, `Point`, and `&[Coord]` get TriangulateDelaunayUnconstrained via the `CoordsIter` blanket impl
- They do NOT get `TriangulateDelaunay` (constrained methods) because they don't implement `LinesIter + Contains`
- Existing types like `Polygon`, `Triangle`, `Rect` etc. get both traits

Why are you doing this?? Because I want to be able to generate Voronoi diagrams from `Point` collections (and, indeed triangulate them).

**NB** I don't believe this is breaking, as the new trait structure is additive.

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
