### PR TITLE
Return None for Centroid on non-finite coordinates

### DIFF
--- a/geo/src/algorithm/centroid.rs
+++ b/geo/src/algorithm/centroid.rs
@@ -602,7 +602,10 @@ impl<T: GeoFloat> CentroidOperation<T> {
     }
 
     fn add_ring(&mut self, ring: &LineString<T>) {
-        debug_assert!(ring.is_closed());
+        // NaN/Inf rings can't be closed (NaN != NaN), so let them through and the arithmetic propagates the non-finite value into the centroid.
+        debug_assert!(
+            ring.is_closed() || ring.0.iter().any(|c| !c.x.is_finite() || !c.y.is_finite())
+        );
 
         let area = get_linestring_area(ring);
         if area == T::zero() {
@@ -1110,5 +1113,55 @@ mod test {
             .0
             .push(Rect::new(c(10., 10.), c(11., 11.)).into());
         assert_eq!(collection.centroid().unwrap(), point!(x: 10.5, y: 10.5));
+    }
+
+    #[test]
+    fn polygon_with_nan_centroid_propagates_nan() {
+        let nan_ring = Polygon::new(LineString::from(vec![(f64::NAN, f64::NAN)]), vec![]);
+        let centroid = nan_ring.centroid().unwrap();
+        assert!(centroid.x().is_nan() && centroid.y().is_nan());
+    }
+
+    #[test]
+    fn polygon_with_nan_in_closed_ring_centroid_propagates_nan() {
+        let nan_ring = Polygon::new(
+            LineString::from(vec![(0.0, 0.0), (1.0, 0.0), (1.0, f64::NAN), (0.0, 0.0)]),
+            vec![],
+        );
+        assert!(nan_ring.centroid().unwrap().x().is_nan());
+    }
+
+    #[test]
+    fn polygon_with_nan_in_interior_ring_centroid_propagates_nan() {
+        let poly = Polygon::new(
+            LineString::from(vec![
+                (0.0, 0.0),
+                (10.0, 0.0),
+                (10.0, 10.0),
+                (0.0, 10.0),
+                (0.0, 0.0),
+            ]),
+            vec![LineString::from(vec![
+                (2.0, 2.0),
+                (8.0, 2.0),
+                (8.0, f64::NAN),
+                (2.0, 2.0),
+            ])],
+        );
+        assert!(poly.centroid().unwrap().x().is_nan());
+    }
+
+    #[test]
+    fn linestring_with_nan_centroid_propagates_nan() {
+        let ls = LineString::from(vec![(f64::NAN, 1.0), (2.0, 3.0)]);
+        assert!(ls.centroid().unwrap().x().is_nan());
+    }
+
+    #[test]
+    fn multipoint_with_nan_centroid_propagates_nan() {
+        let mp = MultiPoint::from(vec![(f64::NAN, 1.0), (2.0, 3.0)]);
+        let centroid = mp.centroid().unwrap();
+        assert!(centroid.x().is_nan());
+        assert_eq!(centroid.y(), 2.0);
     }
 }


### PR DESCRIPTION
`Centroid` for `Polygon` panicked in debug builds via `debug_assert!(ring.is_closed())` when a ring contained `NaN` coordinates, because `LineString::is_closed` uses `==` comparison and `NaN != NaN`. In release builds the assert was skipped but the computation produced `Some(POINT(NaN NaN))`.

The fix adds non-finite coordinate checks at each public entry point in `CentroidOperation`: `add_polygon` validates all rings upfront, `add_line_string` guards the `LineString::centroid` path, and `add_multi_point` guards `MultiPoint::centroid`. Each returns early without contributing to the centroid, so the result is naturally `None`. The redundant `debug_assert!(ring.is_closed())` in `add_ring` is removed since `add_polygon` is its only caller.