### PR TITLE
Add reusable Earcutter instance

### DIFF
--- a/geo-benches/src/triangulate.rs
+++ b/geo-benches/src/triangulate.rs
@@ -2,8 +2,30 @@ use criterion::{criterion_group, criterion_main};
 use geo::algorithm::{TriangulateDelaunay, TriangulateDelaunayUnconstrained, TriangulateEarcut};
 use geo::geometry::Polygon;
 use geo::triangulate_delaunay::DelaunayTriangulationConfig;
+use geo::triangulate_earcut::Earcutter;
 
 fn criterion_benchmark(c: &mut criterion::Criterion) {
+    c.bench_function("TriangulateEarcut - tiny polys", |bencher| {
+        let multi_poly = geo_test_fixtures::nl_plots_wgs84::<f64>();
+        bencher.iter(|| {
+            for poly in &multi_poly {
+                let triangulation = TriangulateEarcut::earcut_triangles(poly);
+                criterion::black_box(triangulation);
+            }
+        });
+    });
+
+    c.bench_function("Earcutter (reused) - tiny polys", |bencher| {
+        let multi_poly = geo_test_fixtures::nl_plots_wgs84::<f64>();
+        let mut earcutter = Earcutter::new();
+        bencher.iter(|| {
+            for poly in &multi_poly {
+                let triangulation = earcutter.triangulate(poly);
+                criterion::black_box(triangulation.triangle_indices);
+            }
+        });
+    });
+
     c.bench_function(
         "TriangulateSpade (unconstrained) - small polys",
         |bencher| {
@@ -46,6 +68,18 @@ fn criterion_benchmark(c: &mut criterion::Criterion) {
         });
     });
 
+    c.bench_function("Earcutter (reused) - small polys", |bencher| {
+        let multi_poly = geo_test_fixtures::nl_zones::<f64>();
+        let mut earcutter = Earcutter::new();
+        bencher.iter(|| {
+            for poly in &multi_poly {
+                let triangulation = earcutter.triangulate(poly);
+                assert!(triangulation.triangle_indices.len() > 3);
+                criterion::black_box(triangulation.triangle_indices);
+            }
+        });
+    });
+
     c.bench_function("TriangulateSpade (unconstrained) - large_poly", |bencher| {
         let poly = Polygon::new(geo_test_fixtures::norway_main::<f64>(), vec![]);
         bencher.iter(|| {
@@ -75,6 +109,16 @@ fn criterion_benchmark(c: &mut criterion::Criterion) {
             let triangulation = TriangulateEarcut::earcut_triangles(&poly);
             assert!(triangulation.len() > 1);
             criterion::black_box(triangulation);
+        });
+    });
+
+    c.bench_function("Earcutter (reused) - large_poly", |bencher| {
+        let poly = Polygon::new(geo_test_fixtures::norway_main::<f64>(), vec![]);
+        let mut earcutter = Earcutter::new();
+        bencher.iter(|| {
+            let triangulation = earcutter.triangulate(&poly);
+            assert!(triangulation.triangle_indices.len() > 3);
+            criterion::black_box(triangulation.triangle_indices);
         });
     });
 }

--- a/geo-benches/src/triangulate.rs
+++ b/geo-benches/src/triangulate.rs
@@ -21,7 +21,7 @@ fn criterion_benchmark(c: &mut criterion::Criterion) {
         bencher.iter(|| {
             for poly in &multi_poly {
                 let triangulation = earcutter.triangulate(poly);
-                criterion::black_box(triangulation.triangle_indices);
+                criterion::black_box(triangulation.triangle_indices());
             }
         });
     });
@@ -74,8 +74,8 @@ fn criterion_benchmark(c: &mut criterion::Criterion) {
         bencher.iter(|| {
             for poly in &multi_poly {
                 let triangulation = earcutter.triangulate(poly);
-                assert!(triangulation.triangle_indices.len() > 3);
-                criterion::black_box(triangulation.triangle_indices);
+                assert!(triangulation.triangle_indices().len() > 3);
+                criterion::black_box(triangulation.triangle_indices());
             }
         });
     });
