### PR TITLE
Add ball tree spatial index

### DIFF
--- a/geo-benches/Cargo.toml
+++ b/geo-benches/Cargo.toml
@@ -169,3 +169,8 @@ harness = false
 name = "voronoi"
 path = "src/voronoi.rs"
 harness = false
+
+[[bench]]
+name = "ball_tree"
+path = "src/ball_tree.rs"
+harness = false

--- a/geo-benches/src/ball_tree.rs
+++ b/geo-benches/src/ball_tree.rs
@@ -1,0 +1,160 @@
+use criterion::{Criterion, criterion_group, criterion_main};
+use geo::{BuildBallTree, Point, point};
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+use rand_distr::{Distribution, Uniform};
+
+/// Generate uniformly distributed random 2D points in [0, 1) x [0, 1).
+fn random_points(n: usize, seed: u64) -> Vec<Point<f64>> {
+    let mut rng = StdRng::seed_from_u64(seed);
+    let dist = Uniform::new(0.0, 1.0).unwrap();
+    (0..n)
+        .map(|_| point!(x: dist.sample(&mut rng), y: dist.sample(&mut rng)))
+        .collect()
+}
+
+fn ball_tree_benchmarks(c: &mut Criterion) {
+    let points_1k = random_points(1_000, 42);
+    let points_10k = random_points(10_000, 42);
+    let points_100k = random_points(100_000, 42);
+
+    // Fixed query point near the centre of the distribution.
+    let query = point!(x: 0.5, y: 0.5);
+
+    // Radius chosen so that roughly 1% of the unit square's area is covered:
+    // pi * r^2 ~ 0.01  =>  r ~ 0.056
+    let radius = 0.056;
+
+    // -- construction --------------------------------------------------------
+    {
+        let mut group = c.benchmark_group("ball_tree_construction");
+
+        group.bench_function("1k_points", |b| {
+            b.iter(|| {
+                let tree = criterion::black_box(&points_1k).build_ball_tree();
+                criterion::black_box(tree);
+            });
+        });
+
+        group.bench_function("10k_points", |b| {
+            b.iter(|| {
+                let tree = criterion::black_box(&points_10k).build_ball_tree();
+                criterion::black_box(tree);
+            });
+        });
+
+        group.sample_size(10);
+        group.bench_function("100k_points", |b| {
+            b.iter(|| {
+                let tree = criterion::black_box(&points_100k).build_ball_tree();
+                criterion::black_box(tree);
+            });
+        });
+
+        group.finish();
+    }
+
+    // Pre-build trees for the query benchmarks.
+    let tree_1k = points_1k.build_ball_tree();
+    let tree_10k = points_10k.build_ball_tree();
+    let tree_100k = points_100k.build_ball_tree();
+
+    // -- nearest neighbour ---------------------------------------------------
+    {
+        let mut group = c.benchmark_group("ball_tree_nearest_neighbour");
+
+        group.bench_function("1k_points", |b| {
+            b.iter(|| {
+                let result =
+                    criterion::black_box(&tree_1k).nearest_neighbour(criterion::black_box(&query));
+                criterion::black_box(result);
+            });
+        });
+
+        group.bench_function("10k_points", |b| {
+            b.iter(|| {
+                let result =
+                    criterion::black_box(&tree_10k).nearest_neighbour(criterion::black_box(&query));
+                criterion::black_box(result);
+            });
+        });
+
+        group.sample_size(10);
+        group.bench_function("100k_points", |b| {
+            b.iter(|| {
+                let result = criterion::black_box(&tree_100k)
+                    .nearest_neighbour(criterion::black_box(&query));
+                criterion::black_box(result);
+            });
+        });
+
+        group.finish();
+    }
+
+    // -- k-NN (k=10) ---------------------------------------------------------
+    {
+        let mut group = c.benchmark_group("ball_tree_knn_k10");
+
+        group.bench_function("1k_points", |b| {
+            b.iter(|| {
+                let result = criterion::black_box(&tree_1k)
+                    .nearest_neighbours(criterion::black_box(&query), 10);
+                criterion::black_box(result);
+            });
+        });
+
+        group.bench_function("10k_points", |b| {
+            b.iter(|| {
+                let result = criterion::black_box(&tree_10k)
+                    .nearest_neighbours(criterion::black_box(&query), 10);
+                criterion::black_box(result);
+            });
+        });
+
+        group.sample_size(10);
+        group.bench_function("100k_points", |b| {
+            b.iter(|| {
+                let result = criterion::black_box(&tree_100k)
+                    .nearest_neighbours(criterion::black_box(&query), 10);
+                criterion::black_box(result);
+            });
+        });
+
+        group.finish();
+    }
+
+    // -- within_radius -------------------------------------------------------
+    {
+        let mut group = c.benchmark_group("ball_tree_within_radius");
+
+        group.bench_function("1k_points", |b| {
+            b.iter(|| {
+                let result = criterion::black_box(&tree_1k)
+                    .within_radius(criterion::black_box(&query), radius);
+                criterion::black_box(result);
+            });
+        });
+
+        group.bench_function("10k_points", |b| {
+            b.iter(|| {
+                let result = criterion::black_box(&tree_10k)
+                    .within_radius(criterion::black_box(&query), radius);
+                criterion::black_box(result);
+            });
+        });
+
+        group.sample_size(10);
+        group.bench_function("100k_points", |b| {
+            b.iter(|| {
+                let result = criterion::black_box(&tree_100k)
+                    .within_radius(criterion::black_box(&query), radius);
+                criterion::black_box(result);
+            });
+        });
+
+        group.finish();
+    }
+}
+
+criterion_group!(benches, ball_tree_benchmarks);
+criterion_main!(benches);

--- a/geo-benches/src/ball_tree.rs
+++ b/geo-benches/src/ball_tree.rs
@@ -1,5 +1,5 @@
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
-use geo::{BallTree, Point, point};
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use geo::{BallTree, BallTreeBuilder, Point, point};
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 use rand_distr::{Distribution, Uniform};
@@ -144,6 +144,75 @@ fn ball_tree_benchmarks(c: &mut Criterion) {
         });
 
         group.finish();
+    }
+
+    // -- leaf size sweep at 10k points --------------------------------------
+    //
+    // Sweep `leaf_size` across a representative range to inform the default
+    // for 2-D geospatial workloads. We focus on 10k points (large enough to
+    // matter, small enough to iterate on quickly) and on query operations
+    // relevant to HDBSCAN: k-NN with k=5 (a typical `min_samples`) and
+    // fixed-radius neighbour search.
+    {
+        let leaf_sizes = [2usize, 4, 8, 16, 32, 64];
+        let trees: Vec<BallTree<f64>> = leaf_sizes
+            .iter()
+            .map(|&ls| BallTreeBuilder::with_leaf_size(ls).build(points_10k.clone()))
+            .collect();
+
+        // Construction
+        {
+            let mut group = c.benchmark_group("ball_tree_leaf_size_build_10k");
+            for &ls in &leaf_sizes {
+                group.bench_with_input(BenchmarkId::from_parameter(ls), &ls, |b, &ls| {
+                    b.iter(|| {
+                        let tree = BallTreeBuilder::with_leaf_size(ls)
+                            .build(black_box(points_10k.clone()));
+                        black_box(tree);
+                    });
+                });
+            }
+            group.finish();
+        }
+
+        // NN
+        {
+            let mut group = c.benchmark_group("ball_tree_leaf_size_nn_10k");
+            for (ls, tree) in leaf_sizes.iter().zip(trees.iter()) {
+                group.bench_with_input(BenchmarkId::from_parameter(ls), tree, |b, tree| {
+                    b.iter(|| {
+                        black_box(tree.nearest_neighbour(black_box(&query)));
+                    });
+                });
+            }
+            group.finish();
+        }
+
+        // k-NN at k=5 (HDBSCAN-typical min_samples)
+        {
+            let mut group = c.benchmark_group("ball_tree_leaf_size_knn5_10k");
+            for (ls, tree) in leaf_sizes.iter().zip(trees.iter()) {
+                group.bench_with_input(BenchmarkId::from_parameter(ls), tree, |b, tree| {
+                    b.iter(|| {
+                        black_box(tree.nearest_neighbours(black_box(&query), 5));
+                    });
+                });
+            }
+            group.finish();
+        }
+
+        // Fixed-radius search
+        {
+            let mut group = c.benchmark_group("ball_tree_leaf_size_radius_10k");
+            for (ls, tree) in leaf_sizes.iter().zip(trees.iter()) {
+                group.bench_with_input(BenchmarkId::from_parameter(ls), tree, |b, tree| {
+                    b.iter(|| {
+                        black_box(tree.within_radius(black_box(&query), radius));
+                    });
+                });
+            }
+            group.finish();
+        }
     }
 }
 

