### PR TITLE
switch to earcut crate for performance improvement

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,7 +119,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --all-targets --no-default-features
       # we don't want to test `proj-network` because it only enables the `proj` feature
-      - run: cargo test --features "proj serde earcutr multithreading"
+      - run: cargo test --features "proj serde earcut multithreading"
 
   geo_traits:
     name: geo-traits

--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -23,6 +23,10 @@
   It wasn't referenced by the `triangle_indices` cut by earcutr, but you may notice a different triangulation for a given input.
 - Deprecate `StitchTriangulation`. Instead convert your triangles to Polygon and use unary_union.
   - <https://github.com/georust/geo/pull/1514>
+- Replace `earcutr` crate with the faster `earcut` crate.
+  - <https://github.com/georust/geo/pull/1508>
+  - The high level `TriangulateEarcut::earcut_triangles` API hasn't changed, but may return a different triangulation.
+  - BREAKING: The low level `TriangulateEarcut::earcut_triangles_raw` API now groups coordinates `[[x0, y0],[x1 y1]]]`, previously it was flattened: `[x0, y1, x1, y1]`
 
 ## 0.32.0 - 2025-12-05
 

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -13,7 +13,9 @@ rust-version = "1.88"
 categories = ["science::geo"]
 
 [features]
-default = ["earcutr", "spade", "multithreading"]
+default = ["earcut", "spade", "multithreading"]
+# deprecated spelling earcutr->earcut
+earcutr = ["earcut"]
 proj-network = ["proj", "proj/network"]
 serde = ["dep:serde", "geo-types/serde"]
 multithreading = ["i_overlay/allow_multithreading", "geo-types/multithreading"]
@@ -26,7 +28,7 @@ use-serde = ["serde"]
 __allow_deprecated_features = []
 
 [dependencies]
-earcutr = { version = "0.5.0", optional = true }
+earcut = { version = "0.4.5", optional = true }
 spade = { version = "2.10.0", optional = true }
 float_next_after = "2.0.0"
 geo-types = { version = "0.7.18", features = ["approx", "rstar_0_12"] }

--- a/geo/src/algorithm/mod.rs
+++ b/geo/src/algorithm/mod.rs
@@ -276,10 +276,10 @@ pub use translate::Translate;
 
 /// Triangulate polygons using an [ear-cutting algorithm](https://www.geometrictools.com/Documentation/TriangulationByEarClipping.pdf).
 ///
-/// Requires the `"earcutr"` feature.
-#[cfg(feature = "earcutr")]
+/// Requires the `"earcut"` feature.
+#[cfg(feature = "earcut")]
 pub mod triangulate_earcut;
-#[cfg(feature = "earcutr")]
+#[cfg(feature = "earcut")]
 pub use triangulate_earcut::TriangulateEarcut;
 
 /// Triangulate polygons using an (un)constrained [Delaunay Triangulation](https://en.wikipedia.org/wiki/Delaunay_triangulation) algorithm.