@@ -117,8 +117,8 @@ fn criterion_benchmark(c: &mut criterion::Criterion) {
         let mut earcutter = Earcutter::new();
         bencher.iter(|| {
             let triangulation = earcutter.triangulate(&poly);
-            assert!(triangulation.triangle_indices.len() > 3);
-            criterion::black_box(triangulation.triangle_indices);
+            assert!(triangulation.triangle_indices().len() > 3);
+            criterion::black_box(triangulation.triangle_indices());
         });
     });
 }

--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -4,6 +4,8 @@
 
 - Unpin the `earcut` dependency now that the upstream semver violation has been reverted. 
   - <https://github.com/georust/geo/pull/1533>
+- Add `Earcutter`, a reusable triangulator that avoids per-call memory allocations across multiple triangulations.
+  - <https://github.com/georust/geo/pull/1534>
 
 ## 0.33.1 - 2026-4-20
 

--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -2,9 +2,11 @@
 
 ## Unreleased
 
-- Unpin the `earcut` dependency now that the upstream semver violation has been reverted. 
+- Unpin the `earcut` dependency now that the upstream semver violation has been reverted.
   - <https://github.com/georust/geo/pull/1533>
-- Add `Earcutter`, a reusable triangulator that avoids per-call memory allocations across multiple triangulations.
+- Added `Earcutter` and `TriangulateEarcut::earcut_triangulation_ref` to avoid per-call memory allocations across multiple triangulations.
+  - <https://github.com/georust/geo/pull/1534>
+- Rename `TriangulateEarcut::earcut_triangles_raw` to `TriangulateEarcut::earcut_triangulation`
   - <https://github.com/georust/geo/pull/1534>
 
 ## 0.33.1 - 2026-4-20

