### PR TITLE
chore: simplify all errors with `thiserror`

### DIFF
--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Derive error types via `thiserror` instead of hand-written `Display`/`Error` impls. `Error` and the deprecated `InvalidRectCoordinatesError` now implement `core::error::Error` unconditionally (previously only under the `std` feature).
 - Document that the inherent `GeometryCollection::is_empty` is a purely structural check (zero geometries) and does not recurse into element emptiness, unlike `geo::HasDimensions::is_empty`.
   - <https://github.com/georust/geo/issues/1431>
 - Add support for `rstar` 0.13 via the `rstar_0_13` feature, alongside the existing `rstar` versions.

--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -2,12 +2,12 @@
 
 ## Unreleased
 
-- Derive error types via `thiserror` instead of hand-written `Display`/`Error` impls. `Error` and the deprecated `InvalidRectCoordinatesError` now implement `core::error::Error` unconditionally (previously only under the `std` feature).
 - Document that the inherent `GeometryCollection::is_empty` is a purely structural check (zero geometries) and does not recurse into element emptiness, unlike `geo::HasDimensions::is_empty`.
   - <https://github.com/georust/geo/issues/1431>
 - Add support for `rstar` 0.13 via the `rstar_0_13` feature, alongside the existing `rstar` versions.
 - Add `rstar` support for `Rect`.
   - <https://github.com/georust/geo/pull/1549>
+- Derive all error types via `thiserror` instead of hand-written `Display`/`Error` impls.
 
 ## 0.7.19 - 2026-04-15
 

--- a/geo-types/Cargo.toml
+++ b/geo-types/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 
 [features]
 default = ["std"]
-std = ["approx?/std", "num-traits/std", "serde?/std"]
+std = ["approx?/std", "num-traits/std", "serde?/std", "thiserror/std"]
 multithreading = ["rayon"]
 serde = [ "dep:serde", "rstar_0_8?/serde", "rstar_0_9?/serde", "rstar_0_10?/serde", "rstar_0_11?/serde", "rstar_0_12?/serde", "rstar_0_13?/serde"]
 
@@ -47,6 +47,7 @@ rstar_0_12 = { package = "rstar", version = "0.12", optional = true }
 rstar_0_13 = { package = "rstar", version = "0.13", optional = true }
 serde = { version = "1", optional = true, default-features = false, features = ["alloc", "derive"] }
 spade_2 = { package = "spade", version = "2", optional = true }
+thiserror = { version = "2.0.19", default-features = false }
 
 [dev-dependencies]
 approx = ">= 0.4.0, < 0.6.0"

--- a/geo-types/src/error.rs
+++ b/geo-types/src/error.rs
@@ -1,24 +1,10 @@
-use core::fmt;
-
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
+    #[error("Expected a {expected}, but found a {found}")]
     MismatchedGeometry {
         expected: &'static str,
         found: &'static str,
     },
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for Error {}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Error::MismatchedGeometry { expected, found } => {
-                write!(f, "Expected a {expected}, but found a {found}")
-            }
-        }
-    }
 }
 
 #[cfg(test)]

--- a/geo-types/src/geometry/rect.rs
+++ b/geo-types/src/geometry/rect.rs
@@ -485,19 +485,9 @@ mod approx_integration {
     since = "0.6.2",
     note = "Use `Rect::new` instead, since `Rect::try_new` will never Error"
 )]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("{}", RECT_INVALID_BOUNDS_ERROR)]
 pub struct InvalidRectCoordinatesError;
-
-#[cfg(feature = "std")]
-#[allow(deprecated)]
-impl std::error::Error for InvalidRectCoordinatesError {}
-
-#[allow(deprecated)]
-impl core::fmt::Display for InvalidRectCoordinatesError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{RECT_INVALID_BOUNDS_ERROR}")
-    }
-}
 
 #[cfg(any(
     feature = "rstar_0_8",

--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Derive all error types via `thiserror` instead of hand-written `Display`/`Error` impls. The error variants for the underlying-triangulation cases (`VoronoiError::Triangulation`, `TriangulationError::SpadeError`) and the nested validation errors now expose the wrapped error through `Error::source()`. `InvalidGeometry` variants are now `#[error(transparent)]` and gain `From` conversions from each inner validation error (e.g. `From<InvalidPolygon> for InvalidGeometry`).
 - FIX: `Line::haversine_closest_point` no longer returns an endpoint for valid high-latitude projections.
   - <https://github.com/georust/geo/issues/1325>
 - Add index-returning methods `Simplify::simplify_idx`, `SimplifyVw::simplify_vw_idx`, `SimplifyVwPreserve::simplify_vw_preserve_idx`, and `ConvexHull::convex_hull_idx`, returning input-relative indices of the retained vertices. Adds the `PolygonIndices` type and the `quick_hull_indices` free function.

--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -2,7 +2,6 @@
 
 ## Unreleased
 
-- Derive all error types via `thiserror` instead of hand-written `Display`/`Error` impls. The error variants for the underlying-triangulation cases (`VoronoiError::Triangulation`, `TriangulationError::SpadeError`) and the nested validation errors now expose the wrapped error through `Error::source()`. `InvalidGeometry` variants are now `#[error(transparent)]` and gain `From` conversions from each inner validation error (e.g. `From<InvalidPolygon> for InvalidGeometry`).
 - FIX: `Line::haversine_closest_point` no longer returns an endpoint for valid high-latitude projections.
   - <https://github.com/georust/geo/issues/1325>
 - Add index-returning methods `Simplify::simplify_idx`, `SimplifyVw::simplify_vw_idx`, `SimplifyVwPreserve::simplify_vw_preserve_idx`, and `ConvexHull::convex_hull_idx`, returning input-relative indices of the retained vertices. Adds the `PolygonIndices` type and the `quick_hull_indices` free function.
