### PR TITLE
release 0.33.1: fixup earcut semver

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 0.33.1 - 2026-4-20
+
+- Fix build breakage introduced by semver incompatible earcut dependency release
+  - <https://github.com/georust/geo/pull/1527>
+
 ## 0.33.0 - 2026-4-15
 
 - Polygon validation now uses `PreparedGeometry` to cache R-tree structures for interior/exterior containment checks, improving validation speed for polygons with many holes.

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -28,7 +28,10 @@ use-serde = ["serde"]
 __allow_deprecated_features = []
 
 [dependencies]
-earcut = { version = "0.4.5", optional = true }
+# NOTE: The 0.4.7 release introduced semver incompatible trait constraints
+# We can adapt to them, but it'll have to be in a breaking release.
+# Tracked here: https://github.com/georust/geo/issues/1526
+earcut = { version = "=0.4.5", optional = true }
 spade = { version = "2.10.0", optional = true }
 float_next_after = "2.0.0"
 geo-types = { version = "0.7.19", features = ["approx", "rstar_0_12"] }

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "geo"
 description = "Geospatial primitives and algorithms"
-version = "0.33.0"
+version = "0.33.1"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/georust/geo"
 documentation = "https://docs.rs/geo/"


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
Fixes upstream issue: https://github.com/ciscorn/earcut-rs/issues/27

This is a PR for the fix, and for the 0.33.1 hotfix release. 

Alternatively we could just wait a bit and see how quickly `earcut` addresses the issue. Given that we've already had 2 reports, it seems like it's bothering people, so I wouldn't want to wait too long.