### PR TITLE
prepare for geo-types v0.7.19 release

### DIFF
--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -1,6 +1,6 @@
 # Changes
 
-## Unreleased
+## 0.7.19 - 2026-04-15
 
 - POSSIBLY BREAKING: `Triangle::from([a, b, c])` now enforces CCW winding (same as `Triangle::new`).
 - Add `Triangle::unchecked_winding(v1, v2, v3)` for callers that have pre-verified CCW order or don't require a specific winding.

--- a/geo-types/Cargo.toml
+++ b/geo-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geo-types"
-version = "0.7.18"
+version = "0.7.19"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/georust/geo"
 documentation = "https://docs.rs/geo-types/"


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Note that the upcoming `geo` release will need to depend on this.