@@ -30,6 +29,7 @@
 - FIX: `lex_cmp` uses `total_cmp` and no longer panics on `NaN` coordinates.
 - BREAKING: Tightens the bound on `Contains<MultiPoint<T>> for MultiPoint<T>` from `T: CoordNum` to `T: GeoNum`
   - <https://github.com/georust/geo/pull/1555>
+- Derive all error types via `thiserror` instead of hand-written `Display`/`Error` impls.
 
 ## 0.33.1 - 2026-4-20
 

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -39,6 +39,7 @@ proj = { version = "0.31.0", optional = true }
 robust = "1.1.0"
 rstar = "0.13.0"
 serde = { version = "1.0", optional = true, features = ["derive"] }
+thiserror = "2.0.19"
 i_overlay = { version = "4.5.1, < 4.6.0", default-features = false }
 sif-itree = "0.4.0"
 rand = { version = "0.10.0", default-features = false, features = [ "alloc" ] }

--- a/geo/src/algorithm/kmeans/error.rs
+++ b/geo/src/algorithm/kmeans/error.rs
@@ -2,18 +2,20 @@ use crate::GeoFloat;
 use rand::distr::weighted::Error;
 
 /// Errors that can occur during k-means++ initialisation
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
 pub enum KMeansInitError {
     /// Input data contains `NaN` coordinates
     ///
     /// This typically indicates invalid or corrupted input data. Check your point coordinates
     /// for NaN values before running k-means.
+    #[error("Input data contains NaN coordinates")]
     NaNCoordinate,
 
     /// Input data contains infinite coordinates
     ///
     /// This typically indicates invalid or corrupted input data. Check your point coordinates
     /// for infinite values before running k-means.
+    #[error("Input data contains infinite coordinates")]
     InfiniteCoordinate,
 
     /// All points are at identical locations, making clustering impossible
@@ -25,48 +27,26 @@ pub enum KMeansInitError {
     /// Consider:
     /// - Checking if your data has been properly loaded
     /// - Adding small random perturbations to break ties if appropriate.
+    #[error("All points are at identical locations, making clustering impossible")]
     DegenerateData,
 
     /// Failed to create weighted distribution for k-means++ sampling
     ///
     /// This error occurs when the random weighted sampling distribution cannot be constructed,
     /// typically because all weights sum to zero or contain invalid values.
+    #[error("Failed to create weighted distribution for k-means++ sampling: {error}")]
     WeightedDistributionFailed {
         /// The underlying error from rand's WeightedIndex
+        #[source]
         error: Error,
     },
 }
 
-impl std::fmt::Display for KMeansInitError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            KMeansInitError::NaNCoordinate => {
-                write!(f, "Input data contains NaN coordinates")
-            }
-            KMeansInitError::InfiniteCoordinate => {
-                write!(f, "Input data contains infinite coordinates")
-            }
-            KMeansInitError::DegenerateData => {
-                write!(
-                    f,
-                    "All points are at identical locations, making clustering impossible"
-                )
-            }
-            KMeansInitError::WeightedDistributionFailed { error } => {
-                write!(
-                    f,
-                    "Failed to create weighted distribution for k-means++ sampling: {}",
-                    error
-                )
-            }
-        }
-    }
-}
-
 /// Errors that can occur during k-means clustering
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
 pub enum KMeansError<T: GeoFloat> {
     /// Invalid number of clusters requested
+    #[error("Invalid k={k}: must be > 0 and <= {n} (number of points)")]
     InvalidK {
         /// The requested number of clusters
         k: usize,
@@ -75,6 +55,7 @@ pub enum KMeansError<T: GeoFloat> {
     },
 
     /// An empty cluster was encountered and could not be recovered
+    #[error("Empty cluster {cluster_id} at iteration {iteration} could not be recovered")]
     EmptyCluster {
         /// The iteration number when the error occurred
         iteration: usize,
@@ -86,7 +67,8 @@ pub enum KMeansError<T: GeoFloat> {
     ///
     /// Contains specific information about the initialisation failure mode.
     /// See [`KMeansInitError`] for details on each failure type.
-    InitializationFailed(KMeansInitError),
+    #[error("K-means initialisation failed: {0}")]
+    InitializationFailed(#[source] KMeansInitError),
 
     /// Maximum iterations reached without convergence
     ///
@@ -105,6 +87,14 @@ pub enum KMeansError<T: GeoFloat> {
     /// - `max_centroid_shift` is large relative to tolerance
     /// - A significant number of points are still changing clusters
     /// - You require guaranteed convergence
+    #[error(
+        "k-means did not converge within {iterations} iterations. \
+         Final centroid shift: {:.6} (tolerance: {:.6}), \
+         {changed_assignments} points changed clusters in final iteration. \
+         Consider increasing max_iter or using the partial result.",
+        .max_centroid_shift.to_f64().expect("max_centroid_shift must be representable as f64"),
+        .tolerance.to_f64().expect("tolerance must be representable as f64")
+    )]
     MaxIterationsReached {
         /// Cluster assignments from the final iteration.
         ///
@@ -121,54 +111,3 @@ pub enum KMeansError<T: GeoFloat> {
         changed_assignments: usize,
     },
 }
-
-impl<T: GeoFloat> std::fmt::Display for KMeansError<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            KMeansError::InvalidK { k, n } => {
-                write!(
-                    f,
-                    "Invalid k={}: must be > 0 and <= {} (number of points)",
-                    k, n
-                )
-            }
-            KMeansError::EmptyCluster {
-                iteration,
-                cluster_id,
-            } => {
-                write!(
-                    f,
-                    "Empty cluster {} at iteration {} could not be recovered",
-                    cluster_id, iteration
-                )
-            }
-            KMeansError::InitializationFailed(init_error) => {
-                write!(f, "K-means initialisation failed: {}", init_error)
-            }
-            KMeansError::MaxIterationsReached {
-                iterations,
-                max_centroid_shift,
-                tolerance,
-                changed_assignments,
-                ..
-            } => {
-                let shift_f64 = max_centroid_shift
-                    .to_f64()
-                    .expect("max_centroid_shift must be representable as f64");
-                let tol_f64 = tolerance
-                    .to_f64()
-                    .expect("tolerance must be representable as f64");
-                write!(
-                    f,
-                    "k-means did not converge within {} iterations. \
-                     Final centroid shift: {:.6} (tolerance: {:.6}), \
-                     {} points changed clusters in final iteration. \
-                     Consider increasing max_iter or using the partial result.",
-                    iterations, shift_f64, tol_f64, changed_assignments
-                )
-            }
-        }
-    }
-}
-
-impl<T: GeoFloat> std::error::Error for KMeansError<T> {}

--- a/geo/src/algorithm/line_measures/substring.rs
+++ b/geo/src/algorithm/line_measures/substring.rs
@@ -22,41 +22,21 @@ use crate::algorithm::vector_ops::Vector2DOps;
 use geo_types::{Coord, CoordFloat, Line, LineString};
 
 /// Errors returned by substring extraction. See [`SubstringableLine`].
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum SubstringError {
     /// Input line string contains no coordinates.
+    #[error("LineString contains no coordinates")]
     EmptyLineString,
     /// Input line string contains a single vertex (no segments).
+    #[error("LineString contains only a single vertex")]
     SingleVertex,
     /// Input contains a non-finite coordinate (NaN or infinity).
+    #[error("input contains a non-finite coordinate")]
     NonFiniteCoordinate,
     /// Range invalid: `start > end`, or `start`/`end` is not finite.
+    #[error("invalid range: start must be <= end and both must be finite")]
     InvalidRange,
 }
-
-impl std::fmt::Display for SubstringError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            SubstringError::EmptyLineString => {
-                write!(f, "LineString contains no coordinates")
-            }
-            SubstringError::SingleVertex => {
-                write!(f, "LineString contains only a single vertex")
-            }
-            SubstringError::NonFiniteCoordinate => {
-                write!(f, "input contains a non-finite coordinate")
-            }
-            SubstringError::InvalidRange => {
-                write!(
-                    f,
-                    "invalid range: start must be <= end and both must be finite"
-                )
-            }
-        }
-    }
-}
-
-impl std::error::Error for SubstringError {}
 
 /// A linear geometry from which a sub-linestring can be extracted between
 /// two distance-along-line (or ratio-along-line) bounds.