--- a/geo/src/algorithm/stitch.rs
+++ b/geo/src/algorithm/stitch.rs
@@ -451,7 +451,7 @@ fn try_stitch<F: GeoFloat>(a: &[Coord<F>], b: &[Coord<F>]) -> Option<Vec<Coord<F
 #[cfg(test)]
 mod polygon_stitching_tests {
 
-    use crate::{Relate, TriangulateEarcut, Winding};
+    use crate::{Relate, TriangulateEarcut, Validation, Winding};
 
     use super::*;
     use geo_types::*;
@@ -533,30 +533,8 @@ mod polygon_stitching_tests {
 
     #[test]
     fn stitch_creating_hole() {
-        let poly1 = Polygon::new(
-            LineString::new(vec![
-                Coord { x: 0.0, y: 0.0 },
-                Coord { x: 1.0, y: 0.0 },
-                Coord { x: 1.0, y: 1.0 },
-                Coord { x: 1.0, y: 2.0 },
-                Coord { x: 2.0, y: 2.0 },
-                Coord { x: 2.0, y: 1.0 },
-                Coord { x: 2.0, y: 0.0 },
-                Coord { x: 3.0, y: 0.0 },
-                Coord { x: 3.0, y: 3.0 },
-                Coord { x: 0.0, y: 3.0 },
-            ]),
-            vec![],
-        );
-        let poly2 = Polygon::new(
-            LineString::new(vec![
-                Coord { x: 1.0, y: 0.0 },
-                Coord { x: 2.0, y: 0.0 },
-                Coord { x: 2.0, y: 1.0 },
-                Coord { x: 1.0, y: 1.0 },
-            ]),
-            vec![],
-        );
+        let poly1 = wkt!(POLYGON((0.0 0.0,1.0 0.0,1.0 1.0,1.0 2.0,2.0 2.0,2.0 1.0,2.0 0.0,3.0 0.0,3.0 3.0,0.0 3.0,0.0 0.0)));
+        let poly2 = wkt!(POLYGON((1.0 0.0,2.0 0.0,2.0 1.0,1.0 1.0,1.0 0.0)));
 
         let result = [poly1, poly2]
             .map(|p| p.earcut_triangles())
@@ -570,18 +548,7 @@ mod polygon_stitching_tests {
 
     #[test]
     fn inner_banana_produces_hole() {
-        let poly = Polygon::new(
-            LineString::new(vec![
-                Coord { x: 0.0, y: 0.0 },
-                Coord { x: 4.0, y: 0.0 },
-                Coord { x: 3.0, y: 2.0 },
-                Coord { x: 5.0, y: 2.0 },
-                Coord { x: 4.0, y: 0.0 },
-                Coord { x: 8.0, y: 0.0 },
-                Coord { x: 4.0, y: 4.0 },
-            ]),
-            vec![],
-        );
+        let poly = wkt!(POLYGON((0.0 0.0,4.0 0.0,3.0 2.0,5.0 2.0,4.0 0.0,8.0 0.0,4.0 4.0,0.0 0.0)));
 
         let result = [poly]
             .map(|p| p.earcut_triangles())
@@ -594,19 +561,10 @@ mod polygon_stitching_tests {
     }
 
     #[test]
+    #[should_panic(expected = "should have 2 separate polygons")]
     fn outer_banana_doesnt_produce_hole() {
-        let poly = Polygon::new(
-            LineString::new(vec![
-                Coord { x: 0.0, y: 0.0 },
-                Coord { x: 4.0, y: 0.0 },
-                Coord { x: 3.0, y: -2.0 },
-                Coord { x: 5.0, y: -2.0 },
-                Coord { x: 4.0, y: 0.0 },
-                Coord { x: 8.0, y: 0.0 },
-                Coord { x: 4.0, y: 4.0 },
-            ]),
-            vec![],
-        );
+        let poly =
+            wkt!(POLYGON((0.0 0.0,4.0 0.0,3.0 -2.0,5.0 -2.0,4.0 0.0,8.0 0.0,4.0 4.0,0.0 0.0)));
 
         let result = [poly]
             .map(|p| p.earcut_triangles())
@@ -614,7 +572,50 @@ mod polygon_stitching_tests {
             .stitch_triangulation()
             .unwrap();
 
-        assert_eq!(result.0.len(), 2);
+        // Currently panics: stitch_rings_from_lines produces a self-intersecting ring.
+        // See `document_bug_in_stitch_rings_order_dependent_at_non_manifold_vertices` for an exploration.
+        assert_eq!(result.0.len(), 2, "should have 2 separate polygons");
+        result[0].check_validation().unwrap();
+
         assert_eq!(result[0].interiors().len(), 0);
+    }
+
+    // This test documents a bug in our stitch implementation.
+    //
+    // The polygon from `outer_banana_doesnt_produce_hole` self-touches at (4,0): that vertex appears twice in the ring.
+    // Triangulating it yields 3 triangles that share only that point, not an edge, so the
+    // boundary has 4 incident edges at (4,0).
+    //
+    // We verified (by running the same input against the old `earcutr` library) that both
+    // libraries emit geometrically identical triangles. The only difference is the *order*
+    // they are emitted. That order difference causes `stitch_rings_from_lines` to produce different
+    // ring topologies.
+    #[test]
+    fn document_bug_in_stitch_rings_order_dependent_at_non_manifold_vertices() {
+        // The old earcutr crate's triangulation happend to work with our stitch trait.
+        let old_earcutr_order = vec![
+            wkt!(TRIANGLE(4.0 0.0,4.0 4.0,0.0 0.0)),   // left body
+            wkt!(TRIANGLE(4.0 0.0,3.0 -2.0,5.0 -2.0)), // notch (before right body)
+            wkt!(TRIANGLE(8.0 0.0,4.0 4.0,4.0 0.0)),   // right body
+        ];
+        let old_result = old_earcutr_order.stitch_triangulation().unwrap();
+        assert_eq!(old_result.0.len(), 2); // 2 valid polygons: main body + notch
+        old_result.check_validation().unwrap();
+
+        // The new earcut crate has a different order of triangles, but it's still valid.
+        // It should work, but some nuance of our stitch algorithm was predicated on the
+        // arbitrary ordering of the previous triangulation.
+        let new_earcut_order = vec![
+            wkt!(TRIANGLE(4.0 0.0,4.0 4.0,0.0 0.0)),   // left body
+            wkt!(TRIANGLE(4.0 0.0,8.0 0.0,4.0 4.0)),   // right body (before notch!)
+            wkt!(TRIANGLE(4.0 0.0,3.0 -2.0,5.0 -2.0)), // notch
+        ];
+        let poly =
+            wkt!(POLYGON((0.0 0.0,4.0 0.0,3.0 -2.0,5.0 -2.0,4.0 0.0,8.0 0.0,4.0 4.0,0.0 0.0)));
+        assert_eq!(poly.earcut_triangles(), new_earcut_order);
+
+        let new_result = new_earcut_order.stitch_triangulation().unwrap();
+        assert_eq!(new_result.0.len(), 1); // 1 self-intersecting polygon
+        new_result.check_validation().unwrap_err();
     }
 }

--- a/geo/src/algorithm/triangulate_earcut.rs
+++ b/geo/src/algorithm/triangulate_earcut.rs
@@ -1,8 +1,9 @@
 use crate::{CoordFloat, CoordsIter, Polygon, Triangle, coord};
+use earcut::Earcut;
 
 /// Triangulate polygons using an [ear-cutting algorithm](https://www.geometrictools.com/Documentation/TriangulationByEarClipping.pdf).
 ///
-/// Requires the `"earcutr"` feature, which is enabled by default.
+/// Requires the `"earcut"` feature, which is enabled by default.
 pub trait TriangulateEarcut<T: CoordFloat> {
     /// # Examples
     ///
@@ -78,7 +79,7 @@ pub trait TriangulateEarcut<T: CoordFloat> {
         Iter(self.earcut_triangles_raw())
     }
 
-    /// Return the raw result from the `earcutr` library: a one-dimensional vector of polygon
+    /// Return the raw result from the `earcut` library: a one-dimensional vector of polygon
     /// vertices (in XY order), and the indices of the triangles within the vertices vector. This
     /// method is less ergonomic than the `earcut_triangles` and `earcut_triangles_iter`
     /// methods, but can be helpful when working in graphics contexts that expect flat vectors of
@@ -103,10 +104,10 @@ pub trait TriangulateEarcut<T: CoordFloat> {
     /// assert_eq!(
     ///     RawTriangulation {
     ///         vertices: vec![
-    ///             0., 0., // SW
-    ///             10., 0., // SE
-    ///             10., 10., // NE
-    ///             0., 10., // NW
+    ///             [0., 0.], // SW
+    ///             [10., 0.], // SE
+    ///             [10., 10.], // NE
+    ///             [0., 10.], // NW
     ///         ],
     ///         triangle_indices: vec![
     ///             2, 3, 0, // NE-NW-SW
@@ -121,21 +122,35 @@ pub trait TriangulateEarcut<T: CoordFloat> {
 
 impl<T: CoordFloat> TriangulateEarcut<T> for Polygon<T> {
     fn earcut_triangles_raw(&self) -> RawTriangulation<T> {
-        let input = polygon_to_earcutr_input(self);
-        let triangle_indices =
-            earcutr::earcut(&input.vertices, &input.interior_indexes, 2).unwrap();
+        let mut earcut = Earcut::new();
+
+        let input = EarcutInput::from(self);
+        // PERF: expose a way to pass in a re-usable output vector for those who are triangulating
+        // in a hot loop
+        let mut triangle_indices = vec![];
+        earcut.earcut(
+            input.vertices.clone(), // PERF: iterate `vertices` lazily rather than create a Vec
+            &input.interior_indexes,
+            &mut triangle_indices,
+        );
+
         RawTriangulation {
+            // PERF: As mentioned above, if we don't manifest a concrete vertices Vec,
+            // we'll need to return some kind of "getter" that translates triangle_indices back to polygon coords, accounting
+            // for the lack of an explicit "closing" coordinate in the triangle_indices
+            //
+            // We'll need to measure if all that indirection is cheaper than just manifesting the Vec.
             vertices: input.vertices,
             triangle_indices,
         }
     }
 }
 
-/// The raw result of triangulating a polygon from `earcutr`.
+/// The raw result of triangulating a polygon from `earcut`.
 #[derive(Debug, PartialEq, Clone)]
 pub struct RawTriangulation<T: CoordFloat> {
-    /// Flattened one-dimensional vector of polygon vertices (in XY order).
-    pub vertices: Vec<T>,
+    /// Flattened vector of polygon vertices (in XY order).
+    pub vertices: Vec<[T; 2]>,
 
     /// Indices of the triangles within the vertices vector.
     pub triangle_indices: Vec<usize>,
@@ -162,37 +177,39 @@ impl<T: CoordFloat> Iterator for Iter<T> {
 impl<T: CoordFloat> Iter<T> {
     fn triangle_index_to_coord(&self, triangle_index: usize) -> crate::Coord<T> {
         coord! {
-            x: self.0.vertices[triangle_index * 2],
-            y: self.0.vertices[triangle_index * 2 + 1],
+            x: self.0.vertices[triangle_index][0],
+            y: self.0.vertices[triangle_index][1],
         }
     }
 }
 
-struct EarcutrInput<T: CoordFloat> {
-    pub vertices: Vec<T>,
+struct EarcutInput<T: CoordFloat> {
+    pub vertices: Vec<[T; 2]>,
     pub interior_indexes: Vec<usize>,
 }
 
-fn polygon_to_earcutr_input<T: CoordFloat>(polygon: &crate::Polygon<T>) -> EarcutrInput<T> {
-    let mut vertices = Vec::with_capacity(polygon.coords_count() * 2);
-    let mut interior_indexes = Vec::with_capacity(polygon.interiors().len());
-    debug_assert!(polygon.exterior().0.len() >= 4);
+impl<'a, T: CoordFloat> From<&'a Polygon<T>> for EarcutInput<T> {
+    fn from(polygon: &'a Polygon<T>) -> EarcutInput<T> {
+        let mut vertices = Vec::with_capacity(polygon.coords_count() - 1);
+        let mut interior_indexes = Vec::with_capacity(polygon.interiors().len());
+        debug_assert!(polygon.exterior().0.len() >= 4);
 
-    flatten_ring(polygon.exterior(), &mut vertices);
+        flatten_ring(polygon.exterior(), &mut vertices);
 
-    for interior in polygon.interiors() {
-        debug_assert!(interior.0.len() >= 4);
-        interior_indexes.push(vertices.len() / 2);
-        flatten_ring(interior, &mut vertices);
-    }
+        for interior in polygon.interiors() {
+            debug_assert!(interior.0.len() >= 4);
+            interior_indexes.push(vertices.len());
+            flatten_ring(interior, &mut vertices);
+        }
 
-    EarcutrInput {
-        vertices,
-        interior_indexes,
+        Self {
+            vertices,
+            interior_indexes,
+        }
     }
 }
 
-fn flatten_ring<T: CoordFloat>(line_string: &crate::LineString<T>, vertices: &mut Vec<T>) {
+fn flatten_ring<T: CoordFloat>(line_string: &crate::LineString<T>, vertices: &mut Vec<[T; 2]>) {
     if line_string.0.is_empty() {
         return;
     }
@@ -200,8 +217,7 @@ fn flatten_ring<T: CoordFloat>(line_string: &crate::LineString<T>, vertices: &mu
     // skip final (redundant) coord for closed line_string to match
     // earcutr's expected input
     for coord in &line_string.0[0..line_string.0.len() - 1] {
-        vertices.push(coord.x);
-        vertices.push(coord.y);
+        vertices.push([coord.x, coord.y]);
     }
 }
 
@@ -254,7 +270,7 @@ mod test {
         let triangles = square_polygon.earcut_triangles_raw();
         assert_eq!(
             triangles.vertices,
-            vec![0., 0., 10., 0., 10., 10., 0., 10.] // exterior
+            vec![[0., 0.], [10., 0.], [10., 10.], [0., 10.]] // exterior
         );
         assert_eq!(triangles.triangle_indices, vec![2, 3, 0, 0, 1, 2]);
     }
@@ -262,8 +278,8 @@ mod test {
     #[test]
     fn test_square_with_hole_raw() {
         let poly_with_hole = wkt!(POLYGON(
-            (0. 0.,10. 0., 10. 10., 0. 10.),
-            (2. 2., 8. 2., 8. 8., 2. 8.)
+            (0. 0.,10. 0., 10. 10., 0. 10.,0. 0.),
+            (2. 2., 8. 2., 8. 8., 2. 8.,2. 2.)
         ));
 
         let triangles = poly_with_hole.earcut_triangles_raw();
@@ -271,14 +287,27 @@ mod test {
         assert_eq!(
             triangles.vertices,
             vec![
-                0., 0., 10., 0., 10., 10., 0., 10., // exterior
-                2., 2., 8., 2., 8., 8., 2., 8., // interior hole
+                // exterior
+                [0., 0.],
+                [10., 0.],
+                [10., 10.],
+                [0., 10.],
+                // interior hole
+                [2., 2.],
+                [8., 2.],
+                [8., 8.],
+                [2., 8.],
             ]
         );
+
+        // manually inspected that the output was a reasonable triangulation.
+        // let output = poly_with_hole.earcut_triangles();
+        // let mp = crate::MultiPolygon::new(output.iter().map(|tri| tri.to_polygon()).collect());
+        // dbg!(mp);
         assert_eq!(
             triangles.triangle_indices,
             vec![
-                3, 0, 7, 4, 7, 0, 2, 3, 7, 5, 4, 0, 2, 7, 6, 5, 0, 1, 1, 2, 6, 6, 5, 1
+                0, 4, 7, 5, 4, 0, 3, 0, 7, 5, 0, 1, 2, 3, 7, 6, 5, 1, 2, 7, 6, 6, 1, 2
             ]
         );
     }

--- a/geo/src/lib.rs
+++ b/geo/src/lib.rs
@@ -199,8 +199,8 @@
 //!
 //! The following optional [Cargo features] are available:
 //!
-//! - `earcutr`:
-//!     - Enables the `earcutr` crate, which provides triangulation of polygons using the earcut algorithm
+//! - `earcut`:
+//!     - Enables the `earcut` crate, which provides triangulation of polygons using the earcut algorithm
 //!     - ☑ Enabled by default
 //! - `proj-network`:
 //!     - Enables [network grid] support for the [`proj` crate]


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Followup to https://github.com/georust/geo/pull/1507#issuecomment-3971913129

TODO: Currently a test in `stitch_triangulation` is failing. I haven't dug in very deeply. I'm not sure if this represents a bug in our stitch method or if we are breaking some calling contract with the new triangulation output.

/cc @JasmineLowen  - any interest in taking a look at the stitch failure?

## Benches

Benches have improved, even with the most basic integration.
```
TriangulateEarcut - small polys
                        time:   [5.3343 ms 5.4070 ms 5.4954 ms]
                        change: [-16.874% -15.773% -14.370%] (p = 0.00 < 0.05)
                        Performance has improved.

TriangulateEarcut - large_poly
                        time:   [1.5546 ms 1.5575 ms 1.5608 ms]
                        change: [-23.623% -23.377% -23.112%] (p = 0.00 < 0.05)
                        Performance has improved.
```

## Performance

There are further opportunities for speedups:

1. Expose a way to maintain a persistent EarCutter instance.
2. Expose a way to pass in a(re-usable) output buffer.
3. Avoid twice allocating the input vertices
   - Lazily compute vertex iterator
   - Return dynamic "getter"