--- a/geo-benches/src/ball_tree.rs
+++ b/geo-benches/src/ball_tree.rs
@@ -1,5 +1,5 @@
-use criterion::{Criterion, criterion_group, criterion_main};
-use geo::{BuildBallTree, Point, point};
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use geo::{BallTree, Point, point};
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 use rand_distr::{Distribution, Uniform};
@@ -31,23 +31,23 @@ fn ball_tree_benchmarks(c: &mut Criterion) {
 
         group.bench_function("1k_points", |b| {
             b.iter(|| {
-                let tree = criterion::black_box(&points_1k).build_ball_tree();
-                criterion::black_box(tree);
+                let tree = BallTree::new(black_box(points_1k.clone()));
+                black_box(tree);
             });
         });
 
         group.bench_function("10k_points", |b| {
             b.iter(|| {
-                let tree = criterion::black_box(&points_10k).build_ball_tree();
-                criterion::black_box(tree);
+                let tree = BallTree::new(black_box(points_10k.clone()));
+                black_box(tree);
             });
         });
 
         group.sample_size(10);
         group.bench_function("100k_points", |b| {
             b.iter(|| {
-                let tree = criterion::black_box(&points_100k).build_ball_tree();
-                criterion::black_box(tree);
+                let tree = BallTree::new(black_box(points_100k.clone()));
+                black_box(tree);
             });
         });
 
@@ -55,9 +55,9 @@ fn ball_tree_benchmarks(c: &mut Criterion) {
     }
 
     // Pre-build trees for the query benchmarks.
-    let tree_1k = points_1k.build_ball_tree();
-    let tree_10k = points_10k.build_ball_tree();
-    let tree_100k = points_100k.build_ball_tree();
+    let tree_1k = BallTree::new(points_1k.clone());
+    let tree_10k = BallTree::new(points_10k.clone());
+    let tree_100k = BallTree::new(points_100k.clone());
 
     // -- nearest neighbour ---------------------------------------------------
     {
@@ -65,26 +65,23 @@ fn ball_tree_benchmarks(c: &mut Criterion) {
 
         group.bench_function("1k_points", |b| {
             b.iter(|| {
-                let result =
-                    criterion::black_box(&tree_1k).nearest_neighbour(criterion::black_box(&query));
-                criterion::black_box(result);
+                let result = black_box(&tree_1k).nearest_neighbour(black_box(&query));
+                black_box(result);
             });
         });
 
         group.bench_function("10k_points", |b| {
             b.iter(|| {
-                let result =
-                    criterion::black_box(&tree_10k).nearest_neighbour(criterion::black_box(&query));
-                criterion::black_box(result);
+                let result = black_box(&tree_10k).nearest_neighbour(black_box(&query));
+                black_box(result);
             });
         });
 
         group.sample_size(10);
         group.bench_function("100k_points", |b| {
             b.iter(|| {
-                let result = criterion::black_box(&tree_100k)
-                    .nearest_neighbour(criterion::black_box(&query));
-                criterion::black_box(result);
+                let result = black_box(&tree_100k).nearest_neighbour(black_box(&query));
+                black_box(result);
             });
         });
 
@@ -97,26 +94,23 @@ fn ball_tree_benchmarks(c: &mut Criterion) {
 
         group.bench_function("1k_points", |b| {
             b.iter(|| {
-                let result = criterion::black_box(&tree_1k)
-                    .nearest_neighbours(criterion::black_box(&query), 10);
-                criterion::black_box(result);
+                let result = black_box(&tree_1k).nearest_neighbours(black_box(&query), 10);
+                black_box(result);
             });
         });
 
         group.bench_function("10k_points", |b| {
             b.iter(|| {
-                let result = criterion::black_box(&tree_10k)
-                    .nearest_neighbours(criterion::black_box(&query), 10);
-                criterion::black_box(result);
+                let result = black_box(&tree_10k).nearest_neighbours(black_box(&query), 10);
+                black_box(result);
             });
         });
 
         group.sample_size(10);
         group.bench_function("100k_points", |b| {
             b.iter(|| {
-                let result = criterion::black_box(&tree_100k)
-                    .nearest_neighbours(criterion::black_box(&query), 10);
-                criterion::black_box(result);
+                let result = black_box(&tree_100k).nearest_neighbours(black_box(&query), 10);
+                black_box(result);
             });
         });
 
@@ -129,26 +123,23 @@ fn ball_tree_benchmarks(c: &mut Criterion) {
 
         group.bench_function("1k_points", |b| {
             b.iter(|| {
-                let result = criterion::black_box(&tree_1k)
-                    .within_radius(criterion::black_box(&query), radius);
-                criterion::black_box(result);
+                let result = black_box(&tree_1k).within_radius(black_box(&query), radius);
+                black_box(result);
             });
         });
 
         group.bench_function("10k_points", |b| {
             b.iter(|| {
-                let result = criterion::black_box(&tree_10k)
-                    .within_radius(criterion::black_box(&query), radius);
-                criterion::black_box(result);
+                let result = black_box(&tree_10k).within_radius(black_box(&query), radius);
+                black_box(result);
             });
         });
 
         group.sample_size(10);
         group.bench_function("100k_points", |b| {
             b.iter(|| {
-                let result = criterion::black_box(&tree_100k)
-                    .within_radius(criterion::black_box(&query), radius);
-                criterion::black_box(result);
+                let result = black_box(&tree_100k).within_radius(black_box(&query), radius);
+                black_box(result);
             });
         });
 

--- a/geo/src/algorithm/ball_tree.rs
+++ b/geo/src/algorithm/ball_tree.rs
@@ -18,7 +18,7 @@
 //! # Construction
 //!
 //! Build a tree from any collection of point-like values via [`BallTree::new`].
-//! Bare [`Point`]s, [`Coord`]s, and [`MultiPoint`](crate::MultiPoint)s are all
+//! Bare [`Point`](crate::Point)s, [`Coord`](crate::Coord)s, and [`MultiPoint`](crate::MultiPoint)s are all
 //! accepted directly; to attach per-point data (labels, identifiers, etc.),
 //! wrap each point in a [`PointWithData`].
 //!

--- a/geo/src/algorithm/ball_tree.rs
+++ b/geo/src/algorithm/ball_tree.rs
@@ -17,60 +17,49 @@
 //!
 //! # Construction
 //!
-//! There are three ways to build a ball tree:
+//! Build a tree from any collection of point-like values via [`BallTree::new`].
+//! Bare [`Point`]s, [`Coord`]s, and [`MultiPoint`](crate::MultiPoint)s are all
+//! accepted directly; to attach per-point data (labels, identifiers, etc.),
+//! wrap each point in a [`PointWithData`].
 //!
-//! - **[`BuildBallTree::build_ball_tree`]**: a convenience trait implemented on
-//!   `[Point<T>]`, `Vec<Point<T>>`, and `MultiPoint<T>`. Use this when you just
-//!   need to index points without associated data.
+//! ```
+//! use geo::point;
+//! use geo::algorithm::ball_tree::BallTree;
 //!
-//!   ```
-//!   use geo::{MultiPoint, point};
-//!   use geo::algorithm::ball_tree::BuildBallTree;
+//! let tree = BallTree::new(vec![
+//!     point!(x: 0.0, y: 0.0),
+//!     point!(x: 1.0, y: 1.0),
+//!     point!(x: 2.0, y: 2.0),
+//! ]);
+//! let nearest = tree.nearest_neighbour(&point!(x: 0.1, y: 0.1)).unwrap();
+//! assert_eq!(nearest.point, point!(x: 0.0, y: 0.0));
+//! ```
 //!
-//!   let points = MultiPoint::new(vec![
-//!       point!(x: 0.0, y: 0.0),
-//!       point!(x: 1.0, y: 1.0),
-//!       point!(x: 2.0, y: 2.0),
-//!   ]);
-//!   let tree = points.build_ball_tree();
-//!   ```
+//! ```
+//! use geo::point;
+//! use geo::algorithm::ball_tree::{BallTree, PointWithData};
 //!
-//! - **[`BallTree::new`]**: takes a `Vec<Point<T>>` and a parallel `Vec<D>` of
-//!   associated data. Use this when each point carries a label, identifier, or
-//!   other payload.
+//! let tree = BallTree::new(vec![
+//!     PointWithData::new(point!(x: 0.0, y: 0.0), "origin"),
+//!     PointWithData::new(point!(x: 1.0, y: 1.0), "middle"),
+//!     PointWithData::new(point!(x: 2.0, y: 2.0), "far"),
+//! ]);
+//! let nearest = tree.nearest_neighbour(&point!(x: 0.1, y: 0.1)).unwrap();
+//! assert_eq!(*nearest.data, "origin");
+//! ```
 //!
-//!   ```
-//!   use geo::point;
-//!   use geo::algorithm::ball_tree::BallTree;
+//! To tune the leaf size, use [`BallTreeBuilder`]:
 //!
-//!   let points = vec![
-//!       point!(x: 0.0, y: 0.0),
-//!       point!(x: 1.0, y: 1.0),
-//!       point!(x: 2.0, y: 2.0),
-//!   ];
-//!   let labels = vec!["origin", "middle", "far"];
-//!   let tree = BallTree::new(points, labels);
-//!   let nearest = tree.nearest_neighbour(&point!(x: 0.1, y: 0.1)).unwrap();
-//!   assert_eq!(*nearest.data, "origin");
-//!   ```
+//! ```
+//! use geo::point;
+//! use geo::algorithm::ball_tree::BallTreeBuilder;
 //!
-//! - **[`BallTreeBuilder`]**: a builder that allows configuring parameters such
-//!   as the leaf size before construction. Use this when you need to tune tree
-//!   structure for your workload.
-//!
-//!   ```
-//!   use geo::point;
-//!   use geo::algorithm::ball_tree::BallTreeBuilder;
-//!
-//!   let points = vec![
-//!       point!(x: 0.0, y: 0.0),
-//!       point!(x: 1.0, y: 1.0),
-//!       point!(x: 2.0, y: 2.0),
-//!   ];
-//!   let tree = BallTreeBuilder::new()
-//!       .leaf_size(8)
-//!       .build_pointset(points);
-//!   ```
+//! let tree = BallTreeBuilder::with_leaf_size(16).build(vec![
+//!     point!(x: 0.0, y: 0.0),
+//!     point!(x: 1.0, y: 1.0),
+//!     point!(x: 2.0, y: 2.0),
+//! ]);
+//! ```
 //!
 //! # Queries
 //!
@@ -78,7 +67,7 @@
 //! - [`BallTree::nearest_neighbours`] -- k nearest neighbours, sorted by distance
 //! - [`BallTree::within_radius`] -- all points within a given radius
 
-use crate::{Coord, GeoFloat, GeoNum, MultiPoint, Point};
+use crate::{Coord, CoordNum, GeoFloat, GeoNum, Point};
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
 
@@ -88,6 +77,95 @@ use std::collections::BinaryHeap;
 /// plateau for NN, radius, and construction. See `geo-benches/ball_tree`'s
 /// `ball_tree_leaf_size_*` groups for the underlying sweep.
 const DEFAULT_LEAF_SIZE: usize = 16;
+
+// -- Trait: BallTreePoint -----------------------------------------------------
+
+/// A point-like value that can be indexed in a [`BallTree`].
+///
+/// Implemented for [`Point`], [`Coord`], and [`PointWithData`]. A collection of
+/// any `BallTreePoint` may be passed to [`BallTree::new`] or
+/// [`BallTreeBuilder::build`]. The associated `Data` type determines the
+/// payload returned from queries: it is `()` for bare points, and `D` for
+/// [`PointWithData<T, D>`].
+pub trait BallTreePoint<T: GeoFloat> {
+    /// Associated data carried alongside each point. `()` for bare points.
+    type Data;
+
+    /// The 2-D coordinate used for distance calculations during tree
+    /// construction and queries.
+    fn coord(&self) -> Coord<T>;
+
+    /// Consume `self`, yielding its point and associated data.
+    fn into_point_data(self) -> (Point<T>, Self::Data);
+}
+
+impl<T: GeoFloat> BallTreePoint<T> for Point<T> {
+    type Data = ();
+
+    fn coord(&self) -> Coord<T> {
+        self.0
+    }
+
+    fn into_point_data(self) -> (Point<T>, ()) {
+        (self, ())
+    }
+}
+
+impl<T: GeoFloat> BallTreePoint<T> for Coord<T> {
+    type Data = ();
+
+    fn coord(&self) -> Coord<T> {
+        *self
+    }
+
+    fn into_point_data(self) -> (Point<T>, ()) {
+        (Point(self), ())
+    }
+}
+
+/// A [`Point`] paired with an associated data payload, for indexing in a
+/// [`BallTree`].
+///
+/// Use this when each point carries a label, identifier, or other user data
+/// that should be returned alongside query hits.
+///
+/// ```
+/// use geo::point;
+/// use geo::algorithm::ball_tree::{BallTree, PointWithData};
+///
+/// let tree = BallTree::new(vec![
+///     PointWithData::new(point!(x: 0.0, y: 0.0), "origin"),
+///     PointWithData::new(point!(x: 1.0, y: 1.0), "middle"),
+/// ]);
+/// let nn = tree.nearest_neighbour(&point!(x: 0.1, y: 0.1)).unwrap();
+/// assert_eq!(*nn.data, "origin");
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct PointWithData<T: CoordNum, D> {
+    pub point: Point<T>,
+    pub data: D,
+}
+
+impl<T: CoordNum, D> PointWithData<T, D> {
+    /// Construct a new `PointWithData` from a point and its associated value.
+    pub fn new(point: Point<T>, data: D) -> Self {
+        Self { point, data }
+    }
+}
+
+impl<T: GeoFloat, D> BallTreePoint<T> for PointWithData<T, D> {
+    type Data = D;
+
+    fn coord(&self) -> Coord<T> {
+        self.point.0
+    }
+
+    fn into_point_data(self) -> (Point<T>, D) {
+        (self.point, self.data)
+    }
+}
+
+// -- BallTree -----------------------------------------------------------------
 
 /// An immutable ball tree built from a set of points, supporting repeated
 /// queries without mutation. Points can carry associated data of type `D`
@@ -100,23 +178,23 @@ const DEFAULT_LEAF_SIZE: usize = 16;
 /// of maximum dispersion, producing a balanced binary tree in O(n log n) time.
 #[derive(Debug, Clone)]
 pub struct BallTree<T: GeoFloat, D = ()> {
-    pub(super) nodes: Vec<Node<T>>,
-    pub(super) points: Vec<Point<T>>,
+    nodes: Vec<Node<T>>,
+    points: Vec<Point<T>>,
     data: Vec<D>,
-    pub(super) indices: Vec<usize>,
+    indices: Vec<usize>,
 }
 
 #[derive(Debug, Clone)]
-pub(super) struct Node<T: GeoFloat> {
-    pub(super) center: Coord<T>,
-    pub(super) radius: T,
-    pub(super) start: usize,
-    pub(super) end: usize,
-    pub(super) kind: NodeKind,
+struct Node<T: GeoFloat> {
+    center: Coord<T>,
+    radius: T,
+    start: usize,
+    end: usize,
+    kind: NodeKind,
 }
 
 #[derive(Debug, Clone, Copy)]
-pub(super) enum NodeKind {
+enum NodeKind {
     Leaf,
     Branch { left: usize, right: usize },
 }
@@ -140,43 +218,31 @@ pub struct NearestNeighbour<'a, T: GeoFloat, D> {
 }
 
 impl<T: GeoFloat, D> BallTree<T, D> {
-    /// Build a ball tree from a vector of points and a parallel vector of
-    /// associated data.
+    /// Build a ball tree from any iterable of point-like items.
     ///
-    /// If you do not need associated data, the [`BuildBallTree`] trait provides
-    /// a convenience method that can be called directly on point collections:
+    /// The `Data` associated type on [`BallTreePoint`] determines the `D`
+    /// parameter of the resulting tree. For bare [`Point`]s, [`Coord`]s, and
+    /// [`MultiPoint`](crate::MultiPoint)s this is `()`; for
+    /// [`PointWithData<T, D>`] it is `D`.
     ///
     /// ```
     /// use geo::point;
-    /// use geo::algorithm::ball_tree::BuildBallTree;
+    /// use geo::algorithm::ball_tree::BallTree;
     ///
-    /// let points = vec![point!(x: 0.0, y: 0.0), point!(x: 1.0, y: 1.0)];
-    /// let tree = points.build_ball_tree();
+    /// let tree = BallTree::new(vec![
+    ///     point!(x: 0.0, y: 0.0),
+    ///     point!(x: 1.0, y: 1.0),
+    /// ]);
+    /// assert_eq!(tree.len(), 2);
     /// ```
     ///
-    /// # Panics
-    ///
-    /// Panics if `points` and `data` have different lengths.
-    pub fn new(points: Vec<Point<T>>, data: Vec<D>) -> Self {
-        assert_eq!(
-            points.len(),
-            data.len(),
-            "points and data must have the same length"
-        );
-        let n = points.len();
-        let mut indices: Vec<usize> = (0..n).collect();
-        let mut nodes = Vec::new();
-
-        if n > 0 {
-            build_recursive(&points, &mut indices, 0, n, &mut nodes, DEFAULT_LEAF_SIZE);
-        }
-
-        BallTree {
-            nodes,
-            points,
-            data,
-            indices,
-        }
+    /// To configure the leaf size, use [`BallTreeBuilder`] instead.
+    pub fn new<I, P>(items: I) -> Self
+    where
+        I: IntoIterator<Item = P>,
+        P: BallTreePoint<T, Data = D>,
+    {
+        BallTreeBuilder::new().build(items)
     }
 
     /// Returns the number of points in the tree.
@@ -192,18 +258,14 @@ impl<T: GeoFloat, D> BallTree<T, D> {
 
 /// Compute the squared Euclidean distance between two coords.
 #[inline]
-pub(super) fn coord_distance_sq<T: GeoFloat>(a: Coord<T>, b: Coord<T>) -> T {
+fn coord_distance_sq<T: GeoFloat>(a: Coord<T>, b: Coord<T>) -> T {
     let dx = a.x - b.x;
     let dy = a.y - b.y;
     dx * dx + dy * dy
 }
 
-/// Squared lower-bound Euclidean distance from a query point to the nearest
-/// possible point inside a ball with the given `center` and `radius`.
-///
-/// Returns zero when the query is inside the ball (no pruning possible).
-/// This consolidates the sqrt-subtract-re-square pattern that otherwise
-/// appears at every ball-bound pruning site.
+/// Squared lower-bound Euclidean distance from `query` to the nearest point
+/// inside the ball `(center, radius)`; zero when `query` is inside the ball.
 #[inline]
 fn ball_lower_bound_sq<T: GeoFloat>(query: Coord<T>, center: Coord<T>, radius: T) -> T {
     let dist_to_center = coord_distance_sq(query, center).sqrt();
@@ -243,8 +305,7 @@ fn build_recursive<T: GeoFloat>(
     let mut max_x = T::neg_infinity();
     let mut min_y = T::infinity();
     let mut max_y = T::neg_infinity();
-    for p in node_points() {
-        let (x, y) = p.x_y();
+    for Point(Coord { x, y }) in node_points() {
         sum_x = sum_x + x;
         sum_y = sum_y + y;
         min_x = min_x.min(x);
@@ -332,6 +393,20 @@ impl<T: GeoFloat, D> BallTree<T, D> {
         })
     }
 
+    /// Order two child node indices so that the one whose centre is closer to
+    /// `query` is visited first — this maximises the chance of shrinking the
+    /// best-distance bound before the farther child is explored, improving
+    /// pruning in both `nn_search` and `knn_search`.
+    fn ordered_children(&self, query: Coord<T>, left: usize, right: usize) -> (usize, usize) {
+        let dl = coord_distance_sq(query, self.nodes[left].center);
+        let dr = coord_distance_sq(query, self.nodes[right].center);
+        if dl <= dr {
+            (left, right)
+        } else {
+            (right, left)
+        }
+    }
+
     fn nn_search(
         &self,
         node_idx: usize,
@@ -364,15 +439,7 @@ impl<T: GeoFloat, D> BallTree<T, D> {
                 }
             }
             NodeKind::Branch { left, right } => {
-                let dl = coord_distance_sq(query, self.nodes[*left].center);
-                let dr = coord_distance_sq(query, self.nodes[*right].center);
-
-                let (first, second) = if dl <= dr {
-                    (*left, *right)
-                } else {
-                    (*right, *left)
-                };
-
+                let (first, second) = self.ordered_children(query, *left, *right);
                 self.nn_search(first, query, best_dist_sq, best_index);
                 self.nn_search(second, query, best_dist_sq, best_index);
             }
@@ -382,16 +449,12 @@ impl<T: GeoFloat, D> BallTree<T, D> {
 
 // -- Query: k-nearest neighbours ----------------------------------------------
 
-/// Entry in the max-heap used during k-NN search.
-/// The largest distance sits at the top and can be evicted first.
-///
-/// Uses [`GeoNum::total_cmp`](crate::GeoNum::total_cmp) to provide a real
-/// total order, so NaN values (which cannot arise here in practice, since
-/// distances are computed by squaring and summing finite coordinates) would
-/// still sort consistently.
+/// Entry in the max-heap used during k-NN search; the largest `dist_sq` sits
+/// at the top and is evicted first. `Ord` uses [`GeoNum::total_cmp`] so the
+/// order is total even if a NaN slipped in.
 struct KnnCandidate<T> {
     dist_sq: T,
-    /// Index into the `indices` array (not the original index).
+    /// Original insertion index of the candidate point.
     idx: usize,
 }
 
@@ -435,14 +498,11 @@ impl<T: GeoFloat, D> BallTree<T, D> {
 
         let mut results: Vec<_> = heap
             .into_iter()
-            .map(|c| {
-                let orig = self.indices[c.idx];
-                NearestNeighbour {
-                    point: self.points[orig],
-                    data: &self.data[orig],
-                    index: orig,
-                    distance: c.dist_sq.sqrt(),
-                }
+            .map(|c| NearestNeighbour {
+                point: self.points[c.idx],
+                data: &self.data[c.idx],
+                index: c.idx,
+                distance: c.dist_sq.sqrt(),
             })
             .collect();
         results.sort_by(|a, b| a.distance.total_cmp(&b.distance));
@@ -474,27 +534,18 @@ impl<T: GeoFloat, D> BallTree<T, D> {
 
         match kind {
             NodeKind::Leaf => {
-                for i in *start..*end {
-                    let idx = self.indices[i];
+                for &idx in &self.indices[*start..*end] {
                     let d = coord_distance_sq(query, self.points[idx].0);
                     if heap.len() < k {
-                        heap.push(KnnCandidate { dist_sq: d, idx: i });
+                        heap.push(KnnCandidate { dist_sq: d, idx });
                     } else if d < heap.peek().unwrap().dist_sq {
                         heap.pop();
-                        heap.push(KnnCandidate { dist_sq: d, idx: i });
+                        heap.push(KnnCandidate { dist_sq: d, idx });
                     }
                 }
             }
             NodeKind::Branch { left, right } => {
-                let dl = coord_distance_sq(query, self.nodes[*left].center);
-                let dr = coord_distance_sq(query, self.nodes[*right].center);
-
-                let (first, second) = if dl <= dr {
-                    (*left, *right)
-                } else {
-                    (*right, *left)
-                };
-
+                let (first, second) = self.ordered_children(query, *left, *right);
                 self.knn_search(first, query, k, heap);
                 self.knn_search(second, query, k, heap);
             }
@@ -529,24 +580,33 @@ impl<T: GeoFloat, D> BallTree<T, D> {
         results: &mut Vec<NearestNeighbour<'a, T, D>>,
     ) {
         let node = &self.nodes[node_idx];
-        let dist_to_center = coord_distance_sq(query, node.center).sqrt();
+        let dist_sq = coord_distance_sq(query, node.center);
 
-        // Prune: the ball is entirely outside the search radius
-        if dist_to_center - node.radius > search_radius {
+        // Prune: the ball is entirely outside the search radius iff
+        // `dist_to_center > search_radius + node.radius`. Both sides are
+        // non-negative so we can square and compare without a `sqrt`.
+        let outer = search_radius + node.radius;
+        if dist_sq > outer * outer {
             return;
         }
 
-        // Bulk include: the ball is entirely within the search radius
-        if dist_to_center + node.radius <= search_radius {
-            results.extend(self.indices[node.start..node.end].iter().map(|&idx| {
-                NearestNeighbour {
-                    point: self.points[idx],
-                    data: &self.data[idx],
-                    index: idx,
-                    distance: coord_distance_sq(query, self.points[idx].0).sqrt(),
-                }
-            }));
-            return;
+        // Bulk include: the ball is entirely within the search radius iff
+        // `dist_to_center <= search_radius - node.radius`. That can only
+        // hold when `node.radius <= search_radius`, otherwise the RHS is
+        // negative and we must fall through to the per-point path.
+        if node.radius <= search_radius {
+            let inner = search_radius - node.radius;
+            if dist_sq <= inner * inner {
+                results.extend(self.indices[node.start..node.end].iter().map(|&idx| {
+                    NearestNeighbour {
+                        point: self.points[idx],
+                        data: &self.data[idx],
+                        index: idx,
+                        distance: coord_distance_sq(query, self.points[idx].0).sqrt(),
+                    }
+                }));
+                return;
+            }
         }
 
         match node.kind {
@@ -584,17 +644,14 @@ impl<T: GeoFloat, D> BallTree<T, D> {
 ///
 /// ```
 /// use geo::point;
-/// use geo::algorithm::ball_tree::BallTreeBuilder;
+/// use geo::algorithm::ball_tree::{BallTreeBuilder, PointWithData};
 ///
-/// let points = vec![
-///     point!(x: 0.0, y: 0.0),
-///     point!(x: 1.0, y: 1.0),
-///     point!(x: 2.0, y: 2.0),
+/// let items = vec![
+///     PointWithData::new(point!(x: 0.0, y: 0.0), "origin"),
+///     PointWithData::new(point!(x: 1.0, y: 1.0), "middle"),
+///     PointWithData::new(point!(x: 2.0, y: 2.0), "far"),
 /// ];
-/// let labels = vec!["origin", "middle", "far"];
-/// let tree = BallTreeBuilder::new()
-///     .leaf_size(8)
-///     .build(points, labels);
+/// let tree = BallTreeBuilder::with_leaf_size(8).build(items);
 /// let nearest = tree.nearest_neighbour(&point!(x: 0.1, y: 0.1)).unwrap();
 /// assert_eq!(*nearest.data, "origin");
 /// ```
@@ -610,6 +667,16 @@ impl BallTreeBuilder {
         }
     }
 
+    /// Create a new builder with the given leaf size.
+    ///
+    /// Shorthand for `BallTreeBuilder::new().leaf_size(size)`. A leaf size of
+    /// zero is treated as one.
+    pub fn with_leaf_size(size: usize) -> Self {
+        Self {
+            leaf_size: size.max(1),
+        }
+    }
+
     /// Set the leaf size (maximum number of points in a leaf node).
     ///
     /// A leaf size of zero is treated as one (every leaf holds at least one point).
@@ -618,17 +685,26 @@ impl BallTreeBuilder {
         self
     }
 
-    /// Build a [`BallTree`] from points and parallel associated data.
+    /// Build a [`BallTree`] from any iterable of point-like items.
     ///
-    /// # Panics
-    ///
-    /// Panics if `points` and `data` have different lengths.
-    pub fn build<T: GeoFloat, D>(self, points: Vec<Point<T>>, data: Vec<D>) -> BallTree<T, D> {
-        assert_eq!(
-            points.len(),
-            data.len(),
-            "points and data must have the same length"
-        );
+    /// The `Data` associated type on [`BallTreePoint`] determines the payload
+    /// type `D` of the resulting tree.
+    pub fn build<T, I, P>(self, items: I) -> BallTree<T, P::Data>
+    where
+        T: GeoFloat,
+        I: IntoIterator<Item = P>,
+        P: BallTreePoint<T>,
+    {
+        let iter = items.into_iter();
+        let (lo, hi) = iter.size_hint();
+        let cap = hi.unwrap_or(lo);
+        let mut points = Vec::with_capacity(cap);
+        let mut data = Vec::with_capacity(cap);
+        for item in iter {
+            let (p, d) = item.into_point_data();
+            points.push(p);
+            data.push(d);
+        }
         let n = points.len();
         let mut indices: Vec<usize> = (0..n).collect();
         let mut nodes = Vec::new();
@@ -644,48 +720,11 @@ impl BallTreeBuilder {
             indices,
         }
     }
-
-    /// Build a [`BallTree`] from points without associated data.
-    ///
-    /// This is the builder equivalent of [`BuildBallTree::build_ball_tree`].
-    pub fn build_pointset<T: GeoFloat>(self, points: Vec<Point<T>>) -> BallTree<T> {
-        let data = vec![(); points.len()];
-        self.build(points, data)
-    }
 }
 
 impl Default for BallTreeBuilder {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-// -- Trait: BuildBallTree -----------------------------------------------------
-
-/// Construct a [`BallTree`] from a collection of points (without associated data).
-///
-/// This is the convenience route for building a `BallTree<T, ()>`. To attach
-/// per-point data, use [`BallTree::new`] directly.
-pub trait BuildBallTree<T: GeoFloat> {
-    fn build_ball_tree(&self) -> BallTree<T>;
-}
-
-impl<T: GeoFloat> BuildBallTree<T> for [Point<T>] {
-    fn build_ball_tree(&self) -> BallTree<T> {
-        let data = vec![(); self.len()];
-        BallTree::new(self.to_vec(), data)
-    }
-}
-
-impl<T: GeoFloat> BuildBallTree<T> for Vec<Point<T>> {
-    fn build_ball_tree(&self) -> BallTree<T> {
-        self.as_slice().build_ball_tree()
-    }
-}
-
-impl<T: GeoFloat> BuildBallTree<T> for MultiPoint<T> {
-    fn build_ball_tree(&self) -> BallTree<T> {
-        self.0.build_ball_tree()
     }
 }
 
@@ -711,21 +750,21 @@ mod tests {
 
     #[test]
     fn test_construction_basic() {
-        let tree = make_points().build_ball_tree();
+        let tree = BallTree::new(make_points());
         assert_eq!(tree.len(), 9);
         assert!(!tree.is_empty());
     }
 
     #[test]
     fn test_construction_empty() {
-        let tree: BallTree<f64> = BallTree::new(vec![], vec![]);
+        let tree: BallTree<f64> = BallTree::new(Vec::<Point<f64>>::new());
         assert!(tree.is_empty());
         assert_eq!(tree.len(), 0);
     }
 
     #[test]
     fn test_construction_single_point() {
-        let tree = vec![point!(x: 1.0_f64, y: 2.0)].build_ball_tree();
+        let tree = BallTree::new(vec![point!(x: 1.0_f64, y: 2.0)]);
         assert_eq!(tree.len(), 1);
         assert_eq!(tree.nodes.len(), 1);
     }
@@ -734,7 +773,7 @@ mod tests {
     fn test_bounding_invariant() {
         // Every point should be within the root node's bounding ball
         let points = make_points();
-        let tree = points.build_ball_tree();
+        let tree = BallTree::new(points.clone());
         let root = &tree.nodes[0];
         let center = Point(root.center);
         for p in &points {
@@ -748,7 +787,7 @@ mod tests {
 
     #[test]
     fn test_nn_exact_match() {
-        let tree = make_points().build_ball_tree();
+        let tree = BallTree::new(make_points());
         let result = tree.nearest_neighbour(&point!(x: 1.0, y: 1.0)).unwrap();
         assert_eq!(result.index, 4);
         assert_relative_eq!(result.distance, 0.0);
@@ -756,14 +795,14 @@ mod tests {
 
     #[test]
     fn test_nn_closest_point() {
-        let tree = make_points().build_ball_tree();
+        let tree = BallTree::new(make_points());
         let result = tree.nearest_neighbour(&point!(x: 0.1, y: 0.1)).unwrap();
         assert_eq!(result.index, 0); // (0,0) is closest to (0.1, 0.1)
     }
 
     #[test]
     fn test_nn_empty_tree() {
-        let tree: BallTree<f64> = BallTree::new(vec![], vec![]);
+        let tree: BallTree<f64> = BallTree::new(Vec::<Point<f64>>::new());
         assert!(tree.nearest_neighbour(&point!(x: 0.0, y: 0.0)).is_none());
     }
 
@@ -771,7 +810,7 @@ mod tests {
     fn test_nn_brute_force_comparison() {
         // Compare ball tree NN against brute-force for various query points
         let points = make_points();
-        let tree = points.build_ball_tree();
+        let tree = BallTree::new(points.clone());
 
         let queries = vec![
             point!(x: 0.5, y: 0.5),
@@ -798,7 +837,7 @@ mod tests {
 
     #[test]
     fn test_knn_basic() {
-        let tree = make_points().build_ball_tree();
+        let tree = BallTree::new(make_points());
         let results = tree.nearest_neighbours(&point!(x: 0.0, y: 0.0), 3);
         assert_eq!(results.len(), 3);
         // Should be sorted by distance
@@ -811,21 +850,21 @@ mod tests {
 
     #[test]
     fn test_knn_k_zero() {
-        let tree = make_points().build_ball_tree();
+        let tree = BallTree::new(make_points());
         let results = tree.nearest_neighbours(&point!(x: 0.0, y: 0.0), 0);
         assert!(results.is_empty());
     }
 
     #[test]
     fn test_knn_k_greater_than_n() {
-        let tree = make_points().build_ball_tree();
+        let tree = BallTree::new(make_points());
         let results = tree.nearest_neighbours(&point!(x: 0.0, y: 0.0), 100);
         assert_eq!(results.len(), 9);
     }
 
     #[test]
     fn test_knn_k_one_equals_nn() {
-        let tree = make_points().build_ball_tree();
+        let tree = BallTree::new(make_points());
         let query = point!(x: 0.5, y: 0.5);
         let nn = tree.nearest_neighbour(&query).unwrap();
         let knn = tree.nearest_neighbours(&query, 1);
@@ -837,7 +876,7 @@ mod tests {
     #[test]
     fn test_knn_brute_force_comparison() {
         let points = make_points();
-        let tree = points.build_ball_tree();
+        let tree = BallTree::new(points.clone());
         let query = point!(x: 0.5, y: 0.5);
         let k = 4;
 
@@ -858,7 +897,7 @@ mod tests {
 
     #[test]
     fn test_within_radius_basic() {
-        let tree = make_points().build_ball_tree();
+        let tree = BallTree::new(make_points());
         // All points within distance 1.0 of origin: (0,0), (1,0), (0,1)
         let results = tree.within_radius(&point!(x: 0.0, y: 0.0), 1.0);
         let mut indices: Vec<usize> = results.iter().map(|r| r.index).collect();
@@ -868,14 +907,14 @@ mod tests {
 
     #[test]
     fn test_within_radius_empty_result() {
-        let tree = make_points().build_ball_tree();
+        let tree = BallTree::new(make_points());
         let results = tree.within_radius(&point!(x: 10.0, y: 10.0), 0.1);
         assert!(results.is_empty());
     }
 
     #[test]
     fn test_within_radius_all_points() {
-        let tree = make_points().build_ball_tree();
+        let tree = BallTree::new(make_points());
         let results = tree.within_radius(&point!(x: 1.0, y: 1.0), 10.0);
         assert_eq!(results.len(), 9);
     }
@@ -883,7 +922,7 @@ mod tests {
     #[test]
     fn test_within_radius_brute_force_comparison() {
         let points = make_points();
-        let tree = points.build_ball_tree();
+        let tree = BallTree::new(points.clone());
         let query = point!(x: 1.0, y: 1.0);
         let radius = 1.1;
 
@@ -905,13 +944,12 @@ mod tests {
 
     #[test]
     fn test_with_associated_data() {
-        let points = vec![
-            point!(x: 0.0, y: 0.0),
-            point!(x: 1.0, y: 1.0),
-            point!(x: 2.0, y: 2.0),
+        let items = vec![
+            PointWithData::new(point!(x: 0.0, y: 0.0), "alpha"),
+            PointWithData::new(point!(x: 1.0, y: 1.0), "beta"),
+            PointWithData::new(point!(x: 2.0, y: 2.0), "gamma"),
         ];
-        let data = vec!["alpha", "beta", "gamma"];
-        let tree = BallTree::new(points, data);
+        let tree = BallTree::new(items);
 
         // NN
         let result = tree.nearest_neighbour(&point!(x: 0.9, y: 0.9)).unwrap();
@@ -932,35 +970,38 @@ mod tests {
     }
 
     #[test]
-    fn test_build_ball_tree_trait_multipoint() {
+    fn test_multipoint_accepted_directly() {
         let mp = MultiPoint::new(vec![
             point!(x: 0.0, y: 0.0),
             point!(x: 1.0, y: 1.0),
             point!(x: 2.0, y: 2.0),
         ]);
-        let tree = mp.build_ball_tree();
+        let tree = BallTree::new(mp);
         assert_eq!(tree.len(), 3);
         let result = tree.nearest_neighbour(&point!(x: 0.1, y: 0.1)).unwrap();
         assert_eq!(result.index, 0);
     }
 
     #[test]
-    fn test_build_ball_tree_trait_slice() {
-        let points = vec![
-            point!(x: 0.0_f64, y: 0.0),
-            point!(x: 1.0, y: 1.0),
-            point!(x: 2.0, y: 2.0),
+    fn test_coord_accepted_directly() {
+        let coords: Vec<Coord<f64>> = vec![
+            Coord { x: 0.0, y: 0.0 },
+            Coord { x: 1.0, y: 1.0 },
+            Coord { x: 2.0, y: 2.0 },
         ];
-        let tree = points.as_slice().build_ball_tree();
+        let tree = BallTree::new(coords);
         assert_eq!(tree.len(), 3);
+        let result = tree.nearest_neighbour(&point!(x: 0.1, y: 0.1)).unwrap();
+        assert_eq!(result.index, 0);
     }
 
     #[test]
-    fn test_duplicate_points() {
-        // All points at the same location
-        let points: Vec<Point<f64>> = (0..20).map(|_| point!(x: 5.0, y: 5.0)).collect();
-        let data: Vec<usize> = (0..20).collect();
-        let tree = BallTree::new(points, data);
+    fn test_duplicate_points_with_data() {
+        // All points at the same location, carrying integer labels
+        let items: Vec<PointWithData<f64, usize>> = (0..20)
+            .map(|i| PointWithData::new(point!(x: 5.0, y: 5.0), i))
+            .collect();
+        let tree = BallTree::new(items);
         assert_eq!(tree.len(), 20);
 
         let nn = tree.nearest_neighbour(&point!(x: 5.0, y: 5.0)).unwrap();
@@ -980,12 +1021,12 @@ mod tests {
     fn test_collinear_points() {
         // All points on the x-axis (zero y-spread)
         let points: Vec<Point<f64>> = (0..20).map(|i| point!(x: i as f64, y: 0.0)).collect();
-        let tree = points.build_ball_tree();
+        let tree = BallTree::new(points.clone());
 
         let nn = tree.nearest_neighbour(&point!(x: 5.5, y: 0.0)).unwrap();
         // Points 5 and 6 are both at distance 0.5; either is a valid result
         assert!(nn.index == 5 || nn.index == 6);
-        assert_eq!(nn.distance, 0.5);
+        assert_relative_eq!(nn.distance, 0.5, epsilon = 1e-10);
 
         let knn = tree.nearest_neighbours(&point!(x: 10.0, y: 0.0), 3);
         assert_eq!(knn.len(), 3);
@@ -1003,7 +1044,7 @@ mod tests {
             point!(x: 1.0, y: 1.0),
             point!(x: 5.0, y: 5.0),
         ];
-        let tree = points.build_ball_tree();
+        let tree = BallTree::new(points.clone());
 
         let nn = tree.nearest_neighbour(&point!(x: -4.0, y: -4.0)).unwrap();
         assert_eq!(nn.index, 0); // (-5,-5) is closest
@@ -1016,7 +1057,7 @@ mod tests {
             point!(x: 1.0_f32, y: 0.0),
             point!(x: 0.0_f32, y: 1.0),
         ];
-        let tree = points.build_ball_tree();
+        let tree = BallTree::new(points.clone());
         assert_eq!(tree.len(), 3);
 
         let nn = tree.nearest_neighbour(&point!(x: 0.1_f32, y: 0.1)).unwrap();
@@ -1029,7 +1070,7 @@ mod tests {
 
     #[test]
     fn test_within_radius_zero() {
-        let tree = make_points().build_ball_tree();
+        let tree = BallTree::new(make_points());
 
         // Radius 0 at an exact point should include that point
         let results = tree.within_radius(&point!(x: 1.0, y: 1.0), 0.0);
@@ -1043,7 +1084,7 @@ mod tests {
 
     #[test]
     fn test_empty_tree_all_queries() {
-        let tree: BallTree<f64> = BallTree::new(vec![], vec![]);
+        let tree: BallTree<f64> = BallTree::new(Vec::<Point<f64>>::new());
         assert!(tree.nearest_neighbour(&point!(x: 0.0, y: 0.0)).is_none());
         assert!(
             tree.nearest_neighbours(&point!(x: 0.0, y: 0.0), 5)
@@ -1053,21 +1094,12 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "points and data must have the same length")]
-    fn test_mismatched_lengths_panics() {
-        let _tree = BallTree::new(
-            vec![point!(x: 0.0, y: 0.0), point!(x: 1.0, y: 1.0)],
-            vec![()],
-        );
-    }
-
-    #[test]
     fn test_large_point_set() {
         // Ensure the tree works with more points than DEFAULT_LEAF_SIZE
         let points: Vec<Point<f64>> = (0..100)
             .map(|i| point!(x: (i % 10) as f64, y: (i / 10) as f64))
             .collect();
-        let tree = points.build_ball_tree();
+        let tree = BallTree::new(points.clone());
         assert_eq!(tree.len(), 100);
 
         // Verify NN for a few queries against brute-force
@@ -1092,11 +1124,14 @@ mod tests {
 
     #[test]
     fn test_builder_default_matches_new() {
-        let points = make_points();
-        let data: Vec<usize> = (0..points.len()).collect();
+        let items: Vec<PointWithData<f64, usize>> = make_points()
+            .into_iter()
+            .enumerate()
+            .map(|(i, p)| PointWithData::new(p, i))
+            .collect();
 
-        let tree_new = BallTree::new(points.clone(), data.clone());
-        let tree_builder = BallTreeBuilder::new().build(points, data);
+        let tree_new = BallTree::new(items.clone());
+        let tree_builder = BallTreeBuilder::new().build(items);
 
         // Both trees should yield identical NN results for several queries
         let queries = vec![
@@ -1160,9 +1195,7 @@ mod tests {
         ];
 
         for leaf_size in [1, 2, 8, 16, 50] {
-            let tree = BallTreeBuilder::new()
-                .leaf_size(leaf_size)
-                .build_pointset(points.clone());
+            let tree = BallTreeBuilder::with_leaf_size(leaf_size).build(points.clone());
 
             for query in &queries {
                 // NN -- compare distances, not indices, because ties are
@@ -1195,11 +1228,13 @@ mod tests {
     }
 
     #[test]
-    fn test_builder_pointset_matches_trait() {
+    fn test_builder_with_leaf_size_shortcut() {
+        // BallTreeBuilder::with_leaf_size should be equivalent to
+        // BallTreeBuilder::new().leaf_size(..).
         let points = make_points();
 
-        let tree_trait = points.build_ball_tree();
-        let tree_builder = BallTreeBuilder::new().build_pointset(points.clone());
+        let tree_a = BallTreeBuilder::with_leaf_size(8).build(points.clone());
+        let tree_b = BallTreeBuilder::new().leaf_size(8).build(points.clone());
 
         let queries = vec![
             point!(x: 0.5, y: 0.5),
@@ -1207,10 +1242,10 @@ mod tests {
             point!(x: -1.0, y: -1.0),
         ];
         for query in &queries {
-            let nn_trait = tree_trait.nearest_neighbour(query).unwrap();
-            let nn_builder = tree_builder.nearest_neighbour(query).unwrap();
-            assert_eq!(nn_trait.index, nn_builder.index);
-            assert_relative_eq!(nn_trait.distance, nn_builder.distance, epsilon = 1e-10);
+            let nn_a = tree_a.nearest_neighbour(query).unwrap();
+            let nn_b = tree_b.nearest_neighbour(query).unwrap();
+            assert_eq!(nn_a.index, nn_b.index);
+            assert_relative_eq!(nn_a.distance, nn_b.distance, epsilon = 1e-10);
         }
     }
 
@@ -1218,9 +1253,7 @@ mod tests {
     fn test_builder_leaf_size_zero_clamped_to_one() {
         // leaf_size(0) should be clamped to 1 and still produce correct results
         let points = make_points();
-        let tree = BallTreeBuilder::new()
-            .leaf_size(0)
-            .build_pointset(points.clone());
+        let tree = BallTreeBuilder::new().leaf_size(0).build(points.clone());
 
         let nn = tree.nearest_neighbour(&point!(x: 0.1, y: 0.1)).unwrap();
         let (bf_idx, _) = brute_force_nn(&points, &point!(x: 0.1, y: 0.1));

--- a/geo/src/algorithm/ball_tree.rs
+++ b/geo/src/algorithm/ball_tree.rs
@@ -1,0 +1,1229 @@
+//! A [ball tree] is a binary space-partitioning index over a set of points.
+//! Each internal node stores the minimum enclosing ball of its descendants, so
+//! nearest-neighbour, k-nearest-neighbour, and fixed-radius queries can prune
+//! whole subtrees using the triangle inequality instead of examining every
+//! point. Construction is O(n log n) and query time is typically O(log n) on
+//! well-distributed data, degrading towards O(n) for adversarial inputs.
+//!
+//! Compared to the alternatives: an r-tree indexes rectangles and handles
+//! arbitrary geometries, while a ball tree only indexes points but tends to
+//! prune more aggressively for non-axis-aligned point clusters. It is also a
+//! natural fit for density-based clustering algorithms such as HDBSCAN, which
+//! rely on repeated k-NN and radius queries.
+//!
+//! This implementation is currently 2-D and uses Euclidean distance.
+//!
+//! [ball tree]: https://en.wikipedia.org/wiki/Ball_tree
+//!
+//! # Construction
+//!
+//! There are three ways to build a ball tree:
+//!
+//! - **[`BuildBallTree::build_ball_tree`]**: a convenience trait implemented on
+//!   `[Point<T>]`, `Vec<Point<T>>`, and `MultiPoint<T>`. Use this when you just
+//!   need to index points without associated data.
+//!
+//!   ```
+//!   use geo::{MultiPoint, point};
+//!   use geo::algorithm::ball_tree::BuildBallTree;
+//!
+//!   let points = MultiPoint::new(vec![
+//!       point!(x: 0.0, y: 0.0),
+//!       point!(x: 1.0, y: 1.0),
+//!       point!(x: 2.0, y: 2.0),
+//!   ]);
+//!   let tree = points.build_ball_tree();
+//!   ```
+//!
+//! - **[`BallTree::new`]**: takes a `Vec<Point<T>>` and a parallel `Vec<D>` of
+//!   associated data. Use this when each point carries a label, identifier, or
+//!   other payload.
+//!
+//!   ```
+//!   use geo::point;
+//!   use geo::algorithm::ball_tree::BallTree;
+//!
+//!   let points = vec![
+//!       point!(x: 0.0, y: 0.0),
+//!       point!(x: 1.0, y: 1.0),
+//!       point!(x: 2.0, y: 2.0),
+//!   ];
+//!   let labels = vec!["origin", "middle", "far"];
+//!   let tree = BallTree::new(points, labels);
+//!   let nearest = tree.nearest_neighbour(&point!(x: 0.1, y: 0.1)).unwrap();
+//!   assert_eq!(*nearest.data, "origin");
+//!   ```
+//!
+//! - **[`BallTreeBuilder`]**: a builder that allows configuring parameters such
+//!   as the leaf size before construction. Use this when you need to tune tree
+//!   structure for your workload.
+//!
+//!   ```
+//!   use geo::point;
+//!   use geo::algorithm::ball_tree::BallTreeBuilder;
+//!
+//!   let points = vec![
+//!       point!(x: 0.0, y: 0.0),
+//!       point!(x: 1.0, y: 1.0),
+//!       point!(x: 2.0, y: 2.0),
+//!   ];
+//!   let tree = BallTreeBuilder::new()
+//!       .leaf_size(8)
+//!       .build_pointset(points);
+//!   ```
+//!
+//! # Queries
+//!
+//! - [`BallTree::nearest_neighbour`] -- single nearest neighbour
+//! - [`BallTree::nearest_neighbours`] -- k nearest neighbours, sorted by distance
+//! - [`BallTree::within_radius`] -- all points within a given radius
+
+use crate::{Coord, GeoFloat, GeoNum, MultiPoint, Point};
+use std::cmp::Ordering;
+use std::collections::BinaryHeap;
+
+/// Default maximum points per leaf before splitting. Empirically chosen for
+/// 2-D Euclidean data: at 10k uniform points, 16 is the fastest setting for
+/// k-NN with k=5 (HDBSCAN-typical) and is within a few percent of the
+/// plateau for NN, radius, and construction. See `geo-benches/ball_tree`'s
+/// `ball_tree_leaf_size_*` groups for the underlying sweep.
+const DEFAULT_LEAF_SIZE: usize = 16;
+
+/// An immutable ball tree built from a set of points, supporting repeated
+/// queries without mutation. Points can carry associated data of type `D`
+/// (defaulting to `()`).
+///
+/// See the [module-level documentation](self) for construction options and
+/// query methods.
+///
+/// Construction uses the KD algorithm: recursive median split along the axis
+/// of maximum dispersion, producing a balanced binary tree in O(n log n) time.
+#[derive(Debug, Clone)]
+pub struct BallTree<T: GeoFloat, D = ()> {
+    pub(super) nodes: Vec<Node<T>>,
+    pub(super) points: Vec<Point<T>>,
+    data: Vec<D>,
+    pub(super) indices: Vec<usize>,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct Node<T: GeoFloat> {
+    pub(super) center: Coord<T>,
+    pub(super) radius: T,
+    pub(super) start: usize,
+    pub(super) end: usize,
+    pub(super) kind: NodeKind,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) enum NodeKind {
+    Leaf,
+    Branch { left: usize, right: usize },
+}
+
+#[derive(Debug, Clone, Copy)]
+enum SplitAxis {
+    X,
+    Y,
+}
+
+/// Result type for nearest-neighbour queries.
+///
+/// Contains the matched point, its associated data, the original insertion
+/// index, and the Euclidean distance from the query point.
+#[derive(Debug, Clone)]
+pub struct NearestNeighbour<'a, T: GeoFloat, D> {
+    pub point: Point<T>,
+    pub data: &'a D,
+    pub index: usize,
+    pub distance: T,
+}
+
+impl<T: GeoFloat, D> BallTree<T, D> {
+    /// Build a ball tree from a vector of points and a parallel vector of
+    /// associated data.
+    ///
+    /// If you do not need associated data, the [`BuildBallTree`] trait provides
+    /// a convenience method that can be called directly on point collections:
+    ///
+    /// ```
+    /// use geo::point;
+    /// use geo::algorithm::ball_tree::BuildBallTree;
+    ///
+    /// let points = vec![point!(x: 0.0, y: 0.0), point!(x: 1.0, y: 1.0)];
+    /// let tree = points.build_ball_tree();
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if `points` and `data` have different lengths.
+    pub fn new(points: Vec<Point<T>>, data: Vec<D>) -> Self {
+        assert_eq!(
+            points.len(),
+            data.len(),
+            "points and data must have the same length"
+        );
+        let n = points.len();
+        let mut indices: Vec<usize> = (0..n).collect();
+        let mut nodes = Vec::new();
+
+        if n > 0 {
+            build_recursive(&points, &mut indices, 0, n, &mut nodes, DEFAULT_LEAF_SIZE);
+        }
+
+        BallTree {
+            nodes,
+            points,
+            data,
+            indices,
+        }
+    }
+
+    /// Returns the number of points in the tree.
+    pub fn len(&self) -> usize {
+        self.points.len()
+    }
+
+    /// Returns `true` if the tree contains no points.
+    pub fn is_empty(&self) -> bool {
+        self.points.is_empty()
+    }
+}
+
+/// Compute the squared Euclidean distance between two coords.
+#[inline]
+pub(super) fn coord_distance_sq<T: GeoFloat>(a: Coord<T>, b: Coord<T>) -> T {
+    let dx = a.x - b.x;
+    let dy = a.y - b.y;
+    dx * dx + dy * dy
+}
+
+/// Squared lower-bound Euclidean distance from a query point to the nearest
+/// possible point inside a ball with the given `center` and `radius`.
+///
+/// Returns zero when the query is inside the ball (no pruning possible).
+/// This consolidates the sqrt-subtract-re-square pattern that otherwise
+/// appears at every ball-bound pruning site.
+#[inline]
+fn ball_lower_bound_sq<T: GeoFloat>(query: Coord<T>, center: Coord<T>, radius: T) -> T {
+    let dist_to_center = coord_distance_sq(query, center).sqrt();
+    let gap = dist_to_center - radius;
+    if gap > T::zero() {
+        gap * gap
+    } else {
+        T::zero()
+    }
+}
+
+/// Recursively build the ball tree using the KD construction algorithm.
+///
+/// Operates on the slice `indices[start..end]`, creating a node for the bounding
+/// ball, then splitting at the median along the axis of maximum dispersion.
+fn build_recursive<T: GeoFloat>(
+    points: &[Point<T>],
+    indices: &mut [usize],
+    start: usize,
+    end: usize,
+    nodes: &mut Vec<Node<T>>,
+    leaf_size: usize,
+) -> usize {
+    let count = end - start;
+    debug_assert!(count > 0);
+
+    // `points` is not reordered during construction; each recursion level
+    // owns `indices[start..end]`, which is partially sorted in place by the
+    // splits below. So we always have to go through `indices` to reach the
+    // points belonging to this node.
+    let node_points = || indices[start..end].iter().map(|&i| points[i]);
+
+    // Single pass: compute centroid (sum) and axis dispersion (min/max)
+    let mut sum_x = T::zero();
+    let mut sum_y = T::zero();
+    let mut min_x = T::infinity();
+    let mut max_x = T::neg_infinity();
+    let mut min_y = T::infinity();
+    let mut max_y = T::neg_infinity();
+    for p in node_points() {
+        let (x, y) = p.x_y();
+        sum_x = sum_x + x;
+        sum_y = sum_y + y;
+        min_x = min_x.min(x);
+        max_x = max_x.max(x);
+        min_y = min_y.min(y);
+        max_y = max_y.max(y);
+    }
+    let n = T::from(count).unwrap();
+    let center = Coord {
+        x: sum_x / n,
+        y: sum_y / n,
+    };
+
+    // Compute radius as max distance from centroid
+    let radius = node_points()
+        .map(|p| coord_distance_sq(center, p.0))
+        .fold(T::zero(), |acc, d| acc.max(d))
+        .sqrt();
+
+    let node_idx = nodes.len();
+
+    // If this subset is small enough, it becomes a leaf
+    if count <= leaf_size {
+        nodes.push(Node {
+            center,
+            radius,
+            start,
+            end,
+            kind: NodeKind::Leaf,
+        });
+        return node_idx;
+    }
+
+    // Reserve our slot -- children will be appended after this
+    nodes.push(Node {
+        center,
+        radius,
+        start,
+        end,
+        kind: NodeKind::Leaf, // placeholder, overwritten below
+    });
+
+    // Partition at the median along the axis of maximum dispersion
+    let mid = start + count / 2;
+    let axis = if (max_x - min_x) >= (max_y - min_y) {
+        SplitAxis::X
+    } else {
+        SplitAxis::Y
+    };
+    let comparator = |&a: &usize, &b: &usize| match axis {
+        SplitAxis::X => points[a].x().total_cmp(&points[b].x()),
+        SplitAxis::Y => points[a].y().total_cmp(&points[b].y()),
+    };
+    indices[start..end].select_nth_unstable_by(mid - start, comparator);
+
+    // Recurse on each half
+    let left = build_recursive(points, indices, start, mid, nodes, leaf_size);
+    let right = build_recursive(points, indices, mid, end, nodes, leaf_size);
+
+    nodes[node_idx].kind = NodeKind::Branch { left, right };
+
+    node_idx
+}
+
+// -- Query: nearest neighbour -------------------------------------------------
+
+impl<T: GeoFloat, D> BallTree<T, D> {
+    /// Find the nearest neighbour to `query`.
+    ///
+    /// Returns `None` if the tree is empty. The returned distance is the true
+    /// Euclidean distance (not squared).
+    pub fn nearest_neighbour(&self, query: &Point<T>) -> Option<NearestNeighbour<'_, T, D>> {
+        if self.is_empty() {
+            return None;
+        }
+        let query_coord = query.0;
+        let mut best_dist_sq = T::infinity();
+        let mut best_orig_idx = 0usize;
+        self.nn_search(0, query_coord, &mut best_dist_sq, &mut best_orig_idx);
+        Some(NearestNeighbour {
+            point: self.points[best_orig_idx],
+            data: &self.data[best_orig_idx],
+            index: best_orig_idx,
+            distance: best_dist_sq.sqrt(),
+        })
+    }
+
+    fn nn_search(
+        &self,
+        node_idx: usize,
+        query: Coord<T>,
+        best_dist_sq: &mut T,
+        best_index: &mut usize,
+    ) {
+        let Node {
+            center,
+            radius,
+            start,
+            end,
+            kind,
+        } = &self.nodes[node_idx];
+
+        // Prune: if the closest possible point in this ball is further than
+        // the current best, skip this subtree.
+        if ball_lower_bound_sq(query, *center, *radius) > *best_dist_sq {
+            return;
+        }
+
+        match kind {
+            NodeKind::Leaf => {
+                for &idx in &self.indices[*start..*end] {
+                    let d = coord_distance_sq(query, self.points[idx].0);
+                    if d < *best_dist_sq {
+                        *best_dist_sq = d;
+                        *best_index = idx;
+                    }
+                }
+            }
+            NodeKind::Branch { left, right } => {
+                let dl = coord_distance_sq(query, self.nodes[*left].center);
+                let dr = coord_distance_sq(query, self.nodes[*right].center);
+
+                let (first, second) = if dl <= dr {
+                    (*left, *right)
+                } else {
+                    (*right, *left)
+                };
+
+                self.nn_search(first, query, best_dist_sq, best_index);
+                self.nn_search(second, query, best_dist_sq, best_index);
+            }
+        }
+    }
+}
+
+// -- Query: k-nearest neighbours ----------------------------------------------
+
+/// Entry in the max-heap used during k-NN search.
+/// The largest distance sits at the top and can be evicted first.
+///
+/// Uses [`GeoNum::total_cmp`](crate::GeoNum::total_cmp) to provide a real
+/// total order, so NaN values (which cannot arise here in practice, since
+/// distances are computed by squaring and summing finite coordinates) would
+/// still sort consistently.
+struct KnnCandidate<T> {
+    dist_sq: T,
+    /// Index into the `indices` array (not the original index).
+    idx: usize,
+}
+
+impl<T: GeoNum> PartialEq for KnnCandidate<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.dist_sq.total_cmp(&other.dist_sq) == Ordering::Equal
+    }
+}
+
+impl<T: GeoNum> Eq for KnnCandidate<T> {}
+
+impl<T: GeoNum> PartialOrd for KnnCandidate<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<T: GeoNum> Ord for KnnCandidate<T> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.dist_sq.total_cmp(&other.dist_sq)
+    }
+}
+
+impl<T: GeoFloat, D> BallTree<T, D> {
+    /// Find the `k` nearest neighbours to `query`, sorted by distance (closest first).
+    ///
+    /// If `k` is zero or the tree is empty, returns an empty vector.
+    /// If `k >= len()`, all points are returned.
+    /// Distances are true Euclidean distances (not squared).
+    pub fn nearest_neighbours(
+        &self,
+        query: &Point<T>,
+        k: usize,
+    ) -> Vec<NearestNeighbour<'_, T, D>> {
+        if k == 0 || self.is_empty() {
+            return Vec::new();
+        }
+        let query_coord = query.0;
+        let mut heap: BinaryHeap<KnnCandidate<T>> = BinaryHeap::with_capacity(k);
+        self.knn_search(0, query_coord, k, &mut heap);
+
+        let mut results: Vec<_> = heap
+            .into_iter()
+            .map(|c| {
+                let orig = self.indices[c.idx];
+                NearestNeighbour {
+                    point: self.points[orig],
+                    data: &self.data[orig],
+                    index: orig,
+                    distance: c.dist_sq.sqrt(),
+                }
+            })
+            .collect();
+        results.sort_by(|a, b| a.distance.total_cmp(&b.distance));
+        results
+    }
+
+    fn knn_search(
+        &self,
+        node_idx: usize,
+        query: Coord<T>,
+        k: usize,
+        heap: &mut BinaryHeap<KnnCandidate<T>>,
+    ) {
+        let Node {
+            center,
+            radius,
+            start,
+            end,
+            kind,
+        } = &self.nodes[node_idx];
+
+        // Prune using the ball bound
+        if heap.len() == k {
+            let worst = heap.peek().unwrap().dist_sq;
+            if ball_lower_bound_sq(query, *center, *radius) > worst {
+                return;
+            }
+        }
+
+        match kind {
+            NodeKind::Leaf => {
+                for i in *start..*end {
+                    let idx = self.indices[i];
+                    let d = coord_distance_sq(query, self.points[idx].0);
+                    if heap.len() < k {
+                        heap.push(KnnCandidate { dist_sq: d, idx: i });
+                    } else if d < heap.peek().unwrap().dist_sq {
+                        heap.pop();
+                        heap.push(KnnCandidate { dist_sq: d, idx: i });
+                    }
+                }
+            }
+            NodeKind::Branch { left, right } => {
+                let dl = coord_distance_sq(query, self.nodes[*left].center);
+                let dr = coord_distance_sq(query, self.nodes[*right].center);
+
+                let (first, second) = if dl <= dr {
+                    (*left, *right)
+                } else {
+                    (*right, *left)
+                };
+
+                self.knn_search(first, query, k, heap);
+                self.knn_search(second, query, k, heap);
+            }
+        }
+    }
+}
+
+// -- Query: within radius -----------------------------------------------------
+
+impl<T: GeoFloat, D> BallTree<T, D> {
+    /// Find all points within `radius` of `query`.
+    ///
+    /// The returned distances are true Euclidean distances (not squared).
+    /// Results are not in any particular order.
+    pub fn within_radius(&self, query: &Point<T>, radius: T) -> Vec<NearestNeighbour<'_, T, D>> {
+        if self.is_empty() {
+            return Vec::new();
+        }
+        let query_coord = query.0;
+        let search_radius_sq = radius * radius;
+        let mut results = Vec::new();
+        self.radius_search(0, query_coord, radius, search_radius_sq, &mut results);
+        results
+    }
+
+    fn radius_search<'a>(
+        &'a self,
+        node_idx: usize,
+        query: Coord<T>,
+        search_radius: T,
+        search_radius_sq: T,
+        results: &mut Vec<NearestNeighbour<'a, T, D>>,
+    ) {
+        let node = &self.nodes[node_idx];
+        let dist_to_center = coord_distance_sq(query, node.center).sqrt();
+
+        // Prune: the ball is entirely outside the search radius
+        if dist_to_center - node.radius > search_radius {
+            return;
+        }
+
+        // Bulk include: the ball is entirely within the search radius
+        if dist_to_center + node.radius <= search_radius {
+            results.extend(self.indices[node.start..node.end].iter().map(|&idx| {
+                NearestNeighbour {
+                    point: self.points[idx],
+                    data: &self.data[idx],
+                    index: idx,
+                    distance: coord_distance_sq(query, self.points[idx].0).sqrt(),
+                }
+            }));
+            return;
+        }
+
+        match node.kind {
+            NodeKind::Leaf => {
+                results.extend(
+                    self.indices[node.start..node.end]
+                        .iter()
+                        .filter_map(|&idx| {
+                            let d = coord_distance_sq(query, self.points[idx].0);
+                            (d <= search_radius_sq).then_some(NearestNeighbour {
+                                point: self.points[idx],
+                                data: &self.data[idx],
+                                index: idx,
+                                distance: d.sqrt(),
+                            })
+                        }),
+                );
+            }
+            NodeKind::Branch { left, right } => {
+                self.radius_search(left, query, search_radius, search_radius_sq, results);
+                self.radius_search(right, query, search_radius, search_radius_sq, results);
+            }
+        }
+    }
+}
+
+// -- Builder: BallTreeBuilder -------------------------------------------------
+
+/// A builder for constructing a [`BallTree`] with configurable parameters.
+///
+/// The main tuneable is the **leaf size**: the maximum number of points stored
+/// in a leaf node before the tree splits further. Larger leaves amortise
+/// traversal overhead for brute-force-heavy queries; smaller leaves prune
+/// more aggressively during search.
+///
+/// ```
+/// use geo::point;
+/// use geo::algorithm::ball_tree::BallTreeBuilder;
+///
+/// let points = vec![
+///     point!(x: 0.0, y: 0.0),
+///     point!(x: 1.0, y: 1.0),
+///     point!(x: 2.0, y: 2.0),
+/// ];
+/// let labels = vec!["origin", "middle", "far"];
+/// let tree = BallTreeBuilder::new()
+///     .leaf_size(8)
+///     .build(points, labels);
+/// let nearest = tree.nearest_neighbour(&point!(x: 0.1, y: 0.1)).unwrap();
+/// assert_eq!(*nearest.data, "origin");
+/// ```
+pub struct BallTreeBuilder {
+    leaf_size: usize,
+}
+
+impl BallTreeBuilder {
+    /// Create a new builder with the default leaf size.
+    pub fn new() -> Self {
+        Self {
+            leaf_size: DEFAULT_LEAF_SIZE,
+        }
+    }
+
+    /// Set the leaf size (maximum number of points in a leaf node).
+    ///
+    /// A leaf size of zero is treated as one (every leaf holds at least one point).
+    pub fn leaf_size(mut self, size: usize) -> Self {
+        self.leaf_size = size.max(1);
+        self
+    }
+
+    /// Build a [`BallTree`] from points and parallel associated data.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `points` and `data` have different lengths.
+    pub fn build<T: GeoFloat, D>(self, points: Vec<Point<T>>, data: Vec<D>) -> BallTree<T, D> {
+        assert_eq!(
+            points.len(),
+            data.len(),
+            "points and data must have the same length"
+        );
+        let n = points.len();
+        let mut indices: Vec<usize> = (0..n).collect();
+        let mut nodes = Vec::new();
+
+        if n > 0 {
+            build_recursive(&points, &mut indices, 0, n, &mut nodes, self.leaf_size);
+        }
+
+        BallTree {
+            nodes,
+            points,
+            data,
+            indices,
+        }
+    }
+
+    /// Build a [`BallTree`] from points without associated data.
+    ///
+    /// This is the builder equivalent of [`BuildBallTree::build_ball_tree`].
+    pub fn build_pointset<T: GeoFloat>(self, points: Vec<Point<T>>) -> BallTree<T> {
+        let data = vec![(); points.len()];
+        self.build(points, data)
+    }
+}
+
+impl Default for BallTreeBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// -- Trait: BuildBallTree -----------------------------------------------------
+
+/// Construct a [`BallTree`] from a collection of points (without associated data).
+///
+/// This is the convenience route for building a `BallTree<T, ()>`. To attach
+/// per-point data, use [`BallTree::new`] directly.
+pub trait BuildBallTree<T: GeoFloat> {
+    fn build_ball_tree(&self) -> BallTree<T>;
+}
+
+impl<T: GeoFloat> BuildBallTree<T> for [Point<T>] {
+    fn build_ball_tree(&self) -> BallTree<T> {
+        let data = vec![(); self.len()];
+        BallTree::new(self.to_vec(), data)
+    }
+}
+
+impl<T: GeoFloat> BuildBallTree<T> for Vec<Point<T>> {
+    fn build_ball_tree(&self) -> BallTree<T> {
+        self.as_slice().build_ball_tree()
+    }
+}
+
+impl<T: GeoFloat> BuildBallTree<T> for MultiPoint<T> {
+    fn build_ball_tree(&self) -> BallTree<T> {
+        self.0.build_ball_tree()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Distance, Euclidean, MultiPoint, point};
+    use approx::assert_relative_eq;
+
+    fn make_points() -> Vec<Point<f64>> {
+        vec![
+            point!(x: 0.0, y: 0.0),
+            point!(x: 1.0, y: 0.0),
+            point!(x: 2.0, y: 0.0),
+            point!(x: 0.0, y: 1.0),
+            point!(x: 1.0, y: 1.0),
+            point!(x: 2.0, y: 1.0),
+            point!(x: 0.0, y: 2.0),
+            point!(x: 1.0, y: 2.0),
+            point!(x: 2.0, y: 2.0),
+        ]
+    }
+
+    #[test]
+    fn test_construction_basic() {
+        let tree = make_points().build_ball_tree();
+        assert_eq!(tree.len(), 9);
+        assert!(!tree.is_empty());
+    }
+
+    #[test]
+    fn test_construction_empty() {
+        let tree: BallTree<f64> = BallTree::new(vec![], vec![]);
+        assert!(tree.is_empty());
+        assert_eq!(tree.len(), 0);
+    }
+
+    #[test]
+    fn test_construction_single_point() {
+        let tree = vec![point!(x: 1.0_f64, y: 2.0)].build_ball_tree();
+        assert_eq!(tree.len(), 1);
+        assert_eq!(tree.nodes.len(), 1);
+    }
+
+    #[test]
+    fn test_bounding_invariant() {
+        // Every point should be within the root node's bounding ball
+        let points = make_points();
+        let tree = points.build_ball_tree();
+        let root = &tree.nodes[0];
+        let center = Point(root.center);
+        for p in &points {
+            let d = Euclidean.distance(p, &center);
+            assert!(
+                d <= root.radius + f64::EPSILON,
+                "point {p:?} outside root ball",
+            );
+        }
+    }
+
+    #[test]
+    fn test_nn_exact_match() {
+        let tree = make_points().build_ball_tree();
+        let result = tree.nearest_neighbour(&point!(x: 1.0, y: 1.0)).unwrap();
+        assert_eq!(result.index, 4);
+        assert_relative_eq!(result.distance, 0.0);
+    }
+
+    #[test]
+    fn test_nn_closest_point() {
+        let tree = make_points().build_ball_tree();
+        let result = tree.nearest_neighbour(&point!(x: 0.1, y: 0.1)).unwrap();
+        assert_eq!(result.index, 0); // (0,0) is closest to (0.1, 0.1)
+    }
+
+    #[test]
+    fn test_nn_empty_tree() {
+        let tree: BallTree<f64> = BallTree::new(vec![], vec![]);
+        assert!(tree.nearest_neighbour(&point!(x: 0.0, y: 0.0)).is_none());
+    }
+
+    #[test]
+    fn test_nn_brute_force_comparison() {
+        // Compare ball tree NN against brute-force for various query points
+        let points = make_points();
+        let tree = points.build_ball_tree();
+
+        let queries = vec![
+            point!(x: 0.5, y: 0.5),
+            point!(x: -1.0, y: -1.0),
+            point!(x: 1.5, y: 1.5),
+            point!(x: 3.0, y: 0.0),
+            point!(x: 1.0, y: 0.5),
+        ];
+
+        for query in &queries {
+            let tree_result = tree.nearest_neighbour(query).unwrap();
+
+            // Brute-force
+            let (_bf_idx, bf_dist) = points
+                .iter()
+                .enumerate()
+                .map(|(i, p)| (i, Euclidean.distance(p, query)))
+                .min_by(|a, b| a.1.partial_cmp(&b.1).unwrap())
+                .unwrap();
+
+            assert_relative_eq!(tree_result.distance, bf_dist, epsilon = 1e-10);
+        }
+    }
+
+    #[test]
+    fn test_knn_basic() {
+        let tree = make_points().build_ball_tree();
+        let results = tree.nearest_neighbours(&point!(x: 0.0, y: 0.0), 3);
+        assert_eq!(results.len(), 3);
+        // Should be sorted by distance
+        for i in 1..results.len() {
+            assert!(results[i].distance >= results[i - 1].distance);
+        }
+        // Closest should be (0,0) itself
+        assert_eq!(results[0].index, 0);
+    }
+
+    #[test]
+    fn test_knn_k_zero() {
+        let tree = make_points().build_ball_tree();
+        let results = tree.nearest_neighbours(&point!(x: 0.0, y: 0.0), 0);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_knn_k_greater_than_n() {
+        let tree = make_points().build_ball_tree();
+        let results = tree.nearest_neighbours(&point!(x: 0.0, y: 0.0), 100);
+        assert_eq!(results.len(), 9);
+    }
+
+    #[test]
+    fn test_knn_k_one_equals_nn() {
+        let tree = make_points().build_ball_tree();
+        let query = point!(x: 0.5, y: 0.5);
+        let nn = tree.nearest_neighbour(&query).unwrap();
+        let knn = tree.nearest_neighbours(&query, 1);
+        assert_eq!(knn.len(), 1);
+        assert_eq!(knn[0].index, nn.index);
+        assert_relative_eq!(knn[0].distance, nn.distance, epsilon = 1e-10);
+    }
+
+    #[test]
+    fn test_knn_brute_force_comparison() {
+        let points = make_points();
+        let tree = points.build_ball_tree();
+        let query = point!(x: 0.5, y: 0.5);
+        let k = 4;
+
+        let results = tree.nearest_neighbours(&query, k);
+
+        // Brute-force k-NN
+        let mut dists: Vec<(usize, f64)> = points
+            .iter()
+            .enumerate()
+            .map(|(i, p)| (i, Euclidean.distance(p, &query)))
+            .collect();
+        dists.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
+
+        for (i, result) in results.iter().enumerate() {
+            assert_relative_eq!(result.distance, dists[i].1, epsilon = 1e-10);
+        }
+    }
+
+    #[test]
+    fn test_within_radius_basic() {
+        let tree = make_points().build_ball_tree();
+        // All points within distance 1.0 of origin: (0,0), (1,0), (0,1)
+        let results = tree.within_radius(&point!(x: 0.0, y: 0.0), 1.0);
+        let mut indices: Vec<usize> = results.iter().map(|r| r.index).collect();
+        indices.sort();
+        assert_eq!(indices, vec![0, 1, 3]);
+    }
+
+    #[test]
+    fn test_within_radius_empty_result() {
+        let tree = make_points().build_ball_tree();
+        let results = tree.within_radius(&point!(x: 10.0, y: 10.0), 0.1);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_within_radius_all_points() {
+        let tree = make_points().build_ball_tree();
+        let results = tree.within_radius(&point!(x: 1.0, y: 1.0), 10.0);
+        assert_eq!(results.len(), 9);
+    }
+
+    #[test]
+    fn test_within_radius_brute_force_comparison() {
+        let points = make_points();
+        let tree = points.build_ball_tree();
+        let query = point!(x: 1.0, y: 1.0);
+        let radius = 1.1;
+
+        let results = tree.within_radius(&query, radius);
+        let mut tree_indices: Vec<usize> = results.iter().map(|r| r.index).collect();
+        tree_indices.sort();
+
+        // Brute-force
+        let mut bf_indices: Vec<usize> = points
+            .iter()
+            .enumerate()
+            .filter(|(_, p)| Euclidean.distance(*p, &query) <= radius)
+            .map(|(i, _)| i)
+            .collect();
+        bf_indices.sort();
+
+        assert_eq!(tree_indices, bf_indices);
+    }
+
+    #[test]
+    fn test_with_associated_data() {
+        let points = vec![
+            point!(x: 0.0, y: 0.0),
+            point!(x: 1.0, y: 1.0),
+            point!(x: 2.0, y: 2.0),
+        ];
+        let data = vec!["alpha", "beta", "gamma"];
+        let tree = BallTree::new(points, data);
+
+        // NN
+        let result = tree.nearest_neighbour(&point!(x: 0.9, y: 0.9)).unwrap();
+        assert_eq!(result.index, 1);
+        assert_eq!(result.point, point!(x: 1.0, y: 1.0));
+        assert_eq!(*result.data, "beta");
+
+        // k-NN
+        let results = tree.nearest_neighbours(&point!(x: 0.1, y: 0.1), 2);
+        assert_eq!(*results[0].data, "alpha");
+        assert_eq!(*results[1].data, "beta");
+
+        // Radius
+        let results = tree.within_radius(&point!(x: 0.0, y: 0.0), 1.5);
+        let mut data_found: Vec<&str> = results.iter().map(|r| *r.data).collect();
+        data_found.sort();
+        assert_eq!(data_found, vec!["alpha", "beta"]);
+    }
+
+    #[test]
+    fn test_build_ball_tree_trait_multipoint() {
+        let mp = MultiPoint::new(vec![
+            point!(x: 0.0, y: 0.0),
+            point!(x: 1.0, y: 1.0),
+            point!(x: 2.0, y: 2.0),
+        ]);
+        let tree = mp.build_ball_tree();
+        assert_eq!(tree.len(), 3);
+        let result = tree.nearest_neighbour(&point!(x: 0.1, y: 0.1)).unwrap();
+        assert_eq!(result.index, 0);
+    }
+
+    #[test]
+    fn test_build_ball_tree_trait_slice() {
+        let points = vec![
+            point!(x: 0.0_f64, y: 0.0),
+            point!(x: 1.0, y: 1.0),
+            point!(x: 2.0, y: 2.0),
+        ];
+        let tree = points.as_slice().build_ball_tree();
+        assert_eq!(tree.len(), 3);
+    }
+
+    #[test]
+    fn test_duplicate_points() {
+        // All points at the same location
+        let points: Vec<Point<f64>> = (0..20).map(|_| point!(x: 5.0, y: 5.0)).collect();
+        let data: Vec<usize> = (0..20).collect();
+        let tree = BallTree::new(points, data);
+        assert_eq!(tree.len(), 20);
+
+        let nn = tree.nearest_neighbour(&point!(x: 5.0, y: 5.0)).unwrap();
+        assert_relative_eq!(nn.distance, 0.0);
+
+        let knn = tree.nearest_neighbours(&point!(x: 5.0, y: 5.0), 5);
+        assert_eq!(knn.len(), 5);
+        for r in &knn {
+            assert_relative_eq!(r.distance, 0.0);
+        }
+
+        let within = tree.within_radius(&point!(x: 5.0, y: 5.0), 0.1);
+        assert_eq!(within.len(), 20);
+    }
+
+    #[test]
+    fn test_collinear_points() {
+        // All points on the x-axis (zero y-spread)
+        let points: Vec<Point<f64>> = (0..20).map(|i| point!(x: i as f64, y: 0.0)).collect();
+        let tree = points.build_ball_tree();
+
+        let nn = tree.nearest_neighbour(&point!(x: 5.5, y: 0.0)).unwrap();
+        // Points 5 and 6 are both at distance 0.5; either is a valid result
+        assert!(nn.index == 5 || nn.index == 6);
+        assert_eq!(nn.distance, 0.5);
+
+        let knn = tree.nearest_neighbours(&point!(x: 10.0, y: 0.0), 3);
+        assert_eq!(knn.len(), 3);
+        let mut indices: Vec<usize> = knn.iter().map(|r| r.index).collect();
+        indices.sort();
+        assert_eq!(indices, vec![9, 10, 11]);
+    }
+
+    #[test]
+    fn test_negative_coordinates() {
+        let points = vec![
+            point!(x: -5.0_f64, y: -5.0),
+            point!(x: -1.0, y: -1.0),
+            point!(x: 0.0, y: 0.0),
+            point!(x: 1.0, y: 1.0),
+            point!(x: 5.0, y: 5.0),
+        ];
+        let tree = points.build_ball_tree();
+
+        let nn = tree.nearest_neighbour(&point!(x: -4.0, y: -4.0)).unwrap();
+        assert_eq!(nn.index, 0); // (-5,-5) is closest
+    }
+
+    #[test]
+    fn test_f32_support() {
+        let points: Vec<Point<f32>> = vec![
+            point!(x: 0.0_f32, y: 0.0),
+            point!(x: 1.0_f32, y: 0.0),
+            point!(x: 0.0_f32, y: 1.0),
+        ];
+        let tree = points.build_ball_tree();
+        assert_eq!(tree.len(), 3);
+
+        let nn = tree.nearest_neighbour(&point!(x: 0.1_f32, y: 0.1)).unwrap();
+        assert_eq!(nn.index, 0);
+
+        let knn = tree.nearest_neighbours(&point!(x: 0.1_f32, y: 0.1), 2);
+        assert_eq!(knn.len(), 2);
+        assert_eq!(knn[0].index, 0);
+    }
+
+    #[test]
+    fn test_within_radius_zero() {
+        let tree = make_points().build_ball_tree();
+
+        // Radius 0 at an exact point should include that point
+        let results = tree.within_radius(&point!(x: 1.0, y: 1.0), 0.0);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].index, 4);
+
+        // Radius 0 at a non-point location should be empty
+        let results = tree.within_radius(&point!(x: 0.5, y: 0.5), 0.0);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_empty_tree_all_queries() {
+        let tree: BallTree<f64> = BallTree::new(vec![], vec![]);
+        assert!(tree.nearest_neighbour(&point!(x: 0.0, y: 0.0)).is_none());
+        assert!(
+            tree.nearest_neighbours(&point!(x: 0.0, y: 0.0), 5)
+                .is_empty()
+        );
+        assert!(tree.within_radius(&point!(x: 0.0, y: 0.0), 10.0).is_empty());
+    }
+
+    #[test]
+    #[should_panic(expected = "points and data must have the same length")]
+    fn test_mismatched_lengths_panics() {
+        let _tree = BallTree::new(
+            vec![point!(x: 0.0, y: 0.0), point!(x: 1.0, y: 1.0)],
+            vec![()],
+        );
+    }
+
+    #[test]
+    fn test_large_point_set() {
+        // Ensure the tree works with more points than DEFAULT_LEAF_SIZE
+        let points: Vec<Point<f64>> = (0..100)
+            .map(|i| point!(x: (i % 10) as f64, y: (i / 10) as f64))
+            .collect();
+        let tree = points.build_ball_tree();
+        assert_eq!(tree.len(), 100);
+
+        // Verify NN for a few queries against brute-force
+        let queries = vec![
+            point!(x: 4.5, y: 4.5),
+            point!(x: 0.0, y: 0.0),
+            point!(x: 9.0, y: 9.0),
+        ];
+        for query in &queries {
+            let tree_result = tree.nearest_neighbour(query).unwrap();
+            let (bf_idx, _) = points
+                .iter()
+                .enumerate()
+                .map(|(i, p)| (i, Euclidean.distance(p, query)))
+                .min_by(|a, b| a.1.partial_cmp(&b.1).unwrap())
+                .unwrap();
+            assert_eq!(tree_result.index, bf_idx);
+        }
+    }
+
+    // -- BallTreeBuilder tests ------------------------------------------------
+
+    #[test]
+    fn test_builder_default_matches_new() {
+        let points = make_points();
+        let data: Vec<usize> = (0..points.len()).collect();
+
+        let tree_new = BallTree::new(points.clone(), data.clone());
+        let tree_builder = BallTreeBuilder::new().build(points, data);
+
+        // Both trees should yield identical NN results for several queries
+        let queries = vec![
+            point!(x: 0.5, y: 0.5),
+            point!(x: 1.5, y: 1.5),
+            point!(x: -1.0, y: -1.0),
+        ];
+        for query in &queries {
+            let nn_new = tree_new.nearest_neighbour(query).unwrap();
+            let nn_builder = tree_builder.nearest_neighbour(query).unwrap();
+            assert_eq!(nn_new.index, nn_builder.index);
+            assert_relative_eq!(nn_new.distance, nn_builder.distance, epsilon = 1e-10);
+        }
+    }
+
+    /// Helper: brute-force nearest neighbour for verification.
+    fn brute_force_nn(points: &[Point<f64>], query: &Point<f64>) -> (usize, f64) {
+        points
+            .iter()
+            .enumerate()
+            .map(|(i, p)| (i, Euclidean.distance(p, query)))
+            .min_by(|a, b| a.1.partial_cmp(&b.1).unwrap())
+            .unwrap()
+    }
+
+    /// Helper: brute-force k-NN for verification.
+    fn brute_force_knn(points: &[Point<f64>], query: &Point<f64>, k: usize) -> Vec<(usize, f64)> {
+        let mut dists: Vec<(usize, f64)> = points
+            .iter()
+            .enumerate()
+            .map(|(i, p)| (i, Euclidean.distance(p, query)))
+            .collect();
+        dists.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
+        dists.truncate(k);
+        dists
+    }
+
+    /// Helper: brute-force radius search for verification.
+    fn brute_force_radius(points: &[Point<f64>], query: &Point<f64>, radius: f64) -> Vec<usize> {
+        let mut indices: Vec<usize> = points
+            .iter()
+            .enumerate()
+            .filter(|(_, p)| Euclidean.distance(*p, query) <= radius)
+            .map(|(i, _)| i)
+            .collect();
+        indices.sort();
+        indices
+    }
+
+    #[test]
+    fn test_builder_custom_leaf_sizes() {
+        let points: Vec<Point<f64>> = (0..50)
+            .map(|i| point!(x: (i % 10) as f64, y: (i / 10) as f64))
+            .collect();
+
+        let queries = vec![
+            point!(x: 3.3, y: 2.7),
+            point!(x: 0.0, y: 0.0),
+            point!(x: 9.0, y: 4.0),
+            point!(x: 5.5, y: 2.5),
+        ];
+
+        for leaf_size in [1, 2, 8, 16, 50] {
+            let tree = BallTreeBuilder::new()
+                .leaf_size(leaf_size)
+                .build_pointset(points.clone());
+
+            for query in &queries {
+                // NN -- compare distances, not indices, because ties are
+                // broken arbitrarily depending on tree structure.
+                let nn = tree.nearest_neighbour(query).unwrap();
+                let (_, bf_dist) = brute_force_nn(&points, query);
+                assert_relative_eq!(nn.distance, bf_dist, epsilon = 1e-10);
+
+                // k-NN
+                let k = 5;
+                let knn = tree.nearest_neighbours(query, k);
+                let bf_knn = brute_force_knn(&points, query, k);
+                assert_eq!(knn.len(), bf_knn.len());
+                for (tree_r, bf_r) in knn.iter().zip(bf_knn.iter()) {
+                    assert_relative_eq!(tree_r.distance, bf_r.1, epsilon = 1e-10);
+                }
+
+                // Radius
+                let radius = 2.0;
+                let within = tree.within_radius(query, radius);
+                let mut tree_indices: Vec<usize> = within.iter().map(|r| r.index).collect();
+                tree_indices.sort();
+                let bf_indices = brute_force_radius(&points, query, radius);
+                assert_eq!(
+                    tree_indices, bf_indices,
+                    "Radius search mismatch with leaf_size={leaf_size} for query {query:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_builder_pointset_matches_trait() {
+        let points = make_points();
+
+        let tree_trait = points.build_ball_tree();
+        let tree_builder = BallTreeBuilder::new().build_pointset(points.clone());
+
+        let queries = vec![
+            point!(x: 0.5, y: 0.5),
+            point!(x: 1.5, y: 1.5),
+            point!(x: -1.0, y: -1.0),
+        ];
+        for query in &queries {
+            let nn_trait = tree_trait.nearest_neighbour(query).unwrap();
+            let nn_builder = tree_builder.nearest_neighbour(query).unwrap();
+            assert_eq!(nn_trait.index, nn_builder.index);
+            assert_relative_eq!(nn_trait.distance, nn_builder.distance, epsilon = 1e-10);
+        }
+    }
+
+    #[test]
+    fn test_builder_leaf_size_zero_clamped_to_one() {
+        // leaf_size(0) should be clamped to 1 and still produce correct results
+        let points = make_points();
+        let tree = BallTreeBuilder::new()
+            .leaf_size(0)
+            .build_pointset(points.clone());
+
+        let nn = tree.nearest_neighbour(&point!(x: 0.1, y: 0.1)).unwrap();
+        let (bf_idx, _) = brute_force_nn(&points, &point!(x: 0.1, y: 0.1));
+        assert_eq!(nn.index, bf_idx);
+    }
+}

--- a/geo/src/algorithm/mod.rs
+++ b/geo/src/algorithm/mod.rs
@@ -2,6 +2,10 @@
 pub mod kernels;
 pub use kernels::{Kernel, Orientation};
 
+/// Nearest-neighbour queries on point sets using a ball tree.
+pub mod ball_tree;
+pub use ball_tree::{BallTree, BallTreeBuilder, BuildBallTree};
+
 /// Calculate the area of the surface of a `Geometry`.
 pub mod area;
 pub use area::Area;

--- a/geo/src/algorithm/mod.rs
+++ b/geo/src/algorithm/mod.rs
@@ -4,7 +4,7 @@ pub use kernels::{Kernel, Orientation};
 
 /// Nearest-neighbour queries on point sets using a ball tree.
 pub mod ball_tree;
-pub use ball_tree::{BallTree, BallTreeBuilder, BuildBallTree};
+pub use ball_tree::{BallTree, BallTreeBuilder, BallTreePoint, PointWithData};
 
 /// Calculate the area of the surface of a `Geometry`.
 pub mod area;

--- a/geo/src/lib.rs
+++ b/geo/src/lib.rs
@@ -206,6 +206,10 @@
 //! their members and adding them. Note in particular the availability of the [`bulk_load`](https://docs.rs/rstar/0.12.0/rstar/struct.RTree.html#method.bulk_load)
 //! method and [`GeomWithData`](https://docs.rs/rstar/0.12.0/rstar/primitives/struct.GeomWithData.html) struct.
 //!
+//! For point-only data, the [`BallTree`] provides an alternative spatial index with nearest-neighbour,
+//! k-nearest-neighbours, and radius search queries. Construct one via the [`BuildBallTree`] trait,
+//! [`BallTree::new`] (for associated data), or [`BallTreeBuilder`] (for configurable leaf size).
+//!
 //! # Features
 //!
 //! The following optional [Cargo features] are available:

--- a/geo/src/lib.rs
+++ b/geo/src/lib.rs
@@ -207,8 +207,9 @@
 //! method and [`GeomWithData`](https://docs.rs/rstar/0.12.0/rstar/primitives/struct.GeomWithData.html) struct.
 //!
 //! For point-only data, the [`BallTree`] provides an alternative spatial index with nearest-neighbour,
-//! k-nearest-neighbours, and radius search queries. Construct one via the [`BuildBallTree`] trait,
-//! [`BallTree::new`] (for associated data), or [`BallTreeBuilder`] (for configurable leaf size).
+//! k-nearest-neighbours, and radius search queries. Construct one via [`BallTree::new`] (wrapping
+//! each point in a [`PointWithData`] when you need an associated payload), or [`BallTreeBuilder`]
+//! for a configurable leaf size.
 //!
 //! # Features
 //!


### PR DESCRIPTION


- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Ball trees are a somewhat specialised spatial index that are more performant then e.g. KD trees or r-trees for certain arrangements of input data, for higher-dimensional data (not really relevant to us), and for clustering (highly relevant, as will become apparent in a follow-up PR).

I wrote this impl with Claude's assistance, but very happy to answer questions. It draws directly from license-compatible implementations in other crates (ball-tree, petal_cluster). One thing to note is that I've intentionally left it out of the `indexed` module as that's intended for existing geometries backed by a spatial index, and this is a bit more general-purpose.
 
