### PR TITLE
chore: Unpin earcut version

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## Unreleased
+
+- Unpin the `earcut` dependency now that the upstream semver violation has been reverted. 
+  - <https://github.com/georust/geo/pull/1533>
+
 ## 0.33.1 - 2026-4-20
 
 - Fix build breakage introduced by semver incompatible earcut dependency release

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -28,10 +28,7 @@ use-serde = ["serde"]
 __allow_deprecated_features = []
 
 [dependencies]
-# NOTE: The 0.4.7 release introduced semver incompatible trait constraints
-# We can adapt to them, but it'll have to be in a breaking release.
-# Tracked here: https://github.com/georust/geo/issues/1526
-earcut = { version = "=0.4.5", optional = true }
+earcut = { version = "0.4.9", optional = true }
 spade = { version = "2.10.0", optional = true }
 float_next_after = "2.0.0"
 geo-types = { version = "0.7.19", features = ["approx", "rstar_0_12"] }


### PR DESCRIPTION
Unpins the earcut version that was pinned (#1527) due to my own semver violation (sorry).

The `AsPrimitive<u32>` trait bound was reverted upstream, so we can take advantage of the performance improvements without any breaking changes.

Benchmark improvements from earcut 0.4.5 -> 0.4.9:

| Bench                            |   0.4.5 |   0.4.9 |       Δ |
| -------------------------------- | ------: | ------: | ------: |
| TriangulateEarcut - small polys  | 5.31 ms | 3.88 ms | -26.9 % |
| TriangulateEarcut - large_poly   | 1.58 ms | 1.19 ms | -23.8 % |

---
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.