### PR TITLE
prepare for geo 0.33.0 release

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -1,6 +1,6 @@
 # Changes
 
-## Unreleased
+## 0.33.0 - 2026-4-15
 
 - Polygon validation now uses `PreparedGeometry` to cache R-tree structures for interior/exterior containment checks, improving validation speed for polygons with many holes.
   - <https://github.com/georust/geo/pull/1501>
@@ -19,6 +19,7 @@
   - <https://github.com/georust/geo/pull/1499>
 - Bump `float_next_after` dependency to 2.0.0
 - Bump geo MSRV to 1.88
+- Bump geo-types to 0.7.19
 - Update `earcutr` dependency to 0.5.0
 - POSSIBLY BREAKING: `Triangle`s returned by `earcut_triangles` are now oriented CCW.
 - POSSIBLY BREAKING: `earcut_triangles_raw` now omits the redundant "closing" coordinate from `vertices`.

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "geo"
 description = "Geospatial primitives and algorithms"
-version = "0.32.0"
+version = "0.33.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/georust/geo"
 documentation = "https://docs.rs/geo/"
@@ -31,7 +31,7 @@ __allow_deprecated_features = []
 earcut = { version = "0.4.5", optional = true }
 spade = { version = "2.10.0", optional = true }
 float_next_after = "2.0.0"
-geo-types = { version = "0.7.18", features = ["approx", "rstar_0_12"] }
+geo-types = { version = "0.7.19", features = ["approx", "rstar_0_12"] }
 geographiclib-rs = { version = "0.2.3", default-features = false }
 log = "0.4.11"
 num-traits = "0.2"


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

I think we might be waiting for #1502, which seems very close? Anything else on the horizon?

#1522 isn't quite ready, and would be a reasonable non-breaking followup release, so I don't think we need to wait for it.