### PR TITLE
Include license texts in all published crates

### DIFF
--- a/geo-traits/LICENSE-APACHE
+++ b/geo-traits/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/geo-traits/LICENSE-MIT
+++ b/geo-traits/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/geo-types/LICENSE-APACHE
+++ b/geo-types/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/geo-types/LICENSE-MIT
+++ b/geo-types/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/geo/LICENSE-APACHE
+++ b/geo/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/geo/LICENSE-MIT
+++ b/geo/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
We noticed that the license texts are currently missing when packaging the geo / geo-types crates for Fedora Linux as a dependency of the latest GNOME Papers (PDF / document viewer).

Both the Apache-2.0 and MIT licenses require that redistributed sources contain a copy of the original license text.

Including symbolic links should be enough since `cargo package` / `cargo publish` resolve all symbolic links prior to packaging / publishing - unless you run those commands on a system that doesn't support symlinks properly (i.e. Windows without symbolic link support enabled).

We don't need new releases of the crates - we can temporarily include the `LICENSE-{APACHE,MIT}` files from the GitHub repo until such time as there are new releases published to crates.io.

Thanks!

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users (not a user-visible change).
