### PR TITLE
Guard Relate geometry graph construction against NaN coordinates

### DIFF
--- a/geo/src/algorithm/relate/geomgraph/geometry_graph.rs
+++ b/geo/src/algorithm/relate/geomgraph/geometry_graph.rs
@@ -206,6 +206,13 @@ where
         cw_left: CoordPos,
         cw_right: CoordPos,
     ) {
+        if linear_ring
+            .0
+            .iter()
+            .any(|c| !c.x.is_finite() || !c.y.is_finite())
+        {
+            return;
+        }
         debug_assert!(linear_ring.is_closed());
         if linear_ring.is_empty() {
             return;
@@ -264,6 +271,13 @@ where
         if line_string.is_empty() {
             return;
         }
+        if line_string
+            .0
+            .iter()
+            .any(|c| !c.x.is_finite() || !c.y.is_finite())
+        {
+            return;
+        }
 
         let mut coords: Vec<Coord<F>> = Vec::with_capacity(line_string.0.len());
         for coord in &line_string.0 {
@@ -292,6 +306,13 @@ where
     }
 
     fn add_line(&mut self, line: &Line<F>) {
+        if !line.start.x.is_finite()
+            || !line.start.y.is_finite()
+            || !line.end.x.is_finite()
+            || !line.end.y.is_finite()
+        {
+            return;
+        }
         self.insert_boundary_point(line.start);
         self.insert_boundary_point(line.end);
 
@@ -309,6 +330,9 @@ where
     /// Add a point computed externally.  The point is assumed to be a
     /// Point Geometry part, which has a location of INTERIOR.
     fn add_point(&mut self, point: &Point<F>) {
+        if !point.x().is_finite() || !point.y().is_finite() {
+            return;
+        }
         self.insert_point(self.arg_index, (*point).into(), CoordPos::Inside);
     }
 
@@ -428,5 +452,22 @@ where
         } else {
             self.insert_point(self.arg_index, coord, position)
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn line_graph_has_both_endpoints_as_boundary() {
+        let line = Line::new((2.0, 2.0), (4.0, 4.0));
+        let cow: GeometryCow<f64> = GeometryCow::Line(std::borrow::Cow::Borrowed(&line));
+        let graph = GeometryGraph::new(0, cow);
+
+        let boundary_coords: Vec<_> = graph.boundary_nodes().map(|n| *n.coordinate()).collect();
+
+        assert!(boundary_coords.contains(&line.start));
+        assert!(boundary_coords.contains(&line.end));
     }
 }

--- a/geo/src/algorithm/relate/relate_operation.rs
+++ b/geo/src/algorithm/relate/relate_operation.rs
@@ -378,7 +378,7 @@ mod test {
     use crate::Relate;
 
     use super::*;
-    use geo_types::{Geometry, line_string, polygon};
+    use geo_types::{Geometry, LineString, Polygon, line_string, polygon};
     use std::str::FromStr;
 
     #[test]
@@ -484,5 +484,33 @@ mod test {
         let de9im_eq = "T*F**FFF*";
         assert!(polyrelation.matches(de9im_eq).unwrap());
         assert!(lsrelation.matches(de9im_eq).unwrap());
+    }
+
+    #[test]
+    fn relate_with_nan_does_not_panic() {
+        let nan_ring = Polygon::new(LineString::from(vec![(f64::NAN, f64::NAN)]), vec![]);
+        let _ = nan_ring.relate(&nan_ring);
+    }
+
+    #[test]
+    fn relate_with_inf_does_not_panic() {
+        let inf_ring = Polygon::new(
+            LineString::from(vec![
+                (0.0, 0.0),
+                (f64::INFINITY, 0.0),
+                (f64::INFINITY, f64::INFINITY),
+                (0.0, f64::INFINITY),
+                (0.0, 0.0),
+            ]),
+            vec![],
+        );
+        let valid = polygon![
+            (x: 1.0, y: 1.0),
+            (x: 2.0, y: 1.0),
+            (x: 2.0, y: 2.0),
+            (x: 1.0, y: 2.0),
+            (x: 1.0, y: 1.0),
+        ];
+        let _ = inf_ring.relate(&valid);
     }
 }


### PR DESCRIPTION
`Relate` panicked via `debug_assert!(linear_ring.is_closed())` in geometry graph construction when a polygon ring contained `NaN` coordinates, because `is_closed` uses `==` comparison and `NaN != NaN`. This affected every relate-based predicate (`is_intersects`, `is_contains`, `is_within`, and others).

The fix adds non-finite coordinate checks at each geometry entry point in `GeometryGraph`: `add_polygon_ring`, `add_line_string`, `add_line`, and `add_point`. Each returns early without contributing to the graph when NaN coordinates are encountered, so the relate operation completes with a degenerate but defined result instead of panicking. A now-unreachable NaN assert in `NodeMap` is removed.