### PR TITLE
Fix GeometryCollection::is_empty semantics

### DIFF
--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## Unreleased
+
+- Document that the inherent `GeometryCollection::is_empty` is a purely structural check (zero geometries) and does not recurse into element emptiness, unlike `geo::HasDimensions::is_empty`.
+  - <https://github.com/georust/geo/issues/1431>
+
 ## 0.7.19 - 2026-04-15
 
 - POSSIBLY BREAKING: `Triangle::from([a, b, c])` now enforces CCW winding (same as `Triangle::new`).

--- a/geo-types/src/geometry/geometry_collection.rs
+++ b/geo-types/src/geometry/geometry_collection.rs
@@ -108,7 +108,36 @@ impl<T: CoordNum> GeometryCollection<T> {
         self.0.len()
     }
 
-    /// Is this GeometryCollection empty
+    /// Returns `true` if this `GeometryCollection` contains zero geometries.
+    ///
+    /// This is a purely structural check: it tests only whether the
+    /// underlying collection has no elements. It does **not** recurse into
+    /// the contained geometries, so a collection holding only empty
+    /// geometries (for example a single empty [`LineString`]) is **not**
+    /// considered empty by this method.
+    ///
+    /// If you need the dimensional notion of emptiness — where a collection
+    /// is empty when it has no geometries *or* all of its geometries are
+    /// themselves empty — use `geo::HasDimensions::is_empty` instead.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use geo_types::{GeometryCollection, LineString};
+    ///
+    /// // A collection with no geometries is empty.
+    /// let gc = GeometryCollection::<f64>::new_from(vec![]);
+    /// assert!(gc.is_empty());
+    ///
+    /// // A collection containing a single (empty) geometry is NOT empty:
+    /// // the element is present even though it has no coordinates.
+    /// let gc = GeometryCollection::<f64>::new_from(vec![
+    ///     LineString::<f64>::new(vec![]).into(),
+    /// ]);
+    /// assert!(!gc.is_empty());
+    /// ```
+    ///
+    /// [`LineString`]: crate::LineString
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }


### PR DESCRIPTION
## Summary

The inherent `GeometryCollection::is_empty` in `geo-types/src/geometry/geometry_collection.rs` only checks whether the underlying `Vec` has zero elements (`self.0.is_empty()`), while `geo`'s `HasDimensions::is_empty` treats a collection as empty when it has no geometries *or* all of its geometries are themselves empty. A collection holding only an empty `LineString` therefore reports `false` from the inherent method but `true` from `HasDimensions` — a surprising inconsistency.

This makes the inherent method's contract explicit rather than silently changing a long-stable return value:

- Expands the doc comment on `is_empty` to state it is a purely structural check (zero geometries) that does not recurse into element emptiness, and points to `geo::HasDimensions::is_empty` for the dimensional notion.
- Adds a doctest demonstrating the distinction: an empty `Vec` is empty; a `Vec` containing one empty `LineString` is not.
- Adds a `CHANGES.md` entry.

No behavior change: the `geo` `HasDimensions` impl is already correct and is left untouched.

## Why this matters

The two definitions of "empty" diverge silently, which is easy to trip over when iterating over collections or filtering empties. Documenting the contract and cross-referencing `HasDimensions::is_empty` removes the foot-gun while preserving backward compatibility for the inherent method.

See https://github.com/georust/geo/issues/1431.

## Testing

- `cargo test -p geo-types --doc geometry_collection` — new doctest passes.
- `cargo fmt --check -p geo-types` — clean.
- `RUSTDOCFLAGS="-D warnings" cargo doc -p geo-types --no-deps` — builds with no intra-doc link warnings.

Fixes #1431.
