### PR TITLE
Add Hdbscan trait, public API, and benchmark

### DIFF
--- a/geo-benches/Cargo.toml
+++ b/geo-benches/Cargo.toml
@@ -172,6 +172,11 @@ path = "src/dbscan.rs"
 harness = false
 
 [[bench]]
+name = "hdbscan"
+path = "src/hdbscan.rs"
+harness = false
+
+[[bench]]
 name = "kmeans"
 path = "src/kmeans.rs"
 harness = false

--- a/geo-benches/src/hdbscan.rs
+++ b/geo-benches/src/hdbscan.rs
@@ -1,0 +1,79 @@
+use criterion::{Criterion, criterion_group, criterion_main};
+use geo::Hdbscan;
+use geo_benches::utils::random::make_moons;
+
+fn hdbscan_benchmarks(c: &mut Criterion) {
+    let points_1k = make_moons(1_000, 0.1, 42);
+    let points_10k = make_moons(10_000, 0.1, 42);
+    let points_100k = make_moons(100_000, 0.1, 42);
+
+    // HDBSCAN parameters: min_cluster_size=15, min_samples=5 are typical
+    // starting values for this kind of dataset.
+    let min_cluster_size = 15;
+    let min_samples = 5;
+
+    let mut group = c.benchmark_group("hdbscan");
+
+    group.bench_function("1k_points", |bencher| {
+        bencher.iter(|| {
+            let result = criterion::black_box(&points_1k)
+                .hdbscan_with_min_samples(min_cluster_size, min_samples)
+                .unwrap();
+            criterion::black_box(result);
+        });
+    });
+
+    group.bench_function("10k_points", |bencher| {
+        bencher.iter(|| {
+            let result = criterion::black_box(&points_10k)
+                .hdbscan_with_min_samples(min_cluster_size, min_samples)
+                .unwrap();
+            criterion::black_box(result);
+        });
+    });
+
+    group.sample_size(10);
+    group.bench_function("100k_points", |bencher| {
+        bencher.iter(|| {
+            let result = criterion::black_box(&points_100k)
+                .hdbscan_with_min_samples(min_cluster_size, min_samples)
+                .unwrap();
+            criterion::black_box(result);
+        });
+    });
+
+    let points_500k = make_moons(500_000, 0.1, 42);
+    group.bench_function("500k_points", |bencher| {
+        bencher.iter(|| {
+            let result = criterion::black_box(&points_500k)
+                .hdbscan_with_min_samples(min_cluster_size, min_samples)
+                .unwrap();
+            criterion::black_box(result);
+        });
+    });
+
+    let points_1e6 = make_moons(1_000_000, 0.1, 42);
+    group.bench_function("1e6_points", |bencher| {
+        bencher.iter(|| {
+            let result = criterion::black_box(&points_1e6)
+                .hdbscan_with_min_samples(min_cluster_size, min_samples)
+                .unwrap();
+            criterion::black_box(result);
+        });
+    });
+
+    let points_3e6 = make_moons(3_000_000, 0.1, 42);
+    group.bench_function("3e6_points", |bencher| {
+        bencher.iter(|| {
+            let result = criterion::black_box(&points_3e6)
+                .hdbscan_with_min_samples(min_cluster_size, min_samples)
+                .unwrap();
+            criterion::black_box(result);
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, hdbscan_benchmarks);
+criterion_main!(benches);

--- a/geo/src/algorithm/hdbscan/mod.rs
+++ b/geo/src/algorithm/hdbscan/mod.rs
@@ -10,18 +10,370 @@
 //! *Density-Based Clustering Based on Hierarchical Density Estimates.*
 //! In Advances in Knowledge Discovery and Data Mining (PAKDD 2013).
 
-// Temporary allowance while the algorithm is built up over several
-// commits; removed in the commit that adds the public API.
-#![allow(dead_code)]
-
 use crate::Distance;
 use crate::Euclidean;
 use crate::GeoFloat;
+use crate::GeoNum;
+use crate::MultiPoint;
 use crate::Point;
 use crate::algorithm::ball_tree::BallTree;
 use crate::algorithm::ball_tree::NodeKind;
 use std::collections::HashMap;
 use std::collections::HashSet;
+
+/// Result of an HDBSCAN clustering run.
+///
+/// Contains both cluster labels and GLOSH outlier scores for every input point.
+#[derive(Debug, Clone, PartialEq)]
+pub struct HdbscanResult<T> {
+    /// Cluster assignment for each input point, in input order.
+    /// `Some(id)` for clustered points, `None` for noise.
+    pub labels: Vec<Option<usize>>,
+
+    /// GLOSH (Global-Local Outlier Scores from Hierarchies) outlier score for
+    /// each input point, in the range [0, 1]. Higher values indicate stronger
+    /// outliers.
+    pub outlier_scores: Vec<T>,
+}
+
+/// Errors that can occur during [`hdbscan`](Hdbscan::hdbscan) clustering.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum HdbscanError {
+    /// `min_cluster_size` is out of range.
+    ///
+    /// `min_cluster_size` must be at least 2 and no greater than the number
+    /// of input points.
+    #[error(
+        "invalid min_cluster_size {min_cluster_size}: must be in 2..={n} (number of input points)"
+    )]
+    InvalidMinClusterSize {
+        /// The supplied `min_cluster_size`.
+        min_cluster_size: usize,
+        /// The number of input points.
+        n: usize,
+    },
+    /// `min_samples` is out of range.
+    ///
+    /// `min_samples` must be at least 1 and no greater than `n - 1`, since
+    /// the core distance is the distance to the `min_samples`-th nearest
+    /// neighbour excluding the point itself, and only `n - 1` other points
+    /// exist.
+    #[error(
+        "invalid min_samples {min_samples}: must be in 1..={} (n - 1, where n = {n} is the number of input points)",
+        .n.saturating_sub(1)
+    )]
+    InvalidMinSamples {
+        /// The supplied `min_samples`.
+        min_samples: usize,
+        /// The number of input points.
+        n: usize,
+    },
+    /// The minimum spanning tree could not connect all input points.
+    ///
+    /// HDBSCAN builds a single spanning tree over the mutual-reachability
+    /// graph. If the input contains non-finite coordinates (NaN or infinity),
+    /// or coordinates so large in magnitude that squared distances overflow
+    /// to infinity, the tree is left disconnected and any clustering would be
+    /// meaningless. Clean or rescale the input.
+    #[error(
+        "could not connect all input points: found {edges} spanning-tree edges, expected {expected}. Input may contain non-finite or extremely large coordinates"
+    )]
+    DisconnectedSpanningTree {
+        /// The number of spanning-tree edges that were found.
+        edges: usize,
+        /// The number of edges required to span all points (`n - 1`).
+        expected: usize,
+    },
+}
+
+/// Perform [HDBSCAN](https://en.wikipedia.org/wiki/HDBSCAN) (Hierarchical Density-Based Spatial Clustering of Applications with Noise) clustering on a set of points.
+///
+/// HDBSCAN extends DBSCAN by converting it into a hierarchical clustering
+/// algorithm, then extracting a flat clustering based on cluster stability.
+/// Unlike DBSCAN, it does not require an epsilon parameter and can find
+/// clusters of varying densities.
+///
+/// The central concept is the *mutual reachability distance* between two
+/// points *a* and *b*: `max(core_dist(a), core_dist(b), dist(a, b))`, where
+/// `core_dist(p)` is the distance from *p* to its *k*-th nearest neighbour
+/// (with *k* = `min_samples`). This inflates distances in sparse regions
+/// while leaving dense regions unchanged: in effect, a point in a sparse
+/// region is treated as farther from everything than it geometrically is.
+/// The minimum spanning tree (MST) of the resulting complete graph – the
+/// mutual reachability graph – therefore captures the density-based
+/// cluster structure of the data.
+///
+/// The MST makes it cheap to answer the question: "which points are grouped
+/// together if we only connect points closer than some threshold?" Imagine
+/// raising that threshold from zero: at first only the tightest pairs are
+/// connected; as it grows, small groups merge into larger ones, until every
+/// point belongs to a single group. Recording which groups merge at which
+/// threshold produces a tree, the *dendrogram*:
+///
+/// ```text
+///                    distance at which groups merge ──►
+///
+///  a ───┐
+///  b ───┴─────┐               {a,b} and {c,d} each merge at a small
+///  c ───┐     ├───────┐       distance; the two pairs join at a larger
+///  d ───┴─────┘       ├───    one; the isolated point e is absorbed
+///  e ─────────────────┘       last, at a much larger distance
+/// ```
+///
+/// This is a *single-linkage* hierarchy: the distance between two groups is
+/// simply the distance between their two closest members. Clusters that
+/// persist over a wide range of thresholds (like `{a, b}`) are "stable";
+/// short-lived groupings are artefacts of a particular threshold. HDBSCAN
+/// condenses the dendrogram and keeps only the most stable clusters, and
+/// points such as `e` that never joined a stable cluster become noise.
+///
+/// # Parameters
+///
+/// - `min_cluster_size`: The minimum number of points required to form a
+///   cluster. Larger values produce fewer, more conservative clusters.
+///   Also used as the number of neighbours for core distance computation
+///   when calling [`hdbscan`](Hdbscan::hdbscan).
+/// - `min_samples` (only on [`hdbscan_with_min_samples`](Hdbscan::hdbscan_with_min_samples)):
+///   The number of nearest neighbours (excluding the point itself) used to
+///   compute core distances. Controls how conservative the clustering is.
+///
+/// # Returns
+///
+/// A [`Result`] containing an [`HdbscanResult`] with cluster labels and
+/// GLOSH outlier scores, or an [`HdbscanError`] if parameters are invalid.
+/// Empty input is not an error; it yields an `HdbscanResult` with empty
+/// vectors.
+///
+/// # Errors
+///
+/// Returns [`HdbscanError::InvalidMinClusterSize`] when `min_cluster_size`
+/// is less than 2 or greater than the number of input points;
+/// [`HdbscanError::InvalidMinSamples`] when `min_samples` is less than 1 or
+/// greater than `n - 1` (the core distance is the distance to the
+/// `min_samples`-th nearest *other* point); and
+/// [`HdbscanError::DisconnectedSpanningTree`] when the input contains
+/// non-finite or extremely large coordinates that leave the
+/// mutual-reachability graph disconnected.
+///
+/// # Algorithm
+///
+/// 1. **Compute core distances** – each point's distance to its
+///    `min_samples`-th nearest neighbour – using a
+///    [ball tree](https://en.wikipedia.org/wiki/Ball_tree) (this crate's
+///    [`BallTree`]) rather than brute-force search.
+/// 2. **Build the minimum spanning tree** of the mutual-reachability graph
+///    using [Borůvka's algorithm](https://en.wikipedia.org/wiki/Bor%C5%AFvka%27s_algorithm),
+///    again accelerated by the ball tree, so the complete graph's O(n²)
+///    pairwise distances are never materialised.
+/// 3. **Build the dendrogram.** Sort the MST edges by weight and merge
+///    components with a union-find structure, recording each merge (as in
+///    the diagram above).
+/// 4. **Condense the tree.** Walk the dendrogram from the top, lowering the
+///    threshold (the reverse of the direction the intro built it). A split
+///    counts as two new clusters only if both sides have at least
+///    `min_cluster_size` points; otherwise the smaller side "falls out" of
+///    the parent, which carries on. The result is a much smaller tree whose
+///    nodes are candidate clusters, each recording the threshold at which
+///    every point left it.
+/// 5. **Extract the most stable clusters.** Stability formalises "persists
+///    over a wide range of thresholds": each point contributes to a
+///    cluster's stability for as long as it remains inside it (the "excess
+///    of mass" criterion from the reference paper). A parent is selected
+///    only when its own stability exceeds the combined stability of its
+///    children; otherwise the children are kept. Points in no selected
+///    cluster are labelled noise.
+/// 6. **Score outliers.** [GLOSH](https://doi.org/10.1007/978-3-319-18123-3_2)
+///    compares the density at which each point fell out of its cluster with
+///    the highest density that cluster reached: points that persist into
+///    the dense core score near 0, points that leave while the cluster is
+///    still sparse score near 1.
+///
+/// For an accessible walk-through with visualisations, see
+/// [How HDBSCAN Works](https://hdbscan.readthedocs.io/en/latest/how_hdbscan_works.html).
+///
+/// # Examples
+///
+/// ```
+/// use geo::{Hdbscan, point};
+///
+/// let points = vec![
+///     // Cluster 1 (six points near the origin)
+///     point!(x: 0.0, y: 0.0),
+///     point!(x: 1.0, y: 0.0),
+///     point!(x: 0.0, y: 1.0),
+///     point!(x: 1.0, y: 1.0),
+///     point!(x: 0.5, y: 0.5),
+///     point!(x: 0.5, y: 0.0),
+///     // Cluster 2 (six points near (10, 10))
+///     point!(x: 10.0, y: 10.0),
+///     point!(x: 11.0, y: 10.0),
+///     point!(x: 10.0, y: 11.0),
+///     point!(x: 11.0, y: 11.0),
+///     point!(x: 10.5, y: 10.5),
+///     point!(x: 10.5, y: 10.0),
+/// ];
+///
+/// let result = points.hdbscan(5).unwrap();
+///
+/// // Both clusters are found
+/// assert!(result.labels[0].is_some());
+/// assert!(result.labels[6].is_some());
+/// // Points in cluster 1 share the same label
+/// assert_eq!(result.labels[0], result.labels[1]);
+/// // Points in cluster 2 share a different label
+/// assert_eq!(result.labels[6], result.labels[7]);
+/// // The two clusters have different labels
+/// assert_ne!(result.labels[0], result.labels[6]);
+/// ```
+pub trait Hdbscan<T>
+where
+    T: GeoNum,
+{
+    /// Perform HDBSCAN clustering using `min_cluster_size` for both the
+    /// minimum cluster size and the number of neighbours used to compute
+    /// core distances.
+    ///
+    /// See the [trait-level documentation](Hdbscan) for details and error
+    /// conditions.
+    fn hdbscan(&self, min_cluster_size: usize) -> Result<HdbscanResult<T>, HdbscanError> {
+        self.hdbscan_with_min_samples(min_cluster_size, min_cluster_size)
+    }
+
+    /// Perform HDBSCAN clustering with separate `min_cluster_size` and
+    /// `min_samples` parameters.
+    ///
+    /// `min_samples` controls the number of nearest neighbours (excluding the
+    /// point itself) used to compute core distances. See the
+    /// [trait-level documentation](Hdbscan) for details and error conditions.
+    fn hdbscan_with_min_samples(
+        &self,
+        min_cluster_size: usize,
+        min_samples: usize,
+    ) -> Result<HdbscanResult<T>, HdbscanError>;
+}
+
+impl<T> Hdbscan<T> for MultiPoint<T>
+where
+    T: GeoFloat + Send + Sync,
+{
+    fn hdbscan_with_min_samples(
+        &self,
+        min_cluster_size: usize,
+        min_samples: usize,
+    ) -> Result<HdbscanResult<T>, HdbscanError> {
+        hdbscan_impl(&self.0, min_cluster_size, min_samples)
+    }
+}
+
+impl<T> Hdbscan<T> for [Point<T>]
+where
+    T: GeoFloat + Send + Sync,
+{
+    fn hdbscan_with_min_samples(
+        &self,
+        min_cluster_size: usize,
+        min_samples: usize,
+    ) -> Result<HdbscanResult<T>, HdbscanError> {
+        hdbscan_impl(self, min_cluster_size, min_samples)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Core implementation
+// ---------------------------------------------------------------------------
+
+fn hdbscan_impl<T: GeoFloat + Send + Sync>(
+    points: &[Point<T>],
+    min_cluster_size: usize,
+    min_samples: usize,
+) -> Result<HdbscanResult<T>, HdbscanError> {
+    let n = points.len();
+
+    // Check `min_cluster_size` before `min_samples` so that the default
+    // `hdbscan(k)` method – which forwards `k` to both parameters – surfaces
+    // the more user-facing `InvalidMinClusterSize` on `k < 2`.
+    if min_cluster_size < 2 {
+        return Err(HdbscanError::InvalidMinClusterSize {
+            min_cluster_size,
+            n,
+        });
+    }
+
+    if min_samples < 1 {
+        return Err(HdbscanError::InvalidMinSamples { min_samples, n });
+    }
+
+    if n == 0 {
+        return Ok(HdbscanResult {
+            labels: Vec::new(),
+            outlier_scores: Vec::new(),
+        });
+    }
+
+    if min_cluster_size > n {
+        return Err(HdbscanError::InvalidMinClusterSize {
+            min_cluster_size,
+            n,
+        });
+    }
+
+    // The core distance is the distance to the `min_samples`-th nearest
+    // neighbour excluding the point itself, so at least `min_samples` other
+    // points must exist. `n >= 1` here, so `n - 1` does not underflow.
+    if min_samples > n - 1 {
+        return Err(HdbscanError::InvalidMinSamples { min_samples, n });
+    }
+
+    // Build ball tree once for both core distances and MST construction
+    let tree = BallTree::new(points.iter().copied());
+
+    // 1. Compute core distances using ball tree k-NN
+    let core_data = compute_core_data(&tree, points, min_samples);
+
+    // 2. Build MST over the mutual reachability graph (dual-tree Boruvka)
+    let mst = boruvka_mst(&tree, points, &core_data);
+
+    // A spanning tree over n points has exactly n - 1 edges. Fewer means the
+    // mutual-reachability graph is disconnected, which happens when distances
+    // are non-finite or overflow to infinity (e.g. coordinates near 1e200).
+    // Bail out rather than proceed with a forest that downstream stages
+    // would mis-size. `n >= 2` here (min_cluster_size >= 2 and <= n).
+    if mst.len() != n - 1 {
+        return Err(HdbscanError::DisconnectedSpanningTree {
+            edges: mst.len(),
+            expected: n - 1,
+        });
+    }
+
+    // 3. Build dendrogram (label step): sort MST edges, merge via union-find
+    let dendrogram = label(&mst, n);
+
+    // 4. Condense the dendrogram
+    let condensed = condense_tree(&dendrogram, min_cluster_size, n);
+
+    // Steps 5-7 use HashMaps keyed by cluster ID. Cluster IDs are dense
+    // integers starting at n_points and incrementing, so these could be
+    // replaced with flat Vecs using offset indexing (id - n_points) for
+    // lower overhead. Left as-is because these stages are <1% of total
+    // runtime at scale.
+
+    // 5. Compute cluster stabilities and select clusters
+    let stability = get_stability(&condensed);
+    // Reverse child->parent map, shared by find_clusters and extract_labels.
+    let parent_of = build_parent_of(&condensed);
+    let (cluster_labels, is_cluster) = find_clusters(&condensed, &stability, &parent_of);
+
+    // 6. Extract flat labels from selected clusters
+    let labels = extract_labels(&condensed, &cluster_labels, &is_cluster, &parent_of, n);
+
+    // 7. Compute GLOSH outlier scores
+    let outlier_scores = glosh(&condensed, n);
+
+    Ok(HdbscanResult {
+        labels,
+        outlier_scores,
+    })
+}
 
 // ---------------------------------------------------------------------------
 // Step 1: Core distances via ball tree k-NN

--- a/geo/src/algorithm/hdbscan/tests.rs
+++ b/geo/src/algorithm/hdbscan/tests.rs
@@ -1,6 +1,280 @@
 use super::*;
+use crate::point;
 use crate::wkt;
 use approx::assert_relative_eq;
+
+#[test]
+fn test_empty_input() {
+    let points: Vec<Point<f64>> = wkt!(MULTIPOINT EMPTY).0;
+    let result = points.hdbscan(5).unwrap();
+    assert!(result.labels.is_empty());
+    assert!(result.outlier_scores.is_empty());
+}
+
+#[test]
+fn test_single_point() {
+    // A single point cannot satisfy min_cluster_size=2, so this is an
+    // out-of-range parameter error, not a silent all-noise result.
+    let points = wkt!(MULTIPOINT(0.0 0.0)).0;
+    assert_eq!(
+        points.hdbscan(2),
+        Err(HdbscanError::InvalidMinClusterSize {
+            min_cluster_size: 2,
+            n: 1,
+        }),
+    );
+}
+
+/// The empty-input vs tiny-input asymmetry is intentional and pinned here.
+///
+/// `[].hdbscan(k)` returns `Ok(empty)`: clustering an empty set yields an empty
+/// result, which is unambiguous (empty vectors, not a misleading zero-valued
+/// geometry). `[p].hdbscan(k)` with `k >= 2` returns
+/// `Err(InvalidMinClusterSize)`: a single point cannot satisfy
+/// `min_cluster_size >= 2`. The `n == 0` check in `hdbscan_impl` deliberately
+/// precedes the checks that compare a parameter against `n`
+/// (`min_cluster_size > n`, `min_samples > n - 1`), so an empty input never
+/// surfaces a too-large-for-n error. The absolute range checks
+/// (`min_cluster_size < 2`, `min_samples < 1`) come first and still reject
+/// out-of-range parameters even on empty input.
+///
+/// This contract matches the crate's `KMeans`: `kmeans` on empty input
+/// returns `Ok` with an empty assignment (the `n == 0` check precedes the
+/// `k > n` check), while `k > n` on non-empty input is `InvalidK`. An empty
+/// collection is a natural no-op for a clustering pipeline; a non-empty
+/// input whose parameters are unsatisfiable indicates a caller error.
+#[test]
+fn test_empty_vs_tiny_input_asymmetry() {
+    // Empty input: Ok with an empty result, regardless of the parameters.
+    let empty: Vec<Point<f64>> = wkt!(MULTIPOINT EMPTY).0;
+    let result = empty.hdbscan(5).unwrap();
+    assert!(result.labels.is_empty());
+    assert!(result.outlier_scores.is_empty());
+
+    // One point with the same parameters: an out-of-range error.
+    let one = wkt!(MULTIPOINT(0.0 0.0)).0;
+    assert_eq!(
+        one.hdbscan(5),
+        Err(HdbscanError::InvalidMinClusterSize {
+            min_cluster_size: 5,
+            n: 1,
+        }),
+    );
+}
+
+#[test]
+fn test_min_cluster_size_too_large() {
+    let points = wkt!(MULTIPOINT(0.0 0.0, 1.0 0.0, 0.0 1.0)).0;
+    assert_eq!(
+        points.hdbscan(100),
+        Err(HdbscanError::InvalidMinClusterSize {
+            min_cluster_size: 100,
+            n: 3,
+        }),
+    );
+}
+
+/// Verify that the MultiPoint trait impl delegates correctly and
+/// produces the same result as calling on the underlying slice.
+#[test]
+fn test_multipoint_trait_impl() {
+    let mp: MultiPoint<f64> = wkt!(MULTIPOINT(
+        0.0 0.0, 0.1 0.0, 0.0 0.1, 0.1 0.1, 0.05 0.05
+    ));
+
+    let result_mp = mp.hdbscan(3).unwrap();
+    let result_slice = mp.0.hdbscan(3).unwrap();
+
+    assert_eq!(result_mp.labels, result_slice.labels);
+    assert_eq!(result_mp.outlier_scores, result_slice.outlier_scores);
+}
+
+#[test]
+fn test_identical_points() {
+    // Ten coincident points at (5, 5).
+    let points: Vec<Point<f64>> = wkt!(MULTIPOINT(
+        5.0 5.0, 5.0 5.0, 5.0 5.0, 5.0 5.0, 5.0 5.0,
+        5.0 5.0, 5.0 5.0, 5.0 5.0, 5.0 5.0, 5.0 5.0
+    ))
+    .0;
+    let result = points.hdbscan(3).unwrap();
+    // Identical points must end up with a single verdict: either all
+    // clustered with the same label, or all noise.
+    let first = result.labels[0];
+    assert_eq!(result.labels, vec![first; 10]);
+    // Coincident points produce zero-distance MST edges, which become
+    // `lambda = infinity` in the condensed tree. Guard against that
+    // propagating into GLOSH as NaN.
+    for score in &result.outlier_scores {
+        assert!(
+            score.is_finite(),
+            "GLOSH outlier score must be finite, got {score}"
+        );
+        assert!(
+            (0.0..=1.0).contains(score),
+            "GLOSH outlier score must be in [0, 1], got {score}"
+        );
+    }
+}
+
+#[test]
+fn test_min_cluster_size_one() {
+    // min_cluster_size < 2 is a parameter error.
+    let points = wkt!(MULTIPOINT(0.0 0.0, 1.0 1.0)).0;
+    assert_eq!(
+        points.hdbscan(1),
+        Err(HdbscanError::InvalidMinClusterSize {
+            min_cluster_size: 1,
+            n: 2,
+        }),
+    );
+}
+
+#[test]
+fn test_invalid_min_samples() {
+    // Four points so that min_cluster_size = 2 is valid and the min_samples
+    // check is what fails.
+    let points = wkt!(MULTIPOINT(0.0 0.0, 1.0 1.0, 2.0 2.0, 3.0 3.0)).0;
+    assert_eq!(
+        points.hdbscan_with_min_samples(2, 0),
+        Err(HdbscanError::InvalidMinSamples {
+            min_samples: 0,
+            n: 4
+        }),
+    );
+}
+
+#[test]
+fn test_disconnected_spanning_tree_errors() {
+    // Two clusters separated by a distance large enough that the squared
+    // distance overflows to infinity: cluster A near the origin, and cluster
+    // B a vertical line at x = 1e160 (intra-cluster spacing 1e150 keeps
+    // distances within B finite, while every A-B distance overflows).
+    // Boruvka connects each cluster internally but the infinite cross-cluster
+    // distances are pruned, so the spanning tree is left disconnected.
+    // Unfixed, this produced a forest that downstream stages mis-sized; it
+    // must now be reported as an error.
+    // 16 points per cluster (> the ball tree's leaf size) so the two
+    // clusters land in separate subtrees and their infinite cross distances
+    // are only ever seen through the pruned node-to-node bound.
+    let mut points = Vec::new();
+    for i in 0..16 {
+        points.push(point!(x: (i % 4) as f64, y: (i / 4) as f64));
+    }
+    for i in 0..16 {
+        points.push(point!(x: 1.0e160, y: (i as f64) * 1.0e150));
+    }
+    let result = points.hdbscan_with_min_samples(2, 2);
+    assert!(
+        matches!(result, Err(HdbscanError::DisconnectedSpanningTree { .. })),
+        "expected DisconnectedSpanningTree, got {result:?}"
+    );
+}
+
+#[test]
+fn test_min_samples_too_large() {
+    // The core distance is the distance to the min_samples-th nearest
+    // neighbour excluding self, so min_samples must not exceed n - 1.
+    let points = wkt!(MULTIPOINT(0.0 0.0, 1.0 1.0, 2.0 2.0)).0;
+    assert_eq!(
+        points.hdbscan_with_min_samples(2, 3),
+        Err(HdbscanError::InvalidMinSamples {
+            min_samples: 3,
+            n: 3
+        }),
+    );
+}
+
+#[test]
+fn test_two_points() {
+    // With only 2 points, hdbscan(2) forwards min_samples = 2, but the core
+    // distance needs min_samples other points and only 1 exists, so this is
+    // an out-of-range min_samples error.
+    let points = wkt!(MULTIPOINT(0.0 0.0, 1.0 1.0)).0;
+    assert_eq!(
+        points.hdbscan(2),
+        Err(HdbscanError::InvalidMinSamples {
+            min_samples: 2,
+            n: 2
+        }),
+    );
+}
+
+#[test]
+fn test_three_clusters() {
+    // Three 5x2 grids (spacing 0.1): cluster A near the origin, cluster B
+    // near (10, 10), and cluster C near (20, 0).
+    let points = wkt!(MULTIPOINT(
+        0.0 0.0, 0.1 0.0, 0.2 0.0, 0.3 0.0, 0.4 0.0,
+        0.0 0.1, 0.1 0.1, 0.2 0.1, 0.3 0.1, 0.4 0.1,
+        10.0 10.0, 10.1 10.0, 10.2 10.0, 10.3 10.0, 10.4 10.0,
+        10.0 10.1, 10.1 10.1, 10.2 10.1, 10.3 10.1, 10.4 10.1,
+        20.0 0.0, 20.1 0.0, 20.2 0.0, 20.3 0.0, 20.4 0.0,
+        20.0 0.1, 20.1 0.1, 20.2 0.1, 20.3 0.1, 20.4 0.1
+    ))
+    .0;
+
+    // min_cluster_size=6 ensures no sub-split within a 10-point cluster
+    // can produce two children both >= 6, preventing internal over-splitting.
+    let result = points.hdbscan(6).unwrap();
+
+    // Each group should be a distinct cluster
+    let label_a = result.labels[0];
+    let label_b = result.labels[10];
+    let label_c = result.labels[20];
+    assert!(label_a.is_some(), "cluster A should be found");
+    assert!(label_b.is_some(), "cluster B should be found");
+    assert!(label_c.is_some(), "cluster C should be found");
+
+    // All three labels should be distinct
+    assert_ne!(label_a, label_b, "A and B should differ");
+    assert_ne!(label_a, label_c, "A and C should differ");
+    assert_ne!(label_b, label_c, "B and C should differ");
+
+    // All points within each group should share their cluster label
+    for i in 0..10 {
+        assert_eq!(
+            result.labels[i], label_a,
+            "point {i} should be in cluster A"
+        );
+    }
+    for i in 10..20 {
+        assert_eq!(
+            result.labels[i], label_b,
+            "point {i} should be in cluster B"
+        );
+    }
+    for i in 20..30 {
+        assert_eq!(
+            result.labels[i], label_c,
+            "point {i} should be in cluster C"
+        );
+    }
+}
+
+/// Uniform data with no density structure is labelled entirely noise.
+///
+/// A regular 4x4 grid has no denser sub-region that could form a cluster, so
+/// with the condensed-tree root excluded from selection every point is noise.
+/// The root exclusion matches the reference python `hdbscan` library's
+/// default behaviour (its `allow_single_cluster` parameter set to `False`;
+/// this implementation does not expose the option). Verified against python
+/// `hdbscan`, which also returns all-noise for this fixture.
+#[test]
+fn test_uniform_noise_all_none() {
+    let points: MultiPoint<f64> = wkt!(MULTIPOINT(
+        0.0 0.0, 0.0 1.0, 0.0 2.0, 0.0 3.0,
+        1.0 0.0, 1.0 1.0, 1.0 2.0, 1.0 3.0,
+        2.0 0.0, 2.0 1.0, 2.0 2.0, 2.0 3.0,
+        3.0 0.0, 3.0 1.0, 3.0 2.0, 3.0 3.0
+    ));
+    let result = points.hdbscan(4).unwrap();
+    assert!(
+        result.labels.iter().all(Option::is_none),
+        "uniform grid should be all noise, got {:?}",
+        result.labels
+    );
+}
 
 // -- Union-Find unit tests ------------------------------------------------
 
@@ -30,6 +304,267 @@ fn test_union_find_chain() {
     assert_eq!(uf.find(3), root);
     assert_eq!(uf.size(root), 4);
     assert_eq!(uf.component_label(root), 6);
+}
+
+// -- Known-answer tests (ported from petal-clustering) --------------------
+//
+// petal-clustering is a Rust clustering crate with an HDBSCAN
+// implementation: https://github.com/petabi/petal-clustering
+
+/// Dataset from [petal-clustering](https://github.com/petabi/petal-clustering)'s
+/// `partial_labels` test (unsupervised).
+///
+/// Three spatial groups plus one isolated noise point:
+///   Group 1 (5 pts): indices 0..5, near (1-3, 7-9)
+///   Group 2 (4 pts): indices 5..9, near (5-6, 3-4)
+///   Group 3 (6 pts): indices 9..15, near (8-9, 1-3)
+///   Outlier:         index 15, at (7, 8)
+///
+/// geo's labels and GLOSH scores match the reference python `hdbscan`
+/// library exactly: groups 2 and 3 merge into one cluster and the isolated
+/// point (index 15) is labelled noise. The dataset is ported from petal-clustering's
+/// `partial_labels` test; the expected values below are python `hdbscan`'s.
+///
+/// The original test name (`partial_labels`) is not preserved because the
+/// assertions are pinned to python `hdbscan`, not to petal-clustering's
+/// output: this is a python-`hdbscan` known-answer test that reuses
+/// petal-clustering's dataset.
+#[test]
+fn test_known_answer_petal_clustering() {
+    // Point layout:
+    //   indices  0..5:  group 1 near (1-3, 7-9)
+    //   indices  5..9:  group 2 near (5-6, 3-4)
+    //   indices 9..15:  group 3 near (8-9, 1-3)
+    //   index   15:     outlier at (7, 8)
+    let points: MultiPoint<f64> = wkt!(MULTIPOINT(
+        1.0 9.0, 2.0 9.0, 1.0 8.0, 2.0 8.0, 3.0 7.0,
+        5.0 4.0, 6.0 4.0, 5.0 3.0, 6.0 3.0,
+        8.0 3.0, 9.0 3.0, 8.0 2.0, 9.0 2.0, 8.0 1.0, 9.0 1.0,
+        7.0 8.0
+    ));
+    let result = points.hdbscan_with_min_samples(4, 4).unwrap();
+
+    // Group 1 is cluster 0; groups 2 and 3 merge into cluster 1; the isolated
+    // point is noise. (Matches python hdbscan.)
+    let expected_labels: Vec<Option<usize>> = vec![
+        Some(0),
+        Some(0),
+        Some(0),
+        Some(0),
+        Some(0),
+        Some(1),
+        Some(1),
+        Some(1),
+        Some(1),
+        Some(1),
+        Some(1),
+        Some(1),
+        Some(1),
+        Some(1),
+        Some(1),
+        None,
+    ];
+    assert_eq!(result.labels, expected_labels);
+
+    // GLOSH outlier scores, matching python hdbscan's `outlier_scores_`.
+    let expected_scores = [
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.367_544_467_966_324_1,
+        0.105_572_809_000_084_14,
+        0.333_333_333_333_333_37,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.6,
+    ];
+    assert_eq!(result.outlier_scores.len(), expected_scores.len());
+    for (&got, &want) in result.outlier_scores.iter().zip(expected_scores.iter()) {
+        assert_relative_eq!(got, want, epsilon = 1e-9);
+    }
+}
+
+/// Dataset from [petal-clustering](https://github.com/petabi/petal-clustering)'s
+/// `outlier_scores` test.
+///
+/// Three spatial groups plus two outlier points. geo's labels and GLOSH
+/// scores match the reference python `hdbscan` library exactly.
+/// Two clusters are recovered:
+/// the two upper groups merge into cluster 1 and the lower group (plus point
+/// 18) forms cluster 0; points 10, 17 and 19 are noise. Those noise points
+/// still receive graded GLOSH scores rather than a flat 1.0.
+///
+/// The original test name (`outlier_scores`) is not preserved because the
+/// assertions are pinned to python `hdbscan`, not to petal-clustering's
+/// output: this is a python-`hdbscan` known-answer test that reuses
+/// petal-clustering's dataset.
+#[test]
+fn test_known_answer_glosh_scores() {
+    // Point layout:
+    //   indices  0..8:  group near (1-4, 7-9)
+    //   indices  8..13: group near (7-9, 7-9)
+    //   indices 13..18: group near (5-7, 1-3)
+    //   index   18:     point at (8, 4)
+    //   index   19:     point at (3, 3)
+    let points: MultiPoint<f64> = wkt!(MULTIPOINT(
+        2.0 9.0, 3.0 9.0, 2.0 8.0, 3.0 8.0, 2.0 7.0, 3.0 7.0, 1.0 8.0, 4.0 8.0,
+        7.0 9.0, 7.0 8.0, 8.0 8.0, 8.0 7.0, 9.0 7.0,
+        6.0 3.0, 5.0 2.0, 6.0 2.0, 7.0 2.0, 6.0 1.0,
+        8.0 4.0,
+        3.0 3.0
+    ));
+    let result = points.hdbscan_with_min_samples(5, 5).unwrap();
+
+    // Two clusters; points 10, 17 and 19 are noise. (Matches python hdbscan.)
+    let expected_labels: Vec<Option<usize>> = vec![
+        Some(1),
+        Some(1),
+        Some(1),
+        Some(1),
+        Some(1),
+        Some(1),
+        Some(1),
+        Some(1),
+        Some(1),
+        Some(1),
+        None,
+        Some(1),
+        Some(1),
+        Some(0),
+        Some(0),
+        Some(0),
+        Some(0),
+        None,
+        Some(0),
+        None,
+    ];
+    assert_eq!(result.labels, expected_labels);
+
+    // GLOSH outlier scores, matching python hdbscan's `outlier_scores_`.
+    let expected_scores = [
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.105_572_809_000_084_14,
+        0.105_572_809_000_084_14,
+        0.367_544_467_966_324_1,
+        0.333_333_333_333_333_37,
+        0.5,
+        0.333_333_333_333_333_37,
+        0.367_544_467_966_324_1,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.445_299_803_774_770_85,
+        0.0,
+        0.5,
+    ];
+    assert_eq!(result.outlier_scores.len(), expected_scores.len());
+    for (&got, &want) in result.outlier_scores.iter().zip(expected_scores.iter()) {
+        assert_relative_eq!(got, want, epsilon = 1e-9);
+    }
+}
+
+// -- Clusters with noise --------------------------------------------------
+
+/// Two clusters with distant outlier points.
+///
+/// Points far from all clusters merge at the top of the hierarchy
+/// and get classified as noise when the root is deselected in favour
+/// of its child clusters.
+#[test]
+fn test_clusters_with_distant_noise() {
+    // Two dense 5x2 grids (spacing 0.2): cluster A near the origin and
+    // cluster B near (20, 20), plus a distant outlier at (100, 100)
+    // (index 20) that merges at the very top of the hierarchy.
+    let points = wkt!(MULTIPOINT(
+        0.0 0.0, 0.2 0.0, 0.4 0.0, 0.6 0.0, 0.8 0.0,
+        0.0 0.2, 0.2 0.2, 0.4 0.2, 0.6 0.2, 0.8 0.2,
+        20.0 20.0, 20.2 20.0, 20.4 20.0, 20.6 20.0, 20.8 20.0,
+        20.0 20.2, 20.2 20.2, 20.4 20.2, 20.6 20.2, 20.8 20.2,
+        100.0 100.0
+    ))
+    .0;
+
+    let result = points.hdbscan(5).unwrap();
+
+    // Both clusters should be found
+    let label_a = result.labels[0];
+    let label_b = result.labels[10];
+    assert!(label_a.is_some(), "cluster A should be found");
+    assert!(label_b.is_some(), "cluster B should be found");
+    assert_ne!(label_a, label_b);
+
+    // Cluster membership should be consistent
+    for i in 0..10 {
+        assert_eq!(
+            result.labels[i], label_a,
+            "point {i} should be in cluster A"
+        );
+    }
+    for i in 10..20 {
+        assert_eq!(
+            result.labels[i], label_b,
+            "point {i} should be in cluster B"
+        );
+    }
+
+    // Distant outlier should be noise
+    assert_eq!(result.labels[20], None, "distant outlier should be noise");
+    // And should have a high outlier score
+    assert!(
+        result.outlier_scores[20] > 0.5,
+        "distant outlier score ({}) should be high",
+        result.outlier_scores[20]
+    );
+}
+
+/// Points between two clusters get absorbed into the nearest cluster
+/// (correct HDBSCAN behaviour) but should have higher outlier scores.
+#[test]
+fn test_absorbed_bridge_points_have_high_scores() {
+    // Two dense 5x2 grids (spacing 0.2): cluster A near the origin and
+    // cluster B near (20, 20), plus three bridge points (indices 20..23)
+    // on the diagonal between them.
+    let points = wkt!(MULTIPOINT(
+        0.0 0.0, 0.2 0.0, 0.4 0.0, 0.6 0.0, 0.8 0.0,
+        0.0 0.2, 0.2 0.2, 0.4 0.2, 0.6 0.2, 0.8 0.2,
+        20.0 20.0, 20.2 20.0, 20.4 20.0, 20.6 20.0, 20.8 20.0,
+        20.0 20.2, 20.2 20.2, 20.4 20.2, 20.6 20.2, 20.8 20.2,
+        5.0 5.0, 10.0 10.0, 15.0 15.0
+    ))
+    .0;
+
+    let result = points.hdbscan(5).unwrap();
+
+    // Both clusters should be found
+    let label_a = result.labels[0];
+    let label_b = result.labels[10];
+    assert!(label_a.is_some(), "cluster A should be found");
+    assert!(label_b.is_some(), "cluster B should be found");
+    assert_ne!(label_a, label_b);
+
+    // Bridge points are absorbed into the nearest cluster; their
+    // outlier scores should be higher than the average cluster member.
+    let cluster_avg: f64 = result.outlier_scores[0..20].iter().sum::<f64>() / 20.0;
+    for i in 20..23 {
+        assert!(
+            result.outlier_scores[i] >= cluster_avg,
+            "bridge point {i} score ({}) should be >= cluster avg ({cluster_avg})",
+            result.outlier_scores[i]
+        );
+    }
 }
 
 // -- Internal pipeline unit tests -----------------------------------------
@@ -328,6 +863,213 @@ fn test_condense_tree_single_cluster() {
     //
     // This means there are no true splits – no cluster children.
     assert_eq!(cluster_entries.len(), 0, "no true split should occur");
+}
+
+/// A group of coincident points embedded in a larger cluster must not zero
+/// out GLOSH for the whole cluster.
+///
+/// Enough coincident points (indices 0..4) drive their core distance to zero,
+/// so the merge that joins them has zero mutual-reachability distance. Without
+/// capping this becomes lambda = infinity, making the cluster's death lambda
+/// infinite and (under the old is_finite guard) forcing every member's score
+/// to zero – including the boundary point. After capping at the hierarchy
+/// layer, scores stay finite and the boundary point scores above the core.
+/// (The reference python `hdbscan` produces NaN scores for this input.)
+#[test]
+fn test_embedded_duplicates_keep_finite_scores() {
+    // Cluster A: four coincident points at the core, a few spread points,
+    // and a boundary point further out at (2, 0.5) (index 7). Cluster B is
+    // a 3x3 grid far away at (20, 20) so the condensed-tree root splits and
+    // A is selected.
+    let points: Vec<Point<f64>> = wkt!(MULTIPOINT(
+        0.0 0.0, 0.0 0.0, 0.0 0.0, 0.0 0.0,
+        0.5 0.0, 1.0 0.0, 0.0 1.0,
+        2.0 0.5,
+        20.0 20.0, 21.0 20.0, 22.0 20.0,
+        20.0 21.0, 21.0 21.0, 22.0 21.0,
+        20.0 22.0, 21.0 22.0, 22.0 22.0
+    ))
+    .0;
+
+    let result = points.hdbscan_with_min_samples(4, 2).unwrap();
+
+    // Cluster A is found and every point in it shares a label.
+    let label_a = result.labels[0];
+    assert!(label_a.is_some(), "cluster A should be found");
+    for i in 0..8 {
+        assert_eq!(
+            result.labels[i], label_a,
+            "point {i} should be in cluster A"
+        );
+    }
+
+    // No score is NaN or infinite, and all lie in [0, 1].
+    for (i, &score) in result.outlier_scores.iter().enumerate() {
+        assert!(
+            score.is_finite() && (0.0..=1.0).contains(&score),
+            "score for point {i} must be finite in [0, 1], got {score}"
+        );
+    }
+
+    // The boundary point (index 7) scores strictly above zero – the whole
+    // cluster is not zeroed out by the embedded duplicates.
+    assert!(
+        result.outlier_scores[7] > 0.0,
+        "boundary point should score above zero, got {}",
+        result.outlier_scores[7]
+    );
+}
+
+// -- GLOSH score ordering -------------------------------------------------
+
+/// Points near the centre of a cluster should have lower outlier scores
+/// than points at the periphery.
+///
+/// A second dense cluster is included so the condensed-tree root splits:
+/// without it the data would be a single blob and, with the root excluded
+/// from selection, every point would be noise. Validated against python
+/// `hdbscan` (cluster A core avg ~0.073, periphery avg ~0.66).
+#[test]
+fn test_glosh_score_ordering() {
+    // Cluster A core: dense 4x4 grid (16 points, spacing 0.1) at the origin.
+    // Cluster A periphery: 4 points further from the core (indices 16..20).
+    // Cluster B: a second dense 4x4 grid far away at (5, 5) (indices 20..36).
+    let points = wkt!(MULTIPOINT(
+        0.0 0.0, 0.1 0.0, 0.2 0.0, 0.3 0.0,
+        0.0 0.1, 0.1 0.1, 0.2 0.1, 0.3 0.1,
+        0.0 0.2, 0.1 0.2, 0.2 0.2, 0.3 0.2,
+        0.0 0.3, 0.1 0.3, 0.2 0.3, 0.3 0.3,
+        -0.25 0.15, 0.55 0.15, 0.15 -0.25, 0.15 0.55,
+        5.0 5.0, 5.1 5.0, 5.2 5.0, 5.3 5.0,
+        5.0 5.1, 5.1 5.1, 5.2 5.1, 5.3 5.1,
+        5.0 5.2, 5.1 5.2, 5.2 5.2, 5.3 5.2,
+        5.0 5.3, 5.1 5.3, 5.2 5.3, 5.3 5.3
+    ))
+    .0;
+
+    let result = points.hdbscan_with_min_samples(5, 3).unwrap();
+
+    // Cluster A absorbs its periphery: indices 0..20 share one label.
+    let label = result.labels[0];
+    assert!(label.is_some(), "cluster A should be found");
+    for i in 0..20 {
+        assert_eq!(result.labels[i], label, "point {i} should be in cluster A");
+    }
+
+    // Average score of core points (first 16)
+    let core_avg: f64 = result.outlier_scores[0..16].iter().sum::<f64>() / 16.0;
+
+    // Average score of peripheral points (indices 16..20)
+    let peripheral_avg: f64 = result.outlier_scores[16..20].iter().sum::<f64>() / 4.0;
+
+    assert!(
+        peripheral_avg > core_avg,
+        "peripheral avg ({peripheral_avg}) should exceed core avg ({core_avg})"
+    );
+}
+
+// -- Large-n correctness --------------------------------------------------
+
+/// Test with ~500 deterministic points in 3 well-separated blobs.
+///
+/// Uses a simple LCG with CLT-based Gaussian approximation for
+/// reproducibility. Gaussian-like density (high at centre, tapering
+/// outward) gives HDBSCAN a clear density gradient to work with,
+/// avoiding the over-splitting that occurs with uniform distributions.
+#[test]
+fn test_large_n_correctness() {
+    // Simple LCG for deterministic pseudo-random numbers in [0, 1)
+    let mut seed: u64 = 42;
+    let mut next_f64 = || -> f64 {
+        seed = seed.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1);
+        (seed >> 33) as f64 / (1u64 << 31) as f64
+    };
+
+    // CLT Gaussian approximation: sum of 6 uniform [0,1) values
+    // produces approximately N(3, sqrt(0.5)) – shifted to N(0, ~0.7)
+    let mut next_gaussian = || -> f64 {
+        let sum = next_f64() + next_f64() + next_f64() + next_f64() + next_f64() + next_f64();
+        sum - 3.0
+    };
+
+    let mut points = Vec::new();
+
+    // Blob A: 200 points centred at (0, 0)
+    for _ in 0..200 {
+        points.push(Point::new(next_gaussian(), next_gaussian()));
+    }
+
+    // Blob B: 150 points centred at (30, 30)
+    for _ in 0..150 {
+        points.push(Point::new(30.0 + next_gaussian(), 30.0 + next_gaussian()));
+    }
+
+    // Blob C: 150 points centred at (60, 0)
+    for _ in 0..150 {
+        points.push(Point::new(60.0 + next_gaussian(), next_gaussian()));
+    }
+
+    let result = points.hdbscan_with_min_samples(15, 5).unwrap();
+
+    // Should find exactly 3 clusters
+    let mut distinct: Vec<usize> = result.labels.iter().filter_map(|l| *l).collect();
+    distinct.sort();
+    distinct.dedup();
+    assert_eq!(
+        distinct.len(),
+        3,
+        "expected 3 clusters, found {}",
+        distinct.len()
+    );
+
+    // Blob A (indices 0..200) should share a label
+    let label_a = result.labels[0];
+    assert!(label_a.is_some(), "blob A should be clustered");
+    let a_consistent = (0..200).all(|i| result.labels[i] == label_a);
+    assert!(a_consistent, "all blob A points should share a label");
+
+    // Blob B (indices 200..350) should share a different label
+    let label_b = result.labels[200];
+    assert!(label_b.is_some(), "blob B should be clustered");
+    let b_consistent = (200..350).all(|i| result.labels[i] == label_b);
+    assert!(b_consistent, "all blob B points should share a label");
+
+    // Blob C (indices 350..500) should share a third label
+    let label_c = result.labels[350];
+    assert!(label_c.is_some(), "blob C should be clustered");
+    let c_consistent = (350..500).all(|i| result.labels[i] == label_c);
+    assert!(c_consistent, "all blob C points should share a label");
+
+    // All three labels should differ
+    assert_ne!(label_a, label_b);
+    assert_ne!(label_a, label_c);
+    assert_ne!(label_b, label_c);
+}
+
+// -- f32 test -------------------------------------------------------------
+
+/// Verify that the algorithm works with f32 coordinates.
+#[test]
+fn test_f32_two_clusters() {
+    let points: Vec<Point<f32>> = wkt!(MULTIPOINT(
+        0.0 0.0, 0.1 0.0, 0.0 0.1, 0.1 0.1, 0.05 0.05,
+        10.0 10.0, 10.1 10.0, 10.0 10.1, 10.1 10.1, 10.05 10.05
+    ))
+    .0;
+    let result = points.hdbscan(3).unwrap();
+
+    let label_a = result.labels[0];
+    let label_b = result.labels[5];
+    assert!(label_a.is_some(), "cluster A should be found");
+    assert!(label_b.is_some(), "cluster B should be found");
+    assert_ne!(label_a, label_b);
+
+    for i in 0..5 {
+        assert_eq!(result.labels[i], label_a);
+    }
+    for i in 5..10 {
+        assert_eq!(result.labels[i], label_b);
+    }
 }
 
 #[test]

--- a/geo/src/algorithm/mod.rs
+++ b/geo/src/algorithm/mod.rs
@@ -359,6 +359,7 @@ pub use dbscan::Dbscan;
 
 /// Cluster points using [HDBSCAN](https://en.wikipedia.org/wiki/HDBSCAN) (Hierarchical Density-Based Spatial Clustering of Applications with Noise)
 pub mod hdbscan;
+pub use hdbscan::{Hdbscan, HdbscanError, HdbscanResult};
 
 /// Cluster points using [k-means clustering](https://en.wikipedia.org/wiki/K-means_clustering)
 pub mod kmeans;

--- a/geo/src/lib.rs
+++ b/geo/src/lib.rs
@@ -8,7 +8,7 @@
 //! - Affine operations on geometries (scale, rotate, skew, translate)
 //! - Boolean operations on geometries (clip, union, difference, intersection, xor)
 //! - Buffer / offset operations on geometries
-//! - Clustering operations such as DBSCAN and _k_-means
+//! - Clustering operations such as DBSCAN, HDBSCAN, and _k_-means
 //! - Euclidean, as well as spherical, haversine and other non-planar length and distance calculations
 //! - Support for projecting and converting between coordinate reference systems using PROJ
 //! - IO using the `geojson` and `geozero` crates.
@@ -88,6 +88,7 @@
 //!
 //! - **[`OutlierDetection`]**: Detect outliers in a group of points using [LOF](https://en.wikipedia.org/wiki/Local_outlier_factor)
 //! - **[`Dbscan`]**: Calculate point clusters using the DBSCAN algorithm
+//! - **[`Hdbscan`]**: Calculate point clusters using the HDBSCAN algorithm
 //! - **[`KMeans`]**: Calculate point clusters using the k-means algorithm
 //!
 //! ## Simplification


### PR DESCRIPTION
Completes the HDBSCAN stack: the `Hdbscan` trait (with an impl for `MultiPoint` and slices of `Point`), the `HdbscanResult` and `HdbscanError` types, input validation, and the `hdbscan_impl` orchestration that wires the pipeline steps together. Exported from the algorithm module alongside `Dbscan`, with the crate docs updated.

Removes the temporary `#![allow(dead_code)]` now that every internal item has a caller.

Adds the known-answer tests (labels and GLOSH scores validated against the reference python `hdbscan` library), end-to-end and edge case tests, and a criterion benchmark using the shared `make_moons` generator.

---

Part of the HDBSCAN stack (6 of 6). Based on #1557.
