### PR TITLE
clamp in haversine distance calculation to prevent NaN

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -8,6 +8,8 @@
   - <https://github.com/georust/geo/pull/1534>
 - Rename `TriangulateEarcut::earcut_triangles_raw` to `TriangulateEarcut::earcut_triangulation`
   - <https://github.com/georust/geo/pull/1534>
+- FIX: `Haversine::distance` no longer returns NaN on nearly antipodal points.
+  - <https://github.com/georust/geo/pull/1535>
 
 ## 0.33.1 - 2026-4-20
 

--- a/geo/src/algorithm/line_measures/metric_spaces/haversine.rs
+++ b/geo/src/algorithm/line_measures/metric_spaces/haversine.rs
@@ -271,7 +271,8 @@ impl<F: CoordFloat + FromPrimitive> Distance<F, Point<F>, Point<F>> for Haversin
         let delta_lambda = (destination.x() - origin.x()).to_radians();
         let a = (delta_theta / two).sin().powi(2)
             + theta1.cos() * theta2.cos() * (delta_lambda / two).sin().powi(2);
-        let c = two * a.sqrt().asin();
+        let a_clamped = a.min(F::one());
+        let c = two * a_clamped.sqrt().asin();
         F::from(self.radius).unwrap() * c
     }
 }
@@ -572,7 +573,17 @@ mod tests {
                 distance.round()
             );
         }
+
+        #[test]
+        fn near_antipodal_points() {
+            let d: f64 = Haversine.distance(
+                Point::new(-121.96981239217565, 65.09034271683089),
+                Point::new(58.03018760782425, -65.0903427168311),
+            );
+            assert_relative_eq!(d, 20015114.442035925);
+        }
     }
+
     mod interpolate_point {
         use super::*;
 


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Clamp the intermediate value `a` in the haversine distance calculation to prevent a NaN value for inputs that are nearly antipodal. The added test shows an example of an input that returns NaN before this change and no longer does after.

This (very deliberately) changes the output of `Haversine.distance()` for some inputs.