--- a/geo/src/algorithm/triangulate_earcut.rs
+++ b/geo/src/algorithm/triangulate_earcut.rs
@@ -76,7 +76,7 @@ pub trait TriangulateEarcut<T: CoordFloat> {
     /// assert!(triangles_iter.next().is_none());
     /// ```
     fn earcut_triangles_iter(&self) -> Iter<T> {
-        Iter(self.earcut_triangles_raw())
+        Iter(self.earcut_triangulation())
     }
 
     /// Return the raw result from the `earcut` library: a one-dimensional vector of polygon
@@ -85,11 +85,14 @@ pub trait TriangulateEarcut<T: CoordFloat> {
     /// methods, but can be helpful when working in graphics contexts that expect flat vectors of
     /// data.
     ///
+    /// See [`earcut_triangulation_ref`](TriangulateEarcut::earcut_triangulation_ref) if you want
+    /// to speed up repeated triangulations.
+    ///
     /// # Examples
     ///
     /// ```
     /// use geo::{coord, polygon, Triangle, TriangulateEarcut};
-    /// use geo::triangulate_earcut::RawTriangulation;
+    /// use geo::triangulate_earcut::EarcutTriangulation;
     ///
     /// let square_polygon = polygon![
     ///     (x: 0., y: 0.), // SW
@@ -99,10 +102,10 @@ pub trait TriangulateEarcut<T: CoordFloat> {
     ///     (x: 0., y: 0.), // SW
     /// ];
     ///
-    /// let mut triangles_raw = square_polygon.earcut_triangles_raw();
+    /// let mut triangles_raw = square_polygon.earcut_triangulation();
     ///
     /// assert_eq!(
-    ///     RawTriangulation {
+    ///     EarcutTriangulation {
     ///         vertices: vec![
     ///             [0., 0.], // SW
     ///             [10., 0.], // SE
@@ -117,30 +120,52 @@ pub trait TriangulateEarcut<T: CoordFloat> {
     ///     triangles_raw,
     /// );
     /// ```
-    fn earcut_triangles_raw(&self) -> RawTriangulation<T>;
+    fn earcut_triangulation(&self) -> EarcutTriangulation<T> {
+        // waiting for breaking release before deleting the old spelling
+        #[allow(deprecated)]
+        self.earcut_triangles_raw()
+    }
+
+    #[deprecated(note = "renamed to earcut_triangulation")]
+    fn earcut_triangles_raw(&self) -> EarcutTriangulation<T>;
+
+    /// Like [`earcut_triangulation`](TriangulateEarcut::earcut_triangulation), but reuses internal buffers for a performance boost when
+    /// doing repeated triangulations.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use geo::wkt;
+    /// use geo::triangulate_earcut::{TriangulateEarcut, Earcutter};
+    ///
+    /// let square = wkt!(POLYGON((0. 0.,10. 0.,10. 10.,0. 10.)));
+    /// let triangle = wkt!(POLYGON((0. 0.,10. 0.,10. 10.)));
+    ///
+    /// let mut earcutter = Earcutter::new();
+    ///
+    /// let triangulation = square.earcut_triangulation_ref(&mut earcutter);
+    /// assert_eq!(triangulation.vertices(), &[[0., 0.], [10., 0.], [10., 10.], [0., 10.]]);
+    /// assert_eq!(triangulation.triangle_indices(), &[2, 3, 0, 0, 1, 2]);
+    ///
+    /// let triangulation = triangle.earcut_triangulation_ref(&mut earcutter);
+    /// assert_eq!(triangulation.vertices(), &[[0., 0.], [10., 0.], [10., 10.]]);
+    /// assert_eq!(triangulation.triangle_indices(), &[1, 2, 0]);
+    /// ```
+    fn earcut_triangulation_ref<'a>(
+        &self,
+        earcutter: &'a mut Earcutter<T>,
+    ) -> EarcutTriangulationRef<'a, T>;
 }
 
 impl<T: CoordFloat> TriangulateEarcut<T> for Polygon<T> {
-    fn earcut_triangles_raw(&self) -> RawTriangulation<T> {
-        let mut vertices = Vec::new();
-        let mut interior_indexes = Vec::new();
-        flatten_ring(self.exterior(), &mut vertices);
-        for interior in self.interiors() {
-            interior_indexes.push(vertices.len());
-            flatten_ring(interior, &mut vertices);
-        }
-
-        let mut triangle_indices = Vec::new();
-        Earcut::new().earcut(
-            vertices.iter().copied(),
-            &interior_indexes,
-            &mut triangle_indices,
-        );
-
-        RawTriangulation {
-            vertices,
-            triangle_indices,
-        }
+    fn earcut_triangles_raw(&self) -> EarcutTriangulation<T> {
+        Earcutter::new().into_triangulation(self)
+    }
+    fn earcut_triangulation_ref<'a>(
+        &self,
+        earcutter: &'a mut Earcutter<T>,
+    ) -> EarcutTriangulationRef<'a, T> {
+        earcutter.triangulate(self)
     }
 }
 
@@ -155,28 +180,27 @@ impl<T: CoordFloat> TriangulateEarcut<T> for Polygon<T> {
 /// # Examples
 ///
 /// ```
-/// use geo::polygon;
+/// use geo::wkt;
 /// use geo::triangulate_earcut::Earcutter;
 ///
 /// let polygons = vec![
-///     polygon![(x: 0., y: 0.), (x: 10., y: 0.), (x: 10., y: 10.), (x: 0., y: 10.)],
-///     polygon![(x: 1., y: 1.), (x: 5., y: 1.), (x: 5., y: 5.), (x: 1., y: 5.)],
+///     wkt!(POLYGON((0. 0.,10. 0.,10. 10.,0. 10.))),
+///     wkt!(POLYGON((1. 1.,5. 1.,5. 5.,1. 5.))),
 /// ];
 ///
 /// let mut earcutter = Earcutter::new();
 /// for polygon in &polygons {
 ///     let triangulation = earcutter.triangulate(polygon);
-///     for tri in triangulation.triangle_indices.chunks_exact(3) {
-///         let v = |i: u32| triangulation.vertices[i as usize];
+///     for tri in triangulation.triangle_indices().chunks_exact(3) {
+///         let v = |i| triangulation.vertices()[i];
 ///         let _ = (v(tri[0]), v(tri[1]), v(tri[2]));
 ///     }
 /// }
 /// ```
 pub struct Earcutter<T: CoordFloat> {
     earcut: Earcut<T>,
-    vertices: Vec<[T; 2]>,
-    interior_indexes: Vec<u32>,
-    triangle_indices: Vec<u32>,
+    interior_indexes: Vec<usize>,
+    scratch: EarcutTriangulation<T>,
 }
 
 impl<T: CoordFloat> Default for Earcutter<T> {
@@ -189,60 +213,77 @@ impl<T: CoordFloat> Earcutter<T> {
     pub fn new() -> Self {
         Self {
             earcut: Earcut::new(),
-            vertices: Vec::new(),
             interior_indexes: Vec::new(),
-            triangle_indices: Vec::new(),
+            scratch: EarcutTriangulation {
+                vertices: Vec::new(),
+                triangle_indices: Vec::new(),
+            },
         }
     }
 
     /// Triangulate `polygon`, reusing the internal buffers. The returned
-    /// [`EarcutTriangulation`] borrows from `self`, so each call must finish
+    /// [`EarcutTriangulationRef`] borrows from `self`, so each call must finish
     /// using the previous result before the next call.
-    pub fn triangulate(&mut self, polygon: &Polygon<T>) -> EarcutTriangulation<'_, T> {
-        self.vertices.clear();
+    pub fn triangulate(&mut self, polygon: &Polygon<T>) -> EarcutTriangulationRef<'_, T> {
+        self.scratch.vertices.clear();
         self.interior_indexes.clear();
 
-        flatten_ring(polygon.exterior(), &mut self.vertices);
+        flatten_ring(polygon.exterior(), &mut self.scratch.vertices);
         for interior in polygon.interiors() {
-            self.interior_indexes.push(self.vertices.len() as u32);
-            flatten_ring(interior, &mut self.vertices);
+            self.interior_indexes.push(self.scratch.vertices.len());
+            flatten_ring(interior, &mut self.scratch.vertices);
         }
 
         // `Earcut::earcut` clears `triangle_indices` internally before writing.
         self.earcut.earcut(
-            self.vertices.iter().copied(),
+            self.scratch.vertices.iter().copied(),
             &self.interior_indexes,
-            &mut self.triangle_indices,
+            &mut self.scratch.triangle_indices,
         );
 
-        EarcutTriangulation {
-            vertices: &self.vertices,
-            triangle_indices: &self.triangle_indices,
-        }
+        EarcutTriangulationRef(&self.scratch)
     }
-}
 
-/// Borrowed view of a triangulation produced by [`Earcutter::triangulate`].
-#[derive(Debug)]
-pub struct EarcutTriangulation<'a, T: CoordFloat> {
-    /// Flattened polygon vertices (XY pairs).
-    pub vertices: &'a [[T; 2]],
-    /// Indices into `vertices`, in groups of three per triangle.
-    pub triangle_indices: &'a [u32],
+    /// Triangulate `polygon`, returning [`EarcutTriangulation`].
+    ///
+    /// This consumes `Earcutter`.
+    ///
+    /// If you'd instead like to make repeated calls with fewer allocations,
+    /// you can borrow the inner buffers by using the [`triangulate`](Earcutter::triangulate) method.
+    pub fn into_triangulation(mut self, polygon: &Polygon<T>) -> EarcutTriangulation<T> {
+        _ = self.triangulate(polygon);
+        self.scratch
+    }
 }
 
 /// The raw result of triangulating a polygon from `earcut`.
 #[derive(Debug, PartialEq, Clone)]
-pub struct RawTriangulation<T: CoordFloat> {
+pub struct EarcutTriangulation<T: CoordFloat> {
     /// Flattened vector of polygon vertices (in XY order).
     pub vertices: Vec<[T; 2]>,
 
-    /// Indices of the triangles within the vertices vector.
+    /// Indices into `vertices`, in groups of three per triangle.
     pub triangle_indices: Vec<usize>,
 }
 
+#[deprecated(note = "renamed to EarcutTriangulation")]
+pub type RawTriangulation<T> = EarcutTriangulation<T>;
+
+/// Borrowed view of [`EarcutTriangulation`].
 #[derive(Debug)]
-pub struct Iter<T: CoordFloat>(RawTriangulation<T>);
+pub struct EarcutTriangulationRef<'a, T: CoordFloat>(&'a EarcutTriangulation<T>);
+
+impl<'a, T: CoordFloat> EarcutTriangulationRef<'a, T> {
+    pub fn triangle_indices(&self) -> &[usize] {
+        self.0.triangle_indices.as_slice()
+    }
+    pub fn vertices(&self) -> &[[T; 2]] {
+        self.0.vertices.as_slice()
+    }
+}
+
+#[derive(Debug)]
+pub struct Iter<T: CoordFloat>(EarcutTriangulation<T>);
 
 impl<T: CoordFloat> Iterator for Iter<T> {
     type Item = Triangle<T>;
@@ -326,7 +367,7 @@ mod test {
             (0. 0.,10. 0., 10. 10., 0. 10.)
         ));
 
-        let triangles = square_polygon.earcut_triangles_raw();
+        let triangles = square_polygon.earcut_triangulation();
         assert_eq!(
             triangles.vertices,
             vec![[0., 0.], [10., 0.], [10., 10.], [0., 10.]] // exterior
@@ -341,7 +382,7 @@ mod test {
             (2. 2., 8. 2., 8. 8., 2. 8.,2. 2.)
         ));
 
-        let triangles = poly_with_hole.earcut_triangles_raw();
+        let triangles = poly_with_hole.earcut_triangulation();
 
         assert_eq!(
             triangles.vertices,
@@ -381,10 +422,10 @@ mod test {
         let triangulation = earcutter.triangulate(&square_polygon);
 
         assert_eq!(
-            triangulation.vertices,
+            triangulation.vertices(),
             &[[0., 0.], [10., 0.], [10., 10.], [0., 10.]][..]
         );
-        assert_eq!(triangulation.triangle_indices, &[2u32, 3, 0, 0, 1, 2][..]);
+        assert_eq!(triangulation.triangle_indices(), &[2, 3, 0, 0, 1, 2][..]);
     }
 
     #[test]
@@ -396,12 +437,12 @@ mod test {
 
         // Square: 4 vertices, 6 triangle indices.
         let result = earcutter.triangulate(&square);
-        assert_eq!(result.vertices.len(), 4);
-        assert_eq!(result.triangle_indices.len(), 6);
+        assert_eq!(result.vertices().len(), 4);
+        assert_eq!(result.triangle_indices().len(), 6);
 
         // Triangle: 3 vertices, 3 triangle indices. Buffers must shrink, not append.
         let result = earcutter.triangulate(&triangle);
-        assert_eq!(result.vertices.len(), 3);
-        assert_eq!(result.triangle_indices.len(), 3);
+        assert_eq!(result.vertices().len(), 3);
+        assert_eq!(result.triangle_indices().len(), 3);
     }
 }

--- a/geo/src/algorithm/triangulate_earcut.rs
+++ b/geo/src/algorithm/triangulate_earcut.rs
@@ -1,4 +1,4 @@
-use crate::{CoordFloat, CoordsIter, Polygon, Triangle, coord};
+use crate::{CoordFloat, Polygon, Triangle, coord};
 use earcut::Earcut;
 
 /// Triangulate polygons using an [ear-cutting algorithm](https://www.geometrictools.com/Documentation/TriangulationByEarClipping.pdf).
@@ -122,28 +122,113 @@ pub trait TriangulateEarcut<T: CoordFloat> {
 
 impl<T: CoordFloat> TriangulateEarcut<T> for Polygon<T> {
     fn earcut_triangles_raw(&self) -> RawTriangulation<T> {
-        let mut earcut = Earcut::new();
+        let mut vertices = Vec::new();
+        let mut interior_indexes = Vec::new();
+        flatten_ring(self.exterior(), &mut vertices);
+        for interior in self.interiors() {
+            interior_indexes.push(vertices.len());
+            flatten_ring(interior, &mut vertices);
+        }
 
-        let input = EarcutInput::from(self);
-        // PERF: expose a way to pass in a re-usable output vector for those who are triangulating
-        // in a hot loop
-        let mut triangle_indices = vec![];
-        earcut.earcut(
-            input.vertices.clone(), // PERF: iterate `vertices` lazily rather than create a Vec
-            &input.interior_indexes,
+        let mut triangle_indices = Vec::new();
+        Earcut::new().earcut(
+            vertices.iter().copied(),
+            &interior_indexes,
             &mut triangle_indices,
         );
 
         RawTriangulation {
-            // PERF: As mentioned above, if we don't manifest a concrete vertices Vec,
-            // we'll need to return some kind of "getter" that translates triangle_indices back to polygon coords, accounting
-            // for the lack of an explicit "closing" coordinate in the triangle_indices
-            //
-            // We'll need to measure if all that indirection is cheaper than just manifesting the Vec.
-            vertices: input.vertices,
+            vertices,
             triangle_indices,
         }
     }
+}
+
+/// Reusable triangulator that retains internal buffers across calls,
+/// avoiding per-call allocations when triangulating many polygons.
+///
+/// Methods on the [`TriangulateEarcut`] trait construct a fresh `earcut`
+/// instance, vertex buffer, and output buffer on every call. When
+/// triangulating many polygons in a hot loop, prefer reusing a single
+/// `Earcutter` to amortize those allocations.
+///
+/// # Examples
+///
+/// ```
+/// use geo::polygon;
+/// use geo::triangulate_earcut::Earcutter;
+///
+/// let polygons = vec![
+///     polygon![(x: 0., y: 0.), (x: 10., y: 0.), (x: 10., y: 10.), (x: 0., y: 10.)],
+///     polygon![(x: 1., y: 1.), (x: 5., y: 1.), (x: 5., y: 5.), (x: 1., y: 5.)],
+/// ];
+///
+/// let mut earcutter = Earcutter::new();
+/// for polygon in &polygons {
+///     let triangulation = earcutter.triangulate(polygon);
+///     for tri in triangulation.triangle_indices.chunks_exact(3) {
+///         let v = |i: u32| triangulation.vertices[i as usize];
+///         let _ = (v(tri[0]), v(tri[1]), v(tri[2]));
+///     }
+/// }
+/// ```
+pub struct Earcutter<T: CoordFloat> {
+    earcut: Earcut<T>,
+    vertices: Vec<[T; 2]>,
+    interior_indexes: Vec<u32>,
+    triangle_indices: Vec<u32>,
+}
+
+impl<T: CoordFloat> Default for Earcutter<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T: CoordFloat> Earcutter<T> {
+    pub fn new() -> Self {
+        Self {
+            earcut: Earcut::new(),
+            vertices: Vec::new(),
+            interior_indexes: Vec::new(),
+            triangle_indices: Vec::new(),
+        }
+    }
+
+    /// Triangulate `polygon`, reusing the internal buffers. The returned
+    /// [`EarcutTriangulation`] borrows from `self`, so each call must finish
+    /// using the previous result before the next call.
+    pub fn triangulate(&mut self, polygon: &Polygon<T>) -> EarcutTriangulation<'_, T> {
+        self.vertices.clear();
+        self.interior_indexes.clear();
+
+        flatten_ring(polygon.exterior(), &mut self.vertices);
+        for interior in polygon.interiors() {
+            self.interior_indexes.push(self.vertices.len() as u32);
+            flatten_ring(interior, &mut self.vertices);
+        }
+
+        // `Earcut::earcut` clears `triangle_indices` internally before writing.
+        self.earcut.earcut(
+            self.vertices.iter().copied(),
+            &self.interior_indexes,
+            &mut self.triangle_indices,
+        );
+
+        EarcutTriangulation {
+            vertices: &self.vertices,
+            triangle_indices: &self.triangle_indices,
+        }
+    }
+}
+
+/// Borrowed view of a triangulation produced by [`Earcutter::triangulate`].
+#[derive(Debug)]
+pub struct EarcutTriangulation<'a, T: CoordFloat> {
+    /// Flattened polygon vertices (XY pairs).
+    pub vertices: &'a [[T; 2]],
+    /// Indices into `vertices`, in groups of three per triangle.
+    pub triangle_indices: &'a [u32],
 }
 
 /// The raw result of triangulating a polygon from `earcut`.
@@ -183,32 +268,6 @@ impl<T: CoordFloat> Iter<T> {
     }
 }
 