--- a/geo/src/algorithm/relate/geomgraph/intersection_matrix.rs
+++ b/geo/src/algorithm/relate/geomgraph/intersection_matrix.rs
@@ -229,7 +229,8 @@ impl<T> std::ops::IndexMut<CoordPos> for LocationArray<T> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
+#[error("invalid input:  {message}")]
 pub struct InvalidInputError {
     message: String,
 }
@@ -237,13 +238,6 @@ pub struct InvalidInputError {
 impl InvalidInputError {
     fn new(message: String) -> Self {
         Self { message }
-    }
-}
-
-impl std::error::Error for InvalidInputError {}
-impl std::fmt::Display for InvalidInputError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "invalid input:  {}", self.message)
     }
 }
 

--- a/geo/src/algorithm/repair_polygon/mod.rs
+++ b/geo/src/algorithm/repair_polygon/mod.rs
@@ -195,40 +195,24 @@ mod tests;
 // ====== Error ======
 
 /// Errors that can occur during polygon repair.
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, thiserror::Error)]
 pub enum RepairPolygonError {
     /// A coordinate value was NaN.
+    #[error("coordinate value is NaN")]
     CoordinateIsNaN,
     /// A coordinate value was too large for the triangulation kernel.
+    #[error("coordinate value exceeds triangulation kernel limit")]
     CoordinateTooLarge,
     /// A coordinate value was too small (non-zero but below the
     /// triangulation kernel's minimum representable value).
+    #[error("coordinate value is non-zero but below triangulation kernel minimum")]
     CoordinateTooSmall,
     /// An internal constraint edge could not be inserted into the
     /// triangulation. This typically indicates a numerical precision
     /// issue in the input geometry.
+    #[error("internal constraint edge insertion failed")]
     ConstraintFailure,
 }
