### PR TITLE
Inline GeoNum::total_cmp impls for cross-crate perf

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -33,6 +33,7 @@
 - BREAKING: Tightens the bound on `Contains<MultiPoint<T>> for MultiPoint<T>` from `T: CoordNum` to `T: GeoNum`
   - <https://github.com/georust/geo/pull/1555>
 - Derive all error types via `thiserror` instead of hand-written `Display`/`Error` impls.
+- Inline total_cmp for downstream users who don't use LTO
 
 ## 0.33.1 - 2026-4-20
 

--- a/geo/src/lib.rs
+++ b/geo/src/lib.rs
@@ -410,6 +410,7 @@ macro_rules! impl_geo_num_for_float {
     ($t: ident) => {
         impl GeoNum for $t {
             type Ker = RobustKernel;
+            #[inline]
             fn total_cmp(&self, other: &Self) -> Ordering {
                 self.total_cmp(other)
             }
@@ -420,6 +421,7 @@ macro_rules! impl_geo_num_for_int {
     ($t: ident) => {
         impl GeoNum for $t {
             type Ker = SimpleKernel;
+            #[inline]
             fn total_cmp(&self, other: &Self) -> Ordering {
                 self.cmp(other)
             }


### PR DESCRIPTION
If an agent or LLM was involved in this change, please say so below, and note what it was used for. Autonomously-opened pull requests are not accepted: see our [policy on agents and LLMs](https://github.com/georust/geo/blob/main/CONTRIBUTING.md#agents-llms-and-autonomously-written-code).

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Found by Claude while searching for extra perf for https://github.com/georust/geo/pull/1571 (https://github.com/gauteh/roaring-landmask/pull/39).

<s>NB: this won't be visible to us for `geo` benchmarks (our in-crate calls are always inlined AFAIK); it only affects downstream users who don't use LTO.</s>

Update: as per https://github.com/georust/geo/pull/1579#issuecomment-5221990914 we use a separate crate for benchmarks, so this should be visible to us.