-struct EarcutInput<T: CoordFloat> {
-    pub vertices: Vec<[T; 2]>,
-    pub interior_indexes: Vec<usize>,
-}
-
-impl<'a, T: CoordFloat> From<&'a Polygon<T>> for EarcutInput<T> {
-    fn from(polygon: &'a Polygon<T>) -> EarcutInput<T> {
-        let mut vertices = Vec::with_capacity(polygon.coords_count() - 1);
-        let mut interior_indexes = Vec::with_capacity(polygon.interiors().len());
-        debug_assert!(polygon.exterior().0.len() >= 4);
-
-        flatten_ring(polygon.exterior(), &mut vertices);
-
-        for interior in polygon.interiors() {
-            debug_assert!(interior.0.len() >= 4);
-            interior_indexes.push(vertices.len());
-            flatten_ring(interior, &mut vertices);
-        }
-
-        Self {
-            vertices,
-            interior_indexes,
-        }
-    }
-}
-
 fn flatten_ring<T: CoordFloat>(line_string: &crate::LineString<T>, vertices: &mut Vec<[T; 2]>) {
     if line_string.0.is_empty() {
         return;
@@ -223,7 +282,7 @@ fn flatten_ring<T: CoordFloat>(line_string: &crate::LineString<T>, vertices: &mu
 
 #[cfg(test)]
 mod test {
-    use super::TriangulateEarcut;
+    use super::{Earcutter, TriangulateEarcut};
     use crate::{polygon, wkt};
 
     #[test]
@@ -310,5 +369,39 @@ mod test {
                 0, 4, 7, 5, 4, 0, 3, 0, 7, 5, 0, 1, 2, 3, 7, 6, 5, 1, 2, 7, 6, 6, 1, 2
             ]
         );
+    }
+
+    #[test]
+    fn test_earcutter_square() {
+        let square_polygon = wkt!(POLYGON(
+            (0. 0.,10. 0., 10. 10., 0. 10.)
+        ));
+
+        let mut earcutter = Earcutter::new();
+        let triangulation = earcutter.triangulate(&square_polygon);
+
+        assert_eq!(
+            triangulation.vertices,
+            &[[0., 0.], [10., 0.], [10., 10.], [0., 10.]][..]
+        );
+        assert_eq!(triangulation.triangle_indices, &[2u32, 3, 0, 0, 1, 2][..]);
+    }
+
+    #[test]
+    fn test_earcutter_reuse_shrinks_buffers() {
+        let square = wkt!(POLYGON((0. 0., 10. 0., 10. 10., 0. 10.)));
+        let triangle = wkt!(POLYGON((0. 0., 10. 0., 10. 10.)));
+
+        let mut earcutter = Earcutter::new();
+
+        // Square: 4 vertices, 6 triangle indices.
+        let result = earcutter.triangulate(&square);
+        assert_eq!(result.vertices.len(), 4);
+        assert_eq!(result.triangle_indices.len(), 6);
+
+        // Triangle: 3 vertices, 3 triangle indices. Buffers must shrink, not append.
+        let result = earcutter.triangulate(&triangle);
+        assert_eq!(result.vertices.len(), 3);
+        assert_eq!(result.triangle_indices.len(), 3);
     }
 }


### PR DESCRIPTION
As noted in https://github.com/georust/geo/pull/1508#issue-4002434807, exposing a reusable `Earcutter` instance (and the `earcut_triangulation_ref` trait method) avoids memory allocations across multiple triangulations.

This is especially effective when processing a bunch of simple polygons (e.g. OSM buildings), where per-call allocation cost would otherwise be significant.

## Benchmarks

| Bench       | per-call malloc | reuse scratch |       Δ |
| ----------- | ---------------------: | -----------------: | ------: |
| tiny polys  |                ~245 µs |            ~130 µs | -47 %   |
| small polys |               ~3.96 ms |           ~3.76 ms |  -5 %   |
| large_poly  |               ~1.22 ms |           ~1.15 ms |  -5 %   |

---
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.