### PR TITLE
Fix clipping for unbounded Voronoi edges

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- FIX: Clip unbounded Voronoi edges when their circumcenter lies outside the
+  padded input bounds.
+  - <https://github.com/georust/geo/issues/1558>
 - FIX: `Line::haversine_closest_point` no longer returns an endpoint for valid high-latitude projections.
   - <https://github.com/georust/geo/issues/1325>
 - Add index-returning methods `Simplify::simplify_idx`, `SimplifyVw::simplify_vw_idx`, `SimplifyVwPreserve::simplify_vw_preserve_idx`, and `ConvexHull::convex_hull_idx`, returning input-relative indices of the retained vertices. Adds the `PolygonIndices` type and the `quick_hull_indices` free function.

--- a/geo/src/algorithm/voronoi.rs
+++ b/geo/src/algorithm/voronoi.rs
@@ -90,18 +90,15 @@ use crate::algorithm::triangulate_delaunay::{
     DelaunayTriangulationConfig, SpadeTriangulationFloat,
 };
 use crate::algorithm::vector_ops::Vector2DOps;
-use crate::line_intersection::{LineIntersection, line_intersection};
 use crate::utils::lex_cmp;
-use geo_types::{Coord, Line, LineString, Point, Polygon, Rect};
+use geo_types::{Coord, Line, LineString, Polygon, Rect};
 use num_traits::Float;
 use spade::Triangulation;
 use spade::handles::{VoronoiVertex::Inner, VoronoiVertex::Outer};
 
 use crate::algorithm::bool_ops::BoolOpsNum;
 use crate::algorithm::triangulate_delaunay::TriangulationError;
-use crate::{
-    BooleanOps, BoundingRect, Contains, Distance, Euclidean, TriangulateDelaunayUnconstrained,
-};
+use crate::{BooleanOps, BoundingRect, Contains, TriangulateDelaunayUnconstrained};
 
 /// Error type for Voronoi diagram computation.
 ///
