### PR TITLE
feat: add `Geometry::static_name()` for type identification

### DIFF
--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -8,6 +8,7 @@
 - Add `rstar` support for `Rect`.
   - <https://github.com/georust/geo/pull/1549>
 - Derive all error types via `thiserror` instead of hand-written `Display`/`Error` impls.
+- Add `Geometry::static_name()` to get the type of geometry like `Point` and `MultiLineString` as a static string.
 
 ## 0.7.19 - 2026-04-15
 

--- a/geo-types/Cargo.toml
+++ b/geo-types/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 default = ["std"]
 std = ["approx?/std", "num-traits/std", "serde?/std", "thiserror/std"]
 multithreading = ["rayon"]
-serde = [ "dep:serde", "rstar_0_8?/serde", "rstar_0_9?/serde", "rstar_0_10?/serde", "rstar_0_11?/serde", "rstar_0_12?/serde", "rstar_0_13?/serde"]
+serde = ["dep:serde", "rstar_0_8?/serde", "rstar_0_9?/serde", "rstar_0_10?/serde", "rstar_0_11?/serde", "rstar_0_12?/serde", "rstar_0_13?/serde"]
 
 rstar = ["rstar_0_8"]
 rstar_0_8 = ["dep:rstar_0_8", "approx"]

--- a/geo-types/src/geometry/mod.rs
+++ b/geo-types/src/geometry/mod.rs
@@ -210,6 +210,22 @@ impl<T: CoordNum> Geometry<T> {
             None
         }
     }
+
+    /// Get simple geometry type name as a string.
+    pub fn static_name(&self) -> &'static str {
+        match self {
+            Geometry::Point(_) => "Point",
+            Geometry::Line(_) => "Line",
+            Geometry::LineString(_) => "LineString",
+            Geometry::Polygon(_) => "Polygon",
+            Geometry::MultiPoint(_) => "MultiPoint",
+            Geometry::MultiLineString(_) => "MultiLineString",
+            Geometry::MultiPolygon(_) => "MultiPolygon",
+            Geometry::GeometryCollection(_) => "GeometryCollection",
+            Geometry::Rect(_) => "Rect",
+            Geometry::Triangle(_) => "Triangle",
+        }
+    }
 }
 
 macro_rules! try_from_geometry_impl {


### PR DESCRIPTION
Many of my projects end up having a simplified Display impl for Geometry to print just the type of the geometry. Might as well move this to the core.

Notes:
* there is another any-based impl that includes geometry type - this is different, as it is more suitable for dev than for end user
* I have also considered using [strum::IntoStaticStr](https://docs.rs/strum_macros/latest/strum_macros/derive.IntoStaticStr.html) as a simpler and more popular path, but using it for a single case seems a bit overkill


- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