-
-impl std::fmt::Display for RepairPolygonError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::CoordinateIsNaN => write!(f, "coordinate value is NaN"),
-            Self::CoordinateTooLarge => {
-                write!(f, "coordinate value exceeds triangulation kernel limit")
-            }
-            Self::CoordinateTooSmall => write!(
-                f,
-                "coordinate value is non-zero but below triangulation kernel minimum"
-            ),
-            Self::ConstraintFailure => {
-                write!(f, "internal constraint edge insertion failed")
-            }
-        }
-    }
-}
-
-impl std::error::Error for RepairPolygonError {}
 
 impl From<TriangulationError> for RepairPolygonError {
     fn from(err: TriangulationError) -> Self {

--- a/geo/src/algorithm/stitch.rs
+++ b/geo/src/algorithm/stitch.rs
@@ -7,18 +7,11 @@ use crate::{Contains, GeoFloat};
 
 // ========= Error Type ============
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum LineStitchingError {
+    #[error("{0}")]
     IncompleteRing(&'static str),
 }
-
-impl std::fmt::Display for LineStitchingError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{self:?}")
-    }
-}
-
-impl std::error::Error for LineStitchingError {}
 
 pub(crate) type TriangleStitchingResult<T> = Result<T, LineStitchingError>;
 

--- a/geo/src/algorithm/triangulate_delaunay.rs
+++ b/geo/src/algorithm/triangulate_delaunay.rs
@@ -31,20 +31,15 @@ where
 
 // ====== Error ========
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, thiserror::Error)]
 pub enum TriangulationError {
-    SpadeError(spade::InsertionError),
+    #[error("error during spade triangulation: {0}")]
+    SpadeError(#[source] spade::InsertionError),
+    #[error("loop trap: triangulation did not terminate")]
     LoopTrap,
+    #[error("failed to insert a constraint edge into the triangulation")]
     ConstraintFailure,
 }
-
-impl std::fmt::Display for TriangulationError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{self:?}")
-    }
-}
-
-impl std::error::Error for TriangulationError {}
 
 pub type TriangulationResult<T> = Result<T, TriangulationError>;
 

--- a/geo/src/algorithm/triangulate_spade.rs
+++ b/geo/src/algorithm/triangulate_spade.rs
@@ -36,20 +36,15 @@ where
 
 // ====== Error ========
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum TriangulationError {
-    SpadeError(spade::InsertionError),
+    #[error("error during spade triangulation: {0}")]
+    SpadeError(#[source] spade::InsertionError),
+    #[error("loop trap: triangulation did not terminate")]
     LoopTrap,
+    #[error("failed to insert a constraint edge into the triangulation")]
     ConstraintFailure,
 }
-
-impl std::fmt::Display for TriangulationError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{self:?}")
-    }
-}
-
-impl std::error::Error for TriangulationError {}
 
 pub type TriangulationResult<T> = Result<T, TriangulationError>;
 

--- a/geo/src/algorithm/validation/coord.rs
+++ b/geo/src/algorithm/validation/coord.rs
@@ -1,23 +1,12 @@
 use super::{Validation, utils};
 use crate::{Coord, GeoFloat};
 
-use std::fmt;
-
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
 pub enum InvalidCoord {
     /// A valid [`Coord`] must be finite.
+    #[error("coordinate was non-finite")]
     NonFinite,
 }
