### PR TITLE
Document that a LineString's endpoints are not contained

### DIFF
--- a/geo/src/algorithm/contains/mod.rs
+++ b/geo/src/algorithm/contains/mod.rs
@@ -31,6 +31,14 @@
 ///
 /// // Point in Polygon
 /// assert!(polygon.contains(&point!(x: 1., y: 1.)));
+///
+/// // A `LineString`'s endpoints belong to its *boundary*, not its interior,
+/// // so a point at an endpoint is not contained, while a point along the
+/// // interior is (a consequence of the [DE-9IM] semantics described above):
+/// let path = line_string![(x: 0., y: 0.), (x: 2., y: 0.), (x: 2., y: 2.)];
+/// assert!(path.contains(&point!(x: 1., y: 0.)));   // interior point
+/// assert!(!path.contains(&point!(x: 0., y: 0.)));  // start endpoint
+/// assert!(!path.contains(&point!(x: 2., y: 2.)));  // end endpoint
 /// ```
 ///
 /// # Performance Note


### PR DESCRIPTION
The `Contains` trait's `# Examples` currently shows only positive "X in Y" cases. This adds a short example documenting a subtler, easy-to-miss behavior: a `LineString`'s endpoints are part of its *boundary*, not its interior, so they are not "contained", while interior points are — a direct consequence of the DE-9IM matrix already described in the trait docs. The example is a doc-test, so it's compile- and assertion-checked.

(Spotted while looking at #621, whose requested example — a 1-D `LineString` not containing *itself* — no longer holds: `contains` is reflexive across dimensions today. That issue looks obsolete and could probably be closed.)
