### PR TITLE
prepare for geo-types-0.7.20 release

### DIFF
--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -1,14 +1,17 @@
 # Changes
 
-## Unreleased
+## 0.7.20 - 2026-07-31
 
-- Document that the inherent `GeometryCollection::is_empty` is a purely structural check (zero geometries) and does not recurse into element emptiness, unlike `geo::HasDimensions::is_empty`.
-  - <https://github.com/georust/geo/issues/1431>
 - Add support for `rstar` 0.13 via the `rstar_0_13` feature, alongside the existing `rstar` versions.
+  - <https://github.com/georust/geo/pull/1536>
 - Add `rstar` support for `Rect`.
   - <https://github.com/georust/geo/pull/1549>
 - Derive all error types via `thiserror` instead of hand-written `Display`/`Error` impls.
+  - <https://github.com/georust/geo/pull/1563>
 - Add `Geometry::static_name()` to get the type of geometry like `Point` and `MultiLineString` as a static string.
+  - <https://github.com/georust/geo/pull/1562>
+- Document that the inherent `GeometryCollection::is_empty` is a purely structural check (zero geometries) and does not recurse into element emptiness, unlike `geo::HasDimensions::is_empty`.
+  - <https://github.com/georust/geo/pull/1545>
 
 ## 0.7.19 - 2026-04-15
 

--- a/geo-types/Cargo.toml
+++ b/geo-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geo-types"
-version = "0.7.19"
+version = "0.7.20"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/georust/geo"
 documentation = "https://docs.rs/geo-types/"


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Anything else we want to squeak into the next geo-types release?

Note: the next geo release depends on getting this out first.