### PR TITLE
Add Intersects impls for IntervalTreeMultiPolygon

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add `Intersects<Coord>` and `Intersects<Point>` implementations for `IntervalTreeMultiPolygon`. Unlike the existing `Contains` impls, these return `true` for points on the polygon's boundary.
+
 - Add simply connected interior validation for polygons. Polygons with holes that touch at vertices in ways that disconnect the interior (e.g., two holes sharing 2+ vertices, or cycles of holes each sharing a vertex) are now detected as invalid via `Validation::is_valid()`. This aligns with OGC Simple Features and matches PostGIS behavior.
 - BREAKING: adds the `InvalidPolygon::InteriorNotSimplyConnected` error variant.
   - <https://github.com/georust/geo/pull/1472>

--- a/geo/src/algorithm/indexed/interval_tree_multipolygon.rs
+++ b/geo/src/algorithm/indexed/interval_tree_multipolygon.rs
@@ -63,15 +63,16 @@ struct YIntervalSegment<T: GeoNum> {
 /// rejection, and runs a robust winding-number test on the survivors. This avoids the linear scan
 /// over every segment that a naive ray cast would perform.
 ///
-/// Containment queries are exposed via the [`Contains`](crate::Contains) trait for both
-/// [`Coord`] and [`Point`](crate::Point), and follow the same semantics as
-/// `MultiPolygon::contains` (points strictly on the boundary are not contained).
+/// Queries are exposed via the [`Contains`](crate::Contains) and
+/// [`Intersects`](crate::Intersects) traits for both [`Coord`] and [`Point`](crate::Point), and
+/// follow the same semantics as their `MultiPolygon` counterparts: `contains` is true only for
+/// points strictly in the interior, whereas `intersects` is also true for points on the boundary.
 ///
 /// # Example
 ///
 /// ```
 /// use geo::indexed::IntervalTreeMultiPolygon;
-/// use geo::{Contains, MultiPolygon, Point, wkt};
+/// use geo::{Contains, Intersects, MultiPolygon, Point, wkt};
 ///
 /// // A square with a square hole.
 /// let mp: MultiPolygon = wkt!(
@@ -85,6 +86,11 @@ struct YIntervalSegment<T: GeoNum> {
 /// assert!(indexed.contains(&Point::new(0.5, 0.5))); // inside the shell
 /// assert!(!indexed.contains(&Point::new(2.0, 2.0))); // inside the hole
 /// assert!(!indexed.contains(&Point::new(5.0, 5.0))); // outside
+///
+/// // Unlike `contains`, `intersects` includes the boundary.
+/// assert!(indexed.intersects(&Point::new(0.0, 2.0))); // on the shell
+/// assert!(indexed.intersects(&Point::new(1.0, 2.0))); // on the hole's edge
+/// assert!(!indexed.contains(&Point::new(0.0, 2.0)));
 /// ```
 ///
 /// [interval tree]: https://en.wikipedia.org/wiki/Interval_tree

--- a/geo/src/algorithm/intersects/polygon.rs
+++ b/geo/src/algorithm/intersects/polygon.rs
@@ -1,5 +1,6 @@
 use super::{Intersects, has_disjoint_bboxes};
 use crate::coordinate_position::CoordPos;
+use crate::indexed::IntervalTreeMultiPolygon;
 use crate::{BoundingRect, CoordinatePosition, CoordsIter, LinesIter};
 use crate::{
     Coord, CoordNum, GeoNum, Line, LineString, MultiLineString, MultiPoint, MultiPolygon, Point,
@@ -32,6 +33,18 @@ where
 
 symmetric_intersects_impl!(Polygon<T>, Point<T>);
 symmetric_intersects_impl!(Polygon<T>, MultiPoint<T>);
+
+impl<T: GeoNum> Intersects<Coord<T>> for IntervalTreeMultiPolygon<T> {
+    fn intersects(&self, rhs: &Coord<T>) -> bool {
+        self.containment(*rhs) != CoordPos::Outside
+    }
+}
+
+impl<T: GeoNum> Intersects<Point<T>> for IntervalTreeMultiPolygon<T> {
+    fn intersects(&self, rhs: &Point<T>) -> bool {
+        self.containment(rhs.0) != CoordPos::Outside
+    }
+}
 
 impl<T> Intersects<Polygon<T>> for Polygon<T>
 where
@@ -111,5 +124,169 @@ mod tests {
         let a = Geometry::<f64>::from(polygon![]);
         let b = Geometry::from(polygon![]);
         assert!(!a.intersects(&b));
+    }
+
+    mod interval_tree_multipolygon {
+        use crate::indexed::IntervalTreeMultiPolygon;
+        use crate::*;
+
+        /// Assert that the indexed `Intersects`/`Contains` impls agree with the unindexed
+        /// `MultiPolygon` impls and with `Relate`, and that they match the expectation.
+        fn assert_agrees(mp: &MultiPolygon, coord: Coord, intersects: bool, contains: bool) {
+            let indexed = IntervalTreeMultiPolygon::new(mp);
+            let point = Point::from(coord);
+
+            assert_eq!(
+                indexed.intersects(&coord),
+                intersects,
+                "indexed.intersects(coord) at {coord:?}"
+            );
+            assert_eq!(
+                indexed.intersects(&point),
+                intersects,
+                "indexed.intersects(point) at {coord:?}"
+            );
+            assert_eq!(
+                indexed.contains(&coord),
+                contains,
+                "indexed.contains(coord) at {coord:?}"
+            );
+            assert_eq!(
+                indexed.contains(&point),
+                contains,
+                "indexed.contains(point) at {coord:?}"
+            );
+
+            // Sanity check against the unindexed implementations...
+            assert_eq!(
+                mp.intersects(&coord),
+                intersects,
+                "MultiPolygon::intersects at {coord:?}"
+            );
+            assert_eq!(
+                mp.contains(&coord),
+                contains,
+                "MultiPolygon::contains at {coord:?}"
+            );
+
+            // ...and against Relate, which is the reference implementation.
+            let im = mp.relate(&point);
+            assert_eq!(
+                im.is_intersects(),
+                intersects,
+                "Relate intersects {coord:?}"
+            );
+            assert_eq!(im.is_contains(), contains, "Relate contains {coord:?}");
+        }
+
+        #[test]
+        fn interior_point_both_intersects_and_contains() {
+            let mp = wkt!(MULTIPOLYGON(((0. 0.,4. 0.,4. 4.,0. 4.,0. 0.))));
+            assert_agrees(&mp, coord! { x: 2., y: 2. }, true, true);
+        }
+
+        #[test]
+        fn point_on_edge_intersects_but_is_not_contained() {
+            let mp = wkt!(MULTIPOLYGON(((0. 0.,4. 0.,4. 4.,0. 4.,0. 0.))));
+
+            // Midpoint of each of the four edges
+            assert_agrees(&mp, coord! { x: 2., y: 0. }, true, false);
+            assert_agrees(&mp, coord! { x: 4., y: 2. }, true, false);
+            assert_agrees(&mp, coord! { x: 2., y: 4. }, true, false);
+            assert_agrees(&mp, coord! { x: 0., y: 2. }, true, false);
+        }
+
+        #[test]
+        fn point_on_vertex_intersects_but_is_not_contained() {
+            let mp = wkt!(MULTIPOLYGON(((0. 0.,4. 0.,4. 4.,0. 4.,0. 0.))));
+
+            for vertex in [
+                coord! { x: 0., y: 0. },
+                coord! { x: 4., y: 0. },
+                coord! { x: 4., y: 4. },
+                coord! { x: 0., y: 4. },
+            ] {
+                assert_agrees(&mp, vertex, true, false);
+            }
+        }
+
+        #[test]
+        fn exterior_point_neither() {
+            let mp = wkt!(MULTIPOLYGON(((0. 0.,4. 0.,4. 4.,0. 4.,0. 0.))));
+
+            assert_agrees(&mp, coord! { x: 5., y: 2. }, false, false);
+            // Outside, but sharing a y-value with the shell — exercises the interval tree's
+            // x-based early rejection in both directions.
+            assert_agrees(&mp, coord! { x: -1., y: 2. }, false, false);
+            assert_agrees(&mp, coord! { x: 2., y: -1. }, false, false);
+        }
+
+        #[test]
+        fn hole_interior_is_outside_but_hole_boundary_intersects() {
+            // A 4x4 square with a 2x2 hole in the middle.
+            let mp = wkt!(MULTIPOLYGON(
+                ((0. 0.,4. 0.,4. 4.,0. 4.,0. 0.),(1. 1.,1. 3.,3. 3.,3. 1.,1. 1.))
+            ));
+
+            // Strictly inside the hole: not part of the polygon at all.
+            assert_agrees(&mp, coord! { x: 2., y: 2. }, false, false);
+
+            // On the hole's boundary: part of the polygon's boundary, so it intersects
+            // but is not contained.
+            assert_agrees(&mp, coord! { x: 1., y: 2. }, true, false);
+            assert_agrees(&mp, coord! { x: 2., y: 1. }, true, false);
+            assert_agrees(&mp, coord! { x: 1., y: 1. }, true, false);
+
+            // In the solid ring between shell and hole.
+            assert_agrees(&mp, coord! { x: 0.5, y: 2. }, true, true);
+        }
+
+        #[test]
+        fn multiple_polygons() {
+            let mp = wkt!(MULTIPOLYGON(
+                ((0. 0.,2. 0.,2. 2.,0. 2.,0. 0.)),
+                ((5. 0.,7. 0.,7. 2.,5. 2.,5. 0.))
+            ));
+
+            // Interior of each component
+            assert_agrees(&mp, coord! { x: 1., y: 1. }, true, true);
+            assert_agrees(&mp, coord! { x: 6., y: 1. }, true, true);
+
+            // Boundary of each component
+            assert_agrees(&mp, coord! { x: 2., y: 1. }, true, false);
+            assert_agrees(&mp, coord! { x: 5., y: 1. }, true, false);
+
+            // The gap between them
+            assert_agrees(&mp, coord! { x: 3.5, y: 1. }, false, false);
+        }
+
+        #[test]
+        fn agrees_with_relate_over_a_grid() {
+            // A concave "C" shape, so the sample grid hits interiors, boundaries,
+            // vertices, and the concave notch.
+            let mp = wkt!(MULTIPOLYGON(
+                ((0. 0.,3. 0.,3. 1.,1. 1.,1. 2.,3. 2.,3. 3.,0. 3.,0. 0.))
+            ));
+            let indexed = IntervalTreeMultiPolygon::new(&mp);
+
+            // Half-steps land on edges and vertices; quarter-steps land off them.
+            for i in -2..=14 {
+                for j in -2..=14 {
+                    let coord = coord! { x: f64::from(i) / 4., y: f64::from(j) / 4. };
+                    let im = mp.relate(&Point::from(coord));
+
+                    assert_eq!(
+                        indexed.intersects(&coord),
+                        im.is_intersects(),
+                        "intersects disagrees with Relate at {coord:?}"
+                    );
+                    assert_eq!(
+                        indexed.contains(&coord),
+                        im.is_contains(),
+                        "contains disagrees with Relate at {coord:?}"
+                    );
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

Adds `Intersects<Coord>` and `Intersects<Point>` for `IntervalTreeMultiPolygon`

Written with claude opus, but reviewed by me.