### PR TITLE
Fix WASM build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,7 @@ jobs:
       - geo_fuzz
       - geo_benches
       - docs
+      - wasm_build
     if: success()
     steps:
       - name: Mark the job as a success
@@ -56,6 +57,7 @@ jobs:
       - geo_fuzz
       - geo_benches
       - docs
+      - wasm_build
     if: failure()
     steps:
       - name: Mark the job as a failure
@@ -186,3 +188,17 @@ jobs:
         uses: actions/checkout@v6
       - uses: Swatinem/rust-cache@v2
       - run: RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps
+
+  wasm_build:
+    name: WASM Build
+    needs: set-matrix
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - uses: Swatinem/rust-cache@v2
+      - run: rustup target add wasm32-unknown-unknown
+      - run: cargo check --target wasm32-unknown-unknown -p geo-traits
+      - run: cargo check --target wasm32-unknown-unknown -p geo-types
+      - run: cargo check --target wasm32-unknown-unknown -p geo

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -38,7 +38,12 @@ rstar = "0.12.0"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 i_overlay = { version = "4.0.0, < 4.1.0", default-features = false }
 sif-itree = "0.4.0"
+
+[target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
 rand = "0.9.2"
+
+[target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
+rand = { version = "0.9.2", default-features = false, features = ["std_rng", "std"] } 
 
 [dev-dependencies]
 approx = ">= 0.4.0, < 0.6.0"


### PR DESCRIPTION
This commit fixes the wasm build of geo by reducing the amount of enabled features for the rand crate to a subset that's wasm compatible by default. This requires putting some functionality of k-means behind feature gates.

This commit also adds a CI check for wasm-builds.

This is an alternative to #1476 

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