@@ -391,59 +388,15 @@ where
                 [Inner(from), Outer(edge)] | [Outer(edge), Inner(from)] => {
                     let start = from.circumcenter();
                     let dir = edge.direction_vector();
-
-                    // Create a line extending beyond bounds in direction of outer edge
-                    let extended_end = Point::new(
-                        start.x + dir.x * (width + height),
-                        start.y + dir.y * (width + height),
-                    );
-                    let infinite_voronoi_edge =
-                        Line::new(Point::new(start.x, start.y), extended_end);
-
-                    // Manual line-bbox intersection is simpler than BooleanOps here:
-                    // BooleanOps operates on polygons, not line strings, and for a single
-                    // ray-rectangle intersection the geometric calculation is straightforward.
-                    //
-                    // Check intersection with each bounding box edge
-                    // Improper intersections (at bbox corners or ray origin) are handled correctly:
-                    // - Corner hits produce duplicate points; min_by distance deduplicates
-                    // - Collinear rays (edge parallel to bbox side) are dropped; this case is
-                    //   geometrically degenerate and would require exact float alignment,
-                    //   so is almost certainly not a problem for non-adversarial inputs
-                    let intersections = bounds
-                        .to_lines()
-                        .iter()
-                        .filter_map(|edge| line_intersection(infinite_voronoi_edge, *edge))
-                        .filter_map(|inter| match inter {
-                            LineIntersection::SinglePoint {
-                                intersection,
-                                is_proper: _,
-                            } => Some(intersection),
-                            LineIntersection::Collinear { intersection: _ } => None,
-                        })
-                        .collect::<Vec<_>>();
-                    // Because we extend our infinite edge well beyond the bounding box
-                    // we should always expect to see at least one infinite edge intersection
-                    debug_assert!(
-                        !intersections.is_empty(),
-                        "No infinite edges intersect the bounding box. Degenerate or invalid geometry?"
-                    );
-
-                    // Take the closest intersection to the start point
-                    if let Some(intersection) = intersections.into_iter().min_by(|a, b| {
-                        let dist_a: T = Euclidean
-                            .distance(&Point::new(start.x, start.y), &Point::new(a.x, a.y));
-                        let dist_b: T = Euclidean
-                            .distance(&Point::new(start.x, start.y), &Point::new(b.x, b.y));
-                        dist_a.total_cmp(&dist_b)
-                    }) {
-                        edges.push(Line::new(
-                            Coord {
-                                x: start.x,
-                                y: start.y,
-                            },
-                            intersection,
-                        ));
+                    if let Some(clipped) = clip_ray_to_rect(
+                        Coord {
+                            x: start.x,
+                            y: start.y,
+                        },
+                        Coord { x: dir.x, y: dir.y },
+                        bounds,
+                    ) {
+                        edges.push(clipped);
                     }
                 }
                 [Outer(edge1), Outer(_)] => {
@@ -701,6 +654,51 @@ where
     Rect::new((min_x, min_y), (max_x, max_y))
 }
 
+fn clip_ray_to_rect<T>(start: Coord<T>, direction: Coord<T>, bounds: Rect<T>) -> Option<Line<T>>
+where
+    T: SpadeTriangulationFloat,
+{
+    if direction.x == T::zero() && direction.y == T::zero() {
+        return None;
+    }
+
+    let mut t_min = T::zero();
+    let mut t_max = T::infinity();
+
+    // Intersect the ray `start + t * direction` (`t >= 0`) with both rectangular slabs.
+    for (origin, direction, min, max) in [
+        (start.x, direction.x, bounds.min().x, bounds.max().x),
+        (start.y, direction.y, bounds.min().y, bounds.max().y),
+    ] {
+        if direction == T::zero() {
+            if origin < min || origin > max {
+                return None;
+            }
+            continue;
+        }
+
+        let t1 = (min - origin) / direction;
+        let t2 = (max - origin) / direction;
+        t_min = Float::max(t_min, Float::min(t1, t2));
+        t_max = Float::min(t_max, Float::max(t1, t2));
+
+        if t_min >= t_max {
+            return None;
+        }
+    }
+
+    Some(Line::new(
+        Coord {
+            x: start.x + direction.x * t_min,
+            y: start.y + direction.y * t_min,
+        },
+        Coord {
+            x: start.x + direction.x * t_max,
+            y: start.y + direction.y * t_max,
+        },
+    ))
+}
+
 /// Compute a padded bounding box around the base bounds.
 ///
 /// Padding is calculated as `padding_factor * max(width, height)` and applied
@@ -742,6 +740,65 @@ mod tests {
             result.relate(&expected).is_equal_topo(),
             "Expected {expected:?}, got {result:?}"
         );
+    }
+
+    #[test]
+    fn clip_ray_to_rect_cases() {
+        let bounds = Rect::new((0.0, 0.0), (2.0, 2.0));
+        let coord = |x, y| Coord { x, y };
+        let cases = [
+            (
+                "outside entering",
+                coord(-1.0, 1.0),
+                coord(1.0, 0.0),
+                Some(Line::new(coord(0.0, 1.0), coord(2.0, 1.0))),
+            ),
+            (
+                "inside",
+                coord(1.0, 1.0),
+                coord(1.0, 0.0),
+                Some(Line::new(coord(1.0, 1.0), coord(2.0, 1.0))),
+            ),
+            ("outside outward", coord(-1.0, 1.0), coord(-1.0, 0.0), None),
+            ("parallel outside", coord(-1.0, 1.0), coord(0.0, 1.0), None),
+            (
+                "through opposite corners",
+                coord(-1.0, -1.0),
+                coord(1.0, 1.0),
+                Some(Line::new(coord(0.0, 0.0), coord(2.0, 2.0))),
+            ),
+            (
+                "tangent at one corner",
+                coord(-1.0, 1.0),
+                coord(1.0, 1.0),
+                None,
+            ),
+        ];
+
+        for (name, start, direction, expected) in cases {
+            assert_eq!(
+                clip_ray_to_rect(start, direction, bounds),
+                expected,
+                "{name}"
+            );
+        }
+    }
+
+    #[test]
+    fn voronoi_edges_circumcenter_outside_bounds() {
+        let triangle = wkt!(POLYGON((0.0 0.0, 1.0 0.1, 2.0 0.0, 0.0 0.0)));
+
+        let edges = triangle.voronoi_edges().unwrap();
+
+        assert_eq!(edges.len(), 2);
+        assert!(edges.iter().all(|edge| edge.start != edge.end));
+        for coord in edges
+            .iter()
+            .flat_map(|edge| [edge.start, edge.end].into_iter())
+        {
+            assert!((-1.0 - 1e-12..=3.0 + 1e-12).contains(&coord.x));
+            assert!((-1.0 - 1e-12..=1.1 + 1e-12).contains(&coord.y));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- clip unbounded Voronoi rays against the padded rectangle with a slab intersection
- preserve the part of an entering ray inside the rectangle, even when its circumcenter starts far outside
- add focused ray-clipping cases and the obtuse-triangle regression from #1558
- record the fix in the `geo` changelog

## Root cause

The previous implementation converted an infinite Voronoi ray into a finite
segment whose length was only the input width plus height. For a sufficiently
obtuse triangle, the circumcenter can be farther from the padded bounds than
that segment length. Debug builds then asserted because no intersection was
found, while release builds silently dropped the valid edges.

Clipping the full ray by its parameter interval avoids choosing an arbitrary
extension length. Rays entering from outside produce the rectangle's
entry-to-exit segment; rays starting inside produce start-to-exit; outward or
tangent-only rays produce no zero-length edge.

Fixes #1558.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p geo --lib voronoi` — 15 passed
- `cargo test -p geo --lib --release voronoi_edges_circumcenter_outside_bounds` — 1 passed
- `cargo check -p geo --all-targets`
- `cargo check -p geo --all-targets --no-default-features`
- `cargo clippy -p geo --all-targets -- -D warnings -A clippy::collapsible-match -A clippy::useless-conversion`
- broad `cargo test -p geo --lib` — 1,156 passed, 6 failed, 2 ignored; all six failures reproduce unchanged on the pinned base commit

The two allowed Clippy lints are unrelated Rust 1.96 diagnostics that also
reproduce on the base commit. All-features Clippy was unavailable locally
because the native PROJ/pkg-config/CMake toolchain is absent; Linux and MSRV
coverage are left to CI.

_Disclosure: this change was prepared and validated by an autonomous
open-source contribution agent under human-owned GitHub credentials._
