### PR TITLE
Optimise the separable geometry distance fast path

### DIFF
--- a/geo-benches/src/euclidean_distance.rs
+++ b/geo-benches/src/euclidean_distance.rs
@@ -1,6 +1,6 @@
 use criterion::{criterion_group, criterion_main};
 use geo::algorithm::{ConvexHull, Distance, Euclidean};
-use geo::{Polygon, polygon};
+use geo::{LineString, Polygon, polygon};
 
 fn criterion_benchmark(c: &mut criterion::Criterion) {
     c.bench_function("Polygon Euclidean distance RTree f64", |bencher| {
@@ -80,6 +80,30 @@ fn criterion_benchmark(c: &mut criterion::Criterion) {
             .convex_hull();
             bencher.iter(|| {
                 criterion::black_box(Euclidean.distance(&poly1, &poly2));
+            });
+        },
+    );
+
+    c.bench_function(
+        "LineString Euclidean distance separable overlapping projections f64",
+        |bencher| {
+            // Two dense zigzag linestrings, separated along the x axis but offset
+            // along y so that their projections onto the axis connecting the two
+            // bounding-box centroids overlap over half of each geometry. This
+            // exercises the prefix-pruning step of the separable fast path, which
+            // would otherwise scan the overlapping region quadratically.
+            let n = 1_000;
+            let a: LineString<f64> = (0..n)
+                .map(|i| (0.5 * (i % 2) as f64, i as f64 * 0.02))
+                .collect::<Vec<_>>()
+                .into();
+            let y_offset = n as f64 * 0.02 * 0.5;
+            let b: LineString<f64> = (0..n)
+                .map(|i| (2.0 + 0.5 * (i % 2) as f64, y_offset + i as f64 * 0.02))
+                .collect::<Vec<_>>()
+                .into();
+            bencher.iter(|| {
+                criterion::black_box(Euclidean.distance(&a, &b));
             });
         },
     );

--- a/geo/src/algorithm/line_measures/metric_spaces/euclidean/distance.rs
+++ b/geo/src/algorithm/line_measures/metric_spaces/euclidean/distance.rs
@@ -9,7 +9,6 @@ use crate::{CoordFloat, GeoFloat, GeoNum};
 use num_traits::{Bounded, Float};
 use rstar::RTree;
 use rstar::primitives::CachedEnvelope;
-use std::ops::ControlFlow;
 
 // Distance is a symmetric operation, so we can implement it once for both
 macro_rules! symmetric_distance_impl {
@@ -571,10 +570,17 @@ fn separable_geometry_distance_fast<F: GeoFloat>(
     let p_coords = &linestring_p.0;
     let q_coords = &linestring_q.0;
 
+    // Closed-ring detection is invariant for the whole search: compute it once here
+    // rather than on every distance evaluation in the inner loop
+    let p_closed = p_coords.first() == p_coords.last();
+    let q_closed = q_coords.first() == q_coords.last();
+
     // Step 1: Project all vertices into 1D space
     // This gives us intercepts + index of original vertex
-    let mut projected_vertices_p = calculate_vertex_intercepts(p_coords, slope, use_x_projection);
-    let mut projected_vertices_q = calculate_vertex_intercepts(q_coords, slope, use_x_projection);
+    let mut projected_vertices_p =
+        calculate_vertex_intercepts(p_coords, slope, use_x_projection, p_closed);
+    let mut projected_vertices_q =
+        calculate_vertex_intercepts(q_coords, slope, use_x_projection, q_closed);
 
     // Step 2: Sort vertices by intercepts for spatial locality
     projected_vertices_p.sort_unstable_by(|a, b| a.intercept.total_cmp(&b.intercept));
@@ -594,13 +600,15 @@ fn separable_geometry_distance_fast<F: GeoFloat>(
     };
     // the geometry whose midpoint has the lower projection value becomes
     // the "left" geometry.
-    let (left_intercepts, right_intercepts, left_coords, right_coords) =
+    let (left_intercepts, right_intercepts, left_coords, right_coords, left_closed, right_closed) =
         if centroid_p_projection < centroid_q_projection {
             (
                 &projected_vertices_p,
                 &projected_vertices_q,
                 p_coords,
                 q_coords,
+                p_closed,
+                q_closed,
             )
         } else {
             (
@@ -608,6 +616,8 @@ fn separable_geometry_distance_fast<F: GeoFloat>(
                 &projected_vertices_p,
                 q_coords,
                 p_coords,
+                q_closed,
+                p_closed,
             )
         };
 
@@ -626,15 +636,27 @@ fn separable_geometry_distance_fast<F: GeoFloat>(
         .first()
         .expect("right intercepts should not be empty")
         .vertex_idx;
-    let min_distance =
-        get_min_segment_distance(left_coords, highest_left, right_coords, lowest_right);
+    let min_distance = get_min_segment_distance(
+        left_coords,
+        highest_left,
+        left_closed,
+        right_coords,
+        lowest_right,
+        right_closed,
+    );
 
     // Step 4b: calculate the upper bound for a projection delta that could yield a smaller distance
     // This threshold allows us to skip vertex pairs that are too far apart by breaking early
     // this is the key piece of the algorithm!
-    let max_projection_delta = min_distance * (F::one() + (slope * slope)).sqrt();
+    // The scale factor is constant for the whole search, so compute it once. Note that
+    // min_distance * scale is preferred over sqrt(min_distance² * (1 + slope²)): the squared
+    // form overflows to infinity for min_distance beyond ~1e154, which would silently disable
+    // pruning
+    let projection_scale = (F::one() + slope * slope).sqrt();
+    let mut min_distance = min_distance;
+    let mut max_projection_delta = min_distance * projection_scale;
 
-    // Step 5: minimum distance calculation. This is a bit hairy as an iterator, but the logic is straightforward:
+    // Step 5: minimum distance calculation.
     //
     // First: geometry vertex order: the vertices are ordered by their intercepts, NOT in original order!
     // We iterate through left geometry vertices in reverse (high→low intercept values)
@@ -644,55 +666,54 @@ fn separable_geometry_distance_fast<F: GeoFloat>(
     // 2. As we iterate, the gap between projection values grows
     // 3. We break whenever the gap exceeds our threshold
     // 4. If we find a new minimum distance, store it and update the threshold.
-    let result = left_intercepts.iter().rev().try_fold(
-        (min_distance, max_projection_delta),
-        |(min_dist, max_delta), vertex1| {
-            // Outer loop early termination: skip if remaining vertices are too far away.
-            // Uses strict inequality to check if the best-case scenario (smallest possible gap)
-            // is already too large, in which case we can skip the entire inner loop.
-            if right_intercepts[0].intercept - vertex1.intercept > max_delta {
-                return ControlFlow::Break((min_dist, max_delta));
+    for vertex1 in left_intercepts.iter().rev() {
+        // Outer loop early termination: all remaining left vertices have even lower
+        // intercepts, so once the smallest right intercept is already beyond the
+        // threshold, no closer pair can exist and we can stop entirely.
+        if right_intercepts[0].intercept - vertex1.intercept > max_projection_delta {
+            break;
+        }
+
+        // The distance bound is symmetric in the intercept difference, so right
+        // vertices whose intercepts lie *below* vertex1's by more than the threshold
+        // cannot yield a closer pair either. When the two projections overlap, that
+        // prefix can be long: locate its end by binary search instead of evaluating
+        // full segment distances for it. The cheap first-element check skips the
+        // search in the common non-overlapping case
+        let start = if vertex1.intercept - right_intercepts[0].intercept > max_projection_delta {
+            right_intercepts
+                .partition_point(|v| vertex1.intercept - v.intercept > max_projection_delta)
+        } else {
+            0
+        };
+
+        for vertex2 in &right_intercepts[start..] {
+            // Inner loop early termination: skip vertices beyond threshold.
+            // Uses non-strict inequality (>=) as we iterate through increasingly distant points:
+            // Once we reach OR exceed the threshold, this point and all subsequent points are too far.
+            if vertex2.intercept - vertex1.intercept >= max_projection_delta {
+                break;
             }
 
-            // Inner loop with early termination
-            let inner_result = right_intercepts.iter().try_fold(
-                (min_dist, max_delta),
-                |(mut min_d, mut max_d), vertex2| {
-                    // Inner loop early termination: skip vertices beyond threshold.
-                    // Uses non-strict inequality (>=) as we iterate through increasingly distant points:
-                    // Once we reach OR exceed the threshold, this point and all subsequent points are too far.
-                    if vertex2.intercept - vertex1.intercept >= max_d {
-                        return ControlFlow::Break((min_d, max_d));
-                    }
-
-                    // Calculate minimum distance between segments adjacent to these vertices
-                    let dist = get_min_segment_distance(
-                        left_coords,
-                        vertex1.vertex_idx,
-                        right_coords,
-                        vertex2.vertex_idx,
-                    );
-
-                    if dist < min_d {
-                        min_d = dist;
-                        // Update threshold when we find a closer distance
-                        max_d = (min_d * min_d * (F::one() + slope * slope)).sqrt();
-                    }
-                    ControlFlow::Continue((min_d, max_d))
-                },
+            // Calculate minimum distance between segments adjacent to these vertices
+            let dist = get_min_segment_distance(
+                left_coords,
+                vertex1.vertex_idx,
+                left_closed,
+                right_coords,
+                vertex2.vertex_idx,
+                right_closed,
             );
 
-            let (new_min, new_delta) = match inner_result {
-                ControlFlow::Continue(values) | ControlFlow::Break(values) => values,
-            };
-
-            ControlFlow::Continue((new_min, new_delta))
-        },
-    );
-
-    match result {
-        ControlFlow::Continue((min, _)) | ControlFlow::Break((min, _)) => min,
+            if dist < min_distance {
+                min_distance = dist;
+                // Update threshold when we find a closer distance
+                max_projection_delta = min_distance * projection_scale;
+            }
+        }
     }
+
+    min_distance
 }
 
 /// Projects vertices into 1D space (their intercept, given a slope and axis)
@@ -707,12 +728,12 @@ fn calculate_vertex_intercepts<F: GeoFloat>(
     coords: &[Coord<F>],
     perpendicular_slope: F,
     use_x_intercept: bool,
+    is_closed: bool,
 ) -> Vec<ProjectedVertex<F>> {
     // If this is a closed ring (polygon exterior/interior), skip the duplicate closing vertex.
     // For open LineStrings, we must include the last vertex; otherwise the fast path can miss
     // the true nearest neighbour.
     // We maintain the original index for later segment construction.
-    let is_closed = coords.first() == coords.last();
     let coords = if is_closed {
         &coords[..coords.len().saturating_sub(1)]
     } else {
@@ -750,86 +771,92 @@ fn calculate_vertex_intercepts<F: GeoFloat>(
 ///
 /// # Algorithm
 ///
-/// For each vertex, we identify 2 adjacent segments:
+/// For each vertex, we identify the adjacent segments:
 /// - Closed ring (polygon): prev and next with wraparound
-/// - Open linestring at endpoint: duplicate the single adjacent segment
+/// - Open linestring at endpoint: the single adjacent segment
 /// - Open linestring at middle vertex: prev and next without wraparound
 ///
-/// Then we compute distances between all 4 combinations.
-///
-/// # Edge Cases
-///
-/// - Closed rings: last coordinate duplicates first, vertices wrap around
-/// - Open linestrings at endpoints: both array entries contain the same segment
-#[inline(always)]
+/// Then we compute distances between all combinations (at most 4)
+#[inline]
 fn get_min_segment_distance<F: GeoFloat>(
     coords_p: &[Coord<F>],
     vertex_idx_p: usize,
+    is_closed_p: bool,
     coords_q: &[Coord<F>],
     vertex_idx_q: usize,
+    is_closed_q: bool,
 ) -> F {
-    // Detect if geometry is closed (ring) or open (linestring)
-    let is_closed_p = coords_p.first() == coords_p.last();
-    let is_closed_q = coords_q.first() == coords_q.last();
+    let (first_p, second_p) = adjacent_segments(coords_p, vertex_idx_p, is_closed_p);
+    let (first_q, second_q) = adjacent_segments(coords_q, vertex_idx_q, is_closed_q);
 
-    // Helper to compute adjacent segment indices for a vertex
-    let get_segment_indices =
-        |coords: &[Coord<F>], vertex_idx: usize, is_closed: bool| -> (usize, usize) {
-            if is_closed {
-                // Closed ring: wraparound logic
-                let n = coords.len() - 1; // Exclude duplicate closing vertex
-                let prev = if vertex_idx == 0 {
-                    n - 1
-                } else {
-                    vertex_idx - 1
-                };
-                let next = if vertex_idx >= n - 1 {
-                    0
-                } else {
-                    vertex_idx + 1
-                };
-                (prev, next)
-            } else {
-                // Open linestring: duplicate segment at endpoints
-                let n = coords.len();
-                if vertex_idx == 0 {
-                    // First vertex: both prev and next use segment [0,1]
-                    (0, 1)
-                } else if vertex_idx == n - 1 {
-                    // Last vertex: both prev and next use segment [n-2, n-1]
-                    (n - 2, n - 1)
-                } else {
-                    // Middle vertex: normal prev/next
-                    (vertex_idx - 1, vertex_idx + 1)
-                }
-            }
-        };
-
-    // Get segment indices for both geometries
-    let (prev_idx_p, next_idx_p) = get_segment_indices(coords_p, vertex_idx_p, is_closed_p);
-    let (prev_idx_q, next_idx_q) = get_segment_indices(coords_q, vertex_idx_q, is_closed_q);
-
-    // Build segment arrays
-    // separate arrays means it's easy to compute the cross product, and we won't have to alter
-    // the iterator if we ever expand the number of segments
-    let segments_p = [
-        Line::new(coords_p[prev_idx_p], coords_p[vertex_idx_p]),
-        Line::new(coords_p[vertex_idx_p], coords_p[next_idx_p]),
-    ];
-    let segments_q = [
-        Line::new(coords_q[prev_idx_q], coords_q[vertex_idx_q]),
-        Line::new(coords_q[vertex_idx_q], coords_q[next_idx_q]),
-    ];
+    let segments_p = [Some(first_p), second_p];
+    let segments_q = [Some(first_q), second_q];
 
     // Find minimum distance between all segment combinations
     segments_p
         .iter()
+        .flatten()
         .flat_map(|seg_p| {
             segments_q
                 .iter()
-                .map(move |seg_q| Euclidean.distance(seg_p, seg_q))
+                .flatten()
+                .map(move |seg_q| disjoint_segment_distance(seg_p, seg_q))
         })
         .fold(Bounded::max_value(), |acc, dist| acc.min(dist))
+}
+
+/// Returns the segment(s) adjacent to a vertex
+///
+/// Closed rings always have two adjacent segments (with wraparound); open
+/// linestring endpoints have exactly one
+#[inline]
+fn adjacent_segments<F: GeoFloat>(
+    coords: &[Coord<F>],
+    vertex_idx: usize,
+    is_closed: bool,
+) -> (Line<F>, Option<Line<F>>) {
+    if is_closed {
+        // Closed ring: wraparound logic. Exclude the duplicate closing vertex
+        let n = coords.len() - 1;
+        let prev = if vertex_idx == 0 {
+            n - 1
+        } else {
+            vertex_idx - 1
+        };
+        let next = if vertex_idx >= n - 1 {
+            0
+        } else {
+            vertex_idx + 1
+        };
+        (
+            Line::new(coords[prev], coords[vertex_idx]),
+            Some(Line::new(coords[vertex_idx], coords[next])),
+        )
+    } else if vertex_idx == 0 {
+        (Line::new(coords[0], coords[1]), None)
+    } else if vertex_idx == coords.len() - 1 {
+        (Line::new(coords[vertex_idx - 1], coords[vertex_idx]), None)
+    } else {
+        (
+            Line::new(coords[vertex_idx - 1], coords[vertex_idx]),
+            Some(Line::new(coords[vertex_idx], coords[vertex_idx + 1])),
+        )
+    }
+}
+
+/// Minimum distance between two segments that are known not to intersect
+///
+/// The separable fast path is only entered when the two geometries' bounding
+/// boxes are strictly separated along an axis, so segments drawn from opposite
+/// geometries can never intersect. This lets us skip the robust intersection
+/// predicate that the generic Line-Line distance must evaluate first
+#[inline]
+fn disjoint_segment_distance<F: GeoFloat>(a: &Line<F>, b: &Line<F>) -> F {
+    use geo_types::private_utils::line_segment_distance;
+    line_segment_distance(a.start, b.start, b.end)
+        .min(line_segment_distance(a.end, b.start, b.end))
+        .min(line_segment_distance(b.start, a.start, a.end))
+        .min(line_segment_distance(b.end, a.start, a.end))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Several improvements to `separable_geometry_distance_fast` (with my robot friend `Fable`)

- Hoist the invariant scale factor `sqrt(1 + slope²)` out of the pruning loop and unify the two threshold formulas. The previous update formula `sqrt(min² · (1 + slope²))` overflowed to infinity for minimum distances beyond `~1e154`, silently disabling pruning
- Compute the closed-ring flags once per search instead of on every segment-distance evaluation
- Skip the robust Line–Line intersection predicate when computing segment distances: the fast path is only entered when the bounding boxes are strictly separated along an axis, so segments from opposite geometries can never intersect
- Use a single adjacent segment at open linestring endpoints instead of a degenerate zero-length duplicate
- Replace the `ControlFlow` `fold`s with plain loops, and use binary search to skip right-hand vertices whose projections trail the current left-hand vertex by more than the pruning threshold. The distance bound is symmetric in the projection delta, but the previous code only pruned in the forward direction, so overlapping projections caused a full scan of the trailing prefix.

Existing polygon distance benchmarks improve by ~12%. For geometries whose projections onto the centroid-connector axis overlap (elongated shapes offset diagonally, neither super-common nor unheard of), the prefix pruning replaces quadratic growth in vertex count with linear: 2.7× faster at 1,000 vertices, 9.1× at 4,000, and 35× at 16,000, with identical results.

Adds a benchmark exercising the overlapping-projection case. No new correctness tests are added by this PR as it's strictly a perf improvement.

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
