### PR TITLE
Reference earcut feature in TriangulateEarcut docs (closes #1530)

### DIFF
--- a/geo/src/lib.rs
+++ b/geo/src/lib.rs
@@ -130,7 +130,7 @@
 //!
 //! ## Triangulation
 //!
-//! - **[`TriangulateEarcut`](triangulate_earcut)**: Triangulate polygons using the earcut algorithm. Requires the `earcutr` feature, which is enabled by default
+//! - **[`TriangulateEarcut`](triangulate_earcut)**: Triangulate polygons using the earcut algorithm. Requires the `earcut` feature, which is enabled by default
 //! - **[`TriangulateDelaunay`](triangulate_delaunay)**: Produce constrained or unconstrained Delaunay triangulations of polygons. Requires the `spade` feature, which is enabled by default
 //! - **[`Voronoi`](voronoi)**: Produce the Voronoi Diagram of a triangulation
 //!


### PR DESCRIPTION
Closes #1530.

The crate-level docs in \`geo/src/lib.rs\` still reference the old \`earcutr\` feature name. \`Cargo.toml\` already documents this:

\`\`\`toml
default = ["earcut", "spade", "multithreading"]
# deprecated spelling earcutr->earcut
earcutr = ["earcut"]
\`\`\`

Updated the doc comment to match. \`cargo check --package geo\` still builds clean.