### PR TITLE
RelateNG port 2/5: predicate layer and node topology

### DIFF
--- a/geo/src/algorithm/relate/geomgraph/intersection_matrix.rs
+++ b/geo/src/algorithm/relate/geomgraph/intersection_matrix.rs
@@ -241,7 +241,7 @@ pub struct InvalidInputError {
 }
 
 impl InvalidInputError {
-    fn new(message: String) -> Self {
+    pub(crate) fn new(message: String) -> Self {
         Self { message }
     }
 }
@@ -847,6 +847,7 @@ pub(crate) mod dimension_matcher {
     use super::InvalidInputError;
 
     /// A single letter from a DE-9IM matching specification like "1*T**FFF*"
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub(crate) enum DimensionMatcher {
         Anything,
         NonEmpty,

--- a/geo/src/algorithm/relate/geomgraph/node_map.rs
+++ b/geo/src/algorithm/relate/geomgraph/node_map.rs
@@ -34,8 +34,10 @@ where
     }
 }
 
+/// A map key for a node coordinate, ordered by `lex_cmp`. Coordinates must
+/// be non-NaN.
 #[derive(Clone)]
-struct NodeKey<F: GeoFloat>(Coord<F>);
+pub(crate) struct NodeKey<F: GeoFloat>(pub(crate) Coord<F>);
 
 impl<F: GeoFloat> std::cmp::Ord for NodeKey<F> {
     fn cmp(&self, other: &NodeKey<F>) -> std::cmp::Ordering {

--- a/geo/src/algorithm/relate/mod.rs
+++ b/geo/src/algorithm/relate/mod.rs
@@ -14,6 +14,7 @@ use crate::{BoundingRect, GeoFloat, GeometryCow, HasDimensions};
 mod edge_end_builder;
 pub(crate) mod geomgraph;
 mod relate_operation;
+pub(crate) mod relateng;
 
 /// Topologically relate two geometries based on [DE-9IM](https://en.wikipedia.org/wiki/DE-9IM) semantics.
 ///

--- a/geo/src/algorithm/relate/relateng/im_predicate.rs
+++ b/geo/src/algorithm/relate/relateng/im_predicate.rs
@@ -1,0 +1,282 @@
+//! Shared state for predicates determined via [`IntersectionMatrix`]
+//! entries, plus the two predicates that work on the raw matrix: the DE-9IM
+//! pattern matcher and the full-matrix evaluator.
+//!
+//! Port of JTS `IMPredicate`, `IMPatternMatcher` and `RelateMatrixPredicate`.
+
+use crate::coordinate_position::CoordPos;
+use crate::dimensions::Dimensions;
+use crate::relate::IntersectionMatrix;
+use crate::relate::geomgraph::intersection_matrix::InvalidInputError;
+use crate::relate::geomgraph::intersection_matrix::dimension_matcher::DimensionMatcher;
+use crate::{GeoFloat, Rect};
+
+use super::topology_predicate::{
+    InputIndex, PredicateValue, TopologyPredicate, envelopes_intersect,
+};
+
+/// Tests whether a geometry of dimension `dim0` can possibly cover a
+/// geometry of dimension `dim1`. Points can be covered by zero-length lines.
+pub(crate) fn is_dims_compatible_with_covers(dim0: Dimensions, dim1: Dimensions) -> bool {
+    if dim0 == Dimensions::ZeroDimensional && dim1 == Dimensions::OneDimensional {
+        return true;
+    }
+    dim0 >= dim1
+}
+
+/// The state shared by predicates which are determined using entries in an
+/// [`IntersectionMatrix`] (JTS `IMPredicate`).
+///
+/// Matrix entries start `Empty` (JTS `Dimension.FALSE`) with E/E pre-set to
+/// dimension 2, and only ever increase in dimension.
+#[derive(Debug, Clone)]
+pub(crate) struct IMState {
+    pub dim_a: Dimensions,
+    pub dim_b: Dimensions,
+    pub im: IntersectionMatrix,
+    pub value: PredicateValue,
+}
+
+impl IMState {
+    pub fn new() -> Self {
+        Self {
+            dim_a: Dimensions::Empty,
+            dim_b: Dimensions::Empty,
+            im: IntersectionMatrix::empty_disjoint(),
+            value: PredicateValue::default(),
+        }
+    }
+
+    pub fn init_dimensions(&mut self, dim_a: Dimensions, dim_b: Dimensions) {
+        self.dim_a = dim_a;
+        self.dim_b = dim_b;
+    }
+
+    /// The common update flow (JTS `IMPredicate.updateDimension`): only an
+    /// increased dimension value is recorded; when the update lets the
+    /// predicate short-circuit, its value is fixed from `value_im`.
+    pub fn update_dimension(
+        &mut self,
+        loc_a: CoordPos,
+        loc_b: CoordPos,
+        dimension: Dimensions,
+        is_determined: impl FnOnce(&IMState) -> bool,
+        value_im: impl FnOnce(&IMState) -> bool,
+    ) {
+        if dimension > self.im.get(loc_a, loc_b) {
+            self.im.set(loc_a, loc_b, dimension);
+            if is_determined(self) {
+                let val = value_im(self);
+                self.value.set_value(val);
+            }
+        }
+    }
+
+    /// Fixes the final value based on the state of the matrix (JTS
+    /// `IMPredicate.finish`).
+    pub fn finish(&mut self, value_im: impl FnOnce(&IMState) -> bool) {
+        let val = value_im(self);
+        self.value.set_value(val);
+    }
+
+    /// Tests whether the exterior of the specified input geometry is
+    /// intersected by any part of the other input.
+    pub fn intersects_exterior_of(&self, input: InputIndex) -> bool {
+        match input {
+            InputIndex::A => {
+                self.is_intersects(CoordPos::Outside, CoordPos::Inside)
+                    || self.is_intersects(CoordPos::Outside, CoordPos::OnBoundary)
+            }
+            InputIndex::B => {
+                self.is_intersects(CoordPos::Inside, CoordPos::Outside)
+                    || self.is_intersects(CoordPos::OnBoundary, CoordPos::Outside)
+            }
+        }
+    }
+
+    pub fn is_intersects(&self, loc_a: CoordPos, loc_b: CoordPos) -> bool {
+        self.im.get(loc_a, loc_b) >= Dimensions::ZeroDimensional
+    }
+
+    pub fn get_dimension(&self, loc_a: CoordPos, loc_b: CoordPos) -> Dimensions {
+        self.im.get(loc_a, loc_b)
+    }
+}
+
+/// A predicate that matches a DE-9IM pattern (JTS `IMPatternMatcher`).
+///
+/// The pattern is a 9-character string of `0`, `1`, `2`, `F`, `T`, `*`
+/// entries, listed row-wise.
+pub(crate) struct IMPatternMatcher {
+    pattern: String,
+    pattern_entries: [[DimensionMatcher; 3]; 3],
+    pub(crate) state: IMState,
+}
+
+pub(crate) const LOCATION_ORDER: [CoordPos; 3] =
+    [CoordPos::Inside, CoordPos::OnBoundary, CoordPos::Outside];
+
+impl IMPatternMatcher {
+    pub fn new(pattern: &str) -> Result<Self, InvalidInputError> {
+        if pattern.len() != 9 {
+            return Err(InvalidInputError::new(format!(
+                "DE-9IM pattern must be 9 characters, got: {pattern}"
+            )));
+        }
+        let mut pattern_entries = [[DimensionMatcher::Anything; 3]; 3];
+        for (i, ch) in pattern.chars().enumerate() {
+            pattern_entries[i / 3][i % 3] = DimensionMatcher::try_from(ch)?;
+        }
+        Ok(Self {
+            pattern: pattern.to_owned(),
+            pattern_entries,
+            state: IMState::new(),
+        })
+    }
+
+    /// A pattern entry requires interaction when it demands a non-empty
+    /// intersection (`T`, `0`, `1`, or `2`).
+    fn entry_requires_interaction(entry: DimensionMatcher) -> bool {
+        match entry {
+            DimensionMatcher::NonEmpty => true,
+            DimensionMatcher::Exact(dim) => dim != Dimensions::Empty,
+            DimensionMatcher::Anything => false,
+        }
+    }
+
+    fn pattern_requires_interaction(&self) -> bool {
+        // Interaction is required if the pattern specifies any non-empty
+        // entry in the I/B rows and columns.
+        [(0, 0), (0, 1), (1, 0), (1, 1)]
+            .iter()
+            .any(|&(i, j)| Self::entry_requires_interaction(self.pattern_entries[i][j]))
+    }
+
+    fn is_determined(state: &IMState, pattern_entries: &[[DimensionMatcher; 3]; 3]) -> bool {
+        // Matrix entries only increase in dimension as topology is computed.
+        // The predicate can be short-circuited (as false) when a computed
+        // entry exceeds an exact pattern entry. A `T` entry keeps the result
+        // undetermined until its matrix entry is non-empty.
+        for (i, row) in pattern_entries.iter().enumerate() {
+            for (j, pattern_entry) in row.iter().enumerate() {
+                let matrix_dim = state.im.get(LOCATION_ORDER[i], LOCATION_ORDER[j]);
+                match pattern_entry {
+                    DimensionMatcher::Anything => continue,
+                    DimensionMatcher::NonEmpty => {
+                        if matrix_dim == Dimensions::Empty {
+                            return false;
+                        }
+                    }
+                    DimensionMatcher::Exact(dim) => {
+                        if matrix_dim > *dim {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        false
+    }
+
+    fn value_im(state: &IMState, pattern_entries: &[[DimensionMatcher; 3]; 3]) -> bool {
+        pattern_entries.iter().enumerate().all(|(i, row)| {
+            row.iter().enumerate().all(|(j, pattern_entry)| {
+                pattern_entry.matches(state.im.get(LOCATION_ORDER[i], LOCATION_ORDER[j]))
+            })
+        })
+    }
+}
+
+impl<F: GeoFloat> TopologyPredicate<F> for IMPatternMatcher {
+    fn requires_interaction(&self) -> bool {
+        self.pattern_requires_interaction()
+    }
+
+    fn init_dimensions(&mut self, dim_a: Dimensions, dim_b: Dimensions) {
+        self.state.init_dimensions(dim_a, dim_b);
+    }
+
+    fn init_envelopes(&mut self, env_a: Option<Rect<F>>, env_b: Option<Rect<F>>) {
+        // If the pattern requires interaction, the envelopes must not be
+        // disjoint.
+        let is_disjoint = !envelopes_intersect(env_a, env_b);
+        self.state
+            .value
+            .set_value_if(false, self.pattern_requires_interaction() && is_disjoint);
+    }
+
+    fn update_dimension(&mut self, loc_a: CoordPos, loc_b: CoordPos, dimension: Dimensions) {
+        let pattern_entries = self.pattern_entries;
+        self.state.update_dimension(
+            loc_a,
+            loc_b,
+            dimension,
+            |state| Self::is_determined(state, &pattern_entries),
+            |state| Self::value_im(state, &pattern_entries),
+        );
+    }
+
+    fn finish(&mut self) {
+        let pattern_entries = self.pattern_entries;
+        self.state
+            .finish(|state| Self::value_im(state, &pattern_entries));
+    }
+
+    fn result(&self) -> PredicateValue {
+        self.state.value
+    }
+}
+
+impl std::fmt::Debug for IMPatternMatcher {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "IMPattern({})", self.pattern)
+    }
+}
+
+/// Evaluates the full relate [`IntersectionMatrix`]: never short-circuits,
+/// so the whole matrix is computed (JTS `RelateMatrixPredicate`).
+#[derive(Debug)]
+pub(crate) struct RelateMatrixPredicate {
+    pub(crate) state: IMState,
+}
+
+impl RelateMatrixPredicate {
+    pub fn new() -> Self {
+        Self {
+            state: IMState::new(),
+        }
+    }
+
+    /// The current state of the matrix (which may only be partially
+    /// complete until evaluation has finished).
+    pub fn into_im(self) -> IntersectionMatrix {
+        self.state.im
+    }
+}
+
+impl<F: GeoFloat> TopologyPredicate<F> for RelateMatrixPredicate {
+    fn requires_interaction(&self) -> bool {
+        // Ensure the entire matrix is computed.
+        false
+    }
+
+    fn init_dimensions(&mut self, dim_a: Dimensions, dim_b: Dimensions) {
+        self.state.init_dimensions(dim_a, dim_b);
+    }
+
+    fn update_dimension(&mut self, loc_a: CoordPos, loc_b: CoordPos, dimension: Dimensions) {
+        // Never determined early: ensure the entire matrix is computed.
+        self.state
+            .update_dimension(loc_a, loc_b, dimension, |_| false, |_| false);
+    }
+
+    fn finish(&mut self) {
+        // The result value signals that a full matrix was evaluated; only
+        // the matrix itself is meaningful.
+        self.state.finish(|_| false);
+    }
+
+    fn result(&self) -> PredicateValue {
+        self.state.value
+    }
+}

--- a/geo/src/algorithm/relate/relateng/mod.rs
+++ b/geo/src/algorithm/relate/relateng/mod.rs
@@ -22,6 +22,9 @@
 
 pub(crate) mod im_predicate;
 pub(crate) mod node_section;
+pub(crate) mod node_sections;
 pub(crate) mod polygon_node_converter;
+pub(crate) mod relate_edge;
+pub(crate) mod relate_node;
 pub(crate) mod relate_predicate;
 pub(crate) mod topology_predicate;

--- a/geo/src/algorithm/relate/relateng/mod.rs
+++ b/geo/src/algorithm/relate/relateng/mod.rs
@@ -21,5 +21,7 @@
 #![allow(dead_code)]
 
 pub(crate) mod im_predicate;
+pub(crate) mod node_section;
+pub(crate) mod polygon_node_converter;
 pub(crate) mod relate_predicate;
 pub(crate) mod topology_predicate;

--- a/geo/src/algorithm/relate/relateng/mod.rs
+++ b/geo/src/algorithm/relate/relateng/mod.rs
@@ -1,0 +1,25 @@
+//! Next-generation relate engine, a port of JTS's `operation.relateng`
+//! package (Martin Davis, JTS 1.20; ported from master at `ab57bff`).
+//!
+//! RelateNG evaluates DE-9IM topological predicates and intersection
+//! matrices without building a noded topology graph. It locates points and
+//! line ends on the opposing geometry, examines each intersection node from
+//! local segment-pair tests with robust orientation predicates, and never
+//! constructs intersection points into shared topology. This avoids the
+//! robustness failures of the graph-based engine when an intersection point
+//! is not exactly representable (see georust/geo issue #1585), supports
+//! GeometryCollections with union semantics, and allows named predicates to
+//! short-circuit as soon as their value is known.
+//!
+//! The module is crate-private while the port is in progress; see
+//! RELATENG_PLAN.md at the workspace root for the implementation plan and
+//! progress log. The boundary node rule is Mod-2 (the OGC SFS rule),
+//! matching the rest of the crate.
+
+// The module is consumed incrementally as the port proceeds; the allowance
+// is removed when the RelateNG driver lands.
+#![allow(dead_code)]
+
+pub(crate) mod im_predicate;
+pub(crate) mod relate_predicate;
+pub(crate) mod topology_predicate;

--- a/geo/src/algorithm/relate/relateng/node_section.rs
+++ b/geo/src/algorithm/relate/relateng/node_section.rs
@@ -1,0 +1,175 @@
+//! A computed node along with the incident edges on either side of it.
+//!
+//! Port of JTS `NodeSection`.
+
+use std::cmp::Ordering;
+
+use crate::algorithm::polygon_node_topology::compare_angle;
+use crate::dimensions::Dimensions;
+use crate::relate::geomgraph::node_map::NodeKey;
+use crate::{Coord, GeoFloat};
+
+use super::topology_predicate::InputIndex;
+
+/// Represents a computed node along with the incident edges on either side
+/// of it (if they exist). This captures the information about a node in a
+/// geometry component required to determine the component's contribution to
+/// the node topology. A node in an area geometry always has edges on both
+/// sides of the node. A node in a linear geometry may have one or other
+/// incident edge missing, if the node occurs at an endpoint of the line.
+///
+/// The edges of an area node must be provided with CW-shell orientation
+/// (the JTS norm). This must be enforced by the caller.
+///
+/// Where JTS stores a reference to the parent polygonal `Geometry`
+/// (compared by identity), this port stores `polygonal_id`: the index of
+/// the parent polygonal element in the owning `RelateGeometry`, or `None`
+/// when the section is not on a polygon boundary.
+#[derive(Debug, Clone)]
+pub(crate) struct NodeSection<F: GeoFloat> {
+    input: InputIndex,
+    dim: Dimensions,
+    id: i32,
+    ring_id: i32,
+    polygonal_id: Option<usize>,
+    is_node_at_vertex: bool,
+    node_pt: Coord<F>,
+    v0: Option<Coord<F>>,
+    v1: Option<Coord<F>>,
+}
+
+impl<F: GeoFloat> NodeSection<F> {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        input: InputIndex,
+        dim: Dimensions,
+        id: i32,
+        ring_id: i32,
+        polygonal_id: Option<usize>,
+        is_node_at_vertex: bool,
+        v0: Option<Coord<F>>,
+        node_pt: Coord<F>,
+        v1: Option<Coord<F>>,
+    ) -> Self {
+        Self {
+            input,
+            dim,
+            id,
+            ring_id,
+            polygonal_id,
+            is_node_at_vertex,
+            node_pt,
+            v0,
+            v1,
+        }
+    }
+
+    /// The incident vertex: `0` is the entering edge vertex, `1` the
+    /// exiting edge vertex. Either may be absent at a line end.
+    pub fn vertex(&self, i: usize) -> Option<Coord<F>> {
+        if i == 0 { self.v0 } else { self.v1 }
+    }
+
+    pub fn node_pt(&self) -> Coord<F> {
+        self.node_pt
+    }
+
+    pub fn dimension(&self) -> Dimensions {
+        self.dim
+    }
+
+    pub fn id(&self) -> i32 {
+        self.id
+    }
+
+    /// The parent polygonal element this section is part of, or `None` if
+    /// the section is not on a polygon boundary.
+    pub fn polygonal_id(&self) -> Option<usize> {
+        self.polygonal_id
+    }
+
+    pub fn is_shell(&self) -> bool {
+        self.ring_id == 0
+    }
+
+    pub fn is_area(&self) -> bool {
+        self.dim == Dimensions::TwoDimensional
+    }
+
+    pub fn is_area_area(a: &Self, b: &Self) -> bool {
+        a.is_area() && b.is_area()
+    }
+
+    pub fn input(&self) -> InputIndex {
+        self.input
+    }
+
+    pub fn is_same_geometry(&self, other: &Self) -> bool {
+        self.input == other.input
+    }
+
+    pub fn is_same_polygon(&self, other: &Self) -> bool {
+        self.input == other.input && self.id == other.id
+    }
+
+    pub fn is_node_at_vertex(&self) -> bool {
+        self.is_node_at_vertex
+    }
+
+    pub fn is_proper(&self) -> bool {
+        !self.is_node_at_vertex
+    }
+
+    pub fn is_proper_pair(a: &Self, b: &Self) -> bool {
+        a.is_proper() && b.is_proper()
+    }
+
+    /// Compares sections by the angle the entering edge makes with the
+    /// positive X axis (JTS `NodeSection.EdgeAngleComparator`). Both
+    /// sections must be at the same node and have an entering edge.
+    pub fn compare_by_edge_angle(&self, other: &Self) -> Ordering {
+        compare_angle(
+            self.node_pt,
+            self.vertex(0).expect("section must have an entering edge"),
+            other.vertex(0).expect("section must have an entering edge"),
+        )
+    }
+
+    /// Compares node sections by parent geometry, dimension, element id,
+    /// ring id, and edge vertices. Sections are assumed to be at the same
+    /// node point.
+    pub fn compare(&self, other: &Self) -> Ordering {
+        // Sort A before B.
+        self.input
+            .cmp(&other.input)
+            .then_with(|| self.dim.cmp(&other.dim))
+            .then_with(|| self.id.cmp(&other.id))
+            .then_with(|| self.ring_id.cmp(&other.ring_id))
+            .then_with(|| compare_optional_coord(&self.v0, &other.v0))
+            .then_with(|| compare_optional_coord(&self.v1, &other.v1))
+    }
+}
+
+impl<F: GeoFloat> PartialEq for NodeSection<F> {
+    fn eq(&self, other: &Self) -> bool {
+        self.compare(other) == Ordering::Equal
+    }
+}
+
+impl<F: GeoFloat> Eq for NodeSection<F> {}
+
+/// An absent vertex sorts lower than any present one; present vertices
+/// compare lexicographically (as JTS `Coordinate.compareTo`).
+fn compare_optional_coord<F: GeoFloat>(a: &Option<Coord<F>>, b: &Option<Coord<F>>) -> Ordering {
+    a.map(NodeKey).cmp(&b.map(NodeKey))
+}
+
+/// The index after `index` in a cyclic sequence of `len` items.
+pub(super) fn next_index(len: usize, index: usize) -> usize {
+    if index + 1 >= len { 0 } else { index + 1 }
+}
+
+/// The index before `index` in a cyclic sequence of `len` items.
+pub(super) fn prev_index(len: usize, index: usize) -> usize {
+    if index > 0 { index - 1 } else { len - 1 }
+}

--- a/geo/src/algorithm/relate/relateng/node_sections.rs
+++ b/geo/src/algorithm/relate/relateng/node_sections.rs
@@ -1,0 +1,109 @@
+//! Accumulates all the node sections at one node point and builds the
+//! corresponding [`RelateNode`].
+//!
+//! Port of JTS `NodeSections`.
+
+use crate::{Coord, GeoFloat};
+
+use super::node_section::NodeSection;
+use super::polygon_node_converter;
+use super::relate_node::RelateNode;
+use super::topology_predicate::InputIndex;
+
+pub(crate) struct NodeSections<F: GeoFloat> {
+    node_pt: Coord<F>,
+    sections: Vec<NodeSection<F>>,
+}
+
+impl<F: GeoFloat> NodeSections<F> {
+    pub fn new(node_pt: Coord<F>) -> Self {
+        Self {
+            node_pt,
+            sections: Vec::new(),
+        }
+    }
+
+    pub fn coordinate(&self) -> Coord<F> {
+        self.node_pt
+    }
+
+    pub fn add_node_section(&mut self, section: NodeSection<F>) {
+        self.sections.push(section);
+    }
+
+    /// Whether sections of both inputs meet at this node; only such nodes
+    /// contribute topology.
+    pub fn has_interaction_ab(&self) -> bool {
+        let mut is_a = false;
+        let mut is_b = false;
+        for ns in &self.sections {
+            match ns.input() {
+                InputIndex::A => is_a = true,
+                InputIndex::B => is_b = true,
+            }
+            if is_a && is_b {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// The parent polygonal element id of the first section of the given
+    /// input that lies on a polygon boundary, if any.
+    pub fn polygonal_id(&self, input: InputIndex) -> Option<usize> {
+        self.sections
+            .iter()
+            .filter(|ns| ns.input() == input)
+            .find_map(|ns| ns.polygonal_id())
+    }
+
+    /// Builds the node with its edges, converting runs of sections that
+    /// belong to one polygon from the touching-rings model to the
+    /// self-touch model first.
+    pub fn create_node(&mut self) -> RelateNode<F> {
+        // Sort the sections so that lines come before areas and sections
+        // from the same polygon are contiguous.
+        self.sections.sort_by(|a, b| a.compare(b));
+
+        let mut node = RelateNode::new(self.node_pt);
+        let mut i = 0;
+        while i < self.sections.len() {
+            let ns = &self.sections[i];
+            // If there are multiple polygon sections incident at the node,
+            // convert them to maximal-ring structure.
+            if ns.is_area() && self.has_multiple_polygon_sections(i) {
+                let poly_sections = self.collect_polygon_sections(i);
+                let count = poly_sections.len();
+                let converted = polygon_node_converter::convert(poly_sections);
+                node.add_edges_list(&converted);
+                i += count;
+            } else {
+                // The most common case: a line or a single polygon ring
+                // section.
+                node.add_edges(ns);
+                i += 1;
+            }
+        }
+        node
+    }
+
+    fn has_multiple_polygon_sections(&self, i: usize) -> bool {
+        // The last section can only be a single one.
+        if i >= self.sections.len() - 1 {
+            return false;
+        }
+        // Check if there are at least two sections for the same polygon.
+        self.sections[i].is_same_polygon(&self.sections[i + 1])
+    }
+
+    /// The run of sections belonging to the same polygon as the section at
+    /// `i`. Element ids are only unique within one input geometry.
+    fn collect_polygon_sections(&self, i: usize) -> Vec<NodeSection<F>> {
+        let poly_section = &self.sections[i];
+        self.sections[i..]
+            .iter()
+            .take_while(|ns| poly_section.is_same_polygon(ns))
+            .cloned()
+            .collect()
+    }
+}

--- a/geo/src/algorithm/relate/relateng/polygon_node_converter.rs
+++ b/geo/src/algorithm/relate/relateng/polygon_node_converter.rs
@@ -1,0 +1,244 @@
+//! Converts the node sections at a polygon node where a shell and one or
+//! more holes touch, or two or more holes touch.
+//!
+//! Port of JTS `PolygonNodeConverter`.
+//!
+//! This converts the node topological structure from the OGC
+//! "touching-rings" (minimal-ring) model to the equivalent "self-touch"
+//! (maximal-ring) model. In the self-touch model the converted section
+//! corners enclose areas which all lie inside the polygon (they do not
+//! enclose hole edges). This allows `RelateNode` to use simple
+//! area-additive semantics for adding edges and propagating edge locations.
+//!
+//! The input node sections must have canonical orientation (CW shells and
+//! CCW holes), and the arrangement of shells and holes must be
+//! topologically valid: the node sections must not cross or be collinear.
+
+use crate::dimensions::Dimensions;
+use crate::{Coord, GeoFloat};
+
+use super::node_section::{NodeSection, next_index};
+
+/// Converts a list of sections of valid polygon rings to have
+/// "self-touching" structure. There are the same number of output sections
+/// as input ones.
+pub(crate) fn convert<F: GeoFloat>(mut poly_sections: Vec<NodeSection<F>>) -> Vec<NodeSection<F>> {
+    poly_sections.sort_by(|a, b| a.compare_by_edge_angle(b));
+
+    let sections = extract_unique(poly_sections);
+    if sections.len() == 1 {
+        return sections;
+    }
+
+    let Some(shell_index) = find_shell(&sections) else {
+        return convert_holes(&sections);
+    };
+    // At least one shell is present. Handle multiple ones if present.
+    let mut converted = Vec::with_capacity(sections.len());
+    let mut next_shell_index = shell_index;
+    loop {
+        next_shell_index = convert_shell_and_holes(&sections, next_shell_index, &mut converted);
+        if next_shell_index == shell_index {
+            break;
+        }
+    }
+    converted
+}
+
+/// Converts the corners around one shell section, pairing its in-vertex
+/// with the out-vertices of the intervening hole sections. Returns the
+/// index of the next shell section.
+fn convert_shell_and_holes<F: GeoFloat>(
+    sections: &[NodeSection<F>],
+    shell_index: usize,
+    converted: &mut Vec<NodeSection<F>>,
+) -> usize {
+    let shell_section = &sections[shell_index];
+    let mut in_vertex = expect_vertex(shell_section, 0);
+    let mut i = next_index(sections.len(), shell_index);
+    while !sections[i].is_shell() {
+        let hole_section = &sections[i];
+        let out_vertex = expect_vertex(hole_section, 1);
+        converted.push(create_section(shell_section, in_vertex, out_vertex));
+
+        in_vertex = expect_vertex(hole_section, 0);
+        i = next_index(sections.len(), i);
+    }
+    // Create the final section for the corner from the last hole to the
+    // shell.
+    let out_vertex = expect_vertex(shell_section, 1);
+    converted.push(create_section(shell_section, in_vertex, out_vertex));
+    i
+}
+
+fn convert_holes<F: GeoFloat>(sections: &[NodeSection<F>]) -> Vec<NodeSection<F>> {
+    let mut converted = Vec::with_capacity(sections.len());
+    let copy_section = &sections[0];
+    for i in 0..sections.len() {
+        let i_next = next_index(sections.len(), i);
+        let in_vertex = expect_vertex(&sections[i], 0);
+        let out_vertex = expect_vertex(&sections[i_next], 1);
+        converted.push(create_section(copy_section, in_vertex, out_vertex));
+    }
+    converted
+}
+
+/// A converted section: an area shell section with the given corner
+/// vertices, carrying the source section's identity.
+fn create_section<F: GeoFloat>(ns: &NodeSection<F>, v0: Coord<F>, v1: Coord<F>) -> NodeSection<F> {
+    NodeSection::new(
+        ns.input(),
+        Dimensions::TwoDimensional,
+        ns.id(),
+        0,
+        ns.polygonal_id(),
+        ns.is_node_at_vertex(),
+        Some(v0),
+        ns.node_pt(),
+        Some(v1),
+    )
+}
+
+/// Drops consecutive duplicate sections from an angle-sorted list.
+fn extract_unique<F: GeoFloat>(sections: Vec<NodeSection<F>>) -> Vec<NodeSection<F>> {
+    let mut unique_sections: Vec<NodeSection<F>> = Vec::with_capacity(sections.len());
+    for ns in sections {
+        match unique_sections.last() {
+            Some(last_unique) if last_unique == &ns => continue,
+            _ => unique_sections.push(ns),
+        }
+    }
+    unique_sections
+}
+
+fn find_shell<F: GeoFloat>(poly_sections: &[NodeSection<F>]) -> Option<usize> {
+    poly_sections.iter().position(|ns| ns.is_shell())
+}
+
+fn expect_vertex<F: GeoFloat>(ns: &NodeSection<F>, i: usize) -> Coord<F> {
+    ns.vertex(i)
+        .expect("polygon node sections have both incident edges")
+}
+
+#[cfg(test)]
+mod tests {
+    // Tests ported from JTS PolygonNodeConverterTest.java (master, ab57bff).
+    use super::super::topology_predicate::InputIndex;
+    use super::*;
+
+    fn section(
+        ring_id: i32,
+        v0x: f64,
+        v0y: f64,
+        nx: f64,
+        ny: f64,
+        v1x: f64,
+        v1y: f64,
+    ) -> NodeSection<f64> {
+        NodeSection::new(
+            InputIndex::A,
+            Dimensions::TwoDimensional,
+            1,
+            ring_id,
+            None,
+            false,
+            Some(Coord { x: v0x, y: v0y }),
+            Coord { x: nx, y: ny },
+            Some(Coord { x: v1x, y: v1y }),
+        )
+    }
+
+    fn section_shell(v0x: f64, v0y: f64, nx: f64, ny: f64, v1x: f64, v1y: f64) -> NodeSection<f64> {
+        section(0, v0x, v0y, nx, ny, v1x, v1y)
+    }
+
+    fn section_hole(v0x: f64, v0y: f64, nx: f64, ny: f64, v1x: f64, v1y: f64) -> NodeSection<f64> {
+        section(1, v0x, v0y, nx, ny, v1x, v1y)
+    }
+
+    fn check_conversion(input: Vec<NodeSection<f64>>, expected: Vec<NodeSection<f64>>) {
+        let mut actual = convert(input);
+        let mut expected = expected;
+        actual.sort_by(|a, b| a.compare_by_edge_angle(b));
+        expected.sort_by(|a, b| a.compare_by_edge_angle(b));
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_shells() {
+        check_conversion(
+            vec![
+                section_shell(1., 1., 5., 5., 9., 9.),
+                section_shell(8., 9., 5., 5., 6., 9.),
+                section_shell(4., 9., 5., 5., 2., 9.),
+            ],
+            vec![
+                section_shell(1., 1., 5., 5., 9., 9.),
+                section_shell(8., 9., 5., 5., 6., 9.),
+                section_shell(4., 9., 5., 5., 2., 9.),
+            ],
+        );
+    }
+
+    #[test]
+    fn test_shell_and_hole() {
+        check_conversion(
+            vec![
+                section_shell(1., 1., 5., 5., 9., 9.),
+                section_hole(6., 0., 5., 5., 4., 0.),
+            ],
+            vec![
+                section_shell(1., 1., 5., 5., 4., 0.),
+                section_shell(6., 0., 5., 5., 9., 9.),
+            ],
+        );
+    }
+
+    #[test]
+    fn test_shells_and_holes() {
+        check_conversion(
+            vec![
+                section_shell(1., 1., 5., 5., 9., 9.),
+                section_hole(6., 0., 5., 5., 4., 0.),
+                section_shell(8., 8., 5., 5., 1., 8.),
+                section_hole(4., 8., 5., 5., 6., 8.),
+            ],
+            vec![
+                section_shell(1., 1., 5., 5., 4., 0.),
+                section_shell(6., 0., 5., 5., 9., 9.),
+                section_shell(4., 8., 5., 5., 1., 8.),
+                section_shell(8., 8., 5., 5., 6., 8.),
+            ],
+        );
+    }
+
+    #[test]
+    fn test_shell_and_2_holes() {
+        check_conversion(
+            vec![
+                section_shell(1., 1., 5., 5., 9., 9.),
+                section_hole(7., 0., 5., 5., 6., 0.),
+                section_hole(4., 0., 5., 5., 3., 0.),
+            ],
+            vec![
+                section_shell(1., 1., 5., 5., 3., 0.),
+                section_shell(4., 0., 5., 5., 6., 0.),
+                section_shell(7., 0., 5., 5., 9., 9.),
+            ],
+        );
+    }
+
+    #[test]
+    fn test_holes() {
+        check_conversion(
+            vec![
+                section_hole(7., 0., 5., 5., 6., 0.),
+                section_hole(4., 0., 5., 5., 3., 0.),
+            ],
+            vec![
+                section_shell(4., 0., 5., 5., 6., 0.),
+                section_shell(7., 0., 5., 5., 3., 0.),
+            ],
+        );
+    }
+}

--- a/geo/src/algorithm/relate/relateng/relate_edge.rs
+++ b/geo/src/algorithm/relate/relateng/relate_edge.rs
@@ -1,0 +1,233 @@
+//! A direction-edge at a relate node, carrying the topological locations
+//! (Left/Right/On) of each input geometry for the edge.
+//!
+//! Port of JTS `RelateEdge`. Where JTS holds a back-pointer to the owning
+//! `RelateNode`, this port stores the node coordinate directly. The
+//! per-input field pairs (`aLocLeft`/`bLocLeft`, ...) collapse into one
+//! [`EdgeLabel`] per input, and the JTS `LOC_UNKNOWN`/`DIM_UNKNOWN`
+//! sentinels become `Option`.
+
+use std::cmp::Ordering;
+
+use crate::algorithm::polygon_node_topology::compare_angle;
+use crate::coordinate_position::CoordPos;
+use crate::dimensions::Dimensions;
+use crate::relate::geomgraph::Direction;
+use crate::{Coord, GeoFloat};
+
+use super::topology_predicate::InputIndex;
+
+pub(crate) const IS_FORWARD: bool = true;
+pub(crate) const IS_REVERSE: bool = false;
+
+/// The topological locations of one input geometry for an edge: the left
+/// and right sides and the edge line itself. `None` is "not yet known".
+#[derive(Debug, Clone, Copy, Default)]
+struct EdgeLabel {
+    dim: Option<Dimensions>,
+    left: Option<CoordPos>,
+    right: Option<CoordPos>,
+    on: Option<CoordPos>,
+}
+
+impl EdgeLabel {
+    fn get(&self, direction: Direction) -> Option<CoordPos> {
+        match direction {
+            Direction::Left => self.left,
+            Direction::Right => self.right,
+            Direction::On => self.on,
+        }
+    }
+
+    fn set(&mut self, direction: Direction, loc: CoordPos) {
+        match direction {
+            Direction::Left => self.left = Some(loc),
+            Direction::Right => self.right = Some(loc),
+            Direction::On => self.on = Some(loc),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RelateEdge<F: GeoFloat> {
+    node_pt: Coord<F>,
+    dir_pt: Coord<F>,
+    a: EdgeLabel,
+    b: EdgeLabel,
+}
+
+impl<F: GeoFloat> RelateEdge<F> {
+    /// Creates an area edge (for dimension 2) or a line edge (otherwise).
+    pub fn create(
+        node_pt: Coord<F>,
+        dir_pt: Coord<F>,
+        input: InputIndex,
+        dim: Dimensions,
+        is_forward: bool,
+    ) -> Self {
+        if dim == Dimensions::TwoDimensional {
+            Self::new_area(node_pt, dir_pt, input, is_forward)
+        } else {
+            Self::new_line(node_pt, dir_pt, input)
+        }
+    }
+
+    /// An area edge: the input's interior lies on the left of a reverse
+    /// (entering) edge and on the right of a forward (exiting) edge, with
+    /// the edge itself on the boundary. Assumes CW shell orientation.
+    pub fn new_area(
+        node_pt: Coord<F>,
+        dir_pt: Coord<F>,
+        input: InputIndex,
+        is_forward: bool,
+    ) -> Self {
+        let mut edge = Self::new_blank(node_pt, dir_pt);
+        let (left, right) = if is_forward {
+            (CoordPos::Outside, CoordPos::Inside)
+        } else {
+            (CoordPos::Inside, CoordPos::Outside)
+        };
+        *edge.label_mut(input) = EdgeLabel {
+            dim: Some(Dimensions::TwoDimensional),
+            left: Some(left),
+            right: Some(right),
+            on: Some(CoordPos::OnBoundary),
+        };
+        edge
+    }
+
+    /// A line edge: both sides are exterior and the edge line is interior.
+    pub fn new_line(node_pt: Coord<F>, dir_pt: Coord<F>, input: InputIndex) -> Self {
+        let mut edge = Self::new_blank(node_pt, dir_pt);
+        *edge.label_mut(input) = EdgeLabel {
+            dim: Some(Dimensions::OneDimensional),
+            left: Some(CoordPos::Outside),
+            right: Some(CoordPos::Outside),
+            on: Some(CoordPos::Inside),
+        };
+        edge
+    }
+
+    fn new_blank(node_pt: Coord<F>, dir_pt: Coord<F>) -> Self {
+        Self {
+            node_pt,
+            dir_pt,
+            a: EdgeLabel::default(),
+            b: EdgeLabel::default(),
+        }
+    }
+
+    fn label(&self, input: InputIndex) -> &EdgeLabel {
+        match input {
+            InputIndex::A => &self.a,
+            InputIndex::B => &self.b,
+        }
+    }
+
+    fn label_mut(&mut self, input: InputIndex) -> &mut EdgeLabel {
+        match input {
+            InputIndex::A => &mut self.a,
+            InputIndex::B => &mut self.b,
+        }
+    }
+
+    /// Compares this edge's direction point angle at the node against
+    /// another direction point.
+    pub fn compare_to_edge(&self, edge_dir_pt: Coord<F>) -> Ordering {
+        compare_angle(self.node_pt, self.dir_pt, edge_dir_pt)
+    }
+
+    /// Merges a coincident edge contribution for one input into this edge.
+    pub fn merge(&mut self, input: InputIndex, dim: Dimensions, is_forward: bool) {
+        let (loc_edge, loc_left, loc_right) = if dim == Dimensions::TwoDimensional {
+            let (left, right) = if is_forward {
+                (CoordPos::Outside, CoordPos::Inside)
+            } else {
+                (CoordPos::Inside, CoordPos::Outside)
+            };
+            (CoordPos::OnBoundary, left, right)
+        } else {
+            (CoordPos::Inside, CoordPos::Outside, CoordPos::Outside)
+        };
+
+        if !self.is_known(input) {
+            let label = self.label_mut(input);
+            label.dim = Some(if loc_edge == CoordPos::OnBoundary {
+                Dimensions::TwoDimensional
+            } else {
+                Dimensions::OneDimensional
+            });
+            label.on = Some(loc_edge);
+            label.left = Some(loc_left);
+            label.right = Some(loc_right);
+            return;
+        }
+
+        self.merge_dim_edge_loc(input, loc_edge);
+        self.merge_side_location(input, Direction::Left, loc_left);
+        self.merge_side_location(input, Direction::Right, loc_right);
+    }
+
+    /// Area edges override line edges. Merging edges of the same dimension
+    /// is a no-op for the dimension and On location, but merging an area
+    /// edge into a line edge sets the dimension to 2 and the On location to
+    /// boundary.
+    fn merge_dim_edge_loc(&mut self, input: InputIndex, loc_edge: CoordPos) {
+        let dim = if loc_edge == CoordPos::OnBoundary {
+            Dimensions::TwoDimensional
+        } else {
+            Dimensions::OneDimensional
+        };
+        if dim == Dimensions::TwoDimensional
+            && self.label(input).dim == Some(Dimensions::OneDimensional)
+        {
+            let label = self.label_mut(input);
+            label.dim = Some(dim);
+            label.on = Some(CoordPos::OnBoundary);
+        }
+    }
+
+    /// Interior takes precedence over exterior on a side.
+    fn merge_side_location(&mut self, input: InputIndex, direction: Direction, loc: CoordPos) {
+        if self.label(input).get(direction) != Some(CoordPos::Inside) {
+            self.label_mut(input).set(direction, loc);
+        }
+    }
+
+    pub fn set_unknown_locations(&mut self, input: InputIndex, loc: CoordPos) {
+        let label = self.label_mut(input);
+        if label.left.is_none() {
+            label.left = Some(loc);
+        }
+        if label.right.is_none() {
+            label.right = Some(loc);
+        }
+        if label.on.is_none() {
+            label.on = Some(loc);
+        }
+    }
+
+    /// Marks the edge as lying in the interior of the input's area.
+    pub fn set_area_interior(&mut self, input: InputIndex) {
+        let label = self.label_mut(input);
+        label.left = Some(CoordPos::Inside);
+        label.right = Some(CoordPos::Inside);
+        label.on = Some(CoordPos::Inside);
+    }
+
+    /// The location of the input at the given edge position, or `None` when
+    /// it has not been determined yet.
+    pub fn location(&self, input: InputIndex, direction: Direction) -> Option<CoordPos> {
+        self.label(input).get(direction)
+    }
+
+    pub fn is_interior(&self, input: InputIndex, direction: Direction) -> bool {
+        self.location(input, direction) == Some(CoordPos::Inside)
+    }
+
+    /// Whether the input's contribution to this edge is known (its
+    /// dimension has been set).
+    pub fn is_known(&self, input: InputIndex) -> bool {
+        self.label(input).dim.is_some()
+    }
+}

--- a/geo/src/algorithm/relate/relateng/relate_node.rs
+++ b/geo/src/algorithm/relate/relateng/relate_node.rs
@@ -1,0 +1,202 @@
+//! A node in the topology graph of a relate evaluation, with its incident
+//! edges kept sorted counter-clockwise by angle.
+//!
+//! Port of JTS `RelateNode`.
+
+use std::cmp::Ordering;
+
+use crate::coordinate_position::CoordPos;
+use crate::dimensions::Dimensions;
+use crate::relate::geomgraph::Direction;
+use crate::{Coord, GeoFloat};
+
+use super::node_section::{NodeSection, next_index, prev_index};
+use super::relate_edge::{IS_FORWARD, IS_REVERSE, RelateEdge};
+use super::topology_predicate::InputIndex;
+
+pub(crate) struct RelateNode<F: GeoFloat> {
+    node_pt: Coord<F>,
+    /// The edges around the node in CCW order, ordered by their CCW angle
+    /// with the positive X-axis.
+    edges: Vec<RelateEdge<F>>,
+}
+
+impl<F: GeoFloat> RelateNode<F> {
+    pub fn new(node_pt: Coord<F>) -> Self {
+        Self {
+            node_pt,
+            edges: Vec::new(),
+        }
+    }
+
+    pub fn edges(&self) -> &[RelateEdge<F>] {
+        &self.edges
+    }
+
+    pub fn add_edges_list(&mut self, sections: &[NodeSection<F>]) {
+        for ns in sections {
+            self.add_edges(ns);
+        }
+    }
+
+    pub fn add_edges(&mut self, ns: &NodeSection<F>) {
+        match ns.dimension() {
+            Dimensions::OneDimensional => {
+                self.add_line_edge(ns.input(), ns.vertex(0));
+                self.add_line_edge(ns.input(), ns.vertex(1));
+            }
+            Dimensions::TwoDimensional => {
+                // Assumes node edges have CW orientation (the JTS norm):
+                // the entering edge has the interior on its left, the
+                // exiting edge on its right.
+                let index0 = self.add_area_edge(ns.input(), ns.vertex(0), IS_REVERSE);
+                let index1 = self.add_area_edge(ns.input(), ns.vertex(1), IS_FORWARD);
+
+                // A well-formed area section has both edges; a degenerate
+                // one (zero-length or absent edge) contributes nothing to
+                // update.
+                if let (Some(index0), Some(index1)) = (index0, index1) {
+                    self.update_edges_in_area(ns.input(), index0, index1);
+                    self.update_if_area_prev(ns.input(), index0);
+                    self.update_if_area_next(ns.input(), index1);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Marks every edge strictly between the entering and exiting edge of
+    /// an area section as lying in the area interior.
+    fn update_edges_in_area(&mut self, input: InputIndex, index_from: usize, index_to: usize) {
+        let mut index = next_index(self.edges.len(), index_from);
+        while index != index_to {
+            self.edges[index].set_area_interior(input);
+            index = next_index(self.edges.len(), index);
+        }
+    }
+
+    fn update_if_area_prev(&mut self, input: InputIndex, index: usize) {
+        let index_prev = prev_index(self.edges.len(), index);
+        if self.edges[index_prev].is_interior(input, Direction::Left) {
+            self.edges[index].set_area_interior(input);
+        }
+    }
+
+    fn update_if_area_next(&mut self, input: InputIndex, index: usize) {
+        let index_next = next_index(self.edges.len(), index);
+        if self.edges[index_next].is_interior(input, Direction::Right) {
+            self.edges[index].set_area_interior(input);
+        }
+    }
+
+    fn add_line_edge(&mut self, input: InputIndex, dir_pt: Option<Coord<F>>) -> Option<usize> {
+        self.add_edge(input, dir_pt, Dimensions::OneDimensional, IS_REVERSE)
+    }
+
+    fn add_area_edge(
+        &mut self,
+        input: InputIndex,
+        dir_pt: Option<Coord<F>>,
+        is_forward: bool,
+    ) -> Option<usize> {
+        self.add_edge(input, dir_pt, Dimensions::TwoDimensional, is_forward)
+    }
+
+    /// Adds or merges an edge to the node, keeping the edge list sorted by
+    /// angle. Returns the index of the created or merged edge, or `None`
+    /// for a missing or zero-length direction point.
+    fn add_edge(
+        &mut self,
+        input: InputIndex,
+        dir_pt: Option<Coord<F>>,
+        dim: Dimensions,
+        is_forward: bool,
+    ) -> Option<usize> {
+        let dir_pt = dir_pt?;
+        if self.node_pt == dir_pt {
+            return None;
+        }
+
+        for i in 0..self.edges.len() {
+            match self.edges[i].compare_to_edge(dir_pt) {
+                Ordering::Equal => {
+                    self.edges[i].merge(input, dim, is_forward);
+                    return Some(i);
+                }
+                Ordering::Greater => {
+                    // Found a further edge, so insert the new edge before
+                    // it.
+                    self.edges.insert(
+                        i,
+                        RelateEdge::create(self.node_pt, dir_pt, input, dim, is_forward),
+                    );
+                    return Some(i);
+                }
+                Ordering::Less => {}
+            }
+        }
+        self.edges.push(RelateEdge::create(
+            self.node_pt,
+            dir_pt,
+            input,
+            dim,
+            is_forward,
+        ));
+        Some(self.edges.len() - 1)
+    }
+
+    /// Computes the final topology for the edges around this node.
+    ///
+    /// Although nodes lie on the boundary of areas or the interior of
+    /// lines, in a mixed GeometryCollection they may also lie in the
+    /// interior of an area; this floods the locations of the sides and
+    /// line to interior.
+    pub fn finish(&mut self, is_area_interior_a: bool, is_area_interior_b: bool) {
+        self.finish_node(InputIndex::A, is_area_interior_a);
+        self.finish_node(InputIndex::B, is_area_interior_b);
+    }
+
+    fn finish_node(&mut self, input: InputIndex, is_area_interior: bool) {
+        if is_area_interior {
+            for edge in &mut self.edges {
+                edge.set_area_interior(input);
+            }
+        } else {
+            let start_index = self
+                .edges
+                .iter()
+                .position(|e| e.is_known(input))
+                // Only interacting nodes are finished, so an edge of each
+                // input is present.
+                .expect("finished node has an edge of each input");
+            self.propagate_side_locations(input, start_index);
+        }
+    }
+
+    /// Propagates the known side locations CCW around the node into edges
+    /// whose locations for the input are still unknown.
+    fn propagate_side_locations(&mut self, input: InputIndex, start_index: usize) {
+        let mut curr_loc = self.edges[start_index]
+            .location(input, Direction::Left)
+            .expect("known edge has side locations");
+        // Edges are stored in CCW order.
+        let mut index = next_index(self.edges.len(), start_index);
+        while index != start_index {
+            let edge = &mut self.edges[index];
+            edge.set_unknown_locations(input, curr_loc);
+            curr_loc = edge
+                .location(input, Direction::Left)
+                .expect("locations were just set");
+            index = next_index(self.edges.len(), index);
+        }
+    }
+
+    /// Whether any edge has the input's exterior on either side. Supports
+    /// `AdjacentEdgeLocator`.
+    pub fn has_exterior_edge(&self, input: InputIndex) -> bool {
+        self.edges.iter().any(|e| {
+            e.location(input, Direction::Left) == Some(CoordPos::Outside)
+                || e.location(input, Direction::Right) == Some(CoordPos::Outside)
+        })
+    }
+}

--- a/geo/src/algorithm/relate/relateng/relate_predicate.rs
+++ b/geo/src/algorithm/relate/relateng/relate_predicate.rs
@@ -1,0 +1,521 @@
+//! Predicates for the OGC-standard named topological relationships.
+//!
+//! Port of JTS `RelatePredicate` and `IntersectionMatrixPattern`. The eight
+//! matrix-determined predicates share one struct over a kind enum; the
+//! behaviour differences between them (JTS's anonymous subclass overrides)
+//! are the match arms below. `intersects` and `disjoint` need no matrix and
+//! have their own types.
+
+use crate::coordinate_position::CoordPos;
+use crate::dimensions::Dimensions;
+#[cfg(test)]
+use crate::relate::geomgraph::intersection_matrix::InvalidInputError;
+use crate::{GeoFloat, Rect};
+
+use super::im_predicate::{IMPatternMatcher, IMState, is_dims_compatible_with_covers};
+use super::topology_predicate::{
+    InputIndex, PredicateValue, TopologyPredicate, envelope_covers, envelopes_equal,
+    envelopes_intersect, is_intersection,
+};
+
+/// DE-9IM matrix patterns for topological relationships that have no OGC
+/// name (JTS `IntersectionMatrixPattern`).
+pub(crate) mod intersection_matrix_pattern {
+    /// Two polygonal geometries are adjacent along an edge, but do not
+    /// overlap.
+    #[cfg(test)]
+    pub const ADJACENT: &str = "F***1****";
+    /// A geometry properly contains another geometry (which lies entirely
+    /// in its interior).
+    pub const CONTAINS_PROPERLY: &str = "T**FF*FF*";
+}
+
+/// Creates a predicate to determine whether two geometries intersect: they
+/// have at least one point in common.
+#[allow(dead_code)] // Not yet routed through a public predicate trait.
+pub(crate) fn intersects() -> IntersectsPredicate {
+    IntersectsPredicate::default()
+}
+
+/// Creates a predicate to determine whether two geometries are disjoint:
+/// they have no point in common.
+#[allow(dead_code)] // Not yet routed through a public predicate trait.
+pub(crate) fn disjoint() -> DisjointPredicate {
+    DisjointPredicate::default()
+}
+
+/// Creates a predicate to determine whether geometry A contains geometry B.
+/// Matches `[T*****FF*]`.
+pub(crate) fn contains() -> NamedPredicate {
+    NamedPredicate::new(PredicateKind::Contains)
+}
+
+/// Creates a predicate to determine whether geometry A is within geometry B.
+/// Matches `[T*F**F***]`.
+#[allow(dead_code)] // Not yet routed through a public predicate trait.
+pub(crate) fn within() -> NamedPredicate {
+    NamedPredicate::new(PredicateKind::Within)
+}
+
+/// Creates a predicate to determine whether geometry A covers geometry B.
+pub(crate) fn covers() -> NamedPredicate {
+    NamedPredicate::new(PredicateKind::Covers)
+}
+
+/// Creates a predicate to determine whether geometry A is covered by
+/// geometry B.
+#[allow(dead_code)] // Not yet routed through a public predicate trait.
+pub(crate) fn covered_by() -> NamedPredicate {
+    NamedPredicate::new(PredicateKind::CoveredBy)
+}
+
+/// Creates a predicate to determine whether two geometries cross.
+#[allow(dead_code)] // Not yet routed through a public predicate trait.
+pub(crate) fn crosses() -> NamedPredicate {
+    NamedPredicate::new(PredicateKind::Crosses)
+}
+
+/// Creates a predicate to determine whether two geometries are
+/// topologically equal. Matches `[T*F**FFF*]`; all empty geometries are
+/// topologically equal, regardless of dimension.
+#[allow(dead_code)] // Not yet routed through a public predicate trait.
+pub(crate) fn equals_topo() -> NamedPredicate {
+    NamedPredicate::new(PredicateKind::EqualsTopo)
+}
+
+/// Creates a predicate to determine whether two geometries overlap.
+#[allow(dead_code)] // Not yet routed through a public predicate trait.
+pub(crate) fn overlaps() -> NamedPredicate {
+    NamedPredicate::new(PredicateKind::Overlaps)
+}
+
+/// Creates a predicate to determine whether two geometries touch.
+#[allow(dead_code)] // Not yet routed through a public predicate trait.
+pub(crate) fn touches() -> NamedPredicate {
+    NamedPredicate::new(PredicateKind::Touches)
+}
+
+/// Creates a predicate to determine whether geometry A properly contains
+/// geometry B: B lies entirely in the interior of A. Matches
+/// [`intersection_matrix_pattern::CONTAINS_PROPERLY`].
+pub(crate) fn contains_properly() -> IMPatternMatcher {
+    IMPatternMatcher::new(intersection_matrix_pattern::CONTAINS_PROPERLY).expect("valid pattern")
+}
+
+/// Creates a predicate that matches a DE-9IM matrix pattern.
+///
+/// See [`intersection_matrix_pattern`] for patterns for some common
+/// unnamed relationships.
+#[cfg(test)]
+pub(crate) fn matches(im_pattern: &str) -> Result<IMPatternMatcher, InvalidInputError> {
+    IMPatternMatcher::new(im_pattern)
+}
+
+/// A predicate to determine whether two geometries intersect (JTS
+/// `RelatePredicate.intersects()`). Needs no matrix: any non-exterior
+/// interaction settles it.
+#[derive(Debug, Default)]
+pub(crate) struct IntersectsPredicate {
+    value: PredicateValue,
+}
+
+impl<F: GeoFloat> TopologyPredicate<F> for IntersectsPredicate {
+    fn requires_self_noding(&self) -> bool {
+        // Self-noding is not required to check for a simple interaction.
+        false
+    }
+
+    fn requires_exterior_check(&self, _source: InputIndex) -> bool {
+        // Intersects only requires testing interaction.
+        false
+    }
+
+    fn init_envelopes(&mut self, env_a: Option<Rect<F>>, env_b: Option<Rect<F>>) {
+        self.value.require(envelopes_intersect(env_a, env_b));
+    }
+
+    fn update_dimension(&mut self, loc_a: CoordPos, loc_b: CoordPos, _dimension: Dimensions) {
+        self.value.set_value_if(true, is_intersection(loc_a, loc_b));
+    }
+
+    fn finish(&mut self) {
+        // No intersecting locations were found.
+        self.value.set_value(false);
+    }
+
+    fn result(&self) -> PredicateValue {
+        self.value
+    }
+}
+
+/// A predicate to determine whether two geometries are disjoint (JTS
+/// `RelatePredicate.disjoint()`).
+#[derive(Debug, Default)]
+pub(crate) struct DisjointPredicate {
+    value: PredicateValue,
+}
+
+impl<F: GeoFloat> TopologyPredicate<F> for DisjointPredicate {
+    fn requires_self_noding(&self) -> bool {
+        // Self-noding is not required to check for a simple interaction.
+        false
+    }
+
+    fn requires_interaction(&self) -> bool {
+        false
+    }
+
+    fn requires_exterior_check(&self, _source: InputIndex) -> bool {
+        // Disjoint only requires testing interaction.
+        false
+    }
+
+    fn init_envelopes(&mut self, env_a: Option<Rect<F>>, env_b: Option<Rect<F>>) {
+        self.value
+            .set_value_if(true, !envelopes_intersect(env_a, env_b));
+    }
+
+    fn update_dimension(&mut self, loc_a: CoordPos, loc_b: CoordPos, _dimension: Dimensions) {
+        self.value
+            .set_value_if(false, is_intersection(loc_a, loc_b));
+    }
+
+    fn finish(&mut self) {
+        // No intersecting locations were found.
+        self.value.set_value(true);
+    }
+
+    fn result(&self) -> PredicateValue {
+        self.value
+    }
+}
+
+/// The OGC-standard named predicates that are determined via intersection
+/// matrix entries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PredicateKind {
+    Contains,
+    Within,
+    Covers,
+    CoveredBy,
+    Crosses,
+    EqualsTopo,
+    Overlaps,
+    Touches,
+}
+
+/// A matrix-determined named predicate. The per-kind behaviour mirrors the
+/// anonymous `IMPredicate` subclasses in JTS `RelatePredicate`.
+#[derive(Debug)]
+pub(crate) struct NamedPredicate {
+    kind: PredicateKind,
+    pub(crate) state: IMState,
+}
+
+impl NamedPredicate {
+    pub fn new(kind: PredicateKind) -> Self {
+        Self {
+            kind,
+            state: IMState::new(),
+        }
+    }
+
+    /// Tests whether predicate evaluation can be short-circuited due to the
+    /// current state of the matrix providing enough information to determine
+    /// the predicate value. If true, `value_im` provides the correct result.
+    fn is_determined(kind: PredicateKind, state: &IMState) -> bool {
+        use CoordPos::{Inside, OnBoundary, Outside};
+        match kind {
+            PredicateKind::Contains | PredicateKind::Covers => {
+                state.intersects_exterior_of(InputIndex::A)
+            }
+            PredicateKind::Within | PredicateKind::CoveredBy => {
+                state.intersects_exterior_of(InputIndex::B)
+            }
+            PredicateKind::Crosses => {
+                if state.dim_a == Dimensions::OneDimensional
+                    && state.dim_b == Dimensions::OneDimensional
+                {
+                    // An L/L interior interaction can only have dimension 0.
+                    state.get_dimension(Inside, Inside) > Dimensions::ZeroDimensional
+                } else if state.dim_a < state.dim_b {
+                    state.is_intersects(Inside, Inside) && state.is_intersects(Inside, Outside)
+                } else if state.dim_a > state.dim_b {
+                    state.is_intersects(Inside, Inside) && state.is_intersects(Outside, Inside)
+                } else {
+                    false
+                }
+            }
+            PredicateKind::EqualsTopo => {
+                // Determined (false) as soon as either exterior is
+                // intersected.
+                state.is_intersects(Inside, Outside)
+                    || state.is_intersects(OnBoundary, Outside)
+                    || state.is_intersects(Outside, Inside)
+                    || state.is_intersects(Outside, OnBoundary)
+            }
+            PredicateKind::Overlaps => {
+                if state.dim_a == Dimensions::TwoDimensional
+                    || state.dim_a == Dimensions::ZeroDimensional
+                {
+                    state.is_intersects(Inside, Inside)
+                        && state.is_intersects(Inside, Outside)
+                        && state.is_intersects(Outside, Inside)
+                } else if state.dim_a == Dimensions::OneDimensional {
+                    state.get_dimension(Inside, Inside) == Dimensions::OneDimensional
+                        && state.is_intersects(Inside, Outside)
+                        && state.is_intersects(Outside, Inside)
+                } else {
+                    false
+                }
+            }
+            PredicateKind::Touches => {
+                // For touches, the interiors cannot intersect.
+                state.is_intersects(Inside, Inside)
+            }
+        }
+    }
+
+    /// The value of the predicate according to the current matrix state.
+    ///
+    /// `crosses`, `equals` and `overlaps` use the dimension-guarded JTS
+    /// `IntersectionMatrix` forms, evaluated from the stored input
+    /// dimensions; the rest delegate to the pattern-only geo matrix
+    /// predicates, which match the JTS definitions exactly.
+    fn value_im(kind: PredicateKind, state: &IMState) -> bool {
+        use CoordPos::{Inside, OnBoundary, Outside};
+        use Dimensions::Empty;
+        match kind {
+            PredicateKind::Contains => state.im.is_contains(),
+            PredicateKind::Within => state.im.is_within(),
+            PredicateKind::Covers => state.im.is_covers(),
+            PredicateKind::CoveredBy => state.im.is_coveredby(),
+            PredicateKind::Crosses => match state.dim_a.cmp(&state.dim_b) {
+                // [T*T******]
+                std::cmp::Ordering::Less => {
+                    state.get_dimension(Inside, Inside) != Empty
+                        && state.get_dimension(Inside, Outside) != Empty
+                }
+                // [T*****T**]
+                std::cmp::Ordering::Greater => {
+                    state.get_dimension(Inside, Inside) != Empty
+                        && state.get_dimension(Outside, Inside) != Empty
+                }
+                // [0********] for the L/L case; equal-dimension P/P and A/A
+                // never cross.
+                std::cmp::Ordering::Equal => {
+                    state.dim_a == Dimensions::OneDimensional
+                        && state.get_dimension(Inside, Inside) == Dimensions::ZeroDimensional
+                }
+            },
+            // JTS `IntersectionMatrix.isEquals(dimA, dimB)`: equal
+            // dimensions and no exterior intersection either way. The
+            // empty-equals-empty case is settled at envelope init and never
+            // reaches here. geo's `is_equal_topo` is not used because its
+            // empty-matrix special case would misread the pre-seeded
+            // predicate matrix.
+            PredicateKind::EqualsTopo => {
+                state.dim_a == state.dim_b
+                    && state.get_dimension(Inside, Inside) != Empty
+                    && state.get_dimension(Inside, Outside) == Empty
+                    && state.get_dimension(OnBoundary, Outside) == Empty
+                    && state.get_dimension(Outside, Inside) == Empty
+                    && state.get_dimension(Outside, OnBoundary) == Empty
+            }
+            // JTS `IntersectionMatrix.isOverlaps(dimA, dimB)`.
+            PredicateKind::Overlaps => match (state.dim_a, state.dim_b) {
+                // [T*T***T**]
+                (Dimensions::ZeroDimensional, Dimensions::ZeroDimensional)
+                | (Dimensions::TwoDimensional, Dimensions::TwoDimensional) => {
+                    state.get_dimension(Inside, Inside) != Empty
+                        && state.get_dimension(Inside, Outside) != Empty
+                        && state.get_dimension(Outside, Inside) != Empty
+                }
+                // [1*T***T**]
+                (Dimensions::OneDimensional, Dimensions::OneDimensional) => {
+                    state.get_dimension(Inside, Inside) == Dimensions::OneDimensional
+                        && state.get_dimension(Inside, Outside) != Empty
+                        && state.get_dimension(Outside, Inside) != Empty
+                }
+                _ => false,
+            },
+            PredicateKind::Touches => state.im.is_touches(),
+        }
+    }
+}
+
+impl<F: GeoFloat> TopologyPredicate<F> for NamedPredicate {
+    fn requires_interaction(&self) -> bool {
+        // equalsTopo allows EMPTY = EMPTY.
+        self.kind != PredicateKind::EqualsTopo
+    }
+
+    fn requires_covers(&self, source: InputIndex) -> bool {
+        match self.kind {
+            PredicateKind::Contains | PredicateKind::Covers => source == InputIndex::A,
+            PredicateKind::Within | PredicateKind::CoveredBy => source == InputIndex::B,
+            _ => false,
+        }
+    }
+
+    fn requires_exterior_check(&self, source: InputIndex) -> bool {
+        match self.kind {
+            // Only the covered geometry needs checking against the exterior
+            // of the covering one.
+            PredicateKind::Contains | PredicateKind::Covers => source == InputIndex::B,
+            PredicateKind::Within | PredicateKind::CoveredBy => source == InputIndex::A,
+            _ => true,
+        }
+    }
+
+    fn init_dimensions(&mut self, dim_a: Dimensions, dim_b: Dimensions) {
+        self.state.init_dimensions(dim_a, dim_b);
+        match self.kind {
+            PredicateKind::Contains | PredicateKind::Covers => self
+                .state
+                .value
+                .require(is_dims_compatible_with_covers(dim_a, dim_b)),
+            PredicateKind::Within | PredicateKind::CoveredBy => self
+                .state
+                .value
+                .require(is_dims_compatible_with_covers(dim_b, dim_a)),
+            PredicateKind::Crosses => {
+                let is_both_points_or_areas = (dim_a == Dimensions::ZeroDimensional
+                    && dim_b == Dimensions::ZeroDimensional)
+                    || (dim_a == Dimensions::TwoDimensional && dim_b == Dimensions::TwoDimensional);
+                self.state.value.require(!is_both_points_or_areas);
+            }
+            PredicateKind::EqualsTopo => {
+                // Equal dimensions are not required, because EMPTY = EMPTY
+                // for all dimensions.
+            }
+            PredicateKind::Overlaps => self.state.value.require(dim_a == dim_b),
+            PredicateKind::Touches => {
+                // Points have only interiors, so they cannot touch.
+                let is_both_points =
+                    dim_a == Dimensions::ZeroDimensional && dim_b == Dimensions::ZeroDimensional;
+                self.state.value.require(!is_both_points);
+            }
+        }
+    }
+
+    fn init_envelopes(&mut self, env_a: Option<Rect<F>>, env_b: Option<Rect<F>>) {
+        match self.kind {
+            PredicateKind::Contains | PredicateKind::Covers => {
+                self.state.value.require(envelope_covers(env_a, env_b));
+            }
+            PredicateKind::Within | PredicateKind::CoveredBy => {
+                self.state.value.require(envelope_covers(env_b, env_a));
+            }
+            PredicateKind::EqualsTopo => {
+                // Handle the EMPTY = EMPTY cases.
+                self.state
+                    .value
+                    .set_value_if(true, env_a.is_none() && env_b.is_none());
+                self.state.value.require(envelopes_equal(env_a, env_b));
+            }
+            PredicateKind::Crosses | PredicateKind::Overlaps | PredicateKind::Touches => {}
+        }
+    }
+
+    fn update_dimension(&mut self, loc_a: CoordPos, loc_b: CoordPos, dimension: Dimensions) {
+        let kind = self.kind;
+        self.state.update_dimension(
+            loc_a,
+            loc_b,
+            dimension,
+            |state| Self::is_determined(kind, state),
+            |state| Self::value_im(kind, state),
+        );
+    }
+
+    fn finish(&mut self) {
+        let kind = self.kind;
+        self.state.finish(|state| Self::value_im(kind, state));
+    }
+
+    fn result(&self) -> PredicateValue {
+        self.state.value
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // Tests ported from JTS RelatePredicateTest.java (master, ab57bff).
+    use super::super::im_predicate::LOCATION_ORDER;
+    use super::super::topology_predicate::TopologyPredicate;
+    use super::*;
+
+    const A_EXT_B_INT: &str = "***.***.1**";
+    const A_INT_B_INT: &str = "1**.***.***";
+
+    /// Applies the non-empty entries of a dotted DE-9IM string to the
+    /// predicate, in row order.
+    fn apply_im(im: &str, pred: &mut impl TopologyPredicate<f64>) {
+        let entries: Vec<char> = im.chars().filter(|&c| c != '.').collect();
+        assert_eq!(entries.len(), 9);
+        for (i, &entry) in entries.iter().enumerate() {
+            let dim = match entry {
+                '0' => Dimensions::ZeroDimensional,
+                '1' => Dimensions::OneDimensional,
+                '2' => Dimensions::TwoDimensional,
+                _ => continue,
+            };
+            pred.update_dimension(LOCATION_ORDER[i / 3], LOCATION_ORDER[i % 3], dim);
+        }
+    }
+
+    fn check_predicate(mut pred: impl TopologyPredicate<f64>, im: &str, expected: bool) {
+        apply_im(im, &mut pred);
+        check_pred(pred, expected);
+    }
+
+    fn check_predicate_partial(mut pred: impl TopologyPredicate<f64>, im: &str, expected: bool) {
+        apply_im(im, &mut pred);
+        assert!(pred.is_known(), "predicate value is not known");
+        check_pred(pred, expected);
+    }
+
+    fn check_pred(mut pred: impl TopologyPredicate<f64>, expected: bool) {
+        pred.finish();
+        assert_eq!(pred.value(), expected);
+    }
+
+    #[test]
+    fn test_intersects() {
+        check_predicate(intersects(), A_INT_B_INT, true);
+    }
+
+    #[test]
+    fn test_disjoint() {
+        check_predicate(intersects(), A_EXT_B_INT, false);
+        check_predicate(disjoint(), A_EXT_B_INT, true);
+    }
+
+    #[test]
+    fn test_covers() {
+        check_predicate(covers(), A_INT_B_INT, true);
+        check_predicate(covers(), A_EXT_B_INT, false);
+    }
+
+    #[test]
+    fn test_covers_fast() {
+        check_predicate_partial(covers(), A_EXT_B_INT, false);
+    }
+
+    #[test]
+    fn test_match() {
+        check_predicate(
+            matches("1***T*0**").expect("valid pattern"),
+            "1**.*2*.0**",
+            true,
+        );
+    }
+
+    // Not from JTS: an invalid pattern must be rejected, not panic.
+    #[test]
+    fn test_match_invalid_pattern() {
+        assert!(matches("1***T*0*").is_err()); // eight characters
+        assert!(matches("1***T*0*X").is_err()); // invalid character
+    }
+}

--- a/geo/src/algorithm/relate/relateng/topology_predicate.rs
+++ b/geo/src/algorithm/relate/relateng/topology_predicate.rs
@@ -10,7 +10,9 @@ use crate::{Contains, GeoFloat, Intersects, Rect};
 /// Identifies one of the two input geometries of a relate operation.
 ///
 /// Replaces JTS's `RelateGeometry.GEOM_A`/`GEOM_B` boolean convention.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// The declaration order gives the "A sorts before B" ordering that
+/// node-section sorting relies on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) enum InputIndex {
     A,
     B,

--- a/geo/src/algorithm/relate/relateng/topology_predicate.rs
+++ b/geo/src/algorithm/relate/relateng/topology_predicate.rs
@@ -1,0 +1,173 @@
+//! The strategy API for DE-9IM topological predicates, and the tri-state
+//! value they share.
+//!
+//! Port of JTS `TopologyPredicate` and `BasicPredicate`.
+
+use crate::coordinate_position::CoordPos;
+use crate::dimensions::Dimensions;
+use crate::{Contains, GeoFloat, Intersects, Rect};
+
+/// Identifies one of the two input geometries of a relate operation.
+///
+/// Replaces JTS's `RelateGeometry.GEOM_A`/`GEOM_B` boolean convention.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum InputIndex {
+    A,
+    B,
+}
+
+impl InputIndex {
+    /// The other input.
+    pub fn other(self) -> Self {
+        match self {
+            InputIndex::A => InputIndex::B,
+            InputIndex::B => InputIndex::A,
+        }
+    }
+}
+
+/// The API for strategy types implementing spatial predicates based on the
+/// DE-9IM topology model. Predicate values for specific geometry pairs are
+/// evaluated by the RelateNG driver.
+pub(crate) trait TopologyPredicate<F: GeoFloat>: std::fmt::Debug {
+    /// Reports whether this predicate requires self-noding for geometries
+    /// which contain crossing edges (for example line strings, or geometry
+    /// collections containing lines or polygons which may self-intersect).
+    /// Self-noding ensures that intersections are computed consistently in
+    /// cases which contain self-crossings and mutual crossings.
+    ///
+    /// Most predicates require this, but it can be avoided for simple
+    /// interaction detection (`intersects` and `disjoint`). Avoiding
+    /// self-noding improves performance for polygonal inputs.
+    fn requires_self_noding(&self) -> bool {
+        true
+    }
+
+    /// Reports whether this predicate requires interaction between the input
+    /// geometries: some of IM[I, I], IM[I, B], IM[B, I], IM[B, B] must be
+    /// non-empty. This allows a fast result if the envelopes of the
+    /// geometries are disjoint.
+    fn requires_interaction(&self) -> bool {
+        true
+    }
+
+    /// Reports whether this predicate requires that the source cover the
+    /// target: IM[Ext(Src), Int(Tgt)] = F and IM[Ext(Src), Bdy(Tgt)] = F.
+    /// If true, this allows a fast result if the source envelope does not
+    /// cover the target envelope.
+    fn requires_covers(&self, _source: InputIndex) -> bool {
+        false
+    }
+
+    /// Reports whether this predicate requires checking if the source input
+    /// intersects the exterior of the target input: IM[Int(Src), Ext(Tgt)]
+    /// or IM[Bdy(Src), Ext(Tgt)] is non-empty. If false, this may permit a
+    /// faster result in some geometric situations.
+    fn requires_exterior_check(&self, _source: InputIndex) -> bool {
+        true
+    }
+
+    /// Initialises the predicate for a specific geometric case. This may
+    /// allow the predicate result to become known if it can be inferred from
+    /// the dimensions.
+    fn init_dimensions(&mut self, _dim_a: Dimensions, _dim_b: Dimensions) {
+        // The default when dimensions provide no information.
+    }
+
+    /// Initialises the predicate from the input envelopes. `None` is the
+    /// null envelope of an empty geometry. This may allow the predicate
+    /// result to become known if it can be inferred from the envelopes.
+    fn init_envelopes(&mut self, _env_a: Option<Rect<F>>, _env_b: Option<Rect<F>>) {
+        // The default when envelopes provide no information.
+    }
+
+    /// Updates the entry in the DE-9IM intersection matrix for the given
+    /// locations in the input geometries. An update with a dimension lower
+    /// than the current value of an entry must not change the entry.
+    fn update_dimension(&mut self, loc_a: CoordPos, loc_b: CoordPos, dimension: Dimensions);
+
+    /// Indicates that the value of the predicate can be finalised based on
+    /// its current state.
+    fn finish(&mut self);
+
+    /// The tri-state result of the predicate.
+    fn result(&self) -> PredicateValue;
+
+    /// Tests if the predicate value is known.
+    fn is_known(&self) -> bool {
+        self.result().is_known()
+    }
+
+    /// The current value of the predicate result. The value is only valid if
+    /// [`Self::is_known`] is `true`.
+    fn value(&self) -> bool {
+        self.result().value()
+    }
+}
+
+/// Tests if two geometries intersect based on an interaction at the given
+/// locations: some location on both geometries is not the exterior.
+pub(crate) fn is_intersection(loc_a: CoordPos, loc_b: CoordPos) -> bool {
+    loc_a != CoordPos::Outside && loc_b != CoordPos::Outside
+}
+
+/// The tri-state predicate value: unknown until set, and the first set value
+/// wins (JTS `BasicPredicate`).
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct PredicateValue(Option<bool>);
+
+impl PredicateValue {
+    /// Updates the value to the given state if it is currently unknown.
+    pub fn set_value(&mut self, val: bool) {
+        if self.0.is_none() {
+            self.0 = Some(val);
+        }
+    }
+
+    pub fn set_value_if(&mut self, val: bool, cond: bool) {
+        if cond {
+            self.set_value(val);
+        }
+    }
+
+    /// Sets the value to `false` unless the condition holds.
+    pub fn require(&mut self, cond: bool) {
+        if !cond {
+            self.set_value(false);
+        }
+    }
+
+    pub fn is_known(&self) -> bool {
+        self.0.is_some()
+    }
+
+    pub fn value(&self) -> bool {
+        self.0 == Some(true)
+    }
+}
+
+// Envelope operations with JTS `Envelope` semantics: `None` is the null
+// envelope of an empty geometry, which intersects, covers, and equals
+// nothing (except that two null envelopes are equal).
+
+pub(crate) fn envelopes_intersect<F: GeoFloat>(a: Option<Rect<F>>, b: Option<Rect<F>>) -> bool {
+    match (a, b) {
+        (Some(a), Some(b)) => a.intersects(&b),
+        _ => false,
+    }
+}
+
+pub(crate) fn envelope_covers<F: GeoFloat>(a: Option<Rect<F>>, b: Option<Rect<F>>) -> bool {
+    match (a, b) {
+        (Some(a), Some(b)) => a.contains(&b),
+        _ => false,
+    }
+}
+
+pub(crate) fn envelopes_equal<F: GeoFloat>(a: Option<Rect<F>>, b: Option<Rect<F>>) -> bool {
+    match (a, b) {
+        (Some(a), Some(b)) => a == b,
+        (None, None) => true,
+        _ => false,
+    }
+}


### PR DESCRIPTION
Part 2 of 5 of the RelateNG port. Based on #1587. This PR ports the predicate layer and the node-topology types.

Commits:
- Port RelateNG predicate layer (TopologyPredicate, IMState, named predicates, pattern matcher)
- Port RelateNG NodeSection and PolygonNodeConverter
- Port RelateNG RelateEdge, RelateNode and NodeSections

Stack: #1587 → #1588 → #1589 → #1590 → #1591
