### PR TITLE
fix: compute reverse bearing exactly in HaversineClosestPoint

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- FIX: `Line::haversine_closest_point` no longer returns an endpoint for valid high-latitude projections.
+  - <https://github.com/georust/geo/issues/1325>
 - Unpin the `earcut` dependency now that the upstream semver violation has been reverted.
   - <https://github.com/georust/geo/pull/1533>
 - Added `Earcutter` and `TriangulateEarcut::earcut_triangulation_ref` to avoid per-call memory allocations across multiple triangulations.

--- a/geo/src/algorithm/haversine_closest_point.rs
+++ b/geo/src/algorithm/haversine_closest_point.rs
@@ -101,14 +101,9 @@ where
             return Closest::SinglePoint(p1);
         }
 
-        let pi = T::from(std::f64::consts::PI).unwrap();
         let crs_ad = Haversine.bearing(p1, *from).to_radians();
         let crs_ab = Haversine.bearing(p1, p2).to_radians();
-        let crs_ba = if crs_ab > T::zero() {
-            crs_ab - pi
-        } else {
-            crs_ab + pi
-        };
+        let crs_ba = Haversine.bearing(p2, p1).to_radians();
         let crs_bd = Haversine.bearing(p2, *from).to_radians();
         let d_crs1 = crs_ad - crs_ab;
         let d_crs2 = crs_bd - crs_ba;
@@ -360,6 +355,8 @@ where
 
 #[cfg(test)]
 mod test {
+    use crate::line_measures::InterpolatePoint;
+
     use wkt::TryFromWkt;
 
     use super::*;
@@ -481,6 +478,35 @@ mod test {
                 Point::new(5.481_094_923_165_54, 82.998_280_987_615_33),
                 epsilon = 1.0e-6
             );
+        } else {
+            panic!("Did not get Closest::SinglePoint!");
+        }
+    }
+
+    #[test]
+    fn point_to_line_high_latitude_midpoint() {
+        let p_1 = Point::new(0.0, 80.0);
+        let p_2 = Point::new(179.99, 80.0);
+        let line = Line::new(p_1, p_2);
+        let p_from = Haversine.point_at_ratio_between(p_1, p_2, 0.5);
+
+        let pt = match line.haversine_closest_point(&p_from) {
+            Closest::Intersection(pt) | Closest::SinglePoint(pt) => pt,
+            Closest::Indeterminate => panic!("Did not get a closest point!"),
+        };
+
+        assert_relative_eq!(pt, p_from, epsilon = 1.0e-6);
+    }
+
+    #[test]
+    fn point_to_line_high_latitude_outside_arc() {
+        let p_1 = Point::new(0.0, 80.0);
+        let p_2 = Point::new(179.99, 80.0);
+        let line = Line::new(p_1, p_2);
+        let p_from = Point::new(0.0, 70.0);
+
+        if let Closest::SinglePoint(pt) = line.haversine_closest_point(&p_from) {
+            assert_relative_eq!(pt, p_1);
         } else {
             panic!("Did not get Closest::SinglePoint!");
         }


### PR DESCRIPTION
## Summary

`HaversineClosestPoint` now returns correct results for segments at high latitudes: interior points resolve to themselves instead of snapping to a segment endpoint.

## Why this matters

The reporter in #1325 hit this with a segment at 80 degrees latitude: the closest point to the segment's own midpoint came back as an endpoint thousands of kilometers away. The cross-track check needs the bearing from the segment end back toward the start, and the code approximated it as `bearing(p1, p2) +/- PI` (haversine_closest_point.rs:104-110 before this change). On a great circle that reverse bearing is only correct near the equator; at high latitudes the approximation is off by tens of degrees, so interior points were classified as outside the arc. The fix computes `Haversine.bearing(p2, p1)` directly, which is exact at any latitude.

## Testing

Two regression tests cover the reported case: the midpoint of a high-latitude segment resolves to itself (`point_to_line_high_latitude_midpoint`), and a point genuinely outside the arc still snaps to the nearest endpoint (`point_to_line_high_latitude_outside_arc`). `cargo test -p geo` passes (1113 unit + 224 doc tests), `cargo fmt --check` is clean, and the two `cargo clippy` warnings in the package predate this change (relate_operation.rs, old_sweep/proc.rs).

Fixes #1325

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
