### PR TITLE
Implement Spade HasPosition for Coord, use Coord as triangulation vertex type

### DIFF
--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## Unreleased
+
+- Implement Spade HasPosition for Coord
+  - <https://github.com/georust/geo/pull/1490>
+
 ## 0.7.18 - 2025-12-01
 
 - Renamed features `use-rstar`, `use-rstar-0_8`, etc. to simply `rstar`, `rstar-0_8`, etc. (removing the `use-` prefix)

--- a/geo-types/Cargo.toml
+++ b/geo-types/Cargo.toml
@@ -44,6 +44,7 @@ rstar_0_10 = { package = "rstar", version = "0.10", optional = true }
 rstar_0_11 = { package = "rstar", version = "0.11", optional = true }
 rstar_0_12 = { package = "rstar", version = "0.12", optional = true }
 serde = { version = "1", optional = true, default-features = false, features = ["alloc", "derive"] }
+spade_2 = { package = "spade", version = "2", optional = true }
 
 [dev-dependencies]
 approx = ">= 0.4.0, < 0.6.0"

--- a/geo-types/src/geometry/coord.rs
+++ b/geo-types/src/geometry/coord.rs
@@ -503,6 +503,18 @@ where
     }
 }
 
+#[cfg(feature = "spade_2")]
+impl<T> ::spade_2::HasPosition for Coord<T>
+where
+    T: crate::CoordNum + ::spade_2::SpadeNum,
+{
+    type Scalar = T;
+
+    fn position(&self) -> ::spade_2::Point2<T> {
+        ::spade_2::Point2::new(self.x, self.y)
+    }
+}
+
 impl<T: CoordNum> AsRef<Coord<T>> for Coord<T> {
     fn as_ref(&self) -> &Coord<T> {
         self

--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -7,6 +7,8 @@
 - Fix `CoordinatePosition` for `Triangle` to correctly return `CoordPos::OnBoundary` for coordinate within vertical segment.
 - Split `TriangulateDelaunay` trait to support Point collections in addition to existing geometries
   - <https://github.com/georust/geo/pull/1486>
+- Use Coord as DelaunayTriangulation vertex type
+  - <https://github.com/georust/geo/pull/1490>
 
 ## 0.32.0 - 2025-12-05
 

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -17,6 +17,7 @@ default = ["earcutr", "spade", "multithreading"]
 proj-network = ["proj", "proj/network"]
 serde = ["dep:serde", "geo-types/serde"]
 multithreading = ["i_overlay/allow_multithreading", "geo-types/multithreading"]
+spade = ["dep:spade", "geo-types/spade_2"]
 
 # Deprecated feature flags with "use-" prefix from the days before `dep:`
 use-proj = ["proj"]


### PR DESCRIPTION
- Add `spade_2` feature and dependency to `geo-types`
- Implement `spade::HasPosition` for `Coord<T`> in `geo-types`
- Update `geo/Cargo.toml` to enable `geo-types/spade_2` when spade is enabled
- Change triangulation to use `Coord<T>` as vertex type instead of `Point2<T>`
- Remove `to_spade_point` and `to_spade_line` helper functions
- Simplify `triangulation_to_triangles` since vertices are now `Coord` directly

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

This is follow-on work from #1486, and _precedes_ #1487. Rather than having to go to and fro between `Coord` and `Point2`, we implement `HasPosition` in a feature which is enabled by default in `geo`. The (mythical) `geo-types` users who don't use `geo` do not have the `spade_2` feature by default.
