### PR TITLE
Add `RectOps` trait with `RectOps::rect_union()` and `RectOps::rect_intersection()` operations

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -10,6 +10,8 @@
   - <https://github.com/georust/geo/pull/1534>
 - FIX: `Haversine::distance` no longer returns NaN on nearly antipodal points.
   - <https://github.com/georust/geo/pull/1535>
+- Add `RectOps` trait with RectOps::rect_union()` and `RectOps::rect_intersection()` operations.
+  - <https://github.com/georust/geo/pull/1542>
 
 ## 0.33.1 - 2026-4-20
 

--- a/geo/src/algorithm/mod.rs
+++ b/geo/src/algorithm/mod.rs
@@ -18,6 +18,10 @@ pub use bool_ops::{BooleanOps, OpType, unary_union};
 pub mod bounding_rect;
 pub use bounding_rect::BoundingRect;
 
+/// Union and intersection of axis-aligned rectangles.
+pub mod rect_ops;
+pub use rect_ops::RectOps;
+
 pub mod buffer;
 pub use buffer::Buffer;
 

--- a/geo/src/algorithm/rect_ops.rs
+++ b/geo/src/algorithm/rect_ops.rs
@@ -1,0 +1,107 @@
+use crate::utils::{partial_max, partial_min};
+use crate::{CoordNum, Intersects, Rect, coord};
+
+/// Union and intersection of axis-aligned rectangles.
+pub trait RectOps<T: CoordNum> {
+    /// Calculate the smallest axis-aligned rectangle that contains both rectangles.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use geo::{coord, Rect, RectOps};
+    ///
+    /// let a = Rect::new(coord! { x: 0., y: 0. }, coord! { x: 2., y: 2. });
+    /// let b = Rect::new(coord! { x: 1., y: 1. }, coord! { x: 3., y: 3. });
+    ///
+    /// assert_eq!(
+    ///     a.rect_union(b),
+    ///     Rect::new(coord! { x: 0., y: 0. }, coord! { x: 3., y: 3. }),
+    /// );
+    /// ```
+    #[must_use]
+    fn rect_union(&self, other: Rect<T>) -> Rect<T>;
+
+    /// Calculate the axis-aligned rectangle contained in both rectangles, if
+    /// there is any.
+    ///
+    /// Returns `None` if the rectangles are disjoint.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use geo::{coord, Rect, RectOps};
+    ///
+    /// let a = Rect::new(coord! { x: 0., y: 0. }, coord! { x: 2., y: 2. });
+    /// let b = Rect::new(coord! { x: 1., y: 1. }, coord! { x: 3., y: 3. });
+    ///
+    /// assert_eq!(
+    ///     a.rect_intersection(b),
+    ///     Some(Rect::new(coord! { x: 1., y: 1. }, coord! { x: 2., y: 2. })),
+    /// );
+    ///
+    /// let c = Rect::new(coord! { x: 5., y: 5. }, coord! { x: 6., y: 6. });
+    /// assert_eq!(a.rect_intersection(c), None);
+    /// ```
+    fn rect_intersection(&self, other: Rect<T>) -> Option<Rect<T>>;
+}
+
+impl<T: CoordNum> RectOps<T> for Rect<T> {
+    fn rect_union(&self, other: Rect<T>) -> Rect<T> {
+        Rect::new(
+            coord! {
+                x: partial_min(self.min().x, other.min().x),
+                y: partial_min(self.min().y, other.min().y),
+            },
+            coord! {
+                x: partial_max(self.max().x, other.max().x),
+                y: partial_max(self.max().y, other.max().y),
+            },
+        )
+    }
+
+    fn rect_intersection(&self, other: Rect<T>) -> Option<Rect<T>> {
+        if !self.intersects(&other) {
+            return None;
+        }
+
+        Some(Rect::new(
+            coord! {
+                x: partial_max(self.min().x, other.min().x),
+                y: partial_max(self.min().y, other.min().y),
+            },
+            coord! {
+                x: partial_min(self.max().x, other.max().x),
+                y: partial_min(self.max().y, other.max().y),
+            },
+        ))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn rect_union() {
+        let a = Rect::new(coord! { x: 0., y: 0. }, coord! { x: 2., y: 2. });
+        let b = Rect::new(coord! { x: 1., y: 1. }, coord! { x: 3., y: 3. });
+
+        assert_eq!(
+            a.rect_union(b),
+            Rect::new(coord! { x: 0., y: 0. }, coord! { x: 3., y: 3. }),
+        );
+    }
+
+    #[test]
+    fn rect_intersection() {
+        let a = Rect::new(coord! { x: 0., y: 0. }, coord! { x: 2., y: 2. });
+        let b = Rect::new(coord! { x: 1., y: 1. }, coord! { x: 3., y: 3. });
+        let c = Rect::new(coord! { x: 5., y: 5. }, coord! { x: 6., y: 6. });
+
+        assert_eq!(
+            a.rect_intersection(b),
+            Some(Rect::new(coord! { x: 1., y: 1. }, coord! { x: 2., y: 2. })),
+        );
+        assert_eq!(a.rect_intersection(c), None);
+    }
+}

--- a/geo/src/lib.rs
+++ b/geo/src/lib.rs
@@ -152,6 +152,8 @@
 //!
 //! - **[`BoundingRect`]**: Calculate the axis-aligned
 //!   bounding rectangle of a geometry
+//! - **[`RectOps`]**: Union and intersection of axis-aligned
+//!   rectangles
 //! - **[`MinimumRotatedRect`]**: Calculate the
 //!   minimum bounding box of a geometry
 //! - **[`ConcaveHull`]**: Calculate the concave hull of a


### PR DESCRIPTION
Add `RectOps` trait with `RectOps::rect_union()` and `RectOps::rect_intersection()` operations.

Reference: https://github.com/georust/geo/discussions/1539

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
