### PR TITLE
Add `rstar` support for `Rect`

### DIFF
--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -5,6 +5,8 @@
 - Document that the inherent `GeometryCollection::is_empty` is a purely structural check (zero geometries) and does not recurse into element emptiness, unlike `geo::HasDimensions::is_empty`.
   - <https://github.com/georust/geo/issues/1431>
 - Add support for `rstar` 0.13 via the `rstar_0_13` feature, alongside the existing `rstar` versions.
+- Add `rstar` support for `Rect`.
+  - <https://github.com/georust/geo/pull/1549>
 
 ## 0.7.19 - 2026-04-15
 

--- a/geo-types/src/geometry/rect.rs
+++ b/geo-types/src/geometry/rect.rs
@@ -499,6 +499,57 @@ impl core::fmt::Display for InvalidRectCoordinatesError {
     }
 }
 
+#[cfg(any(
+    feature = "rstar_0_8",
+    feature = "rstar_0_9",
+    feature = "rstar_0_10",
+    feature = "rstar_0_11",
+    feature = "rstar_0_12",
+    feature = "rstar_0_13"
+))]
+macro_rules! impl_rstar_rect {
+    ($rstar:ident) => {
+        impl<T> ::$rstar::RTreeObject for Rect<T>
+        where
+            T: ::num_traits::Float + ::$rstar::RTreeNum,
+        {
+            type Envelope = ::$rstar::AABB<crate::Point<T>>;
+
+            fn envelope(&self) -> Self::Envelope {
+                ::$rstar::AABB::from_corners(self.min().into(), self.max().into())
+            }
+        }
+
+        impl<T> ::$rstar::PointDistance for Rect<T>
+        where
+            T: ::num_traits::Float + ::$rstar::RTreeNum,
+        {
+            fn distance_2(&self, point: &crate::Point<T>) -> T {
+                use ::$rstar::RTreeObject;
+                self.envelope().distance_2(point)
+            }
+        }
+    };
+}
+
+#[cfg(feature = "rstar_0_8")]
+impl_rstar_rect!(rstar_0_8);
+
+#[cfg(feature = "rstar_0_9")]
+impl_rstar_rect!(rstar_0_9);
+
+#[cfg(feature = "rstar_0_10")]
+impl_rstar_rect!(rstar_0_10);
+
+#[cfg(feature = "rstar_0_11")]
+impl_rstar_rect!(rstar_0_11);
+
+#[cfg(feature = "rstar_0_12")]
+impl_rstar_rect!(rstar_0_12);
+
+#[cfg(feature = "rstar_0_13")]
+impl_rstar_rect!(rstar_0_13);
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -545,5 +596,15 @@ mod test {
             Rect::new((0., 0.), (0., 0.)).center(),
             Coord::from((0., 0.))
         );
+    }
+
+    #[cfg(feature = "rstar_0_13")]
+    #[test]
+    fn rect_rstar_point_distance2() {
+        use rstar_0_13::PointDistance;
+
+        let r = Rect::new((0., 2.), (1., 3.));
+        assert_relative_eq!(r.distance_2(&crate::Point::new(0., 0.)), 4.);
+        assert_relative_eq!(r.distance_2(&crate::Point::new(0.5, 2.5)), 0.);
     }
 }

--- a/geo-types/src/private_utils.rs
+++ b/geo-types/src/private_utils.rs
@@ -86,6 +86,38 @@ where
     s.abs() * dx.hypot(dy)
 }
 
+pub fn line_segment_distance_squared<T, C>(point: C, start: C, end: C) -> T
+where
+    T: CoordFloat,
+    C: Into<Coord<T>>,
+{
+    let point = point.into();
+    let start = start.into();
+    let end = end.into();
+
+    if start == end {
+        return line_euclidean_length_squared(Line::new(point, start));
+    }
+    let dx = end.x - start.x;
+    let dy = end.y - start.y;
+    let d_squared = dx * dx + dy * dy;
+    let r = ((point.x - start.x) * dx + (point.y - start.y) * dy) / d_squared;
+    if r <= T::zero() {
+        return line_euclidean_length_squared(Line::new(point, start));
+    }
+    if r >= T::one() {
+        return line_euclidean_length_squared(Line::new(point, end));
+    }
+    ((start.y - point.y) * dx - (start.x - point.x) * dy).powi(2) / d_squared
+}
+
+fn line_euclidean_length_squared<T>(line: Line<T>) -> T
+where
+    T: CoordFloat,
+{
+    line.dx().powi(2) + line.dy().powi(2)
+}
+
 pub fn line_euclidean_length<T>(line: Line<T>) -> T
 where
     T: CoordFloat,
@@ -173,4 +205,14 @@ where
         }
     }
     false
+}
+
+pub fn rect_contains_coord<T>(rect: &Rect<T>, coord: &Coord<T>) -> bool
+where
+    T: CoordNum,
+{
+    coord.x > rect.min().x
+        && coord.x < rect.max().x
+        && coord.y > rect.min().y
+        && coord.y < rect.max().y
 }

--- a/geo/src/algorithm/contains/rect.rs
+++ b/geo/src/algorithm/contains/rect.rs
@@ -13,10 +13,7 @@ where
     T: CoordNum,
 {
     fn contains(&self, coord: &Coord<T>) -> bool {
-        coord.x > self.min().x
-            && coord.x < self.max().x
-            && coord.y > self.min().y
-            && coord.y < self.max().y
+        geo_types::private_utils::rect_contains_coord(self, coord)
     }
 }
 


### PR DESCRIPTION
To make this work, I had to move the `Rect` contains `Coord` impl into a private util function and then add two simple private util functions for dealing with squared distances; there are already versions of those two functions dealing with unsquared distances right next to them.

The resulting code duplication isn't ideal, but I want to avoid calling `hypot()` and then immediately squaring it since the implicit `sqrt` operation is going to be slow and I don't believe the optimizer will convert `dx.hypot(dy).powi(2)` into `dx.powi(2) + dy.powi(2)`.

- [X] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
