### PR TITLE
fix: Add missing AsPrimitive<u32>

### DIFF
--- a/geo/src/algorithm/triangulate_earcut.rs
+++ b/geo/src/algorithm/triangulate_earcut.rs
@@ -1,5 +1,6 @@
 use crate::{CoordFloat, CoordsIter, Polygon, Triangle, coord};
 use earcut::Earcut;
+use num_traits::AsPrimitive;
 
 /// Triangulate polygons using an [ear-cutting algorithm](https://www.geometrictools.com/Documentation/TriangulationByEarClipping.pdf).
 ///
@@ -120,7 +121,7 @@ pub trait TriangulateEarcut<T: CoordFloat> {
     fn earcut_triangles_raw(&self) -> RawTriangulation<T>;
 }
 
-impl<T: CoordFloat> TriangulateEarcut<T> for Polygon<T> {
+impl<T: CoordFloat + AsPrimitive<u32>> TriangulateEarcut<T> for Polygon<T> {
     fn earcut_triangles_raw(&self) -> RawTriangulation<T> {
         let mut earcut = Earcut::new();
 
@@ -143,6 +144,14 @@ impl<T: CoordFloat> TriangulateEarcut<T> for Polygon<T> {
             vertices: input.vertices,
             triangle_indices,
         }
+    }
+
+    fn earcut_triangles(&self) -> Vec<Triangle<T>> {
+        self.earcut_triangles_iter().collect()
+    }
+
+    fn earcut_triangles_iter(&self) -> Iter<T> {
+        Iter(self.earcut_triangles_raw())
     }
 }
 


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

This fixes a build failure on wasm-32-unknown-unknown with error: the trait bound `T: AsPrimitive<u32>` is not satisfied.

earcut_triangles and earcut_triangles_iter methods have been auto-generated by clippy's auto fix feature.

## Testing

### Success

Builds successfully in the same project after changes for platforms (*My [ci/cd](https://github.com/leomeinel/slimy_mist/actions/runs/24661823056) can be referenced for this*):

- [x] `wasm32-unknown-unknown`
- [x] `aarch64-linux-android` + `armv7-linux-androideabi` + `x86_64-linux-android`
- [x] `x86_64-unknown-linux-gnu`
- [x] `aarch64-unknown-linux-gnu`
- [x] `x86_64-pc-windows-msvc`
- [x] `x86_64-apple-darwin` + `aarch64-apple-darwin`
- [x] `aarch64-apple-ios` + `x86_64-apple-ios` + `aarch64-apple-ios-sim`

### Failure

Seems like your ci tests did pass, so this shouldn't be a regression.

Just to document this, 3 tests failed for me:

<details>
<summary>Test log</summary>

```
❯ cargo test --all --all-features --all-targets -q

running 1110 tests
....................................................................................... 87/1110
....................................................................................... 174/1110
....................................................................................... 261/1110
....................................................................................... 348/1110
....................................................................................... 435/1110
....................................................................................... 522/1110
....................................................................................... 609/1110
....................................................................................... 696/1110
...................................... 734/1110
algorithm::line_measures::metric_spaces::geodesic::tests::destination::interpolate_point::points_along_line_without_endpoints --- FAILED
algorithm::line_measures::metric_spaces::geodesic::tests::destination::interpolate_point::points_along_line_with_endpoints --- FAILED
........ 744/1110
algorithm::line_measures::metric_spaces::geodesic::tests::test_non_standard_geoid --- FAILED
..................................................................i..i................. 832/1110
....................................................................................... 919/1110
....................................................................................... 1006/1110
....................................................................................... 1093/1110
.................
failures:

---- algorithm::line_measures::metric_spaces::geodesic::tests::destination::interpolate_point::points_along_line_without_endpoints stdout ----

thread 'algorithm::line_measures::metric_spaces::geodesic::tests::destination::interpolate_point::points_along_line_without_endpoints' (125034) panicked at geo/src/algorithm/line_measures/metric_spaces/geodesic.rs:520:17:
assert_relative_eq!(route[0], Point::new(17.878754355562464, 24.466667836189565))

    left  = POINT(17.878754355562464 24.466667836189558)
    right = POINT(17.878754355562464 24.466667836189565)



---- algorithm::line_measures::metric_spaces::geodesic::tests::destination::interpolate_point::points_along_line_with_endpoints stdout ----

thread 'algorithm::line_measures::metric_spaces::geodesic::tests::destination::interpolate_point::points_along_line_with_endpoints' (125033) panicked at geo/src/algorithm/line_measures/metric_spaces/geodesic.rs:508:17:
assert_relative_eq!(route[1], Point::new(17.878754355562464, 24.466667836189565))

    left  = POINT(17.878754355562464 24.466667836189558)
    right = POINT(17.878754355562464 24.466667836189565)


note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- algorithm::line_measures::metric_spaces::geodesic::tests::test_non_standard_geoid stdout ----

thread 'algorithm::line_measures::metric_spaces::geodesic::tests::test_non_standard_geoid' (125038) panicked at geo/src/algorithm/line_measures/metric_spaces/geodesic.rs:536:9:
assert_relative_eq!(70684.36315529353, mars_geoid.distance(start, finish))

    left  = 70684.36315529353
    right = 70684.3631552937




failures:
    algorithm::line_measures::metric_spaces::geodesic::tests::destination::interpolate_point::points_along_line_with_endpoints
    algorithm::line_measures::metric_spaces::geodesic::tests::destination::interpolate_point::points_along_line_without_endpoints
    algorithm::line_measures::metric_spaces::geodesic::tests::test_non_standard_geoid

test result: FAILED. 1105 passed; 3 failed; 2 ignored; 0 measured; 0 filtered out; finished in 3.73s

error: test failed, to rerun pass `-p geo --lib`
```

</details>

## Issue details

For the build failure also see [this ci](https://github.com/leomeinel/slimy_mist/actions/runs/24625777964/job/72004433439#step:12:818):

<details>
<summary>CI log</summary>

```
   Compiling geo v0.33.0
error[E0277]: the trait bound `T: AsPrimitive<u32>` is not satisfied
   --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/geo-0.33.0/src/algorithm/triangulate_earcut.rs:131:16
    |
131 |         earcut.earcut(
    |                ^^^^^^ the trait `AsPrimitive<u32>` is not implemented for `T`
    |
note: required by a bound in `Earcut::<T>::earcut`
   --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/earcut-0.4.7/src/lib.rs:167:17
    |
167 | impl<T: Float + AsPrimitive<u32>> Earcut<T> {
    |                 ^^^^^^^^^^^^^^^^ required by this bound in `Earcut::<T>::earcut`
...
189 |     pub fn earcut<N: Index>(
    |            ------ required by a bound in this associated function
help: consider further restricting type parameter `T` with trait `AsPrimitive`
    |
123 | impl<T: CoordFloat + num_traits::AsPrimitive<u32>> TriangulateEarcut<T> for Polygon<T> {
    |                    ++++++++++++++++++++++++++++++

error[E0277]: the trait bound `T: AsPrimitive<u32>` is not satisfied
   --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/geo-0.33.0/src/algorithm/triangulate_earcut.rs:125:26
    |
125 |         let mut earcut = Earcut::new();
    |                          ^^^^^^ the trait `AsPrimitive<u32>` is not implemented for `T`
    |
note: required by a bound in `Earcut`
   --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/earcut-0.4.7/src/lib.rs:155:30
    |
155 | pub struct Earcut<T: Float + AsPrimitive<u32>> {
    |                              ^^^^^^^^^^^^^^^^ required by this bound in `Earcut`
help: consider further restricting type parameter `T` with trait `AsPrimitive`
    |
123 | impl<T: CoordFloat + num_traits::AsPrimitive<u32>> TriangulateEarcut<T> for Polygon<T> {
    |                    ++++++++++++++++++++++++++++++

error[E0277]: the trait bound `T: AsPrimitive<u32>` is not satisfied
   --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/geo-0.33.0/src/algorithm/triangulate_earcut.rs:125:26
    |
125 |         let mut earcut = Earcut::new();
    |                          ^^^^^^^^^^^^^ the trait `AsPrimitive<u32>` is not implemented for `T`
    |
note: required by a bound in `Earcut::<T>::new`
   --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/earcut-0.4.7/src/lib.rs:167:17
    |
167 | impl<T: Float + AsPrimitive<u32>> Earcut<T> {
    |                 ^^^^^^^^^^^^^^^^ required by this bound in `Earcut::<T>::new`
...
171 |     pub fn new() -> Self {
    |            --- required by a bound in this associated function
help: consider further restricting type parameter `T` with trait `AsPrimitive`
    |
123 | impl<T: CoordFloat + num_traits::AsPrimitive<u32>> TriangulateEarcut<T> for Polygon<T> {
    |                    ++++++++++++++++++++++++++++++

For more information about this error, try `rustc --explain E0277`.
error: could not compile `geo` (lib) due to 3 previous errors
warning: build failed, waiting for other jobs to finish...
Error: Process completed with exit code 101.
```

</details>