### PR TITLE
Add IntervalTreeMultiPolygon bench

### DIFF
--- a/geo-benches/Cargo.toml
+++ b/geo-benches/Cargo.toml
@@ -107,6 +107,11 @@ path = "src/prepared_geometry.rs"
 harness = false
 
 [[bench]]
+name = "interval_tree_multipolygon"
+path = "src/interval_tree_multipolygon.rs"
+harness = false
+
+[[bench]]
 name = "rotate"
 path = "src/rotate.rs"
 harness = false

--- a/geo-benches/src/interval_tree_multipolygon.rs
+++ b/geo-benches/src/interval_tree_multipolygon.rs
@@ -1,0 +1,79 @@
+//! Benchmarks for point-in-polygon queries via `IntervalTreeMultiPolygon`.
+
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use geo::indexed::IntervalTreeMultiPolygon;
+use geo::{BoundingRect, Contains, MultiPolygon, Point, Polygon};
+
+/// A deterministic n x n grid of query points across the geometry's bounding
+/// rectangle, giving a stable mix of hits, misses, and near-boundary queries.
+fn query_grid(mp: &MultiPolygon, n: usize) -> Vec<Point> {
+    let rect = mp.bounding_rect().unwrap();
+    let (w, h) = (rect.width(), rect.height());
+    let mut points = Vec::with_capacity(n * n);
+    for i in 0..n {
+        for j in 0..n {
+            points.push(Point::new(
+                rect.min().x + w * (i as f64 + 0.5) / n as f64,
+                rect.min().y + h * (j as f64 + 0.5) / n as f64,
+            ));
+        }
+    }
+    points
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    // Many small polygons: exercises candidate filtering across parcels.
+    let plots: MultiPolygon = geo_test_fixtures::nl_plots_wgs84();
+    // One large, fjord-heavy ring: exercises long interval-tree walks, the
+    // worst case for per-comparison overhead.
+    let norway = MultiPolygon(vec![Polygon::new(
+        geo_test_fixtures::norway_main::<f64>(),
+        vec![],
+    )]);
+
+    c.bench_function("build IntervalTreeMultiPolygon (nl plots)", |bencher| {
+        bencher.iter(|| {
+            black_box(IntervalTreeMultiPolygon::new(&plots));
+        });
+    });
+
+    for (label, mp, expected_hits) in [("nl plots", &plots, 514), ("norway", &norway, 163)] {
+        let index = IntervalTreeMultiPolygon::new(mp);
+        let points = query_grid(mp, 32);
+
+        c.bench_function(
+            &format!("IntervalTreeMultiPolygon contains, 1024 points ({label})"),
+            |bencher| {
+                bencher.iter(|| {
+                    let mut hits = 0;
+                    for point in &points {
+                        if index.contains(black_box(point)) {
+                            hits += 1;
+                        }
+                    }
+                    assert_eq!(hits, expected_hits);
+                    black_box(hits);
+                });
+            },
+        );
+
+        c.bench_function(
+            &format!("MultiPolygon contains unindexed, 1024 points ({label})"),
+            |bencher| {
+                bencher.iter(|| {
+                    let mut hits = 0;
+                    for point in &points {
+                        if mp.contains(black_box(point)) {
+                            hits += 1;
+                        }
+                    }
+                    assert_eq!(hits, expected_hits);
+                    black_box(hits);
+                });
+            },
+        );
+    }
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
If an agent or LLM was involved in this change, please say so below, and note what it was used for. Autonomously-opened pull requests are not accepted: see our [policy on agents and LLMs](https://github.com/georust/geo/blob/main/CONTRIBUTING.md#agents-llms-and-autonomously-written-code).

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

See https://github.com/georust/geo/pull/1579 for context. This benchmark heavily depends on the change made in 1579.