### PR TITLE
Perf: GeometryGraph constructor builds RTree

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -12,6 +12,8 @@
   - <https://github.com/georust/geo/pull/1535>
 - Add `RectOps` trait with RectOps::rect_union()` and `RectOps::rect_intersection()` operations.
   - <https://github.com/georust/geo/pull/1542>
+- Speed up `Relate` operations.
+  - <https://github.com/georust/geo/pull/1521>
 
 ## 0.33.1 - 2026-4-20
 
@@ -59,8 +61,6 @@
   - Preprocessing cost to construct these types, but provide a significant performance boost for intersects and contains_properly checks
   - <https://github.com/georust/geo/issues/1466>
   - <https://github.com/georust/geo/pull/1467>
-- Speed up `Relate` operations.
-  - <https://github.com/georust/geo/pull/1521>
 
 ## 0.32.0 - 2025-12-05
 

--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -59,6 +59,8 @@
   - Preprocessing cost to construct these types, but provide a significant performance boost for intersects and contains_properly checks
   - <https://github.com/georust/geo/issues/1466>
   - <https://github.com/georust/geo/pull/1467>
+- Speed up `Relate` operations.
+  - <https://github.com/georust/geo/pull/1521>
 
 ## 0.32.0 - 2025-12-05
 

--- a/geo/src/algorithm/indexed/prepared_geometry.rs
+++ b/geo/src/algorithm/indexed/prepared_geometry.rs
@@ -1,10 +1,9 @@
 use crate::geometry::*;
-use crate::relate::geomgraph::{GeometryGraph, RobustLineIntersector};
+use crate::relate::geomgraph::GeometryGraph;
 use crate::{BoundingRect, GeometryCow, HasDimensions};
 use crate::{GeoFloat, Relate};
 
 use std::fmt::{Debug, Formatter};
-use std::rc::Rc;
 
 use crate::dimensions::Dimensions;
 use rstar::RTreeNum;
@@ -66,14 +65,8 @@ where
     F: GeoFloat,
     T: Clone + Into<GeometryCow<'a, F>>,
 {
-    let mut geometry_graph = GeometryGraph::new(0, geometry.clone().into());
-    let r_tree = geometry_graph.build_tree();
-    geometry_graph.set_tree(Rc::new(r_tree));
+    let geometry_graph = GeometryGraph::new(0, geometry.clone().into());
     let bounding_rect = geometry_graph.geometry().bounding_rect();
-
-    // TODO: don't pass in line intersector here - in theory we'll want pluggable line intersectors
-    // and the type (Robust) shouldn't be hard coded here.
-    geometry_graph.compute_self_nodes(Box::new(RobustLineIntersector::new()));
     PreparedGeometry {
         geometry,
         geometry_graph,

--- a/geo/src/algorithm/relate/geomgraph/geometry_graph.rs
+++ b/geo/src/algorithm/relate/geomgraph/geometry_graph.rs
@@ -9,6 +9,7 @@ use super::{
 use crate::HasDimensions;
 use crate::{Coord, GeoFloat, GeometryCow, Line, LineString, Point, Polygon};
 
+use crate::relate::geomgraph::RobustLineIntersector;
 use rstar::{RTree, RTreeNum};
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -35,9 +36,8 @@ where
 {
     arg_index: usize,
     parent_geometry: GeometryCow<'a, F>,
-    tree: Option<Rc<RTree<Segment<F>>>>,
+    tree: Rc<RTree<Segment<F>>>,
     use_boundary_determination_rule: bool,
-    has_computed_self_nodes: bool,
     planar_graph: PlanarGraph<F>,
 }
 
@@ -49,17 +49,11 @@ impl<F> GeometryGraph<'_, F>
 where
     F: GeoFloat,
 {
-    pub(crate) fn set_tree(&mut self, tree: Rc<RTree<Segment<F>>>) {
-        self.tree = Some(tree);
+    pub(crate) fn tree(&self) -> &RTree<Segment<F>> {
+        &self.tree
     }
 
-    pub(crate) fn get_or_build_tree(&self) -> Rc<RTree<Segment<F>>> {
-        self.tree
-            .clone()
-            .unwrap_or_else(|| Rc::new(self.build_tree()))
-    }
-
-    pub(crate) fn build_tree(&self) -> RTree<Segment<F>> {
+    fn build_tree(&self) -> RTree<Segment<F>> {
         let segments: Vec<Segment<F>> = self
             .edges()
             .iter()
@@ -88,10 +82,6 @@ where
     }
 
     pub(crate) fn clone_for_arg_index(&self, arg_index: usize) -> Self {
-        debug_assert!(
-            self.has_computed_self_nodes,
-            "should only be called after computing self nodes"
-        );
         let planar_graph = self
             .planar_graph
             .clone_for_arg_index(self.arg_index, arg_index);
@@ -100,7 +90,6 @@ where
             parent_geometry: self.parent_geometry.clone(),
             tree: self.tree.clone(),
             use_boundary_determination_rule: self.use_boundary_determination_rule,
-            has_computed_self_nodes: true,
             planar_graph,
         }
     }
@@ -135,11 +124,14 @@ where
             arg_index,
             parent_geometry,
             use_boundary_determination_rule: true,
-            tree: None,
-            has_computed_self_nodes: false,
+            tree: Rc::new(RTree::new()),
             planar_graph: PlanarGraph::new(),
         };
         graph.add_geometry(&graph.parent_geometry.clone());
+        graph.tree = Rc::new(graph.build_tree());
+        // TODO: don't pass in line intersector here - in theory we'll want pluggable line intersectors
+        // and the type (Robust) shouldn't be hard coded here.
+        graph.compute_self_nodes(Box::new(RobustLineIntersector::new()));
         graph
     }
 
@@ -325,12 +317,7 @@ where
     /// assumed to be valid).
     ///
     /// `line_intersector` the [`LineIntersector`] to use to determine intersection
-    pub(crate) fn compute_self_nodes(&mut self, line_intersector: Box<dyn LineIntersector<F>>) {
-        if self.has_computed_self_nodes {
-            return;
-        }
-        self.has_computed_self_nodes = true;
-
+    fn compute_self_nodes(&mut self, line_intersector: Box<dyn LineIntersector<F>>) {
         let mut segment_intersector = SegmentIntersector::new(line_intersector, true);
 
         // optimize intersection search for valid Polygons and LinearRings

--- a/geo/src/algorithm/relate/geomgraph/index/rstar_edge_set_intersector.rs
+++ b/geo/src/algorithm/relate/geomgraph/index/rstar_edge_set_intersector.rs
@@ -21,8 +21,10 @@ where
     ) {
         let edges = graph.edges();
 
-        let tree = graph.get_or_build_tree();
-        for (segment_0, segment_1) in tree.intersection_candidates_with_other_tree(&tree) {
+        for (segment_0, segment_1) in graph
+            .tree()
+            .intersection_candidates_with_other_tree(graph.tree())
+        {
             if check_for_self_intersecting_edges || segment_0.edge_idx != segment_1.edge_idx {
                 let edge_0 = &edges[segment_0.edge_idx];
                 let edge_1 = &edges[segment_1.edge_idx];
@@ -45,10 +47,10 @@ where
         let edges_0 = graph_0.edges();
         let edges_1 = graph_1.edges();
 
-        let tree_0 = graph_0.get_or_build_tree();
-        let tree_1 = graph_1.get_or_build_tree();
+        let tree_0 = graph_0.tree();
+        let tree_1 = graph_1.tree();
 
-        for (segment_0, segment_1) in tree_0.intersection_candidates_with_other_tree(&tree_1) {
+        for (segment_0, segment_1) in tree_0.intersection_candidates_with_other_tree(tree_1) {
             let edge_0 = &edges_0[segment_0.edge_idx];
             let edge_1 = &edges_1[segment_1.edge_idx];
             segment_intersector.add_intersections(

--- a/geo/src/algorithm/relate/relate_operation.rs
+++ b/geo/src/algorithm/relate/relate_operation.rs
@@ -83,13 +83,8 @@ where
             }
         }
 
-        let mut graph_a = self.geometry_a.geometry_graph(0);
-        let mut graph_b = self.geometry_b.geometry_graph(1);
-
-        // Since changes to topology are inspected at nodes, we must crate a node for each
-        // intersection.
-        graph_a.compute_self_nodes(Box::new(self.line_intersector.clone()));
-        graph_b.compute_self_nodes(Box::new(self.line_intersector.clone()));
+        let graph_a = self.geometry_a.geometry_graph(0);
+        let graph_b = self.geometry_b.geometry_graph(1);
 
         // compute intersections between edges of the two input geometries
         let segment_intersector =


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

My original intent was to be able to use GeometryGraph outside of the context of PreparedGeometry without having to copy the setup code in `prepare_geometry` (specifically while playing around with #1472).

The nice side side effect of this is an incidental speedup. I think it's because we are rebuilding the geometry RTree in a couple places. If we build it once up front, we don't have to worry about this cost.

```
relate overlapping 50-point polygons
                        time:   [27.251 µs 27.693 µs 28.099 µs]
                        change: [-21.806% -19.731% -17.678%] (p = 0.00 < 0.05)
                        Performance has improved.

entire jts test suite   time:   [344.95 ms 346.44 ms 348.46 ms]
                        change: [-0.4298% +0.0268% +0.6061%] (p = 0.93 > 0.05)
                        No change in performance detected.

jts test suite matching *Relate*
                        time:   [33.497 ms 33.642 ms 33.796 ms]
                        change: [-6.1824% -5.5581% -4.9284%] (p = 0.00 < 0.05)
                        Performance has improved.

disjoint polygons       time:   [19.555 µs 19.599 µs 19.656 µs]
                        change: [+0.1938% +0.4692% +0.9024%] (p = 0.00 < 0.05)
                        Change within noise threshold.

large rotated polygons  time:   [4.5333 ms 4.5564 ms 4.5896 ms]
                        change: [-28.900% -28.393% -27.871%] (p = 0.00 < 0.05)
                        Performance has improved.

offset polygons         time:   [4.2994 ms 4.3199 ms 4.3457 ms]
                        change: [-30.030% -29.516% -28.997%] (p = 0.00 < 0.05)
                        Performance has improved.
```
