### PR TITLE
PreparedGeometry (and GeometryGraph) are Send

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -5,6 +5,7 @@
 - Add simply connected interior validation for polygons. Polygons with holes that touch at vertices in ways that disconnect the interior (e.g., two holes sharing 2+ vertices, or cycles of holes each sharing a vertex) are now detected as invalid via `Validation::is_valid()`. This aligns with OGC Simple Features and matches PostGIS behavior.
 - BREAKING: adds the `InvalidPolygon::InteriorNotSimplyConnected` error variant.
   - <https://github.com/georust/geo/pull/1472>
+- `PreparedGeometry` is now `Send`, so it can be moved between threads.
 - FIX: `Line::haversine_closest_point` no longer returns an endpoint for valid high-latitude projections.
   - <https://github.com/georust/geo/issues/1325>
 - Add index-returning methods `Simplify::simplify_idx`, `SimplifyVw::simplify_vw_idx`, `SimplifyVwPreserve::simplify_vw_preserve_idx`, and `ConvexHull::convex_hull_idx`, returning input-relative indices of the retained vertices. Adds the `PolygonIndices` type and the `quick_hull_indices` free function.

--- a/geo/src/algorithm/indexed/prepared_geometry.rs
+++ b/geo/src/algorithm/indexed/prepared_geometry.rs
@@ -136,6 +136,27 @@ mod tests {
     use crate::{polygon, wkt};
 
     #[test]
+    fn clone_and_send() {
+        fn send(_send: impl Send) {}
+        let polygon: Polygon = wkt!(POLYGON EMPTY);
+        let prepared = PreparedGeometry::from(polygon);
+        send(prepared.clone())
+    }
+
+    #[test]
+    fn moved_across_threads() {
+        let polygon = wkt!(POLYGON((0.0 0.0,2.0 0.0,1.0 1.0,0.0 0.0)));
+        let prepared = PreparedGeometry::from(polygon);
+
+        std::thread::spawn(move || {
+            let line = wkt!(LINESTRING(0.0 0.0,3.0 3.0));
+            assert!(prepared.relate(&line).is_intersects());
+        })
+        .join()
+        .unwrap();
+    }
+
+    #[test]
     fn relate() {
         let p1 = polygon![(x: 0.0, y: 0.0), (x: 2.0, y: 0.0), (x: 1.0, y: 1.0)];
         let p2 = polygon![(x: 0.5, y: 0.0), (x: 2.0, y: 0.0), (x: 1.0, y: 1.0)];

--- a/geo/src/algorithm/relate/edge_end_builder.rs
+++ b/geo/src/algorithm/relate/edge_end_builder.rs
@@ -2,7 +2,6 @@ use super::geomgraph::{Edge, EdgeEnd, EdgeIntersection};
 use crate::GeoFloat;
 
 use std::cell::RefCell;
-use std::rc::Rc;
 
 /// Computes the [`EdgeEnd`]s which arise from an [`Edge`] who has had its `edge_intersections`
 /// populated with self and proper [`EdgeIntersection`]s.
@@ -19,7 +18,7 @@ impl<F: GeoFloat> EdgeEndBuilder<F> {
         }
     }
 
-    pub fn compute_ends_for_edges(&self, edges: &[Rc<RefCell<Edge<F>>>]) -> Vec<EdgeEnd<F>> {
+    pub fn compute_ends_for_edges(&self, edges: &[RefCell<Edge<F>>]) -> Vec<EdgeEnd<F>> {
         let mut list = vec![];
         for edge in edges {
             self.compute_ends_for_edge(&mut edge.borrow_mut(), &mut list);

--- a/geo/src/algorithm/relate/geomgraph/geometry_graph.rs
+++ b/geo/src/algorithm/relate/geomgraph/geometry_graph.rs
@@ -12,7 +12,7 @@ use crate::{Coord, GeoFloat, GeometryCow, Line, LineString, Point, Polygon};
 use crate::relate::geomgraph::RobustLineIntersector;
 use rstar::{RTree, RTreeNum};
 use std::cell::RefCell;
-use std::rc::Rc;
+use std::sync::Arc;
 
 /// The computation of the [`IntersectionMatrix`](crate::algorithm::relate::IntersectionMatrix) relies on the use of a
 /// structure called a "topology graph". The topology graph contains nodes (CoordNode) and
@@ -36,7 +36,7 @@ where
 {
     arg_index: usize,
     parent_geometry: GeometryCow<'a, F>,
-    tree: Rc<RTree<Segment<F>>>,
+    tree: Arc<RTree<Segment<F>>>,
     use_boundary_determination_rule: bool,
     planar_graph: PlanarGraph<F>,
 }
@@ -124,11 +124,11 @@ where
             arg_index,
             parent_geometry,
             use_boundary_determination_rule: true,
-            tree: Rc::new(RTree::new()),
+            tree: Arc::new(RTree::new()),
             planar_graph: PlanarGraph::new(),
         };
         graph.add_geometry(&graph.parent_geometry.clone());
-        graph.tree = Rc::new(graph.build_tree());
+        graph.tree = Arc::new(graph.build_tree());
         // TODO: don't pass in line intersector here - in theory we'll want pluggable line intersectors
         // and the type (Robust) shouldn't be hard coded here.
         graph.compute_self_nodes(Box::new(RobustLineIntersector::new()));

--- a/geo/src/algorithm/relate/geomgraph/geometry_graph.rs
+++ b/geo/src/algorithm/relate/geomgraph/geometry_graph.rs
@@ -94,7 +94,7 @@ where
         }
     }
 
-    pub(crate) fn edges(&self) -> &[Rc<RefCell<Edge<F>>>] {
+    pub(crate) fn edges(&self) -> &[RefCell<Edge<F>>] {
         self.planar_graph.edges()
     }
 

--- a/geo/src/algorithm/relate/geomgraph/index/edge_set_intersector.rs
+++ b/geo/src/algorithm/relate/geomgraph/index/edge_set_intersector.rs
@@ -1,9 +1,6 @@
-use super::super::{Edge, GeometryGraph};
+use super::super::GeometryGraph;
 use super::SegmentIntersector;
-use crate::{Coord, GeoFloat};
-
-use std::cell::RefCell;
-use std::rc::Rc;
+use crate::GeoFloat;
 
 pub(crate) trait EdgeSetIntersector<F: GeoFloat> {
     /// Compute all intersections between the edges within a set, recording those intersections on

--- a/geo/src/algorithm/relate/geomgraph/index/rstar_edge_set_intersector.rs
+++ b/geo/src/algorithm/relate/geomgraph/index/rstar_edge_set_intersector.rs
@@ -1,11 +1,8 @@
-use super::super::{Edge, GeometryGraph};
-use super::{EdgeSetIntersector, Segment, SegmentIntersector};
+use super::super::GeometryGraph;
+use super::{EdgeSetIntersector, SegmentIntersector};
 use crate::GeoFloat;
 
-use std::cell::RefCell;
-use std::rc::Rc;
-
-use rstar::{RTree, RTreeNum};
+use rstar::RTreeNum;
 
 pub(crate) struct RStarEdgeSetIntersector;
 

--- a/geo/src/algorithm/relate/geomgraph/index/simple_edge_set_intersector.rs
+++ b/geo/src/algorithm/relate/geomgraph/index/simple_edge_set_intersector.rs
@@ -3,7 +3,6 @@ use super::{EdgeSetIntersector, SegmentIntersector};
 use crate::GeoFloat;
 
 use std::cell::RefCell;
-use std::rc::Rc;
 
 pub(crate) struct SimpleEdgeSetIntersector;
 
@@ -14,8 +13,8 @@ impl SimpleEdgeSetIntersector {
 
     fn compute_intersects<F: GeoFloat>(
         &self,
-        edge0: &Rc<RefCell<Edge<F>>>,
-        edge1: &Rc<RefCell<Edge<F>>>,
+        edge0: &RefCell<Edge<F>>,
+        edge1: &RefCell<Edge<F>>,
         segment_intersector: &mut SegmentIntersector<F>,
     ) {
         let edge0_coords_len = edge0.borrow().coords().len() - 1;

--- a/geo/src/algorithm/relate/geomgraph/planar_graph.rs
+++ b/geo/src/algorithm/relate/geomgraph/planar_graph.rs
@@ -5,7 +5,6 @@ use super::{
 use crate::{Coord, GeoFloat};
 
 use std::cell::RefCell;
-use std::rc::Rc;
 
 #[derive(Clone, PartialEq)]
 pub(crate) struct PlanarGraphNode;
@@ -24,7 +23,7 @@ where
 #[derive(Clone, PartialEq)]
 pub(crate) struct PlanarGraph<F: GeoFloat> {
     pub(crate) nodes: NodeMap<F, PlanarGraphNode>,
-    edges: Vec<Rc<RefCell<Edge<F>>>>,
+    edges: Vec<RefCell<Edge<F>>>,
 }
 
 impl<F: GeoFloat> PlanarGraph<F> {
@@ -35,7 +34,7 @@ impl<F: GeoFloat> PlanarGraph<F> {
             edges: self
                 .edges
                 .iter()
-                .map(|e| Rc::new(RefCell::new(e.borrow().clone())))
+                .map(|e| RefCell::new(e.borrow().clone()))
                 .collect(),
         };
         assert_eq!(from_arg_index, 0);
@@ -59,7 +58,7 @@ impl<F: GeoFloat> PlanarGraph<F> {
         assert_eq!(self.edges, other.edges);
     }
 
-    pub fn edges(&self) -> &[Rc<RefCell<Edge<F>>>] {
+    pub fn edges(&self) -> &[RefCell<Edge<F>>] {
         &self.edges
     }
 
@@ -79,7 +78,7 @@ impl<F: GeoFloat> PlanarGraph<F> {
     }
 
     pub fn insert_edge(&mut self, edge: Edge<F>) {
-        self.edges.push(Rc::new(RefCell::new(edge)));
+        self.edges.push(RefCell::new(edge));
     }
 
     pub fn add_node_with_coordinate(&mut self, coord: Coord<F>) -> &mut CoordNode<F> {

--- a/geo/src/algorithm/relate/relate_operation.rs
+++ b/geo/src/algorithm/relate/relate_operation.rs
@@ -1,8 +1,8 @@
 use super::{EdgeEndBuilder, IntersectionMatrix};
 use crate::dimensions::{Dimensions, HasDimensions};
 use crate::relate::geomgraph::{
-    CoordNode, CoordPos, Edge, EdgeEnd, EdgeEndBundleStar, GeometryGraph, LabeledEdgeEndBundleStar,
-    RobustLineIntersector,
+    CoordNode, CoordPos, Edge, EdgeEnd, EdgeEndBundleStar, GeometryGraph, Label,
+    LabeledEdgeEndBundleStar, RobustLineIntersector,
     index::SegmentIntersector,
     node_map::{NodeFactory, NodeMap},
 };
@@ -10,8 +10,6 @@ use crate::{Coord, GeoFloat, GeometryCow};
 use crate::{CoordinatePosition, Relate};
 
 use geo_types::Rect;
-use std::cell::RefCell;
-use std::rc::Rc;
 
 /// Computes an [`IntersectionMatrix`] describing the topological relationship between two
 /// Geometries.
@@ -32,7 +30,6 @@ where
     geometry_b: &'a dyn Relate<F, Output = BBOX2>,
     nodes: NodeMap<F, RelateNodeFactory>,
     line_intersector: RobustLineIntersector,
-    isolated_edges: Vec<Rc<RefCell<Edge<F>>>>,
 }
 
 #[derive(PartialEq)]
@@ -61,7 +58,6 @@ where
             geometry_a,
             geometry_b,
             nodes: NodeMap::new(),
-            isolated_edges: vec![],
             line_intersector: RobustLineIntersector::new(),
         }
     }
@@ -116,7 +112,7 @@ where
 
         let mut nodes = NodeMap::new();
         std::mem::swap(&mut self.nodes, &mut nodes);
-        let labeled_node_edges = nodes
+        let labeled_node_edges: Vec<_> = nodes
             .into_iter()
             .map(|(node, edges)| (node, edges.into_labeled(&graph_a, &graph_b)))
             .collect();
@@ -131,14 +127,19 @@ where
         // We only need to check components contained in the input graphs, since, by definition,
         // isolated components will not have been replaced by new components formed by
         // intersections.
-        self.label_isolated_edges(&graph_a, &graph_b, 1);
-        self.label_isolated_edges(&graph_b, &graph_a, 0);
+        let mut isolated_edge_labels = vec![];
+        Self::append_isolated_edge_labels(&graph_a, &graph_b, 1, &mut isolated_edge_labels);
+        Self::append_isolated_edge_labels(&graph_b, &graph_a, 0, &mut isolated_edge_labels);
 
         debug!(
             "before update_intersection_matrix: {:?}",
             &intersection_matrix
         );
-        self.update_intersection_matrix(labeled_node_edges, &mut intersection_matrix);
+        Self::update_intersection_matrix(
+            &isolated_edge_labels,
+            &labeled_node_edges,
+            &mut intersection_matrix,
+        );
 
         intersection_matrix
     }
@@ -280,23 +281,19 @@ where
     }
 
     fn update_intersection_matrix(
-        &self,
-        labeled_node_edges: Vec<(CoordNode<F>, LabeledEdgeEndBundleStar<F>)>,
+        isolated_edge_labels: &[Label],
+        labeled_node_edges: &[(CoordNode<F>, LabeledEdgeEndBundleStar<F>)],
         intersection_matrix: &mut IntersectionMatrix,
     ) {
         debug!("before updated_intersection_matrix(isolated_edges): {intersection_matrix:?}",);
-        for isolated_edge in &self.isolated_edges {
-            let edge = isolated_edge.borrow();
-            Edge::<F>::update_intersection_matrix(edge.label(), intersection_matrix);
+        for label in isolated_edge_labels {
+            Edge::<F>::update_intersection_matrix(label, intersection_matrix);
             debug!(
-                "after isolated_edge update_intersection_matrix: {:?}, (isolated_edge: {:?}, label: {:?})",
-                intersection_matrix,
-                edge,
-                edge.label()
+                "after isolated_edge update_intersection_matrix: {intersection_matrix:?}, (label: {label:?})"
             );
         }
 
-        for (node, edges) in labeled_node_edges.iter() {
+        for (node, edges) in labeled_node_edges {
             node.update_intersection_matrix(intersection_matrix);
             edges.update_intersection_matrix(intersection_matrix);
         }
@@ -308,17 +305,17 @@ where
     /// By definition, "isolated" edges are guaranteed not to touch the boundary of the target
     /// (since if they did, they would have caused an intersection to be computed and hence would
     /// not be isolated).
-    fn label_isolated_edges(
-        &mut self,
+    fn append_isolated_edge_labels(
         this_graph: &GeometryGraph<F>,
         target_graph: &GeometryGraph<F>,
         target_index: usize,
+        isolated_edge_labels: &mut Vec<Label>,
     ) {
         for edge in this_graph.edges() {
             let mut mut_edge = edge.borrow_mut();
             if mut_edge.is_isolated() {
                 Self::label_isolated_edge(&mut mut_edge, target_index, target_graph.geometry());
-                self.isolated_edges.push(edge.clone());
+                isolated_edge_labels.push(mut_edge.label().clone());
             }
         }
     }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Supersedes #1198 (/cc @gauteh)

Benches are unremarkable except these two. I don't think it's a big deal. Note the 7% regression is a pretty small diff in absolute terms. 

```
jts test suite matching *Relate*
                        time:   [57.116 ms 57.467 ms 57.857 ms]
                        change: [+1.6262% +2.3887% +3.1370%] (p = 0.00 < 0.05)
                        Performance has regressed.
disjoint polygons       time:   [17.371 µs 17.706 µs 18.102 µs]
                        change: [+6.2106% +7.7836% +9.5288%] (p = 0.00 < 0.05)
                        Performance has regressed.
```