### PR TITLE
Improve MultiPolygon distance perf

### DIFF
--- a/geo-benches/src/euclidean_distance.rs
+++ b/geo-benches/src/euclidean_distance.rs
@@ -85,6 +85,35 @@ fn criterion_benchmark(c: &mut criterion::Criterion) {
     );
 
     c.bench_function(
+        "MultiPolygon Euclidean distance bbox pruning f64",
+        |bencher| {
+            // A 10x10 grid of 64-gon polygons; the target polygon sits to the
+            // left of the grid, so all but the nearest members can be skipped
+            // using the distance between bounding rectangles as a lower bound.
+            let n_sides = 64;
+            let circle = |cx: f64, cy: f64, r: f64| -> Polygon<f64> {
+                let ring: LineString<f64> = (0..=n_sides)
+                    .map(|i| {
+                        let theta = std::f64::consts::TAU * (i % n_sides) as f64 / n_sides as f64;
+                        (cx + r * theta.cos(), cy + r * theta.sin())
+                    })
+                    .collect::<Vec<_>>()
+                    .into();
+                Polygon::new(ring, vec![])
+            };
+            let members: Vec<Polygon<f64>> = (0..10)
+                .flat_map(|gx| (0..10).map(move |gy| ((gx * 10 + 20) as f64, (gy * 10) as f64)))
+                .map(|(cx, cy)| circle(cx, cy, 3.0))
+                .collect();
+            let multi_polygon = geo::MultiPolygon::new(members);
+            let target = circle(0.0, 0.0, 3.0);
+            bencher.iter(|| {
+                criterion::black_box(Euclidean.distance(&multi_polygon, &target));
+            });
+        },
+    );
+
+    c.bench_function(
         "LineString Euclidean distance separable overlapping projections f64",
         |bencher| {
             // Two dense zigzag linestrings, separated along the x axis but offset

--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -37,6 +37,10 @@
   - <https://github.com/georust/geo/pull/1555>
 - Derive all error types via `thiserror` instead of hand-written `Display`/`Error` impls.
 - Inline total_cmp for downstream users who don't use LTO
+- Speed up multi-geometry `Euclidean` distance by pruning members whose bounding rectangle is already further away than the running minimum.
+  - <https://github.com/georust/geo/pull/1561>
+- Speed up `Euclidean.distance` between two `Rect`s with a closed form, instead of converting both to polygons.
+  - <https://github.com/georust/geo/pull/1561>
 
 ## 0.33.1 - 2026-4-20
 

--- a/geo/src/algorithm/line_measures/metric_spaces/euclidean/distance.rs
+++ b/geo/src/algorithm/line_measures/metric_spaces/euclidean/distance.rs
@@ -351,25 +351,33 @@ impl_euclidean_distance_for_polygonlike_geometry!(&Rect<F>,      [&Point<F>, &Li
 // └───────────────────────────────────────────┘
 
 /// Euclidean distance implementation for multi geometry types.
+///
+/// Rather than folding the minimum over full member-to-target distance
+/// computations, members are first sorted by the distance between their
+/// bounding rectangle and the target's bounding rectangle. The exact distance
+/// is then only computed while a member's bounding-rectangle distance could
+/// still improve on the running minimum; the remaining members are skipped.
 macro_rules! impl_euclidean_distance_for_iter_geometry {
     ($iter_geometry:ty,  [$($to_geometry:ty),*]) => {
         impl<F: GeoFloat> Distance<F, $iter_geometry, $iter_geometry> for Euclidean {
             fn distance(&self, origin: $iter_geometry, destination: $iter_geometry) -> F {
-                origin
-                    .iter()
-                    .fold(Bounded::max_value(), |accum: F, member| {
-                        accum.min(self.distance(member, destination))
-                    })
+                bbox_pruned_min_distance(
+                    origin.iter(),
+                    destination.bounding_rect().into(),
+                    |member| member.bounding_rect().into(),
+                    |member| self.distance(member, destination),
+                )
              }
         }
         $(
             impl<F: GeoFloat> Distance<F, $iter_geometry, $to_geometry> for Euclidean {
                 fn distance(&self, iter_geometry: $iter_geometry, to_geometry: $to_geometry) -> F {
-                    iter_geometry
-                        .iter()
-                        .fold(Bounded::max_value(), |accum: F, member| {
-                            accum.min(self.distance(member, to_geometry))
-                        })
+                    bbox_pruned_min_distance(
+                        iter_geometry.iter(),
+                        to_geometry.bounding_rect().into(),
+                        |member| member.bounding_rect().into(),
+                        |member| self.distance(member, to_geometry),
+                    )
                 }
             }
             symmetric_distance_impl!(GeoFloat, $to_geometry, $iter_geometry);
@@ -437,6 +445,71 @@ impl<F: GeoFloat> Distance<F, &Geometry<F>, &Geometry<F>> for Euclidean {
 // ┌───────────────────────────┐
 // │ Implementations utilities │
 // └───────────────────────────┘
+
+/// Minimum distance between two axis-aligned rectangles
+///
+/// Returns zero if the rectangles overlap or touch
+#[inline]
+fn rect_rect_distance<F: GeoFloat>(a: Rect<F>, b: Rect<F>) -> F {
+    let dx = (a.min().x - b.max().x)
+        .max(b.min().x - a.max().x)
+        .max(F::zero());
+    let dy = (a.min().y - b.max().y)
+        .max(b.min().y - a.max().y)
+        .max(F::zero());
+    dx.hypot(dy)
+}
+
+/// Minimum distance from a collection of members to a target geometry, with
+/// bounding-rectangle pruning
+///
+/// The distance between two bounding rectangles is a lower bound on the
+/// distance between the geometries they enclose. Members are sorted by that
+/// lower bound, ascending, and the exact member-to-target distance is only
+/// computed while the bound could still improve on the running minimum: the
+/// first member whose bound reaches the current minimum ends the search, as
+/// every subsequent member's bound is at least as large.
+///
+/// Members without a bounding rectangle (empty geometries) are assigned a zero
+/// bound so they are never pruned; their distance is delegated to the
+/// member-to-target implementation, preserving its handling of empty inputs.
+/// If the target has no bounding rectangle, no pruning occurs.
+fn bbox_pruned_min_distance<F: GeoFloat, M>(
+    members: impl Iterator<Item = M>,
+    target_rect: Option<Rect<F>>,
+    member_rect: impl Fn(&M) -> Option<Rect<F>>,
+    member_distance: impl Fn(M) -> F,
+) -> F {
+    let Some(target_rect) = target_rect else {
+        return members.fold(Bounded::max_value(), |acc: F, member| {
+            acc.min(member_distance(member))
+        });
+    };
+    let mut candidates: Vec<(F, M)> = members
+        .map(|member| {
+            let lower_bound = member_rect(&member)
+                .map(|rect| rect_rect_distance(rect, target_rect))
+                .unwrap_or_else(F::zero);
+            (lower_bound, member)
+        })
+        .collect();
+    candidates.sort_unstable_by(|a, b| a.0.total_cmp(&b.0));
+
+    let mut min_distance: F = Bounded::max_value();
+    for (lower_bound, member) in candidates {
+        // A non-finite bound (coordinate overflow in the bound computation, or
+        // NaN coordinates) proves nothing about the member's distance, so only
+        // finite bounds may end the search
+        if lower_bound.is_finite() && lower_bound >= min_distance {
+            break;
+        }
+        min_distance = min_distance.min(member_distance(member));
+        if min_distance == F::zero() {
+            break;
+        }
+    }
+    min_distance
+}
 
 /// Uses an R* tree and nearest-neighbour lookups to calculate minimum distances
 // This is somewhat slow and memory-inefficient, but certainly better than quadratic time
@@ -863,6 +936,7 @@ fn disjoint_segment_distance<F: GeoFloat>(a: &Line<F>, b: &Line<F>) -> F {
 mod test {
     use super::*;
     use crate::orient::{Direction, Orient};
+    use crate::wkt;
     use crate::{Line, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon};
     use geo_types::{coord, polygon, private_utils::line_segment_distance};
 
@@ -1154,6 +1228,45 @@ mod test {
         let mp = MultiPoint::new(v);
         let p = Point::new(50.0, 50.0);
         assert_relative_eq!(Euclidean.distance(&p, &mp), 64.03124237432849)
+    }
+    #[test]
+    // The member whose bounding rectangle is closest to the target is not the
+    // closest member: the first member's bounding rectangle has corner (1, 1)
+    // (lower bound ~1.414 from the origin) but the diagonal segment it
+    // contains is ~7.78 away. The bounding-rectangle pruning must still visit
+    // the second member (true distance 3), and must prune the third (lower
+    // bound 20)
+    fn multi_geometry_distance_bbox_pruning_visits_true_nearest() {
+        let mls = wkt! { MULTILINESTRING(
+            (1.0 10.0,10.0 1.0),
+            (3.0 0.0,4.0 0.0),
+            (20.0 0.0,21.0 0.0)
+        ) };
+        let p = wkt! { POINT(0.0 0.0) };
+        assert_relative_eq!(Euclidean.distance(&p, &mls), 3.0);
+        assert_relative_eq!(Euclidean.distance(&mls, &p), 3.0);
+    }
+    #[test]
+    // A member intersecting the target yields zero distance regardless of the
+    // other members
+    fn multi_geometry_distance_intersecting_member() {
+        let mp = wkt! { MULTIPOLYGON(
+            ((100.0 0.0,101.0 0.0,101.0 1.0,100.0 1.0,100.0 0.0)),
+            ((0.0 0.0,2.0 0.0,2.0 2.0,0.0 2.0,0.0 0.0))
+        ) };
+        let target = wkt! { POLYGON((1.0 1.0,3.0 1.0,3.0 3.0,1.0 3.0,1.0 1.0)) };
+        assert_relative_eq!(Euclidean.distance(&mp, &target), 0.0);
+    }
+    #[test]
+    // An empty member must not be pruned: its distance is delegated to the
+    // member-to-target implementation, which returns zero for empty inputs
+    fn multi_geometry_distance_empty_member() {
+        let mls = MultiLineString::new(vec![
+            LineString::new(vec![]),
+            LineString::from(vec![(50.0, 50.0), (60.0, 60.0)]),
+        ]);
+        let p = Point::new(0.0, 0.0);
+        assert_relative_eq!(Euclidean.distance(&p, &mls), 0.0);
     }
     #[test]
     fn distance_line_test() {

--- a/geo/src/algorithm/line_measures/metric_spaces/euclidean/distance.rs
+++ b/geo/src/algorithm/line_measures/metric_spaces/euclidean/distance.rs
@@ -322,15 +322,13 @@ impl<F: GeoFloat> Distance<F, &Polygon<F>, &Polygon<F>> for Euclidean {
 // │ Implementations for Rect and Triangle  │
 // └────────────────────────────────────────┘
 
-/// Implements Euclidean distance for Triangles and Rects by converting them to polygons.
+/// Implements Euclidean distance from a Triangle or a Rect to another geometry type by
+/// converting the Triangle or Rect to a polygon.
+///
+/// The Triangle-to-Triangle and Rect-to-Rect implementations are written out below instead,
+/// because Rect-to-Rect has a closed form that does not need the polygon conversion.
 macro_rules! impl_euclidean_distance_for_polygonlike_geometry {
   ($polygonlike:ty,  [$($geometry_b:ty),*]) => {
-      impl<F: GeoFloat> Distance<F, $polygonlike, $polygonlike> for Euclidean
-      {
-          fn distance(&self, origin: $polygonlike, destination: $polygonlike) -> F {
-              self.distance(&origin.to_polygon(), destination)
-          }
-      }
       $(
           impl<F: GeoFloat> Distance<F, $polygonlike, $geometry_b> for Euclidean
           {
@@ -341,6 +339,28 @@ macro_rules! impl_euclidean_distance_for_polygonlike_geometry {
           symmetric_distance_impl!(GeoFloat, $geometry_b, $polygonlike);
       )*
   };
+}
+
+impl<F: GeoFloat> Distance<F, &Triangle<F>, &Triangle<F>> for Euclidean {
+    fn distance(&self, origin: &Triangle<F>, destination: &Triangle<F>) -> F {
+        self.distance(&origin.to_polygon(), destination)
+    }
+}
+
+/// Closed-form distance between two axis-aligned rectangles.
+///
+/// The multi-geometry implementations use this as the lower bound for
+/// bounding-rectangle pruning, so it must stay cheap: it's on the hot path
+impl<F: GeoFloat> Distance<F, &Rect<F>, &Rect<F>> for Euclidean {
+    fn distance(&self, a: &Rect<F>, b: &Rect<F>) -> F {
+        let dx = (a.min().x - b.max().x)
+            .max(b.min().x - a.max().x)
+            .max(F::zero());
+        let dy = (a.min().y - b.max().y)
+            .max(b.min().y - a.max().y)
+            .max(F::zero());
+        dx.hypot(dy)
+    }
 }
 
 impl_euclidean_distance_for_polygonlike_geometry!(&Triangle<F>,  [&Point<F>, &Line<F>, &LineString<F>, &Polygon<F>, &Rect<F>]);
@@ -446,20 +466,6 @@ impl<F: GeoFloat> Distance<F, &Geometry<F>, &Geometry<F>> for Euclidean {
 // │ Implementations utilities │
 // └───────────────────────────┘
 
-/// Minimum distance between two axis-aligned rectangles
-///
-/// Returns zero if the rectangles overlap or touch
-#[inline]
-fn rect_rect_distance<F: GeoFloat>(a: Rect<F>, b: Rect<F>) -> F {
-    let dx = (a.min().x - b.max().x)
-        .max(b.min().x - a.max().x)
-        .max(F::zero());
-    let dy = (a.min().y - b.max().y)
-        .max(b.min().y - a.max().y)
-        .max(F::zero());
-    dx.hypot(dy)
-}
-
 /// Minimum distance from a collection of members to a target geometry, with
 /// bounding-rectangle pruning
 ///
@@ -488,7 +494,7 @@ fn bbox_pruned_min_distance<F: GeoFloat, M>(
     let mut candidates: Vec<(F, M)> = members
         .map(|member| {
             let lower_bound = member_rect(&member)
-                .map(|rect| rect_rect_distance(rect, target_rect))
+                .map(|rect| Euclidean.distance(&rect, &target_rect))
                 .unwrap_or_else(F::zero);
             (lower_bound, member)
         })
@@ -1690,5 +1696,70 @@ mod test {
 
         let test_gc = GeometryCollection(vec![Geometry::Rect(test_rect)]);
         assert_relative_eq!(Euclidean.distance(&test_gc, &gc), 60.959002616512684);
+    }
+
+    /// Exercises the closed-form `Distance<&Rect, &Rect>` implementation. Each expected value is
+    /// also the value the general polygon-to-polygon path produces, which the following test
+    /// checks over random input.
+    #[test]
+    fn distance_rect_rect_test() {
+        let a = Rect::new(coord! { x: 0., y: 0. }, coord! { x: 10., y: 10. });
+
+        // Separated along x only: the gap is the x deficit
+        let right = Rect::new(coord! { x: 13., y: 2. }, coord! { x: 20., y: 8. });
+        assert_relative_eq!(Euclidean.distance(&a, &right), 3.);
+        assert_relative_eq!(Euclidean.distance(&right, &a), 3.);
+
+        // Separated along y only
+        let above = Rect::new(coord! { x: 2., y: 14. }, coord! { x: 8., y: 20. });
+        assert_relative_eq!(Euclidean.distance(&a, &above), 4.);
+
+        // Separated along both axes: the gap is the hypotenuse of the two deficits
+        let diagonal = Rect::new(coord! { x: 13., y: 14. }, coord! { x: 20., y: 20. });
+        assert_relative_eq!(Euclidean.distance(&a, &diagonal), 5.);
+
+        // Touching, overlapping, nested and identical rectangles are all zero
+        let touching = Rect::new(coord! { x: 10., y: 2. }, coord! { x: 20., y: 8. });
+        assert_relative_eq!(Euclidean.distance(&a, &touching), 0.);
+
+        let corner_touching = Rect::new(coord! { x: 10., y: 10. }, coord! { x: 20., y: 20. });
+        assert_relative_eq!(Euclidean.distance(&a, &corner_touching), 0.);
+
+        let overlapping = Rect::new(coord! { x: 5., y: 5. }, coord! { x: 15., y: 15. });
+        assert_relative_eq!(Euclidean.distance(&a, &overlapping), 0.);
+
+        let nested = Rect::new(coord! { x: 2., y: 2. }, coord! { x: 4., y: 4. });
+        assert_relative_eq!(Euclidean.distance(&a, &nested), 0.);
+        assert_relative_eq!(Euclidean.distance(&nested, &a), 0.);
+
+        assert_relative_eq!(Euclidean.distance(&a, &a), 0.);
+
+        // A degenerate rectangle is a point
+        let degenerate = Rect::new(coord! { x: 14., y: 5. }, coord! { x: 14., y: 5. });
+        assert_relative_eq!(Euclidean.distance(&a, &degenerate), 4.);
+    }
+
+    /// The closed-form Rect-to-Rect distance must agree with the general polygon-to-polygon path
+    /// that the other Rect implementations use.
+    #[test]
+    fn distance_rect_rect_agrees_with_polygon_path() {
+        // A small deterministic LCG keeps the input reproducible without a dependency
+        let mut state: u64 = 0x2545_F491_4F6C_DD1D;
+        let mut next = || {
+            state = state
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            ((state >> 11) as f64 / (1u64 << 53) as f64) * 200. - 100.
+        };
+        for _ in 0..2_000 {
+            let (x1, x2, y1, y2) = (next(), next(), next(), next());
+            let (x3, x4, y3, y4) = (next(), next(), next(), next());
+            let a = Rect::new((x1.min(x2), y1.min(y2)), (x1.max(x2), y1.max(y2)));
+            let b = Rect::new((x3.min(x4), y3.min(y4)), (x3.max(x4), y3.max(y4)));
+
+            let closed_form: f64 = Euclidean.distance(&a, &b);
+            let via_polygons: f64 = Euclidean.distance(&a.to_polygon(), &b.to_polygon());
+            assert_relative_eq!(closed_form, via_polygons, epsilon = 1e-9);
+        }
     }
 }


### PR DESCRIPTION
Based on #1560, so merge that first.

Prune multi-geometry Euclidean distance using bounding-rectangle lower bounds (with my robot friend `Fable`)

The distance between two bounding rectangles is a _lower bound_ on the
distance between the geometries they enclose. The multi-geometry distance
implementations previously computed the full member-to-target distance for
every member. Members are now sorted by this lower bound, ascending, and
exact distances are **only** computed while the bound could still improve on
the running minimum: the first member whose bound reaches the current
minimum ends the search, as every subsequent bound is at least as large.
The search also ends early if the minimum reaches zero.

Members without a bounding rectangle (empty geometries) are given a zero
bound so they are never pruned, preserving existing empty-input behaviour.
Non-finite bounds prove nothing and never terminate the search.

Benchmark (10x10 grid of 64-gon polygons against an offset target
polygon): 163.5 µs before, 10.4 µs after, a roughly 16x improvement.

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