-
-impl fmt::Display for InvalidCoord {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            InvalidCoord::NonFinite => write!(f, "coordinite was non-finite"),
-        }
-    }
-}
-
-impl std::error::Error for InvalidCoord {}
 
 impl<F: GeoFloat> Validation for Coord<F> {
     type Error = InvalidCoord;

--- a/geo/src/algorithm/validation/geometry.rs
+++ b/geo/src/algorithm/validation/geometry.rs
@@ -7,56 +7,31 @@ use super::{
 use crate::{GeoFloat, Geometry};
 
 use crate::geometry_cow::GeometryCow;
-use std::fmt;
 
 /// A [`Geometry`] is valid if its inner variant is valid.
 /// e.g. `Geometry::Polygon(polygon)` is valid if and only if `polygon` is valid.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
 pub enum InvalidGeometry {
-    InvalidPoint(InvalidPoint),
-    InvalidLine(InvalidLine),
-    InvalidLineString(InvalidLineString),
-    InvalidPolygon(InvalidPolygon),
-    InvalidMultiPoint(InvalidMultiPoint),
-    InvalidMultiLineString(InvalidMultiLineString),
-    InvalidMultiPolygon(InvalidMultiPolygon),
-    InvalidGeometryCollection(InvalidGeometryCollection),
-    InvalidRect(InvalidRect),
-    InvalidTriangle(InvalidTriangle),
-}
-
-impl fmt::Display for InvalidGeometry {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            InvalidGeometry::InvalidPoint(err) => write!(f, "{err}"),
-            InvalidGeometry::InvalidLine(err) => write!(f, "{err}"),
-            InvalidGeometry::InvalidLineString(err) => write!(f, "{err}"),
-            InvalidGeometry::InvalidPolygon(err) => write!(f, "{err}"),
-            InvalidGeometry::InvalidMultiPoint(err) => write!(f, "{err}"),
-            InvalidGeometry::InvalidMultiLineString(err) => write!(f, "{err}"),
-            InvalidGeometry::InvalidMultiPolygon(err) => write!(f, "{err}"),
-            InvalidGeometry::InvalidGeometryCollection(err) => write!(f, "{err}"),
-            InvalidGeometry::InvalidRect(err) => write!(f, "{err}"),
-            InvalidGeometry::InvalidTriangle(err) => write!(f, "{err}"),
-        }
-    }
-}
-
-impl std::error::Error for InvalidGeometry {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            InvalidGeometry::InvalidPoint(err) => Some(err),
-            InvalidGeometry::InvalidLine(err) => Some(err),
-            InvalidGeometry::InvalidLineString(err) => Some(err),
-            InvalidGeometry::InvalidPolygon(err) => Some(err),
-            InvalidGeometry::InvalidMultiPoint(err) => Some(err),
-            InvalidGeometry::InvalidMultiLineString(err) => Some(err),
-            InvalidGeometry::InvalidMultiPolygon(err) => Some(err),
-            InvalidGeometry::InvalidGeometryCollection(err) => Some(err),
-            InvalidGeometry::InvalidRect(err) => Some(err),
-            InvalidGeometry::InvalidTriangle(err) => Some(err),
-        }
-    }
+    #[error(transparent)]
+    InvalidPoint(#[from] InvalidPoint),
+    #[error(transparent)]
+    InvalidLine(#[from] InvalidLine),
+    #[error(transparent)]
+    InvalidLineString(#[from] InvalidLineString),
+    #[error(transparent)]
+    InvalidPolygon(#[from] InvalidPolygon),
+    #[error(transparent)]
+    InvalidMultiPoint(#[from] InvalidMultiPoint),
+    #[error(transparent)]
+    InvalidMultiLineString(#[from] InvalidMultiLineString),
+    #[error(transparent)]
+    InvalidMultiPolygon(#[from] InvalidMultiPolygon),
+    #[error(transparent)]
+    InvalidGeometryCollection(#[from] InvalidGeometryCollection),
+    #[error(transparent)]
+    InvalidRect(#[from] InvalidRect),
+    #[error(transparent)]
+    InvalidTriangle(#[from] InvalidTriangle),
 }
 
 impl<F: GeoFloat> Validation for Geometry<F> {

--- a/geo/src/algorithm/validation/geometry_collection.rs
+++ b/geo/src/algorithm/validation/geometry_collection.rs
@@ -1,25 +1,12 @@
 use super::{GeometryIndex, InvalidGeometry, Validation};
 use crate::{GeoFloat, GeometryCollection};
 
-use std::fmt;
-
 /// A [`GeometryCollection`] is valid if all its elements are valid.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
 pub enum InvalidGeometryCollection {
     /// Which element is invalid, and what was invalid about it.
-    InvalidGeometry(GeometryIndex, Box<InvalidGeometry>),
-}
-
-impl std::error::Error for InvalidGeometryCollection {}
-
-impl fmt::Display for InvalidGeometryCollection {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            InvalidGeometryCollection::InvalidGeometry(idx, err) => {
-                write!(f, "geometry at index {} is invalid: {}", idx.0, err)
-            }
-        }
-    }
+    #[error("geometry at index {} is invalid: {}", .0.0, .1)]
+    InvalidGeometry(GeometryIndex, #[source] Box<InvalidGeometry>),
 }
 
 impl<F: GeoFloat> Validation for GeometryCollection<F> {

--- a/geo/src/algorithm/validation/line.rs
+++ b/geo/src/algorithm/validation/line.rs
@@ -1,31 +1,16 @@
 use super::{CoordIndex, Validation, utils};
 use crate::{GeoFloat, Line};
 
-use std::fmt;
-
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
 pub enum InvalidLine {
     /// A valid [`Line`] must have at least 2 distinct points to be valid - it must have a non-zero length.
+    #[error("line has identical coordinates")]
     IdenticalCoords,
 
     /// A valid [`Line`] must have finite coordinates.
+    #[error("{} coordinate is non-finite", if .0.0 == 0 { "start" } else { "end" })]
     NonFiniteCoord(CoordIndex),
 }
-
-impl fmt::Display for InvalidLine {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            InvalidLine::IdenticalCoords => write!(f, "line has identical coordinates"),
-            InvalidLine::NonFiniteCoord(idx) => write!(
-                f,
-                "{} coordinate is non-finite",
-                if idx.0 == 0 { "start" } else { "end" }
-            ),
-        }
-    }
-}
-
-impl std::error::Error for InvalidLine {}
 
 impl<F: GeoFloat> Validation for Line<F> {
     type Error = InvalidLine;

--- a/geo/src/algorithm/validation/line_string.rs
+++ b/geo/src/algorithm/validation/line_string.rs
@@ -1,30 +1,15 @@
 use super::{CoordIndex, Validation, utils};
 use crate::{GeoFloat, HasDimensions, LineString};
 
-use std::fmt;
-
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
 pub enum InvalidLineString {
     /// A valid [`LineString`] must have at least 2 distinct points to be valid - it must have a non-zero length.
+    #[error("line string must have at least 2 distinct points")]
     TooFewPoints,
     /// A valid [`LineString`] must have finite coordinates.
+    #[error("coordinate at index {} is non-finite", .0.0)]
     NonFiniteCoord(CoordIndex),
 }
-
-impl fmt::Display for InvalidLineString {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            InvalidLineString::TooFewPoints => {
-                write!(f, "line string must have at least 2 distinct points")
-            }
-            InvalidLineString::NonFiniteCoord(idx) => {
-                write!(f, "coordinate at index {} is non-finite", idx.0)
-            }
-        }
-    }
-}
-
-impl std::error::Error for InvalidLineString {}
 
 impl<F: GeoFloat> Validation for LineString<F> {
     type Error = InvalidLineString;

--- a/geo/src/algorithm/validation/multi_line_string.rs
+++ b/geo/src/algorithm/validation/multi_line_string.rs
@@ -2,26 +2,13 @@ use super::{GeometryIndex, Validation};
 use crate::algorithm::validation::line_string::InvalidLineString;
 use crate::{GeoFloat, MultiLineString};
 
-use std::fmt;
-
 /// A [`MultiLineString`] is valid if each [`LineString`](crate::LineString) in it is valid.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
 pub enum InvalidMultiLineString {
     /// Which element is invalid, and what was invalid about it.
-    InvalidLineString(GeometryIndex, InvalidLineString),
+    #[error("line string at index {} is invalid: {}", .0.0, .1)]
+    InvalidLineString(GeometryIndex, #[source] InvalidLineString),
 }
-
-impl fmt::Display for InvalidMultiLineString {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            InvalidMultiLineString::InvalidLineString(idx, err) => {
-                write!(f, "line string at index {} is invalid: {}", idx.0, err)
-            }
-        }
-    }
-}
-
-impl std::error::Error for InvalidMultiLineString {}
 
 impl<F: GeoFloat> Validation for MultiLineString<F> {
     type Error = InvalidMultiLineString;

--- a/geo/src/algorithm/validation/multi_point.rs
+++ b/geo/src/algorithm/validation/multi_point.rs
@@ -1,26 +1,13 @@
 use super::{GeometryIndex, InvalidPoint, Validation};
 use crate::{GeoFloat, MultiPoint};
 
-use std::fmt;
-
 /// A [`MultiPoint`] is valid if each [`Point`](crate::Point) in it is valid.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
 pub enum InvalidMultiPoint {
     /// Which element is invalid, and what was invalid about it.
-    InvalidPoint(GeometryIndex, InvalidPoint),
+    #[error("point at index {} is invalid: {}", .0.0, .1)]
+    InvalidPoint(GeometryIndex, #[source] InvalidPoint),
 }
-
-impl fmt::Display for InvalidMultiPoint {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            InvalidMultiPoint::InvalidPoint(idx, err) => {
-                write!(f, "point at index {} is invalid: {}", idx.0, err)
-            }
-        }
-    }
-}
-
-impl std::error::Error for InvalidMultiPoint {}
 
 impl<F: GeoFloat> Validation for MultiPoint<F> {
     type Error = InvalidMultiPoint;

--- a/geo/src/algorithm/validation/multi_polygon.rs
+++ b/geo/src/algorithm/validation/multi_polygon.rs
@@ -3,43 +3,22 @@ use crate::coordinate_position::CoordPos;
 use crate::dimensions::Dimensions;
 use crate::{GeoFloat, MultiPolygon, Relate};
 
-use std::fmt;
-
 /// A [`MultiPolygon`] is valid if:
 /// - [x] all its polygons are valid,
 /// - [x] elements do not overlaps (i.e. their interiors must not intersect)
 /// - [x] elements touch only at points
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
 pub enum InvalidMultiPolygon {
     /// For a [`MultiPolygon`] to be valid, each member [`Polygon`](crate::Polygon) must be valid.
-    InvalidPolygon(GeometryIndex, InvalidPolygon),
+    #[error("polygon at index {} is invalid: {}", .0.0, .1)]
+    InvalidPolygon(GeometryIndex, #[source] InvalidPolygon),
     /// No [`Polygon`](crate::Polygon) in a valid [`MultiPolygon`] may overlap (2-dimensional intersection)
+    #[error("polygons at indices {} and {} overlap", .0.0, .1.0)]
     ElementsOverlaps(GeometryIndex, GeometryIndex),
     /// No [`Polygon`](crate::Polygon) in a valid [`MultiPolygon`] may touch on a line (1-dimensional intersection)
+    #[error("polygons at indices {} and {} touch on a line", .0.0, .1.0)]
     ElementsTouchOnALine(GeometryIndex, GeometryIndex),
 }
-
-impl fmt::Display for InvalidMultiPolygon {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            InvalidMultiPolygon::InvalidPolygon(idx, err) => {
-                write!(f, "polygon at index {} is invalid: {}", idx.0, err)
-            }
-            InvalidMultiPolygon::ElementsOverlaps(idx1, idx2) => {
-                write!(f, "polygons at indices {} and {} overlap", idx1.0, idx2.0)
-            }
-            InvalidMultiPolygon::ElementsTouchOnALine(idx1, idx2) => {
-                write!(
-                    f,
-                    "polygons at indices {} and {} touch on a line",
-                    idx1.0, idx2.0
-                )
-            }
-        }
-    }
-}
-
-impl std::error::Error for InvalidMultiPolygon {}
 
 impl<F: GeoFloat> Validation for MultiPolygon<F> {
     type Error = InvalidMultiPolygon;

--- a/geo/src/algorithm/validation/point.rs
+++ b/geo/src/algorithm/validation/point.rs
@@ -1,23 +1,12 @@
 use super::{Validation, utils};
 use crate::{GeoFloat, Point};
 
-use std::fmt;
-
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
 pub enum InvalidPoint {
     /// A valid [`Point`] must be finite.
+    #[error("point has non-finite coordinates")]
     NonFiniteCoord,
 }
-
-impl fmt::Display for InvalidPoint {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            InvalidPoint::NonFiniteCoord => write!(f, "point has non-finite coordinates"),
-        }
-    }
-}
-
-impl std::error::Error for InvalidPoint {}
 
 impl<F: GeoFloat> Validation for Point<F> {
     type Error = InvalidPoint;

--- a/geo/src/algorithm/validation/polygon.rs
+++ b/geo/src/algorithm/validation/polygon.rs
@@ -3,8 +3,6 @@ use crate::coordinate_position::CoordPos;
 use crate::dimensions::Dimensions;
 use crate::{GeoFloat, HasDimensions, Polygon, PreparedGeometry, Relate};
 
-use std::fmt;
-
 /// A [`Polygon`] must follow these rules to be valid:
 /// - [x] the polygon boundary rings (the exterior shell ring and interior hole rings) are simple (do not cross or self-touch). Because of this a polygon cannnot have cut lines, spikes or loops. This implies that polygon holes must be represented as interior rings, rather than by the exterior ring self-touching (a so-called "inverted hole").
 /// - [x] boundary rings do not cross
@@ -13,48 +11,27 @@ use std::fmt;
 /// - [ ] the polygon interior is simply connected (i.e. the rings must not touch in a way that splits the polygon into more than one part)
 ///
 /// Note: the simple connectivity of the interior is not checked by this implementation.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
 pub enum InvalidPolygon {
     /// A ring must have at least 4 points to be valid. Note that, in order to close the ring, the first and final points will be identical.
+    #[error("{0} must have at least 3 distinct points")]
     TooFewPointsInRing(RingRole),
     /// A ring has a self-intersection.
+    #[error("{0} has a self-intersection")]
     SelfIntersection(RingRole),
     /// One of the Polygon's coordinates is non-finite.
+    #[error("{} has a non-finite coordinate at index {}", .0, .1.0)]
     NonFiniteCoord(RingRole, CoordIndex),
     /// A polygon's interiors must be completely within its exterior.
+    #[error("{0} is not contained within the polygon's exterior")]
     InteriorRingNotContainedInExteriorRing(RingRole),
     /// A valid polygon's rings must not intersect one another. In this case, the intersection is 1-dimensional.
+    #[error("{0} and {1} intersect on a line")]
     IntersectingRingsOnALine(RingRole, RingRole),
     /// A valid polygon's rings must not intersect one another. In this case, the intersection is 2-dimensional.
+    #[error("{0} and {1} intersect on an area")]
     IntersectingRingsOnAnArea(RingRole, RingRole),
 }
-
-impl fmt::Display for InvalidPolygon {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            InvalidPolygon::TooFewPointsInRing(ring) => {
-                write!(f, "{ring} must have at least 3 distinct points")
-            }
-            InvalidPolygon::SelfIntersection(ring) => {
-                write!(f, "{ring} has a self-intersection")
-            }
-            InvalidPolygon::NonFiniteCoord(ring, idx) => {
-                write!(f, "{ring} has a non-finite coordinate at index {}", idx.0)
-            }
-            InvalidPolygon::InteriorRingNotContainedInExteriorRing(ring) => {
-                write!(f, "{ring} is not contained within the polygon's exterior")
-            }
-            InvalidPolygon::IntersectingRingsOnALine(ring_1, ring_2) => {
-                write!(f, "{ring_1} and {ring_2} intersect on a line")
-            }
-            InvalidPolygon::IntersectingRingsOnAnArea(ring_1, ring_2) => {
-                write!(f, "{ring_1} and {ring_2} intersect on an area")
-            }
-        }
-    }
-}
-
-impl std::error::Error for InvalidPolygon {}
 
 impl<F: GeoFloat> Validation for Polygon<F> {
     type Error = InvalidPolygon;

--- a/geo/src/algorithm/validation/rect.rs
+++ b/geo/src/algorithm/validation/rect.rs
@@ -1,26 +1,12 @@
 use super::{CoordIndex, Validation, utils};
 use crate::{GeoFloat, Rect};
 
-use std::fmt;
-
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
 pub enum InvalidRect {
     /// A valid [`Rect`] must have finite coordinates.
     /// Index `0` means the min coordinate, index `1` means the max coordinate.
+    #[error("coordinate at rect's {} is non-finite", if .0.0 == 0 { "min" } else { "max" })]
     NonFiniteCoord(CoordIndex),
-}
-
-impl std::error::Error for InvalidRect {}
-
-impl fmt::Display for InvalidRect {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            InvalidRect::NonFiniteCoord(idx) => {
-                let corner = if idx.0 == 0 { "min" } else { "max" };
-                write!(f, "coordinate at rect's {corner} is non-finite")
-            }
-        }
-    }
 }
 impl<F: GeoFloat> Validation for Rect<F> {
     type Error = InvalidRect;

--- a/geo/src/algorithm/validation/triangle.rs
+++ b/geo/src/algorithm/validation/triangle.rs
@@ -1,37 +1,18 @@
 use super::{CoordIndex, Validation, utils};
 use crate::{CoordFloat, Triangle};
 
-use std::fmt;
-
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
 pub enum InvalidTriangle {
     /// A valid [`Triangle`] must have finite coordinates.
+    #[error("coordinate at index {} is non-finite", .0.0)]
     NonFiniteCoord(CoordIndex),
     /// A valid [`Triangle`] must have distinct points.
+    #[error("coordinates at indices {} and {} are identical", .0.0, .1.0)]
     IdenticalCoords(CoordIndex, CoordIndex),
     /// A valid [`Triangle`] must have non-collinear points.
+    #[error("triangle has collinear coordinates")]
     CollinearCoords,
 }
-
-impl fmt::Display for InvalidTriangle {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            InvalidTriangle::NonFiniteCoord(idx) => {
-                write!(f, "coordinate at index {} is non-finite", idx.0)
-            }
-            InvalidTriangle::IdenticalCoords(idx1, idx2) => {
-                write!(
-                    f,
-                    "coordinates at indices {} and {} are identical",
-                    idx1.0, idx2.0
-                )
-            }
-            InvalidTriangle::CollinearCoords => write!(f, "triangle has collinear coordinates"),
-        }
-    }
-}
-
-impl std::error::Error for InvalidTriangle {}
 
 impl<F: CoordFloat> Validation for Triangle<F> {
     type Error = InvalidTriangle;

--- a/geo/src/algorithm/vincenty_distance.rs
+++ b/geo/src/algorithm/vincenty_distance.rs
@@ -6,7 +6,6 @@
 
 use crate::{CoordFloat, EARTH_FLATTENING, EQUATORIAL_EARTH_RADIUS, POLAR_EARTH_RADIUS, Point};
 use num_traits::FromPrimitive;
-use std::{error, fmt};
 
 /// Determine the distance between two geometries using [Vincenty’s formulae].
 ///
@@ -162,20 +161,9 @@ where
     }
 }
 
-#[derive(Eq, PartialEq, Debug)]
+#[derive(Eq, PartialEq, Debug, thiserror::Error)]
+#[error("Vincenty algorithm failed to converge")]
 pub struct FailedToConvergeError;
-
-impl fmt::Display for FailedToConvergeError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Vincenty algorithm failed to converge")
-    }
-}
-
-impl error::Error for FailedToConvergeError {
-    fn description(&self) -> &str {
-        "Vincenty algorithm failed to converge"
-    }
-}
 
 #[cfg(test)]
 mod test {

--- a/geo/src/algorithm/voronoi.rs
+++ b/geo/src/algorithm/voronoi.rs
@@ -107,45 +107,19 @@ use crate::{
 ///
 /// This wraps [`TriangulationError`] (which can occur during the underlying
 /// Delaunay triangulation) and adds Voronoi-specific error variants.
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, thiserror::Error)]
 pub enum VoronoiError {
     /// Error during the underlying Delaunay triangulation.
-    Triangulation(TriangulationError),
+    #[error("triangulation error: {0}")]
+    Triangulation(#[source] TriangulationError),
     /// Input points are collinear; Voronoi cells cannot be computed.
     /// Use [`Voronoi::voronoi_edges`] instead to get perpendicular bisectors.
+    #[error("input points are collinear; Voronoi cells cannot be computed")]
     CollinearInput,
     /// Fewer than 2 unique vertices were provided.
     /// At least 2 vertices are required to compute a Voronoi diagram.
+    #[error("fewer than 2 unique vertices; cannot compute Voronoi diagram")]
     InsufficientVertices,
-}
-
-impl std::fmt::Display for VoronoiError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            VoronoiError::Triangulation(e) => write!(f, "triangulation error: {e}"),
-            VoronoiError::CollinearInput => {
-                write!(
-                    f,
-                    "input points are collinear; Voronoi cells cannot be computed"
-                )
-            }
-            VoronoiError::InsufficientVertices => {
-                write!(
-                    f,
-                    "fewer than 2 unique vertices; cannot compute Voronoi diagram"
-                )
-            }
-        }
-    }
-}
-
-impl std::error::Error for VoronoiError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            VoronoiError::Triangulation(e) => Some(e),
-            VoronoiError::CollinearInput | VoronoiError::InsufficientVertices => None,
-        }
-    }
 }
 
 impl From<TriangulationError> for VoronoiError {

--- a/jts-test-runner/Cargo.toml
+++ b/jts-test-runner/Cargo.toml
@@ -10,6 +10,7 @@ include_dir = { version = "0.7.2", features = ["glob"] }
 log = "0.4.14"
 serde = { version = "1.0.105", features = ["derive"] }
 serde-xml-rs = "0.6.0"
+thiserror = "2.0.19"
 wkt = { version = "0.14.0", features = ["geo-types", "serde"] }
 
 [dev-dependencies]

--- a/jts-test-runner/src/runner.rs
+++ b/jts-test-runner/src/runner.rs
@@ -44,20 +44,11 @@ pub struct TestCase {
     operation: Operation,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("failed {:?}: \"{}\" with error: {}", .test_case.test_id, .test_case.description, .error_description)]
 pub struct TestFailure {
     error_description: String,
     test_case: TestCase,
-}
-
-impl std::fmt::Display for TestFailure {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
-        write!(
-            f,
-            "failed {:?}: \"{}\" with error: {}",
-            &self.test_case.test_id, &self.test_case.description, &self.error_description
-        )
-    }
 }
 
 impl TestRunner {


### PR DESCRIPTION
Tons of manually-maintained code can be done much cleaner and bug-free with `thiserror` crate. Result - shorter by 300 lines.

Note that `TriangulationError` error is duplicated for some reason in `triangulate_delaunay.rs` and `triangulate_spade.rs`, and they are nearly identical. Also, for some weird reason their error message was just the default Debug impl - not helpful. But this is all for another PR.

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
