### PR TITLE
RelateNG port 4/5: engine, driver and test suites

### DIFF
--- a/geo/src/algorithm/line_intersection.rs
+++ b/geo/src/algorithm/line_intersection.rs
@@ -73,6 +73,11 @@ impl<F: GeoFloat> LineIntersection<F> {
 /// assert_eq!(line_intersection(line_1, line_2), Some(expected));
 /// ```
 /// Strongly inspired by, and meant to produce the same results as, [JTS's RobustLineIntersector](https://github.com/locationtech/jts/blob/master/modules/core/src/main/java/org/locationtech/jts/algorithm/RobustLineIntersector.java#L26).
+///
+/// The intersection point of a proper intersection is computed with
+/// double-double extended-precision arithmetic, as JTS
+/// [`CGAlgorithmsDD.intersection`](https://github.com/locationtech/jts/blob/master/modules/core/src/main/java/org/locationtech/jts/algorithm/CGAlgorithmsDD.java)
+/// does, and matches the JTS result exactly.
 pub fn line_intersection<F>(p: Line<F>, q: Line<F>) -> Option<LineIntersection<F>>
 where
     F: GeoFloat,
@@ -230,61 +235,134 @@ fn nearest_endpoint<F: GeoFloat>(p: Line<F>, q: Line<F>) -> Coord<F> {
     nearest_pt
 }
 
+/// Computes the intersection point using double-double extended-precision
+/// arithmetic, as JTS `CGAlgorithmsDD.intersection` does (JTS PR #989 made
+/// this the `RobustLineIntersector` computation; the older conditioned
+/// floating-point formula caused spatial predicate failures, for example
+/// producing points one ULP away from a shared endpoint).
 fn raw_line_intersection<F: GeoFloat>(p: Line<F>, q: Line<F>) -> Option<Coord<F>> {
-    let p_min_x = p.start.x.min(p.end.x);
-    let p_min_y = p.start.y.min(p.end.y);
-    let p_max_x = p.start.x.max(p.end.x);
-    let p_max_y = p.start.y.max(p.end.y);
+    use double_double::DD;
+    use num_traits::NumCast;
 
-    let q_min_x = q.start.x.min(q.end.x);
-    let q_min_y = q.start.y.min(q.end.y);
-    let q_max_x = q.start.x.max(q.end.x);
-    let q_max_y = q.start.y.max(q.end.y);
+    let f = |v: F| <f64 as NumCast>::from(v).unwrap();
+    let (p1x, p1y) = (f(p.start.x), f(p.start.y));
+    let (p2x, p2y) = (f(p.end.x), f(p.end.y));
+    let (q1x, q1y) = (f(q.start.x), f(q.start.y));
+    let (q2x, q2y) = (f(q.end.x), f(q.end.y));
 
-    let int_min_x = p_min_x.max(q_min_x);
-    let int_max_x = p_max_x.min(q_max_x);
-    let int_min_y = p_min_y.max(q_min_y);
-    let int_max_y = p_max_y.min(q_max_y);
+    let px = DD::new(p1y).sub(DD::new(p2y));
+    let py = DD::new(p2x).sub(DD::new(p1x));
+    let pw = DD::new(p1x)
+        .mul(DD::new(p2y))
+        .sub(DD::new(p2x).mul(DD::new(p1y)));
 
-    let two = F::one() + F::one();
-    let mid_x = (int_min_x + int_max_x) / two;
-    let mid_y = (int_min_y + int_max_y) / two;
+    let qx = DD::new(q1y).sub(DD::new(q2y));
+    let qy = DD::new(q2x).sub(DD::new(q1x));
+    let qw = DD::new(q1x)
+        .mul(DD::new(q2y))
+        .sub(DD::new(q2x).mul(DD::new(q1y)));
 
-    // condition ordinate values by subtracting midpoint
-    let p1x = p.start.x - mid_x;
-    let p1y = p.start.y - mid_y;
-    let p2x = p.end.x - mid_x;
-    let p2y = p.end.y - mid_y;
-    let q1x = q.start.x - mid_x;
-    let q1y = q.start.y - mid_y;
-    let q2x = q.end.x - mid_x;
-    let q2y = q.end.y - mid_y;
+    let x = py.mul(qw).sub(qy.mul(pw));
+    let y = qx.mul(pw).sub(px.mul(qw));
+    let w = px.mul(qy).sub(qx.mul(py));
 
-    // unrolled computation using homogeneous coordinates eqn
-    let px = p1y - p2y;
-    let py = p2x - p1x;
-    let pw = p1x * p2y - p2x * p1y;
-
-    let qx = q1y - q2y;
-    let qy = q2x - q1x;
-    let qw = q1x * q2y - q2x * q1y;
-
-    let xw = py * qw - qy * pw;
-    let yw = qx * pw - px * qw;
-    let w = px * qy - qx * py;
-
-    let x_int = xw / w;
-    let y_int = yw / w;
+    let x_int = x.div(w).value();
+    let y_int = y.div(w).value();
 
     // check for parallel lines
     if (x_int.is_nan() || x_int.is_infinite()) || (y_int.is_nan() || y_int.is_infinite()) {
         None
     } else {
-        // de-condition intersection point
         Some(coord! {
-            x: x_int + mid_x,
-            y: y_int + mid_y,
+            x: F::from(x_int).unwrap(),
+            y: F::from(y_int).unwrap(),
         })
+    }
+}
+
+/// Minimal double-double arithmetic: only the operations the intersection
+/// computation needs, ported from JTS `math.DD` (algorithms from the
+/// DoubleDouble library of M. Hida, S. Li and D. Bailey).
+mod double_double {
+    /// The value to split a double-precision value on during
+    /// multiplication: 2^27 + 1.
+    const SPLIT: f64 = 134217729.0;
+
+    #[derive(Clone, Copy, Debug)]
+    pub(super) struct DD {
+        hi: f64,
+        lo: f64,
+    }
+
+    impl DD {
+        pub fn new(x: f64) -> Self {
+            DD { hi: x, lo: 0.0 }
+        }
+
+        pub fn value(self) -> f64 {
+            self.hi + self.lo
+        }
+
+        pub fn sub(self, y: DD) -> DD {
+            let (hi, lo) = (self.hi, self.lo);
+            let (yhi, ylo) = (-y.hi, -y.lo);
+            let s_big = hi + yhi;
+            let t_big = lo + ylo;
+            let e = s_big - hi;
+            let f = t_big - lo;
+            let mut s = s_big - e;
+            let mut t = t_big - f;
+            s = (yhi - e) + (hi - s);
+            t = (ylo - f) + (lo - t);
+            let e = s + t_big;
+            let h_big = s_big + e;
+            let h = e + (s_big - h_big);
+            let e = t + h;
+
+            let zhi = h_big + e;
+            let zlo = e + (h_big - zhi);
+            DD { hi: zhi, lo: zlo }
+        }
+
+        pub fn mul(self, y: DD) -> DD {
+            let (hi, lo) = (self.hi, self.lo);
+            let (yhi, ylo) = (y.hi, y.lo);
+            let mut c_big = SPLIT * hi;
+            let mut hx = c_big - hi;
+            let mut c = SPLIT * yhi;
+            hx = c_big - hx;
+            let tx = hi - hx;
+            let mut hy = c - yhi;
+            c_big = hi * yhi;
+            hy = c - hy;
+            let ty = yhi - hy;
+            c = ((((hx * hy - c_big) + hx * ty) + tx * hy) + tx * ty) + (hi * ylo + lo * yhi);
+            let zhi = c_big + c;
+            hx = c_big - zhi;
+            let zlo = c + hx;
+            DD { hi: zhi, lo: zlo }
+        }
+
+        pub fn div(self, y: DD) -> DD {
+            let (hi, lo) = (self.hi, self.lo);
+            let c_big = hi / y.hi;
+            let mut c = SPLIT * c_big;
+            let mut hc = c - c_big;
+            let mut u = SPLIT * y.hi;
+            hc = c - hc;
+            let tc = c_big - hc;
+            let mut hy = u - y.hi;
+            let u_big = c_big * y.hi;
+            hy = u - hy;
+            let ty = y.hi - hy;
+            u = (((hc * hy - u_big) + hc * ty) + tc * hy) + tc * ty;
+            c = ((((hi - u_big) - u) + lo) - c_big * y.lo) / y.hi;
+            let u2 = c_big + c;
+
+            let zhi = u2;
+            let zlo = (c_big - u2) + c;
+            DD { hi: zhi, lo: zlo }
+        }
     }
 }
 
@@ -386,10 +464,12 @@ mod test {
             },
         );
         let actual = line_intersection(line_1, line_2);
+        // The expected value matches current JTS (DD intersection
+        // computation, JTS PR #989).
         let expected = LineIntersection::SinglePoint {
             intersection: coord! {
-                x: -215.22279674875,
-                y: -158.65425425385,
+                x: -215.22279674875003,
+                y: -158.65425425385004,
             },
             is_proper: true,
         };
@@ -560,10 +640,12 @@ mod test {
             },
         );
         let actual = line_intersection(line_1, line_2);
+        // The expected value matches current JTS (DD intersection
+        // computation, JTS PR #989).
         let expected = LineIntersection::SinglePoint {
             intersection: coord! {
-                x: 2087536.6062609926,
-                y: 1187900.560566967,
+                x: 2087600.4716727887,
+                y: 1187639.7426241424,
             },
             is_proper: true,
         };
@@ -596,9 +678,11 @@ mod test {
             },
         );
         let actual = line_intersection(line_1, line_2);
+        // The expected value matches current JTS (DD intersection
+        // computation, JTS PR #989).
         let expected = LineIntersection::SinglePoint {
             intersection: coord! {
-                x: 4348440.8493874,
+                x: 4348440.849387399,
                 y: 5552599.27202212,
             },
             is_proper: true,

--- a/geo/src/algorithm/polygon_node_topology.rs
+++ b/geo/src/algorithm/polygon_node_topology.rs
@@ -86,9 +86,6 @@ pub(crate) fn compare_angle<T: GeoNum>(origin: Coord<T>, p: Coord<T>, q: Coord<T
 ///
 /// `a0`/`a1` are the segment endpoints adjacent to the node in one ring,
 /// `b0`/`b1` those in the other ring.
-// Consumed by the RelateNG port (see RELATENG_PLAN.md); remove the allow when
-// it lands.
-#[allow(dead_code)]
 pub(crate) fn is_crossing<T: GeoNum>(
     node_pt: Coord<T>,
     a0: Coord<T>,
@@ -120,8 +117,8 @@ pub(crate) fn is_crossing<T: GeoNum>(
 /// The ring interior is assumed to be on the right of the corner (a CW shell
 /// or a CCW hole). The test segment must not be collinear with the corner
 /// segments.
-// Consumed by the RelateNG port (see RELATENG_PLAN.md); remove the allow when
-// it lands.
+// Ported with the rest of JTS PolygonNodeTopology; not used by the crate at
+// present.
 #[allow(dead_code)]
 pub(crate) fn is_interior_segment<T: GeoNum>(
     node_pt: Coord<T>,

--- a/geo/src/algorithm/relate/relateng/edge_segment_intersector.rs
+++ b/geo/src/algorithm/relate/relateng/edge_segment_intersector.rs
@@ -21,12 +21,12 @@ use super::topology_computer::TopologyComputer;
 
 /// Tests segments of [`RelateSegmentString`]s and adds any intersections
 /// to the [`TopologyComputer`].
-pub(crate) struct EdgeSegmentIntersector<'c, 'r, 'a, F: GeoFloat> {
-    topo_computer: &'c mut TopologyComputer<'r, 'a, F>,
+pub(crate) struct EdgeSegmentIntersector<'c, 'r, 'a, 'b, F: GeoFloat> {
+    topo_computer: &'c mut TopologyComputer<'r, 'a, 'b, F>,
 }
 
-impl<'c, 'r, 'a, F: GeoFloat> EdgeSegmentIntersector<'c, 'r, 'a, F> {
-    pub fn new(topo_computer: &'c mut TopologyComputer<'r, 'a, F>) -> Self {
+impl<'c, 'r, 'a, 'b, F: GeoFloat> EdgeSegmentIntersector<'c, 'r, 'a, 'b, F> {
+    pub fn new(topo_computer: &'c mut TopologyComputer<'r, 'a, 'b, F>) -> Self {
         Self { topo_computer }
     }
 
@@ -145,7 +145,7 @@ impl<F: GeoFloat> MutualSegmentSetIntersector<F> {
     pub fn process(
         &self,
         query: &[RelateSegmentString<F>],
-        intersector: &mut EdgeSegmentIntersector<'_, '_, '_, F>,
+        intersector: &mut EdgeSegmentIntersector<'_, '_, '_, '_, F>,
     ) {
         for query_string in query {
             for query_seg in 0..query_string.size().saturating_sub(1) {
@@ -176,7 +176,7 @@ pub(crate) fn intersect_all<F: GeoFloat>(
     edges_a: &[RelateSegmentString<F>],
     edges_b: &[RelateSegmentString<F>],
     env: Option<&Rect<F>>,
-    intersector: &mut EdgeSegmentIntersector<'_, '_, '_, F>,
+    intersector: &mut EdgeSegmentIntersector<'_, '_, '_, '_, F>,
 ) {
     // Combined string indexing: A strings first, then B strings.
     let string = |index: usize| -> &RelateSegmentString<F> {

--- a/geo/src/algorithm/relate/relateng/edge_segment_intersector.rs
+++ b/geo/src/algorithm/relate/relateng/edge_segment_intersector.rs
@@ -1,0 +1,305 @@
+//! The edge phase of a relate evaluation: finds intersections between the
+//! segments of the input geometries and feeds them to the
+//! [`TopologyComputer`].
+//!
+//! Port of JTS `EdgeSegmentIntersector`, plus the candidate-pair sweeps
+//! that replace JTS `MCIndexSegmentSetMutualIntersector` (the mutual,
+//! base-indexed case) and `EdgeSetIntersector` (the self-noding union
+//! case). Where JTS indexes monotone chains in an HPRtree, this port
+//! indexes individual segments in an [`rstar::RTree`] – the established
+//! pattern of the geomgraph edge-set intersector. A chain-level index is a
+//! possible follow-up if benchmarks justify it.
+
+use rstar::{AABB, RTree};
+
+use crate::line_intersection::{LineIntersection, line_intersection};
+use crate::relate::geomgraph::index::Segment;
+use crate::{Coord, GeoFloat, Intersects, Line, Rect};
+
+use super::relate_segment_string::RelateSegmentString;
+use super::topology_computer::TopologyComputer;
+
+/// Tests segments of [`RelateSegmentString`]s and adds any intersections
+/// to the [`TopologyComputer`].
+pub(crate) struct EdgeSegmentIntersector<'c, 'r, 'a, F: GeoFloat> {
+    topo_computer: &'c mut TopologyComputer<'r, 'a, F>,
+}
+
+impl<'c, 'r, 'a, F: GeoFloat> EdgeSegmentIntersector<'c, 'r, 'a, F> {
+    pub fn new(topo_computer: &'c mut TopologyComputer<'r, 'a, F>) -> Self {
+        Self { topo_computer }
+    }
+
+    /// Whether the sweep can stop because the predicate value is known.
+    pub fn is_done(&self) -> bool {
+        self.topo_computer.is_result_known()
+    }
+
+    /// Processes one candidate segment pair. The caller must not pass a
+    /// segment paired with itself.
+    pub fn process_intersections(
+        &mut self,
+        ss0: &RelateSegmentString<F>,
+        seg_index0: usize,
+        ss1: &RelateSegmentString<F>,
+        seg_index1: usize,
+    ) {
+        // Order the arguments so an A-input string comes first.
+        if ss0.is_a() {
+            self.add_intersections(ss0, seg_index0, ss1, seg_index1);
+        } else {
+            self.add_intersections(ss1, seg_index1, ss0, seg_index0);
+        }
+    }
+
+    fn add_intersections(
+        &mut self,
+        ss_a: &RelateSegmentString<F>,
+        seg_index_a: usize,
+        ss_b: &RelateSegmentString<F>,
+        seg_index_b: usize,
+    ) {
+        let a0 = ss_a.coord(seg_index_a);
+        let a1 = ss_a.coord(seg_index_a + 1);
+        let b0 = ss_b.coord(seg_index_b);
+        let b1 = ss_b.coord(seg_index_b + 1);
+
+        match line_intersection(Line::new(a0, a1), Line::new(b0, b1)) {
+            None => {}
+            Some(LineIntersection::SinglePoint {
+                intersection,
+                is_proper,
+            }) => {
+                self.add_intersection_point(
+                    ss_a,
+                    seg_index_a,
+                    ss_b,
+                    seg_index_b,
+                    intersection,
+                    is_proper,
+                );
+            }
+            Some(LineIntersection::Collinear { intersection }) => {
+                // A collinear overlap contributes both overlap endpoints,
+                // neither of which is proper.
+                for int_pt in [intersection.start, intersection.end] {
+                    self.add_intersection_point(
+                        ss_a,
+                        seg_index_a,
+                        ss_b,
+                        seg_index_b,
+                        int_pt,
+                        false,
+                    );
+                }
+            }
+        }
+    }
+
+    fn add_intersection_point(
+        &mut self,
+        ss_a: &RelateSegmentString<F>,
+        seg_index_a: usize,
+        ss_b: &RelateSegmentString<F>,
+        seg_index_b: usize,
+        int_pt: Coord<F>,
+        is_proper: bool,
+    ) {
+        // Ensure endpoint intersections are added once only, for their
+        // canonical segments. Proper intersections lie on a unique segment
+        // so do not need the check – and must not use it, since roundoff
+        // in the computed intersection point makes it unreliable there.
+        if is_proper
+            || (ss_a.is_containing_segment(seg_index_a, int_pt)
+                && ss_b.is_containing_segment(seg_index_b, int_pt))
+        {
+            let nsa = ss_a.create_node_section(seg_index_a, int_pt);
+            let nsb = ss_b.create_node_section(seg_index_b, int_pt);
+            self.topo_computer.add_intersection(nsa, nsb);
+        }
+    }
+}
+
+/// Finds intersections between a base set of segment strings (indexed
+/// once, reusable across queries) and a query set. Fills the role of JTS
+/// `MCIndexSegmentSetMutualIntersector`.
+pub(crate) struct MutualSegmentSetIntersector<F: GeoFloat> {
+    base: Vec<RelateSegmentString<F>>,
+    /// Segment payload: (string index in `base`, segment index).
+    tree: RTree<Segment<F, (usize, usize)>>,
+}
+
+impl<F: GeoFloat> MutualSegmentSetIntersector<F> {
+    /// Builds the index over the base segments, keeping only segments
+    /// intersecting the envelope (if given).
+    pub fn new(base: Vec<RelateSegmentString<F>>, env: Option<&Rect<F>>) -> Self {
+        let segments = index_segments(base.iter().enumerate(), env);
+        Self {
+            base,
+            tree: RTree::bulk_load(segments),
+        }
+    }
+
+    /// Processes each query segment against the indexed base segments,
+    /// stopping early once the predicate value is known.
+    pub fn process(
+        &self,
+        query: &[RelateSegmentString<F>],
+        intersector: &mut EdgeSegmentIntersector<'_, '_, '_, F>,
+    ) {
+        for query_string in query {
+            for query_seg in 0..query_string.size().saturating_sub(1) {
+                let p0 = query_string.coord(query_seg);
+                let p1 = query_string.coord(query_seg + 1);
+                let env = AABB::from_corners(p0, p1);
+                for candidate in self.tree.locate_in_envelope_intersecting(env) {
+                    let (base_string, base_seg) = candidate.payload;
+                    intersector.process_intersections(
+                        &self.base[base_string],
+                        base_seg,
+                        query_string,
+                        query_seg,
+                    );
+                    if intersector.is_done() {
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Finds all intersections within the union of two segment-string sets,
+/// including self-intersections. Fills the role of JTS
+/// `EdgeSetIntersector`, used when self-noding is required.
+pub(crate) fn intersect_all<F: GeoFloat>(
+    edges_a: &[RelateSegmentString<F>],
+    edges_b: &[RelateSegmentString<F>],
+    env: Option<&Rect<F>>,
+    intersector: &mut EdgeSegmentIntersector<'_, '_, '_, F>,
+) {
+    // Combined string indexing: A strings first, then B strings.
+    let string = |index: usize| -> &RelateSegmentString<F> {
+        if index < edges_a.len() {
+            &edges_a[index]
+        } else {
+            &edges_b[index - edges_a.len()]
+        }
+    };
+    let string_count = edges_a.len() + edges_b.len();
+
+    let segments = index_segments((0..string_count).map(|i| (i, string(i))), env);
+    let tree: RTree<Segment<F, (usize, usize)>> = RTree::bulk_load(segments);
+
+    for query in tree.iter() {
+        let (query_string, query_seg) = query.payload;
+        for candidate in tree.locate_in_envelope_intersecting(query.envelope) {
+            let (cand_string, cand_seg) = candidate.payload;
+            // Compare each pair once, and never a segment with itself.
+            if (cand_string, cand_seg) <= (query_string, query_seg) {
+                continue;
+            }
+            intersector.process_intersections(
+                string(query_string),
+                query_seg,
+                string(cand_string),
+                cand_seg,
+            );
+            if intersector.is_done() {
+                return;
+            }
+        }
+    }
+}
+
+/// The index entries for the segments of the given strings, keyed by
+/// (string index, segment index) and filtered to the envelope, if any.
+fn index_segments<'s, F: GeoFloat + 's>(
+    strings: impl Iterator<Item = (usize, &'s RelateSegmentString<F>)>,
+    env: Option<&Rect<F>>,
+) -> Vec<Segment<F, (usize, usize)>> {
+    let mut segments = Vec::new();
+    for (string_index, ss) in strings {
+        for seg_index in 0..ss.size().saturating_sub(1) {
+            let p0 = ss.coord(seg_index);
+            let p1 = ss.coord(seg_index + 1);
+            if env.is_none_or(|env| env.intersects(&Rect::new(p0, p1))) {
+                segments.push(Segment::new((string_index, seg_index), p0, p1));
+            }
+        }
+    }
+    segments
+}
+
+#[cfg(test)]
+mod tests {
+    // Not from JTS: a plumbing test for the edge phase ahead of the
+    // driver. Two crossing lines must produce a 0-dimensional
+    // interior/interior intersection via node evaluation.
+    use super::super::im_predicate::RelateMatrixPredicate;
+    use super::super::relate_geometry::RelateGeometry;
+    use super::super::topology_computer::TopologyComputer;
+    use super::super::topology_predicate::InputIndex;
+    use super::*;
+    use crate::coordinate_position::CoordPos;
+    use crate::dimensions::Dimensions;
+    use crate::geometry_cow::GeometryCow;
+    use crate::wkt;
+
+    #[test]
+    fn crossing_lines_interiors_intersect_zero_dimensional() {
+        let a = wkt!(LINESTRING (0. 0., 2. 2.));
+        let b = wkt!(LINESTRING (0. 2., 2. 0.));
+        let cow_a = GeometryCow::from(&a);
+        let cow_b = GeometryCow::from(&b);
+        let geom_a = RelateGeometry::new(&cow_a);
+        let geom_b = RelateGeometry::new(&cow_b);
+
+        let mut predicate = RelateMatrixPredicate::new();
+        {
+            let mut computer = TopologyComputer::new(&mut predicate, &geom_a, &geom_b);
+            let edges_a = geom_a.extract_segment_strings(InputIndex::A, None);
+            let edges_b = geom_b.extract_segment_strings(InputIndex::B, None);
+
+            let mutual = MutualSegmentSetIntersector::new(edges_a, None);
+            let mut intersector = EdgeSegmentIntersector::new(&mut computer);
+            mutual.process(&edges_b, &mut intersector);
+
+            computer.evaluate_nodes();
+            computer.finish();
+        }
+        let im = predicate.into_im();
+        assert_eq!(
+            im.get(CoordPos::Inside, CoordPos::Inside),
+            Dimensions::ZeroDimensional
+        );
+    }
+
+    #[test]
+    fn self_noding_sweep_finds_the_same_crossing() {
+        let a = wkt!(LINESTRING (0. 0., 2. 2.));
+        let b = wkt!(LINESTRING (0. 2., 2. 0.));
+        let cow_a = GeometryCow::from(&a);
+        let cow_b = GeometryCow::from(&b);
+        let geom_a = RelateGeometry::new(&cow_a);
+        let geom_b = RelateGeometry::new(&cow_b);
+
+        let mut predicate = RelateMatrixPredicate::new();
+        {
+            let mut computer = TopologyComputer::new(&mut predicate, &geom_a, &geom_b);
+            let edges_a = geom_a.extract_segment_strings(InputIndex::A, None);
+            let edges_b = geom_b.extract_segment_strings(InputIndex::B, None);
+
+            let mut intersector = EdgeSegmentIntersector::new(&mut computer);
+            intersect_all(&edges_a, &edges_b, None, &mut intersector);
+
+            computer.evaluate_nodes();
+            computer.finish();
+        }
+        let im = predicate.into_im();
+        assert_eq!(
+            im.get(CoordPos::Inside, CoordPos::Inside),
+            Dimensions::ZeroDimensional
+        );
+    }
+}

--- a/geo/src/algorithm/relate/relateng/mod.rs
+++ b/geo/src/algorithm/relate/relateng/mod.rs
@@ -33,4 +33,5 @@ pub(crate) mod relate_node;
 pub(crate) mod relate_point_locator;
 pub(crate) mod relate_predicate;
 pub(crate) mod relate_segment_string;
+pub(crate) mod topology_computer;
 pub(crate) mod topology_predicate;

--- a/geo/src/algorithm/relate/relateng/mod.rs
+++ b/geo/src/algorithm/relate/relateng/mod.rs
@@ -30,9 +30,13 @@ pub(crate) mod node_sections;
 pub(crate) mod polygon_node_converter;
 pub(crate) mod relate_edge;
 pub(crate) mod relate_geometry;
+pub(crate) mod relate_ng;
 pub(crate) mod relate_node;
 pub(crate) mod relate_point_locator;
 pub(crate) mod relate_predicate;
 pub(crate) mod relate_segment_string;
 pub(crate) mod topology_computer;
 pub(crate) mod topology_predicate;
+
+#[cfg(test)]
+mod tests;

--- a/geo/src/algorithm/relate/relateng/mod.rs
+++ b/geo/src/algorithm/relate/relateng/mod.rs
@@ -22,6 +22,7 @@
 
 pub(crate) mod adjacent_edge_locator;
 pub(crate) mod dimension_location;
+pub(crate) mod edge_segment_intersector;
 pub(crate) mod im_predicate;
 pub(crate) mod linear_boundary;
 pub(crate) mod node_section;

--- a/geo/src/algorithm/relate/relateng/relate_geometry.rs
+++ b/geo/src/algorithm/relate/relateng/relate_geometry.rs
@@ -225,12 +225,15 @@ impl<'a, F: GeoFloat> RelateGeometry<'a, F> {
         self.locator().has_boundary()
     }
 
-    /// The distinct coordinates of the geometry's point elements. Cached
-    /// for reuse in prepared mode. Only meaningful for puntal geometries.
+    /// The distinct representative coordinates of the geometry's point and
+    /// line components (JTS `ComponentCoordinateExtracter`: one coordinate
+    /// per component). Zero-length lines are effectively points, so their
+    /// coordinate is included. Cached for reuse in prepared mode. Only
+    /// used for geometries with real dimension 0.
     pub fn unique_points(&self) -> &BTreeSet<NodeKey<F>> {
         self.unique_points.get_or_init(|| {
             let mut set = BTreeSet::new();
-            collect_point_coords_cow(self.geom, &mut |c| {
+            collect_component_coords_cow(self.geom, &mut |c| {
                 set.insert(NodeKey(c));
             });
             set
@@ -615,6 +618,73 @@ fn is_zero_length_line<F: GeoFloat>(line: &LineString<F>) -> bool {
         return line.0.iter().all(|&p| p == p0);
     }
     true
+}
+
+/// Applies `f` to one representative coordinate (the first) of every
+/// point and line component of the geometry, in document order (the JTS
+/// `ComponentCoordinateExtracter` semantic). Polygonal components are not
+/// visited; the callers only use this for zero-dimensional geometries.
+fn collect_component_coords_cow<F: GeoFloat>(
+    geom: &GeometryCow<'_, F>,
+    f: &mut impl FnMut(Coord<F>),
+) {
+    match geom {
+        GeometryCow::Point(p) => f(p.0),
+        GeometryCow::Line(l) => f(l.start),
+        GeometryCow::LineString(ls) => {
+            if let Some(&c) = ls.0.first() {
+                f(c);
+            }
+        }
+        GeometryCow::MultiPoint(mp) => {
+            for p in &mp.0 {
+                f(p.0);
+            }
+        }
+        GeometryCow::MultiLineString(mls) => {
+            for ls in &mls.0 {
+                if let Some(&c) = ls.0.first() {
+                    f(c);
+                }
+            }
+        }
+        GeometryCow::GeometryCollection(gc) => {
+            for g in &gc.0 {
+                collect_component_coords_geom(g, f);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_component_coords_geom<F: GeoFloat>(geom: &Geometry<F>, f: &mut impl FnMut(Coord<F>)) {
+    match geom {
+        Geometry::Point(p) => f(p.0),
+        Geometry::Line(l) => f(l.start),
+        Geometry::LineString(ls) => {
+            if let Some(&c) = ls.0.first() {
+                f(c);
+            }
+        }
+        Geometry::MultiPoint(mp) => {
+            for p in &mp.0 {
+                f(p.0);
+            }
+        }
+        Geometry::MultiLineString(mls) => {
+            for ls in &mls.0 {
+                if let Some(&c) = ls.0.first() {
+                    f(c);
+                }
+            }
+        }
+        Geometry::GeometryCollection(gc) => {
+            for g in &gc.0 {
+                collect_component_coords_geom(g, f);
+            }
+        }
+        _ => {}
+    }
 }
 
 /// Applies `f` to the coordinate of every point element of the geometry,

--- a/geo/src/algorithm/relate/relateng/relate_ng.rs
+++ b/geo/src/algorithm/relate/relateng/relate_ng.rs
@@ -1,0 +1,615 @@
+//! The RelateNG driver: computes the value of topological predicates (or
+//! the full DE-9IM matrix) between two geometries.
+//!
+//! Port of JTS `RelateNG`.
+//!
+//! Evaluation proceeds in phases, with predicate short-circuit checks
+//! after each step: envelope gates, dimension and envelope predicate
+//! initialisation, an optimised point/point path, point phases (points,
+//! line ends and area vertices located on the opposing geometry), the
+//! edge phase (segment intersection detection and node evaluation), and a
+//! final predicate finish. No noded topology graph is built and no
+//! constructed intersection points enter shared topology, which avoids
+//! the robustness failures of the graph-based engine (see georust/geo
+//! issue #1585).
+
+use std::cell::OnceCell;
+
+use crate::bounding_rect::BoundingRect;
+use crate::coordinate_position::CoordPos;
+use crate::dimensions::Dimensions;
+use crate::geometry_cow::GeometryCow;
+use crate::rect_ops::RectOps;
+use crate::relate::IntersectionMatrix;
+use crate::{Coord, GeoFloat, Geometry, Line, LineString, Polygon, Rect};
+
+use super::edge_segment_intersector::{
+    EdgeSegmentIntersector, MutualSegmentSetIntersector, intersect_all,
+};
+use super::im_predicate::RelateMatrixPredicate;
+use super::relate_geometry::RelateGeometry;
+use super::topology_computer::TopologyComputer;
+use super::topology_predicate::{
+    InputIndex, TopologyPredicate, envelope_covers, envelopes_intersect,
+};
+
+/// Computes the DE-9IM matrix for a pair of geometries.
+pub(crate) fn relate<F: GeoFloat>(
+    a: &GeometryCow<'_, F>,
+    b: &GeometryCow<'_, F>,
+) -> IntersectionMatrix {
+    RelateNG::new(a).evaluate_matrix(b)
+}
+
+/// Evaluates a topological predicate for a pair of geometries, with
+/// short-circuiting.
+pub(crate) fn eval<F: GeoFloat>(
+    a: &GeometryCow<'_, F>,
+    b: &GeometryCow<'_, F>,
+    predicate: &mut dyn TopologyPredicate<F>,
+) -> bool {
+    RelateNG::new(a).evaluate(b, predicate)
+}
+
+pub(crate) struct RelateNG<'a, F: GeoFloat> {
+    geom_a: RelateGeometry<'a, F>,
+    /// The cached A-side segment index. In prepared mode it is built over
+    /// all A edges and reused across evaluations; otherwise it is built
+    /// filtered to the first evaluation's envelope (a non-prepared
+    /// instance is single-use, as in JTS).
+    edge_mutual_int: OnceCell<MutualSegmentSetIntersector<F>>,
+}
+
+impl<'a, F: GeoFloat> RelateNG<'a, F> {
+    pub fn new(a: &'a GeometryCow<'a, F>) -> Self {
+        Self::new_with_prepared(a, false)
+    }
+
+    /// Creates an instance with cached spatial indexes, for repeated
+    /// evaluations against the same A geometry.
+    pub fn prepare(a: &'a GeometryCow<'a, F>) -> Self {
+        Self::new_with_prepared(a, true)
+    }
+
+    fn new_with_prepared(a: &'a GeometryCow<'a, F>, is_prepared: bool) -> Self {
+        Self {
+            geom_a: RelateGeometry::new_with_prepared(a, is_prepared),
+            edge_mutual_int: OnceCell::new(),
+        }
+    }
+
+    /// Computes the full DE-9IM matrix against the B geometry.
+    pub fn evaluate_matrix(&self, b: &GeometryCow<'_, F>) -> IntersectionMatrix {
+        let mut predicate = RelateMatrixPredicate::new();
+        self.evaluate(b, &mut predicate);
+        predicate.into_im()
+    }
+
+    /// Evaluates a topological predicate against the B geometry.
+    pub fn evaluate(
+        &self,
+        b: &GeometryCow<'_, F>,
+        predicate: &mut dyn TopologyPredicate<F>,
+    ) -> bool {
+        // Fast envelope checks.
+        if !self.has_required_envelope_interaction(b, predicate) {
+            return false;
+        }
+
+        let geom_b = RelateGeometry::new(b);
+
+        let dim_a = self.geom_a.dimension_real();
+        let dim_b = geom_b.dimension_real();
+
+        // Check if the predicate is determined by the dimensions or the
+        // envelopes.
+        predicate.init_dimensions(dim_a, dim_b);
+        if predicate.is_known() {
+            return finish_value(predicate);
+        }
+        predicate.init_envelopes(self.geom_a.envelope(), geom_b.envelope());
+        if predicate.is_known() {
+            return finish_value(predicate);
+        }
+
+        let mut computer = TopologyComputer::new(predicate, &self.geom_a, &geom_b);
+
+        // Optimised P/P evaluation.
+        if dim_a == Dimensions::ZeroDimensional && dim_b == Dimensions::ZeroDimensional {
+            self.compute_pp(&geom_b, &mut computer);
+            computer.finish();
+            return computer.result();
+        }
+
+        // Test points against the (potentially indexed) geometry first.
+        compute_at_points(&geom_b, InputIndex::B, &self.geom_a, &mut computer);
+        if computer.is_result_known() {
+            return computer.result();
+        }
+        compute_at_points(&self.geom_a, InputIndex::A, &geom_b, &mut computer);
+        if computer.is_result_known() {
+            return computer.result();
+        }
+
+        if self.geom_a.has_edges() && geom_b.has_edges() {
+            self.compute_at_edges(&geom_b, &mut computer);
+        }
+
+        // After all processing, set the remaining unknown values.
+        computer.finish();
+        computer.result()
+    }
+
+    fn has_required_envelope_interaction(
+        &self,
+        b: &GeometryCow<'_, F>,
+        predicate: &dyn TopologyPredicate<F>,
+    ) -> bool {
+        let env_b = b.bounding_rect();
+        let env_a = self.geom_a.envelope();
+        let mut is_interacts = false;
+        if predicate.requires_covers(InputIndex::A) {
+            if !envelope_covers(env_a, env_b) {
+                return false;
+            }
+            is_interacts = true;
+        } else if predicate.requires_covers(InputIndex::B) {
+            if !envelope_covers(env_b, env_a) {
+                return false;
+            }
+            is_interacts = true;
+        }
+        if !is_interacts && predicate.requires_interaction() && !envelopes_intersect(env_a, env_b) {
+            return false;
+        }
+        true
+    }
+
+    /// An optimised algorithm for evaluating P/P cases: tests one point
+    /// set against the other.
+    fn compute_pp(
+        &self,
+        geom_b: &RelateGeometry<'_, F>,
+        computer: &mut TopologyComputer<'_, '_, '_, F>,
+    ) {
+        let pts_a = self.geom_a.unique_points();
+        let pts_b = geom_b.unique_points();
+
+        let mut num_b_in_a = 0;
+        for pt_b in pts_b {
+            if pts_a.contains(pt_b) {
+                num_b_in_a += 1;
+                computer.add_point_on_point_interior();
+            } else {
+                computer.add_point_on_point_exterior(InputIndex::B);
+            }
+            if computer.is_result_known() {
+                return;
+            }
+        }
+        // If the number of matched B points is less than the size of A,
+        // there must be at least one A point in the exterior of B.
+        if num_b_in_a < pts_a.len() {
+            computer.add_point_on_point_exterior(InputIndex::A);
+        }
+    }
+
+    fn compute_at_edges(
+        &self,
+        geom_b: &RelateGeometry<'_, F>,
+        computer: &mut TopologyComputer<'_, '_, '_, F>,
+    ) {
+        let (Some(env_a), Some(env_b)) = (self.geom_a.envelope(), geom_b.envelope()) else {
+            return;
+        };
+        let Some(env_int) = env_a.rect_intersection(env_b) else {
+            return;
+        };
+
+        let edges_b = geom_b.extract_segment_strings(InputIndex::B, Some(&env_int));
+
+        if computer.is_self_noding_required() {
+            let edges_a = self
+                .geom_a
+                .extract_segment_strings(InputIndex::A, Some(&env_int));
+            let mut intersector = EdgeSegmentIntersector::new(computer);
+            intersect_all(&edges_a, &edges_b, Some(&env_int), &mut intersector);
+        } else {
+            // In prepared mode the A edge index is reused across
+            // evaluations.
+            let mutual = self.edge_mutual_int.get_or_init(|| {
+                let env_extract = if self.geom_a.is_prepared() {
+                    None
+                } else {
+                    Some(&env_int)
+                };
+                let edges_a = self
+                    .geom_a
+                    .extract_segment_strings(InputIndex::A, env_extract);
+                MutualSegmentSetIntersector::new(edges_a, env_extract)
+            });
+            let mut intersector = EdgeSegmentIntersector::new(computer);
+            mutual.process(&edges_b, &mut intersector);
+        }
+        if computer.is_result_known() {
+            return;
+        }
+
+        computer.evaluate_nodes();
+    }
+}
+
+fn finish_value<F: GeoFloat>(predicate: &mut dyn TopologyPredicate<F>) -> bool {
+    predicate.finish();
+    predicate.value()
+}
+
+fn compute_at_points<F: GeoFloat>(
+    geom: &RelateGeometry<'_, F>,
+    input: InputIndex,
+    geom_target: &RelateGeometry<'_, F>,
+    computer: &mut TopologyComputer<'_, '_, '_, F>,
+) {
+    if compute_points(geom, input, geom_target, computer) {
+        return;
+    }
+
+    // Performance optimisation: only check line ends and area vertices
+    // against the target if it has areas, or if the predicate requires
+    // checking for exterior interaction. In particular this avoids
+    // testing line ends against lines for the intersects predicate
+    // (they are checked during segment intersection anyway). Checking
+    // points against areas is necessary, since the input linework is
+    // disjoint if one input lies wholly inside an area.
+    let check_disjoint_points = geom_target.has_dimension(Dimensions::TwoDimensional)
+        || computer.is_exterior_check_required(input);
+    if !check_disjoint_points {
+        return;
+    }
+
+    if compute_line_ends(geom, input, geom_target, computer) {
+        return;
+    }
+
+    compute_area_vertex(geom, input, geom_target, computer);
+}
+
+fn compute_points<F: GeoFloat>(
+    geom: &RelateGeometry<'_, F>,
+    input: InputIndex,
+    geom_target: &RelateGeometry<'_, F>,
+    computer: &mut TopologyComputer<'_, '_, '_, F>,
+) -> bool {
+    if !geom.has_dimension(Dimensions::ZeroDimensional) {
+        return false;
+    }
+
+    for pt in geom.effective_points() {
+        compute_point(input, pt, geom_target, computer);
+        if computer.is_result_known() {
+            return true;
+        }
+    }
+    false
+}
+
+fn compute_point<F: GeoFloat>(
+    input: InputIndex,
+    pt: Coord<F>,
+    geom_target: &RelateGeometry<'_, F>,
+    computer: &mut TopologyComputer<'_, '_, '_, F>,
+) {
+    let loc_dim_target = geom_target.locate_with_dim(pt);
+    let loc_target = loc_dim_target.location();
+    let dim_target = loc_dim_target.dimension_with_exterior(computer.dimension(other(input)));
+    computer.add_point_on_geometry(input, loc_target, dim_target, pt);
+}
+
+fn compute_line_ends<F: GeoFloat>(
+    geom: &RelateGeometry<'_, F>,
+    input: InputIndex,
+    geom_target: &RelateGeometry<'_, F>,
+    computer: &mut TopologyComputer<'_, '_, '_, F>,
+) -> bool {
+    if !geom.has_dimension(Dimensions::OneDimensional) {
+        return false;
+    }
+
+    // Track exterior intersections of interior and boundary line ends
+    // separately (JTS PR #1200): only once both are recorded may
+    // known-exterior line components be skipped.
+    let mut has_interior_exterior_intersection = false;
+    let mut has_boundary_exterior_intersection = false;
+
+    for elem in linear_elements(geom.geometry()) {
+        let (e0, e1, is_closed, elem_env) = match elem {
+            LinearElement::LineString(ls) => {
+                let first = ls.0[0];
+                let last = ls.0[ls.0.len() - 1];
+                (first, last, ls.is_closed(), ls.bounding_rect())
+            }
+            LinearElement::Line(l) => (
+                l.start,
+                l.end,
+                l.start == l.end,
+                Some(Rect::new(l.start, l.end)),
+            ),
+        };
+
+        // Once intersections with the target exterior are recorded for
+        // both interior and boundary line ends, skip further
+        // known-exterior line components.
+        if has_interior_exterior_intersection
+            && has_boundary_exterior_intersection
+            && !envelopes_intersect(elem_env, geom_target.envelope())
+        {
+            continue;
+        }
+
+        let loc0 = compute_line_end(geom, input, e0, geom_target, computer);
+        match loc0 {
+            Some(CoordPos::Inside) => has_interior_exterior_intersection = true,
+            Some(CoordPos::OnBoundary) => has_boundary_exterior_intersection = true,
+            _ => {}
+        }
+        if computer.is_result_known() {
+            return true;
+        }
+
+        if !is_closed {
+            let loc1 = compute_line_end(geom, input, e1, geom_target, computer);
+            match loc1 {
+                Some(CoordPos::Inside) => has_interior_exterior_intersection = true,
+                Some(CoordPos::OnBoundary) => has_boundary_exterior_intersection = true,
+                _ => {}
+            }
+            if computer.is_result_known() {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Computes the topology of a line endpoint. Returns the location of the
+/// line end (interior or boundary) if it lies in the exterior of the
+/// target, to allow skipping further exterior endpoints; `None` otherwise.
+fn compute_line_end<F: GeoFloat>(
+    geom: &RelateGeometry<'_, F>,
+    input: InputIndex,
+    pt: Coord<F>,
+    geom_target: &RelateGeometry<'_, F>,
+    computer: &mut TopologyComputer<'_, '_, '_, F>,
+) -> Option<CoordPos> {
+    let loc_dim_line_end = geom.locate_line_end_with_dim(pt);
+    let dim_line_end = loc_dim_line_end.dimension_with_exterior(computer.dimension(input));
+    // Skip line ends which are in a collection area.
+    if dim_line_end != Dimensions::OneDimensional {
+        return None;
+    }
+    let loc_line_end = loc_dim_line_end.location();
+
+    let loc_dim_target = geom_target.locate_with_dim(pt);
+    let loc_target = loc_dim_target.location();
+    let dim_target = loc_dim_target.dimension_with_exterior(computer.dimension(other(input)));
+    computer.add_line_end_on_geometry(input, loc_line_end, loc_target, dim_target, pt);
+    if loc_target == CoordPos::Outside {
+        return Some(loc_line_end);
+    }
+    None
+}
+
+fn compute_area_vertex<F: GeoFloat>(
+    geom: &RelateGeometry<'_, F>,
+    input: InputIndex,
+    geom_target: &RelateGeometry<'_, F>,
+    computer: &mut TopologyComputer<'_, '_, '_, F>,
+) -> bool {
+    if !geom.has_dimension(Dimensions::TwoDimensional) {
+        return false;
+    }
+    // Evaluate for line and area targets only, since points are handled
+    // in the reverse direction.
+    if geom_target.dimension() < Dimensions::OneDimensional {
+        return false;
+    }
+
+    let mut has_exterior_intersection = false;
+
+    for elem in area_elements(geom.geometry()) {
+        let polygon = elem.polygon();
+        if polygon.exterior().0.is_empty() {
+            continue;
+        }
+        // Once an intersection with the target exterior is recorded, skip
+        // further known-exterior elements.
+        if has_exterior_intersection
+            && !envelopes_intersect(polygon.bounding_rect(), geom_target.envelope())
+        {
+            continue;
+        }
+
+        has_exterior_intersection |=
+            compute_area_vertex_on_ring(geom, input, polygon.exterior(), geom_target, computer);
+        if computer.is_result_known() {
+            return true;
+        }
+        for hole in polygon.interiors() {
+            has_exterior_intersection |=
+                compute_area_vertex_on_ring(geom, input, hole, geom_target, computer);
+            if computer.is_result_known() {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn compute_area_vertex_on_ring<F: GeoFloat>(
+    geom: &RelateGeometry<'_, F>,
+    input: InputIndex,
+    ring: &LineString<F>,
+    geom_target: &RelateGeometry<'_, F>,
+    computer: &mut TopologyComputer<'_, '_, '_, F>,
+) -> bool {
+    if ring.0.is_empty() {
+        return false;
+    }
+    let pt = ring.0[0];
+
+    let loc_area = geom.locate_area_vertex(pt);
+    let loc_dim_target = geom_target.locate_with_dim(pt);
+    let loc_target = loc_dim_target.location();
+    let dim_target = loc_dim_target.dimension_with_exterior(computer.dimension(other(input)));
+    computer.add_area_vertex(input, loc_area, loc_target, dim_target, pt);
+    loc_target == CoordPos::Outside
+}
+
+fn other(input: InputIndex) -> InputIndex {
+    match input {
+        InputIndex::A => InputIndex::B,
+        InputIndex::B => InputIndex::A,
+    }
+}
+
+/// The linear elements of a geometry (LineStrings and Lines), in document
+/// order, skipping empty ones.
+enum LinearElement<'g, F: GeoFloat> {
+    LineString(&'g LineString<F>),
+    Line(&'g Line<F>),
+}
+
+fn linear_elements<'g, F: GeoFloat>(geom: &'g GeometryCow<'g, F>) -> Vec<LinearElement<'g, F>> {
+    let mut elems = Vec::new();
+    match geom {
+        GeometryCow::Line(l) => elems.push(LinearElement::Line(l)),
+        GeometryCow::LineString(ls) => {
+            if !ls.0.is_empty() {
+                elems.push(LinearElement::LineString(ls));
+            }
+        }
+        GeometryCow::MultiLineString(mls) => {
+            for ls in &mls.0 {
+                if !ls.0.is_empty() {
+                    elems.push(LinearElement::LineString(ls));
+                }
+            }
+        }
+        GeometryCow::GeometryCollection(gc) => {
+            for g in &gc.0 {
+                collect_linear_elements(g, &mut elems);
+            }
+        }
+        _ => {}
+    }
+    elems
+}
+
+fn collect_linear_elements<'g, F: GeoFloat>(
+    geom: &'g Geometry<F>,
+    elems: &mut Vec<LinearElement<'g, F>>,
+) {
+    match geom {
+        Geometry::Line(l) => elems.push(LinearElement::Line(l)),
+        Geometry::LineString(ls) => {
+            if !ls.0.is_empty() {
+                elems.push(LinearElement::LineString(ls));
+            }
+        }
+        Geometry::MultiLineString(mls) => {
+            for ls in &mls.0 {
+                if !ls.0.is_empty() {
+                    elems.push(LinearElement::LineString(ls));
+                }
+            }
+        }
+        Geometry::GeometryCollection(gc) => {
+            for g in &gc.0 {
+                collect_linear_elements(g, elems);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// The polygonal elements of a geometry, in document order. Rect and
+/// Triangle elements are converted to owned polygons.
+enum AreaElement<'g, F: GeoFloat> {
+    Polygon(&'g Polygon<F>),
+    Owned(Polygon<F>),
+}
+
+impl<F: GeoFloat> AreaElement<'_, F> {
+    fn polygon(&self) -> &Polygon<F> {
+        match self {
+            AreaElement::Polygon(p) => p,
+            AreaElement::Owned(p) => p,
+        }
+    }
+}
+
+fn area_elements<'g, F: GeoFloat>(geom: &'g GeometryCow<'g, F>) -> Vec<AreaElement<'g, F>> {
+    let mut elems = Vec::new();
+    match geom {
+        GeometryCow::Polygon(p) => elems.push(AreaElement::Polygon(p)),
+        GeometryCow::MultiPolygon(mp) => {
+            elems.extend(mp.0.iter().map(AreaElement::Polygon));
+        }
+        GeometryCow::Rect(r) => elems.push(AreaElement::Owned(r.to_polygon())),
+        GeometryCow::Triangle(t) => elems.push(AreaElement::Owned(t.to_polygon())),
+        GeometryCow::GeometryCollection(gc) => {
+            for g in &gc.0 {
+                collect_area_elements(g, &mut elems);
+            }
+        }
+        _ => {}
+    }
+    elems
+}
+
+fn collect_area_elements<'g, F: GeoFloat>(
+    geom: &'g Geometry<F>,
+    elems: &mut Vec<AreaElement<'g, F>>,
+) {
+    match geom {
+        Geometry::Polygon(p) => elems.push(AreaElement::Polygon(p)),
+        Geometry::MultiPolygon(mp) => {
+            elems.extend(mp.0.iter().map(AreaElement::Polygon));
+        }
+        Geometry::Rect(r) => elems.push(AreaElement::Owned(r.to_polygon())),
+        Geometry::Triangle(t) => elems.push(AreaElement::Owned(t.to_polygon())),
+        Geometry::GeometryCollection(gc) => {
+            for g in &gc.0 {
+                collect_area_elements(g, elems);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::wkt;
+
+    // Regression test for georust/geo issue #1585: a MultiLineString must
+    // contain its own member, even when another member crosses it at a
+    // point which is not exactly representable. The old graph-based
+    // engine returns the incorrect matrix 0F1F001F2 here.
+    #[test]
+    fn test_issue_1585_multilinestring_contains_own_member() {
+        let m0 = wkt!(LINESTRING (-1.0 1.0, -4.0 -1.0));
+        let m1 = wkt!(LINESTRING (-85.38966060611993 -1.0, 0.0 0.0));
+        let mls = crate::MultiLineString::new(vec![m0.clone(), m1]);
+
+        let cow_mls = GeometryCow::from(&mls);
+        let cow_m0 = GeometryCow::from(&m0);
+
+        let im = relate(&cow_mls, &cow_m0);
+        assert_eq!(format!("{im:?}"), "IntersectionMatrix(1F1F00FF2)");
+        assert!(im.is_contains());
+
+        let mut contains = super::super::relate_predicate::contains();
+        assert!(eval(&cow_mls, &cow_m0, &mut contains));
+    }
+}

--- a/geo/src/algorithm/relate/relateng/tests.rs
+++ b/geo/src/algorithm/relate/relateng/tests.rs
@@ -848,3 +848,521 @@ mod relate_ng_test {
         check_prepared_matches(b, a, "T*F**F***");
     }
 }
+
+// Tests ported from JTS RelateNGRobustnessTest.java: reported cases with
+// robustness issues.
+mod relate_ng_robustness_test {
+    use super::*;
+
+    //--------------------------------------------------------
+    //  GeometryCollection semantics
+    //--------------------------------------------------------
+
+    // See https://github.com/libgeos/geos/issues/1033
+    #[test]
+    fn test_geos_1033() {
+        check_contains_within(
+            "POLYGON((1 0,0 4,2 2,1 0))",
+            "GEOMETRYCOLLECTION(POINT(2 2),POINT(1 0),LINESTRING(1 2,1 1))",
+            true,
+        );
+    }
+
+    // https://github.com/libgeos/geos/issues/1027
+    #[test]
+    fn test_geos_1027() {
+        check_covers_covered_by(
+            "MULTIPOLYGON (((0 0, 3 0, 3 3, 0 3, 0 0)))",
+            "GEOMETRYCOLLECTION ( LINESTRING (1 2, 1 1), POINT (0 0))",
+            true,
+        );
+    }
+
+    // https://github.com/libgeos/geos/issues/1022
+    #[test]
+    fn test_geos_1022() {
+        check_crosses(
+            "GEOMETRYCOLLECTION (POINT (7 1), LINESTRING (6 5, 6 4))",
+            "POLYGON ((7 1, 1 3, 3 9, 7 1))",
+            false,
+        );
+    }
+
+    // https://github.com/libgeos/geos/issues/1011
+    #[test]
+    fn test_geos_1011() {
+        let a = "LINESTRING(75 15,55 43)";
+        let b = "GEOMETRYCOLLECTION(POLYGON EMPTY,LINESTRING(75 15,55 43))";
+        check_covers_covered_by(a, b, true);
+        check_equals(a, b, true);
+    }
+
+    // https://github.com/libgeos/geos/issues/983
+    #[test]
+    fn test_geos_983() {
+        let a = "POINT(0 0)";
+        let b = "GEOMETRYCOLLECTION(POINT (1 1), LINESTRING (1 1, 2 2))";
+        check_intersects_disjoint(a, b, false);
+    }
+
+    // https://github.com/libgeos/geos/issues/982
+    #[test]
+    fn test_geos_982() {
+        let a = "POINT(0 0)";
+        let b1 = "GEOMETRYCOLLECTION(POINT(0 0), LINESTRING(0 0, 1 0))";
+        check_contains_within(b1, a, false);
+        check_covers_covered_by(b1, a, true);
+
+        let b2 = "GEOMETRYCOLLECTION(LINESTRING(0 0, 1 0), POINT(0 0))";
+        check_contains_within(b2, a, false);
+        check_covers_covered_by(b2, a, true);
+    }
+
+    // https://github.com/libgeos/geos/issues/981
+    #[test]
+    fn test_geos_981() {
+        let a = "POINT(0 0)";
+        let b = "GEOMETRYCOLLECTION(LINESTRING(0 1, 0 0), POINT(0 0))";
+        check_relate_matches(b, a, intersection_matrix_pattern::CONTAINS_PROPERLY, false);
+    }
+
+    //--------------------------------------------------------
+    //  Noding robustness problems
+    //--------------------------------------------------------
+
+    // https://github.com/libgeos/geos/issues/1053
+    #[test]
+    fn test_geos_1053() {
+        let a = "MULTILINESTRING((2 4, 10 10),(15 10,10 5,5 10))";
+        let b = "MULTILINESTRING((2 4, 10 10))";
+        check_relate(a, b, "1F1F00FF2");
+    }
+
+    // https://github.com/libgeos/geos/issues/968
+    #[test]
+    fn test_geos_968() {
+        let a2 = "LINESTRING(10 0, 0 20)";
+        let b2 = "POINT (9 2)";
+        check_covers_covered_by(a2, b2, true);
+    }
+
+    // JTS xtestGEOS_968_2 is disabled upstream ("this case doesn't work
+    // due to numeric rounding for Orientation test") and is not ported.
+
+    // https://github.com/libgeos/geos/issues/933
+    #[test]
+    fn test_geos_933() {
+        let a = "LINESTRING (0 0, 1 1)";
+        let b = "LINESTRING (0.2 0.2, 0.5 0.5)";
+        check_covers_covered_by(a, b, true);
+    }
+
+    // https://github.com/libgeos/geos/issues/740
+    #[test]
+    fn test_geos_740() {
+        let a = "POLYGON ((1454700 -331500, 1455100 -330700, 1455466.6191038645 -331281.94727476506, 1455467.8182005754 -331293.26796732045, 1454700 -331500))";
+        let b = "LINESTRING (1455389.376551584 -331255.3803222172, 1455467.2422460222 -331287.83037053316)";
+        check_contains_within(a, b, false);
+    }
+
+    //--------------------------------------------------------
+    //  Robustness failures (TopologyException in old code)
+    //--------------------------------------------------------
+
+    // https://github.com/libgeos/geos/issues/766
+    #[test]
+    fn test_geos_766() {
+        let a = "POLYGON ((26639.240191093646 6039.3615818717535, 26639.240191093646 5889.361620883223, 28000.000095100608 5889.362081553552, 28000.000095100608 6039.361620882992, 28700.00019021402 6039.361620882992, 28700.00019021402 5889.361822800367, 29899.538842431968 5889.362160452064, 32465.59665091549 5889.362882757903, 32969.2837182586 -1313.697771558439, 31715.832811969216 -1489.87008918589, 31681.039836323587 -1242.3030298361555, 32279.3890331618 -1158.210534269224, 32237.63710287376 -861.1301136466199, 32682.89764107368 -802.0828534499739, 32247.445200905553 5439.292852892075, 31797.06861513178 5439.292852892075, 31797.06861513178 5639.36178850523, 29899.538849750803 5639.361268079038, 26167.69458275995 5639.3602445643955, 26379.03654594742 2617.0293071870683, 26778.062167926924 2644.9318977193907, 26792.01346261031 2445.419086759444, 26193.472956813417 2403.5650586598513, 25939.238114175267 6039.361685403233, 26639.240191093646 6039.3615818717535), (32682.89764107368 -802.0828534499738, 32682.89764107378 -802.0828534499669, 32247.445200905655 5439.292852892082, 32247.445200905553 5439.292852892075, 32682.89764107368 -802.0828534499738))";
+        let b = "POLYGON ((32450.100392347143 5889.362314133216, 32050.104955691 5891.272957209961, 32100.021071878822 16341.272221116333, 32500.016508656867 16339.361578039587, 32450.100392347143 5889.362314133216))";
+        check_intersects_disjoint(a, b, true);
+    }
+
+    // https://github.com/libgeos/geos/issues/1026
+    #[test]
+    fn test_geos_1026() {
+        let a = "POLYGON((335645.7810000004 5677846.65,335648.6579999998 5677845.801999999,335650.8630842535 5677845.143617179,335650.77673334075 5677844.7250704905,335642.90299999993 5677847.498,335645.7810000004 5677846.65))";
+        let b = "POLYGON((335642.903 5677847.498,335642.894 5677847.459,335645.92 5677846.69,335647.378 5677852.523,335644.403 5677853.285,335644.374 5677853.293,335642.903 5677847.498))";
+        check_touches(a, b, false);
+    }
+
+    // https://github.com/locationtech/jts/issues/1051
+    #[test]
+    fn test_jts_1051() {
+        let a = "POLYGON ((414188.5999999999 6422867.1, 414193.7 6422866.5, 414205.1 6422859.4, 414223.7 6422846.8, 414229.6 6422843.2, 414235.2 6422835.4, 414224.7 6422837.9, 414219.4 6422842.1, 414210.9 6422849, 414199.2 6422857.6, 414191.1 6422863.4, 414188.5999999999 6422867.1))";
+        let b = "LINESTRING (414187.2 6422831.6, 414179 6422836.1, 414182.2 6422841.8, 414176.7 6422844, 414184.5 6422859.5, 414188.6 6422867.1)";
+        check_intersects_disjoint(a, b, true);
+    }
+
+    // https://trac.osgeo.org/postgis/ticket/5362
+    #[test]
+    fn test_postgis_5362() {
+        let a = "POLYGON ((-707259.66 -1121493.36, -707205.9 -1121605.808, -707310.5388 -1121540.5446, -707318.8200000001 -1121533.21, -707259.66 -1121493.36))";
+        let b = "POLYGON ((-707356.18 -1121550.69, -707332.82 -1121536.63, -707318.82 -1121533.21, -707321.72 -1121535.08, -707327.4 -1121539.21, -707356.18 -1121550.69))";
+        check_relate(a, b, "2F2101212");
+        check_intersects_disjoint(a, b, true);
+    }
+
+    //--------------------------------------------------------
+    //  Topological Inconsistency
+    //--------------------------------------------------------
+
+    // https://github.com/libgeos/geos/issues/1064
+    #[test]
+    fn test_geos_1064() {
+        let a = "LINESTRING (16.330791631988802 68.75635661578073, 16.332533372319826 68.75496886016562)";
+        let b =
+            "LINESTRING (16.30641253121884 68.75189557630306, 16.33167771310482 68.75565061843871)";
+        check_relate(a, b, "F01FF0102");
+    }
+
+    // https://github.com/locationtech/jts/issues/396
+    #[test]
+    fn test_jts_396() {
+        let a = "LINESTRING (1 0, 0 2, 0 0, 2 2)";
+        let b = "LINESTRING (0 0, 2 2)";
+        check_relate(a, b, "101F00FF2");
+        check_covers_covered_by(a, b, true);
+    }
+
+    // https://github.com/locationtech/jts/issues/270
+    #[test]
+    fn test_jts_270() {
+        let a = "LINESTRING(0.0 0.0, -10.0 1.2246467991473533E-15)";
+        let b = "LINESTRING(-9.999143275740073 -0.13089595571333978, -10.0 1.0535676356486768E-13)";
+        check_relate(a, b, "FF10F0102");
+        check_intersects_disjoint(a, b, true);
+    }
+
+    // https://gis.stackexchange.com/questions/484691
+    #[test]
+    fn test_gisse_484691() {
+        let a = "POLYGON ((1.839012980156925 43.169860517728324, 1.838983490127865 43.169860200336274, 1.838898525601717 43.169868281549725, 1.838918565176068 43.1699719478626, 1.838920733577112 43.16998636433192, 1.838978629555589 43.16997979090823, 1.838982586839382 43.169966339940714, 1.838974943184281 43.169918580432174, 1.839020497362873 43.169914572864634, 1.839012980156925 43.169860517728324))";
+        let b = "POLYGON ((1.8391355300979277 43.16987802887805, 1.83913336164737 43.16986361241434, 1.8390129801569248 43.169860517728324, 1.8390790978572837 43.16987292371998, 1.8390909520103162 43.16995581178317, 1.8391377530291442 43.16995091801345, 1.8391293863398452 43.16987796276235, 1.8391355300979277 43.16987802887805))";
+        check_relate(a, b, "2F2101212");
+        check_intersects_disjoint(a, b, true);
+    }
+}
+
+// Tests ported from JTS RelateNGGCTest.java: GeometryCollection inputs
+// with union semantics.
+mod relate_ng_gc_test {
+    use super::*;
+
+    #[test]
+    fn test_dimension_with_empty() {
+        let a = "LINESTRING(0 0, 1 1)";
+        let b = "GEOMETRYCOLLECTION(POLYGON EMPTY,LINESTRING(0 0, 1 1))";
+        check_covers_covered_by(a, b, true);
+        check_equals(a, b, true);
+    }
+
+    // See https://github.com/libgeos/geos/issues/1027
+    #[test]
+    fn test_mp_glp_geos1027() {
+        let a = "MULTIPOLYGON (((0 0, 3 0, 3 3, 0 3, 0 0)))";
+        let b = "GEOMETRYCOLLECTION ( LINESTRING (1 2, 1 1), POINT (0 0))";
+        check_relate(a, b, "1020F1FF2");
+        check_intersects_disjoint(a, b, true);
+        check_contains_within(a, b, true);
+        check_crosses(a, b, false);
+        check_equals(a, b, false);
+    }
+
+    // See https://github.com/libgeos/geos/issues/1022
+    #[test]
+    fn test_gpl_a() {
+        let a = "GEOMETRYCOLLECTION (POINT (7 1), LINESTRING (6 5, 6 4))";
+        let b = "POLYGON ((7 1, 1 3, 3 9, 7 1))";
+        check_relate(a, b, "F01FF0212");
+        check_intersects_disjoint(a, b, true);
+        check_contains_within(a, b, false);
+        check_crosses(a, b, false);
+        check_touches(a, b, true);
+        check_equals(a, b, false);
+    }
+
+    // See https://github.com/libgeos/geos/issues/982
+    #[test]
+    fn test_p_gpl() {
+        let a = "POINT(0 0)";
+        let b = "GEOMETRYCOLLECTION(POINT(0 0), LINESTRING(0 0, 1 0))";
+        check_relate(a, b, "F0FFFF102");
+        check_intersects_disjoint(a, b, true);
+        check_contains_within(a, b, false);
+        check_crosses(a, b, false);
+        check_touches(a, b, true);
+        check_equals(a, b, false);
+    }
+
+    #[test]
+    fn test_line_in_overlapping_polygons_touching_interior_edge() {
+        let a = "LINESTRING (3 7, 7 3)";
+        let b = "GEOMETRYCOLLECTION (POLYGON ((1 9, 7 9, 7 3, 1 3, 1 9)), POLYGON ((9 1, 3 1, 3 7, 9 7, 9 1)))";
+        check_relate(a, b, "1FF0FF212");
+        check_contains_within(b, a, true);
+    }
+
+    #[test]
+    fn test_line_in_overlapping_polygons_crossing_interior_edge_at_vertex() {
+        let a = "LINESTRING (2 2, 8 8)";
+        let b = "GEOMETRYCOLLECTION (POLYGON ((1 1, 1 7, 7 7, 7 1, 1 1)), POLYGON ((9 9, 9 3, 3 3, 3 9, 9 9)))";
+        check_relate(a, b, "1FF0FF212");
+        check_contains_within(b, a, true);
+    }
+
+    #[test]
+    fn test_line_in_overlapping_polygons_crossing_interior_edge_proper() {
+        let a = "LINESTRING (2 4, 6 8)";
+        let b = "GEOMETRYCOLLECTION (POLYGON ((1 1, 1 7, 7 7, 7 1, 1 1)), POLYGON ((9 9, 9 3, 3 3, 3 9, 9 9)))";
+        check_relate(a, b, "1FF0FF212");
+        check_contains_within(b, a, true);
+    }
+
+    #[test]
+    fn test_polygon_in_overlapping_polygons_touching_boundaries() {
+        let a = "GEOMETRYCOLLECTION (POLYGON ((1 9, 6 9, 6 4, 1 4, 1 9)), POLYGON ((9 1, 4 1, 4 6, 9 6, 9 1)) )";
+        let b = "POLYGON ((2 6, 6 2, 8 4, 4 8, 2 6))";
+        check_relate(a, b, "212F01FF2");
+        check_contains_within(a, b, true);
+    }
+
+    #[test]
+    fn test_line_in_overlapping_polygons_boundaries() {
+        let a = "LINESTRING (1 6, 9 6, 9 1, 1 1, 1 6)";
+        let b = "GEOMETRYCOLLECTION (POLYGON ((1 1, 1 6, 6 6, 6 1, 1 1)), POLYGON ((9 1, 4 1, 4 6, 9 6, 9 1)))";
+        check_relate(a, b, "F1FFFF2F2");
+        check_contains_within(a, b, false);
+        check_covers_covered_by(a, b, false);
+        check_covers_covered_by(b, a, true);
+    }
+
+    #[test]
+    fn test_line_covers_overlapping_polygons_boundaries() {
+        let a = "LINESTRING (1 6, 9 6, 9 1, 1 1, 1 6)";
+        let b = "GEOMETRYCOLLECTION (POLYGON ((1 1, 1 6, 6 6, 6 1, 1 1)), POLYGON ((9 1, 4 1, 4 6, 9 6, 9 1)))";
+        check_relate(a, b, "F1FFFF2F2");
+        check_contains_within(b, a, false);
+        check_covers_covered_by(b, a, true);
+    }
+
+    #[test]
+    fn test_adjacent_polygons_contained_in_adjacent_polygons() {
+        let a = "GEOMETRYCOLLECTION (POLYGON ((2 2, 2 5, 4 5, 4 2, 2 2)), POLYGON ((8 2, 4 3, 4 4, 8 5, 8 2)))";
+        let b = "GEOMETRYCOLLECTION (POLYGON ((1 1, 1 6, 4 6, 4 1, 1 1)), POLYGON ((9 1, 4 1, 4 6, 9 6, 9 1)))";
+        check_relate(a, b, "2FF1FF212");
+        check_contains_within(b, a, true);
+        check_covers_covered_by(b, a, true);
+    }
+
+    #[test]
+    fn test_gc_multi_polygon_intersects_polygon() {
+        let a = "POLYGON ((2 5, 3 5, 3 3, 2 3, 2 5))";
+        let b = "GEOMETRYCOLLECTION (MULTIPOLYGON (((1 4, 4 4, 4 1, 1 1, 1 4)), ((5 4, 8 4, 8 1, 5 1, 5 4))))";
+        check_relate(a, b, "212101212");
+        check_intersects_disjoint(a, b, true);
+        check_covers_covered_by(b, a, false);
+    }
+
+    #[test]
+    fn test_polygon_contains_gc_multi_polygon_element() {
+        let a = "POLYGON ((0 5, 4 5, 4 1, 0 1, 0 5))";
+        let b = "GEOMETRYCOLLECTION (MULTIPOLYGON (((1 4, 3 4, 3 2, 1 2, 1 4)), ((6 4, 8 4, 8 2, 6 2, 6 4))))";
+        check_relate(a, b, "212FF1212");
+        check_intersects_disjoint(a, b, true);
+        check_covers_covered_by(b, a, false);
+    }
+
+    /// Demonstrates the need for assigning computed nodes to their rings,
+    /// so that subsequent point-in-polygon testing can report the node as
+    /// being on the ring boundary.
+    #[test]
+    fn test_polygon_overlapping_gc_polygon() {
+        let a = "GEOMETRYCOLLECTION (POLYGON ((18.6 40.8, 16.8825 39.618567, 16.9319 39.5461, 17.10985 39.485133, 16.6143 38.4302, 16.43145 38.313267, 16.2 37.5, 14.8 37.8, 14.96475 40.474933, 18.6 40.8)))";
+        let b = "POLYGON ((16.3649953125 38.37219358064516, 16.3649953125 39.545924774193544, 17.949465625000002 39.545924774193544, 17.949465625000002 38.37219358064516, 16.3649953125 38.37219358064516))";
+        check_relate(b, a, "212101212");
+        check_relate(a, b, "212101212");
+        check_intersects_disjoint(a, b, true);
+        check_covers_covered_by(a, b, false);
+    }
+
+    const WKT_ADJACENT_POLYS: &str = "GEOMETRYCOLLECTION (POLYGON ((5 5, 2 9, 9 9, 9 5, 5 5)), POLYGON ((3 1, 5 5, 9 5, 9 1, 3 1)), POLYGON ((1 9, 2 9, 5 5, 3 1, 1 1, 1 9)))";
+
+    #[test]
+    fn test_adj_polygons_cover_polygon_with_endpoint_inside() {
+        let a = WKT_ADJACENT_POLYS;
+        let b = "POLYGON ((3 7, 7 7, 7 3, 3 3, 3 7))";
+        check_relate(b, a, "2FF1FF212");
+        check_relate(a, b, "212FF1FF2");
+        check_intersects_disjoint(a, b, true);
+        check_covers_covered_by(a, b, true);
+    }
+
+    #[test]
+    fn test_adj_polygons_cover_point_at_node() {
+        let a = WKT_ADJACENT_POLYS;
+        let b = "POINT (5 5)";
+        check_relate(b, a, "0FFFFF212");
+        check_relate(a, b, "0F2FF1FF2");
+        check_intersects_disjoint(a, b, true);
+        check_covers_covered_by(a, b, true);
+    }
+
+    #[test]
+    fn test_adj_polygons_cover_point_on_edge() {
+        let a = WKT_ADJACENT_POLYS;
+        let b = "POINT (7 5)";
+        check_relate(b, a, "0FFFFF212");
+        check_relate(a, b, "0F2FF1FF2");
+        check_intersects_disjoint(a, b, true);
+        check_covers_covered_by(a, b, true);
+    }
+
+    #[test]
+    fn test_adj_polygons_containing_polygon_touching_interior_endpoint() {
+        let a = WKT_ADJACENT_POLYS;
+        let b = "POLYGON ((5 5, 7 5, 7 3, 5 3, 5 5))";
+        check_relate(a, b, "212FF1FF2");
+        check_intersects_disjoint(a, b, true);
+        check_covers_covered_by(a, b, true);
+    }
+
+    #[test]
+    fn test_adj_polygons_overlapped_by_polygon_with_hole() {
+        let a = WKT_ADJACENT_POLYS;
+        let b = "POLYGON ((0 10, 10 10, 10 0, 0 0, 0 10), (2 8, 8 8, 8 2, 2 2, 2 8))";
+        check_relate(a, b, "2121FF212");
+        check_intersects_disjoint(a, b, true);
+        check_covers_covered_by(a, b, false);
+    }
+
+    #[test]
+    fn test_adj_polygons_containing_line() {
+        let a = WKT_ADJACENT_POLYS;
+        let b = "LINESTRING (5 5, 7 7)";
+        check_relate(a, b, "102FF1FF2");
+        check_intersects_disjoint(a, b, true);
+        check_covers_covered_by(a, b, true);
+    }
+
+    #[test]
+    fn test_adj_polygons_containing_line_and_point() {
+        let a = WKT_ADJACENT_POLYS;
+        let b = "GEOMETRYCOLLECTION (POINT (5 5), LINESTRING (5 7, 7 7))";
+        check_relate(a, b, "102FF1FF2");
+        check_intersects_disjoint(a, b, true);
+        check_covers_covered_by(a, b, true);
+    }
+
+    // JTS testEmptyMultiPointElements uses MULTIPOINT (EMPTY, (5 5)),
+    // which geo cannot represent (a MultiPoint cannot hold an empty
+    // Point); the test is not ported.
+
+    #[test]
+    fn test_polygon_containing_points_in_boundary() {
+        let a = "POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))";
+        let b = "GEOMETRYCOLLECTION (POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0)), MULTIPOINT ((0 2), (0 5)))";
+        check_equals(a, b, true);
+    }
+
+    #[test]
+    fn test_polygon_containing_line_in_boundary() {
+        let a = "POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))";
+        let b =
+            "GEOMETRYCOLLECTION (POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0)), LINESTRING (0 2, 0 5))";
+        check_equals(a, b, true);
+        check_contains_within(a, b, true);
+        check_covers_covered_by(a, b, true);
+        check_contains_within(b, a, true);
+        check_covers_covered_by(b, a, true);
+    }
+
+    #[test]
+    fn test_polygon_containing_line_in_boundary_and_interior() {
+        let a = "POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))";
+        let b = "GEOMETRYCOLLECTION (POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0)), LINESTRING (0 2, 0 5, 5 5))";
+        check_equals(a, b, true);
+        check_contains_within(a, b, true);
+        check_covers_covered_by(a, b, true);
+        check_contains_within(b, a, true);
+        check_covers_covered_by(b, a, true);
+    }
+}
+
+// The Mod-2 (OGC SFS) assertions of JTS RelateNGBoundaryNodeRuleTest.java.
+// The EndPoint / MonoValent / MultiValent rule assertions are not ported:
+// this port supports the Mod-2 rule only.
+// testMultiLineStringSelfIntTouchAtEndpoint has only an EndPoint-rule
+// assertion and is omitted entirely.
+mod relate_ng_boundary_node_rule_test {
+    use super::*;
+
+    #[test]
+    fn test_line_string_self_int_touch_at_endpoint() {
+        let a = "LINESTRING (20 20, 100 100, 100 20, 20 100)";
+        let b = "LINESTRING (60 60, 20 60)";
+        check_relate(a, b, "F01FF0102");
+    }
+
+    #[test]
+    fn test_multi_line_string_touch_at_endpoint() {
+        let a = "MULTILINESTRING ((0 0, 10 10), (10 10, 20 20))";
+        let b = "LINESTRING (10 10, 20 0)";
+        // Under Mod-2 the A touch point is not a boundary:
+        // A.int / B.bdy = 0.
+        check_relate(a, b, "F01FF0102");
+    }
+
+    #[test]
+    fn test_multi_line_string_closed_touch_at_endpoint() {
+        let a = "MULTILINESTRING ((0 0, 10 10), (10 10, 0 20, 0 0))";
+        let b = "LINESTRING (10 10, 20 0)";
+        // Under Mod-2, A has no boundary: A.int / B.bdy = 0.
+        check_relate(a, b, "F01FFF102");
+    }
+
+    #[test]
+    fn test_line_ring_touch_at_endpoints() {
+        let a = "LINESTRING (20 100, 20 220, 120 100, 20 100)";
+        let b = "LINESTRING (20 20, 20 100)";
+        // Under Mod-2, A has no boundary: A.int / B.bdy = 0.
+        check_relate(a, b, "F01FFF102");
+    }
+
+    #[test]
+    fn test_line_ring_touch_at_endpoint_and_interior() {
+        let a = "LINESTRING (20 100, 20 220, 120 100, 20 100)";
+        let b = "LINESTRING (20 20, 40 100)";
+        check_relate(a, b, "F01FFF102");
+    }
+
+    #[test]
+    fn test_polygon_empty_ring() {
+        let a = "POLYGON EMPTY";
+        let b = "LINESTRING (20 100, 20 220, 120 100, 20 100)";
+        // A closed line has no boundary under the SFS rule.
+        check_relate(a, b, "FFFFFF1F2");
+    }
+
+    #[test]
+    fn test_polygon_empty_multi_line_string_closed() {
+        let a = "POLYGON EMPTY";
+        let b = "MULTILINESTRING ((0 0, 0 1), (0 1, 1 1, 1 0, 0 0))";
+        check_relate(a, b, "FFFFFF1F2");
+    }
+
+    #[test]
+    fn test_polygon_equal_rotated() {
+        let a = "POLYGON ((0 0, 140 0, 140 140, 0 140, 0 0))";
+        let b = "POLYGON ((140 0, 0 0, 0 140, 140 140, 140 0))";
+        // The boundary node rule only considers linear endpoints, so the
+        // result is the same for all rules.
+        check_relate(a, b, "2FFF1FFF2");
+    }
+
+    #[test]
+    fn test_line_string_interior_touch_multivalent() {
+        let a = "POLYGON EMPTY";
+        let b = "MULTILINESTRING ((0 0, 0 1), (0 1, 1 1, 1 0, 0 0))";
+        check_relate(a, b, "FFFFFF1F2");
+    }
+}

--- a/geo/src/algorithm/relate/relateng/tests.rs
+++ b/geo/src/algorithm/relate/relateng/tests.rs
@@ -1,0 +1,850 @@
+//! End-to-end tests for the RelateNG engine, ported from the JTS test
+//! suites (master, ab57bff):
+//! `RelateNGTest`, `RelateNGRobustnessTest`, `RelateNGGCTest`, and the
+//! Mod-2 cases of `RelateNGBoundaryNodeRuleTest`.
+//!
+//! Fixtures are the JTS WKT strings verbatim, parsed at runtime. geo
+//! cannot represent an empty Point, so `POINT EMPTY` fixtures are omitted
+//! where they occur, with a comment.
+
+use wkt::TryFromWkt;
+
+use crate::Geometry;
+use crate::geometry_cow::GeometryCow;
+use crate::relate::IntersectionMatrix;
+
+use super::im_predicate::RelateMatrixPredicate;
+use super::relate_ng::{self, RelateNG};
+use super::relate_predicate as pred;
+use super::relate_predicate::intersection_matrix_pattern;
+use super::topology_predicate::TopologyPredicate;
+
+fn read(wkt_str: &str) -> Geometry<f64> {
+    Geometry::try_from_wkt_str(wkt_str)
+        .unwrap_or_else(|e| panic!("invalid WKT fixture {wkt_str}: {e}"))
+}
+
+fn check_pred(mut predicate: impl TopologyPredicate<f64>, wkta: &str, wktb: &str, expected: bool) {
+    let a = read(wkta);
+    let b = read(wktb);
+    let ca = GeometryCow::from(&a);
+    let cb = GeometryCow::from(&b);
+    let actual = relate_ng::eval(&ca, &cb, &mut predicate);
+    assert_eq!(actual, expected, "{predicate:?}: A = {wkta}, B = {wktb}");
+}
+
+fn check_intersects_disjoint(wkta: &str, wktb: &str, expected: bool) {
+    check_pred(pred::intersects(), wkta, wktb, expected);
+    check_pred(pred::intersects(), wktb, wkta, expected);
+    check_pred(pred::disjoint(), wkta, wktb, !expected);
+    check_pred(pred::disjoint(), wktb, wkta, !expected);
+}
+
+fn check_contains_within(wkta: &str, wktb: &str, expected: bool) {
+    check_pred(pred::contains(), wkta, wktb, expected);
+    check_pred(pred::within(), wktb, wkta, expected);
+}
+
+fn check_covers_covered_by(wkta: &str, wktb: &str, expected: bool) {
+    check_pred(pred::covers(), wkta, wktb, expected);
+    check_pred(pred::covered_by(), wktb, wkta, expected);
+}
+
+fn check_crosses(wkta: &str, wktb: &str, expected: bool) {
+    check_pred(pred::crosses(), wkta, wktb, expected);
+    check_pred(pred::crosses(), wktb, wkta, expected);
+}
+
+fn check_overlaps(wkta: &str, wktb: &str, expected: bool) {
+    check_pred(pred::overlaps(), wkta, wktb, expected);
+    check_pred(pred::overlaps(), wktb, wkta, expected);
+}
+
+fn check_touches(wkta: &str, wktb: &str, expected: bool) {
+    check_pred(pred::touches(), wkta, wktb, expected);
+    check_pred(pred::touches(), wktb, wkta, expected);
+}
+
+fn check_equals(wkta: &str, wktb: &str, expected: bool) {
+    check_pred(pred::equals_topo(), wkta, wktb, expected);
+    check_pred(pred::equals_topo(), wktb, wkta, expected);
+}
+
+fn relate_matrix(wkta: &str, wktb: &str) -> IntersectionMatrix {
+    let a = read(wkta);
+    let b = read(wktb);
+    let ca = GeometryCow::from(&a);
+    let cb = GeometryCow::from(&b);
+    relate_ng::relate(&ca, &cb)
+}
+
+fn check_relate(wkta: &str, wktb: &str, expected: &str) {
+    let im = relate_matrix(wkta, wktb);
+    let expected: IntersectionMatrix = expected.parse().expect("valid DE-9IM matrix");
+    assert_eq!(im, expected, "A = {wkta}, B = {wktb}");
+}
+
+fn check_relate_matches(wkta: &str, wktb: &str, pattern: &str, expected: bool) {
+    check_pred(
+        pred::matches(pattern).expect("valid pattern"),
+        wkta,
+        wktb,
+        expected,
+    );
+}
+
+fn check_prepared(wkta: &str, wktb: &str) {
+    let a = read(wkta);
+    let b = read(wktb);
+    let ca = GeometryCow::from(&a);
+    let cb = GeometryCow::from(&b);
+    let prep_a = RelateNG::prepare(&ca);
+
+    macro_rules! check {
+        ($factory:expr, $name:literal) => {
+            let mut p1 = $factory;
+            let mut p2 = $factory;
+            assert_eq!(
+                prep_a.evaluate(&cb, &mut p1),
+                relate_ng::eval(&ca, &cb, &mut p2),
+                concat!($name, ": A = {}, B = {}"),
+                wkta,
+                wktb
+            );
+        };
+    }
+    check!(pred::equals_topo(), "equalsTopo");
+    check!(pred::intersects(), "intersects");
+    check!(pred::disjoint(), "disjoint");
+    check!(pred::covers(), "covers");
+    check!(pred::covered_by(), "coveredBy");
+    check!(pred::within(), "within");
+    check!(pred::contains(), "contains");
+    check!(pred::crosses(), "crosses");
+    check!(pred::touches(), "touches");
+
+    let mut matrix_pred = RelateMatrixPredicate::new();
+    prep_a.evaluate(&cb, &mut matrix_pred);
+    let prepared_im = matrix_pred.into_im();
+    assert_eq!(
+        prepared_im,
+        relate_ng::relate(&ca, &cb),
+        "relate: A = {wkta}, B = {wktb}"
+    );
+}
+
+fn check_prepared_matches(wkta: &str, wktb: &str, pattern: &str) {
+    let a = read(wkta);
+    let b = read(wktb);
+    let ca = GeometryCow::from(&a);
+    let cb = GeometryCow::from(&b);
+    let prep_a = RelateNG::prepare(&ca);
+
+    let mut p1 = pred::matches(pattern).expect("valid pattern");
+    let mut p2 = pred::matches(pattern).expect("valid pattern");
+    assert_eq!(
+        prep_a.evaluate(&cb, &mut p1),
+        relate_ng::eval(&ca, &cb, &mut p2),
+        "matches {pattern}: A = {wkta}, B = {wktb}"
+    );
+}
+
+// Tests ported from JTS RelateNGTest.java.
+mod relate_ng_test {
+    use super::*;
+
+    #[test]
+    fn test_points_disjoint() {
+        let a = "POINT (0 0)";
+        let b = "POINT (1 1)";
+        check_intersects_disjoint(a, b, false);
+        check_contains_within(a, b, false);
+        check_equals(a, b, false);
+        check_relate(a, b, "FF0FFF0F2");
+    }
+
+    //======= P/P  =============
+
+    #[test]
+    fn test_points_contained() {
+        let a = "MULTIPOINT (0 0, 1 1, 2 2)";
+        let b = "MULTIPOINT (1 1, 2 2)";
+        check_intersects_disjoint(a, b, true);
+        check_contains_within(a, b, true);
+        check_equals(a, b, false);
+        check_relate(a, b, "0F0FFFFF2");
+    }
+
+    #[test]
+    fn test_points_equal() {
+        let a = "MULTIPOINT (0 0, 1 1, 2 2)";
+        let b = "MULTIPOINT (0 0, 1 1, 2 2)";
+        check_intersects_disjoint(a, b, true);
+        check_contains_within(a, b, true);
+        check_equals(a, b, true);
+    }
+
+    #[test]
+    fn test_validate_relate_pp_13() {
+        let a = "MULTIPOINT ((80 70), (140 120), (20 20), (200 170))";
+        let b = "MULTIPOINT ((80 70), (140 120), (80 170), (200 80))";
+        check_intersects_disjoint(a, b, true);
+        check_contains_within(a, b, false);
+        check_contains_within(b, a, false);
+        check_covers_covered_by(a, b, false);
+        check_overlaps(a, b, true);
+        check_touches(a, b, false);
+    }
+
+    //======= L/P  =============
+
+    #[test]
+    fn test_line_point_contains() {
+        let a = "LINESTRING (0 0, 1 1, 2 2)";
+        let b = "MULTIPOINT (0 0, 1 1, 2 2)";
+        check_relate(a, b, "0F10FFFF2");
+        check_intersects_disjoint(a, b, true);
+        check_contains_within(a, b, true);
+        check_contains_within(b, a, false);
+        check_covers_covered_by(a, b, true);
+        check_covers_covered_by(b, a, false);
+    }
+
+    #[test]
+    fn test_line_point_overlaps() {
+        let a = "LINESTRING (0 0, 1 1)";
+        let b = "MULTIPOINT (0 0, 1 1, 2 2)";
+        check_intersects_disjoint(a, b, true);
+        check_contains_within(a, b, false);
+        check_contains_within(b, a, false);
+        check_covers_covered_by(a, b, false);
+        check_covers_covered_by(b, a, false);
+    }
+
+    #[test]
+    fn test_zero_length_line_point() {
+        let a = "LINESTRING (0 0, 0 0)";
+        let b = "POINT (0 0)";
+        check_relate(a, b, "0FFFFFFF2");
+        check_intersects_disjoint(a, b, true);
+        check_contains_within(a, b, true);
+        check_contains_within(b, a, true);
+        check_covers_covered_by(a, b, true);
+        check_covers_covered_by(b, a, true);
+        check_equals(a, b, true);
+    }
+
+    #[test]
+    fn test_zero_length_line_line() {
+        let a = "LINESTRING (10 10, 10 10, 10 10)";
+        let b = "LINESTRING (10 10, 10 10)";
+        check_relate(a, b, "0FFFFFFF2");
+        check_intersects_disjoint(a, b, true);
+        check_contains_within(a, b, true);
+        check_contains_within(b, a, true);
+        check_covers_covered_by(a, b, true);
+        check_covers_covered_by(b, a, true);
+        check_equals(a, b, true);
+    }
+
+    // Tests a bug involving checking for non-zero-length lines.
+    #[test]
+    fn test_non_zero_length_line_point() {
+        let a = "LINESTRING (0 0, 0 0, 9 9)";
+        let b = "POINT (1 1)";
+        check_relate(a, b, "0F1FF0FF2");
+        check_intersects_disjoint(a, b, true);
+        check_contains_within(a, b, true);
+        check_contains_within(b, a, false);
+        check_covers_covered_by(a, b, true);
+        check_covers_covered_by(b, a, false);
+        check_equals(a, b, false);
+    }
+
+    #[test]
+    fn test_line_point_int_and_ext() {
+        let a = "MULTIPOINT((60 60), (100 100))";
+        let b = "LINESTRING(40 40, 80 80)";
+        check_relate(a, b, "0F0FFF102");
+    }
+
+    //======= L/L  =============
+
+    #[test]
+    fn test_lines_cross_proper() {
+        let a = "LINESTRING (0 0, 9 9)";
+        let b = "LINESTRING(0 9, 9 0)";
+        check_intersects_disjoint(a, b, true);
+        check_contains_within(a, b, false);
+    }
+
+    #[test]
+    fn test_lines_overlap() {
+        let a = "LINESTRING (0 0, 5 5)";
+        let b = "LINESTRING(3 3, 9 9)";
+        check_intersects_disjoint(a, b, true);
+        check_touches(a, b, false);
+        check_overlaps(a, b, true);
+    }
+
+    #[test]
+    fn test_lines_cross_vertex() {
+        let a = "LINESTRING (0 0, 8 8)";
+        let b = "LINESTRING(0 8, 4 4, 8 0)";
+        check_intersects_disjoint(a, b, true);
+    }
+
+    #[test]
+    fn test_lines_touch_vertex() {
+        let a = "LINESTRING (0 0, 8 0)";
+        let b = "LINESTRING(0 8, 4 0, 8 8)";
+        check_intersects_disjoint(a, b, true);
+    }
+
+    #[test]
+    fn test_lines_disjoint_by_envelope() {
+        let a = "LINESTRING (0 0, 9 9)";
+        let b = "LINESTRING(10 19, 19 10)";
+        check_intersects_disjoint(a, b, false);
+        check_contains_within(a, b, false);
+    }
+
+    #[test]
+    fn test_lines_disjoint() {
+        let a = "LINESTRING (0 0, 9 9)";
+        let b = "LINESTRING (4 2, 8 6)";
+        check_intersects_disjoint(a, b, false);
+        check_contains_within(a, b, false);
+    }
+
+    #[test]
+    fn test_lines_closed_empty() {
+        let a = "MULTILINESTRING ((0 0, 0 1), (0 1, 1 1, 1 0, 0 0))";
+        let b = "LINESTRING EMPTY";
+        check_relate(a, b, "FF1FFFFF2");
+        check_intersects_disjoint(a, b, false);
+        check_contains_within(a, b, false);
+    }
+
+    #[test]
+    fn test_lines_ring_touch_at_node() {
+        let a = "LINESTRING (5 5, 1 8, 1 1, 5 5)";
+        let b = "LINESTRING (5 5, 9 5)";
+        check_relate(a, b, "F01FFF102");
+        check_intersects_disjoint(a, b, true);
+        check_contains_within(a, b, false);
+        check_touches(a, b, true);
+    }
+
+    #[test]
+    fn test_lines_touch_at_bdy() {
+        let a = "LINESTRING (5 5, 1 8)";
+        let b = "LINESTRING (5 5, 9 5)";
+        check_relate(a, b, "FF1F00102");
+        check_intersects_disjoint(a, b, true);
+        check_contains_within(a, b, false);
+        check_touches(a, b, true);
+    }
+
+    #[test]
+    fn test_lines_overlap_with_disjoint_line() {
+        let a = "LINESTRING (1 1, 9 9)";
+        let b = "MULTILINESTRING ((2 2, 8 8), (6 2, 8 4))";
+        check_relate(a, b, "101FF0102");
+        check_intersects_disjoint(a, b, true);
+        check_contains_within(a, b, false);
+        check_overlaps(a, b, true);
+    }
+
+    #[test]
+    fn test_lines_disjoint_overlapping_envelopes() {
+        let a = "LINESTRING (60 0, 20 80, 100 80, 80 120, 40 140)";
+        let b = "LINESTRING (60 40, 140 40, 140 160, 0 160)";
+        check_relate(a, b, "FF1FF0102");
+        check_intersects_disjoint(a, b, false);
+        check_contains_within(a, b, false);
+        check_touches(a, b, false);
+    }
+
+    /// Case from https://github.com/locationtech/jts/issues/270.
+    /// Strictly, the lines cross, since their interiors intersect
+    /// according to the orientation predicate; but the computation of the
+    /// intersection point is non-robust and reports it as equal to the
+    /// endpoint POINT (-10 0.0000000000000012). For consistency the
+    /// relate algorithm uses the intersection node topology.
+    #[test]
+    fn test_lines_cross_jts270() {
+        let a = "LINESTRING (0 0, -10 0.0000000000000012)";
+        let b = "LINESTRING (-9.999143275740073 -0.1308959557133398, -10 0.0000000000001054)";
+        check_intersects_disjoint(a, b, true);
+        check_contains_within(a, b, false);
+        check_covers_covered_by(a, b, false);
+        check_crosses(a, b, false);
+        check_overlaps(a, b, false);
+        check_touches(a, b, true);
+    }
+
+    #[test]
+    fn test_lines_contained_jts396() {
+        let a = "LINESTRING (1 0, 0 2, 0 0, 2 2)";
+        let b = "LINESTRING (0 0, 2 2)";
+        check_intersects_disjoint(a, b, true);
+        check_contains_within(a, b, true);
+        check_covers_covered_by(a, b, true);
+        check_crosses(a, b, false);
+        check_overlaps(a, b, false);
+        check_touches(a, b, false);
+    }
+
+    /// This case shows that lines must be self-noded, so that node
+    /// topology is constructed correctly (at least for some predicates).
+    #[test]
+    fn test_lines_contained_with_self_intersection() {
+        let a = "LINESTRING (2 0, 0 2, 0 0, 2 2)";
+        let b = "LINESTRING (0 0, 2 2)";
+        check_contains_within(a, b, true);
+        check_covers_covered_by(a, b, true);
+        check_crosses(a, b, false);
+        check_overlaps(a, b, false);
+        check_touches(a, b, false);
+    }
+
+    #[test]
+    fn test_line_contained_in_ring() {
+        let a = "LINESTRING(60 60, 100 100, 140 60)";
+        let b = "LINESTRING(100 100, 180 20, 20 20, 100 100)";
+        check_intersects_disjoint(a, b, true);
+        check_contains_within(b, a, true);
+        check_covers_covered_by(b, a, true);
+        check_crosses(a, b, false);
+        check_overlaps(a, b, false);
+        check_touches(a, b, false);
+    }
+
+    // See https://github.com/libgeos/geos/issues/933
+    #[test]
+    fn test_line_line_proper_intersection() {
+        let a = "MULTILINESTRING ((0 0, 1 1), (0.5 0.5, 1 0.1, -1 0.1))";
+        let b = "LINESTRING (0 0, 1 1)";
+        check_contains_within(a, b, true);
+        check_covers_covered_by(a, b, true);
+        check_crosses(a, b, false);
+        check_overlaps(a, b, false);
+        check_touches(a, b, false);
+    }
+
+    #[test]
+    fn test_line_self_intersection_collinear() {
+        let a = "LINESTRING (9 6, 1 6, 1 0, 5 6, 9 6)";
+        let b = "LINESTRING (9 9, 3 1)";
+        check_relate(a, b, "0F1FFF102");
+    }
+
+    //======= A/P  =============
+
+    #[test]
+    fn test_polygon_point_inside() {
+        let a = "POLYGON ((0 10, 10 10, 10 0, 0 0, 0 10))";
+        let b = "POINT (1 1)";
+        check_intersects_disjoint(a, b, true);
+        check_contains_within(a, b, true);
+    }
+
+    #[test]
+    fn test_polygon_point_outside() {
+        let a = "POLYGON ((10 0, 0 0, 0 10, 10 0))";
+        let b = "POINT (8 8)";
+        check_intersects_disjoint(a, b, false);
+        check_contains_within(a, b, false);
+    }
+
+    #[test]
+    fn test_polygon_point_in_boundary() {
+        let a = "POLYGON ((10 0, 0 0, 0 10, 10 0))";
+        let b = "POINT (1 0)";
+        check_intersects_disjoint(a, b, true);
+        check_contains_within(a, b, false);
+        check_covers_covered_by(a, b, true);
+    }
+
+    #[test]
+    fn test_area_point_in_exterior() {
+        let a = "POLYGON ((1 5, 5 5, 5 1, 1 1, 1 5))";
+        let b = "POINT (7 7)";
+        check_relate(a, b, "FF2FF10F2");
+        check_intersects_disjoint(a, b, false);
+        check_contains_within(a, b, false);
+        check_covers_covered_by(a, b, false);
+        check_touches(a, b, false);
+        check_overlaps(a, b, false);
+    }
+
+    //======= A/L  =============
+
+    #[test]
+    fn test_area_line_contained_at_line_vertex() {
+        let a = "POLYGON ((1 5, 5 5, 5 1, 1 1, 1 5))";
+        let b = "LINESTRING (2 3, 3 5, 4 3)";
+        check_intersects_disjoint(a, b, true);
+        check_touches(a, b, false);
+        check_overlaps(a, b, false);
+    }
+
+    #[test]
+    fn test_area_line_touch_at_line_vertex() {
+        let a = "POLYGON ((1 5, 5 5, 5 1, 1 1, 1 5))";
+        let b = "LINESTRING (1 8, 3 5, 5 8)";
+        check_intersects_disjoint(a, b, true);
+        check_contains_within(a, b, false);
+        check_covers_covered_by(a, b, false);
+        check_touches(a, b, true);
+        check_overlaps(a, b, false);
+    }
+
+    #[test]
+    fn test_polygon_line_inside() {
+        let a = "POLYGON ((0 10, 10 10, 10 0, 0 0, 0 10))";
+        let b = "LINESTRING (1 8, 3 5, 5 8)";
+        check_relate(a, b, "102FF1FF2");
+        check_intersects_disjoint(a, b, true);
+        check_contains_within(a, b, true);
+    }
+
+    #[test]
+    fn test_polygon_line_outside() {
+        let a = "POLYGON ((10 0, 0 0, 0 10, 10 0))";
+        let b = "LINESTRING (4 8, 9 3)";
+        check_intersects_disjoint(a, b, false);
+        check_contains_within(a, b, false);
+    }
+
+    #[test]
+    fn test_polygon_line_in_boundary() {
+        let a = "POLYGON ((10 0, 0 0, 0 10, 10 0))";
+        let b = "LINESTRING (1 0, 9 0)";
+        check_intersects_disjoint(a, b, true);
+        check_contains_within(a, b, false);
+        check_covers_covered_by(a, b, true);
+        check_touches(a, b, true);
+        check_overlaps(a, b, false);
+    }
+
+    #[test]
+    fn test_polygon_line_crossing_contained() {
+        let a =
+            "MULTIPOLYGON (((20 80, 180 80, 100 0, 20 80)), ((20 160, 180 160, 100 80, 20 160)))";
+        let b = "LINESTRING (100 140, 100 40)";
+        check_relate(a, b, "1020F1FF2");
+        check_intersects_disjoint(a, b, true);
+        check_contains_within(a, b, true);
+        check_covers_covered_by(a, b, true);
+        check_touches(a, b, false);
+        check_overlaps(a, b, false);
+    }
+
+    #[test]
+    fn test_validate_relate_la_220() {
+        let a = "LINESTRING (90 210, 210 90)";
+        let b = "POLYGON ((150 150, 410 150, 280 20, 20 20, 150 150))";
+        check_intersects_disjoint(a, b, true);
+        check_contains_within(a, b, false);
+        check_covers_covered_by(a, b, false);
+        check_touches(a, b, false);
+        check_overlaps(a, b, false);
+    }
+
+    /// See RelateLA.xml (line 585).
+    #[test]
+    fn test_line_crossing_polygon_at_shell_hole_point() {
+        let a = "LINESTRING (60 160, 150 70)";
+        let b = "POLYGON ((190 190, 360 20, 20 20, 190 190), (110 110, 250 100, 140 30, 110 110))";
+        check_relate(a, b, "F01FF0212");
+        check_touches(a, b, true);
+        check_intersects_disjoint(a, b, true);
+        check_contains_within(a, b, false);
+        check_covers_covered_by(a, b, false);
+        check_touches(a, b, true);
+        check_overlaps(a, b, false);
+    }
+
+    #[test]
+    fn test_line_crossing_polygon_at_non_vertex() {
+        let a = "LINESTRING (20 60, 150 60)";
+        let b = "POLYGON ((150 150, 410 150, 280 20, 20 20, 150 150))";
+        check_intersects_disjoint(a, b, true);
+        check_contains_within(a, b, false);
+        check_covers_covered_by(a, b, false);
+        check_touches(a, b, false);
+        check_overlaps(a, b, false);
+    }
+
+    #[test]
+    fn test_polygon_lines_contained_collinear_edge() {
+        let a = "POLYGON ((110 110, 200 20, 20 20, 110 110))";
+        let b =
+            "MULTILINESTRING ((110 110, 60 40, 70 20, 150 20, 170 40), (180 30, 40 30, 110 80))";
+        check_relate(a, b, "102101FF2");
+    }
+
+    //======= A/A  =============
+
+    #[test]
+    fn test_polygons_edge_adjacent() {
+        let a = "POLYGON ((1 3, 3 3, 3 1, 1 1, 1 3))";
+        let b = "POLYGON ((5 3, 5 1, 3 1, 3 3, 5 3))";
+        check_overlaps(a, b, false);
+        check_touches(a, b, true);
+        check_overlaps(a, b, false);
+    }
+
+    #[test]
+    fn test_polygons_edge_adjacent2() {
+        let a = "POLYGON ((1 3, 4 3, 3 0, 1 1, 1 3))";
+        let b = "POLYGON ((5 3, 5 1, 3 0, 4 3, 5 3))";
+        check_overlaps(a, b, false);
+        check_touches(a, b, true);
+        check_overlaps(a, b, false);
+    }
+
+    #[test]
+    fn test_polygons_nested() {
+        let a = "POLYGON ((1 9, 9 9, 9 1, 1 1, 1 9))";
+        let b = "POLYGON ((2 8, 8 8, 8 2, 2 2, 2 8))";
+        check_intersects_disjoint(a, b, true);
+        check_contains_within(a, b, true);
+        check_covers_covered_by(a, b, true);
+        check_overlaps(a, b, false);
+        check_touches(a, b, false);
+    }
+
+    #[test]
+    fn test_polygons_overlap_proper() {
+        let a = "POLYGON ((1 1, 1 7, 7 7, 7 1, 1 1))";
+        let b = "POLYGON ((2 8, 8 8, 8 2, 2 2, 2 8))";
+        check_intersects_disjoint(a, b, true);
+        check_contains_within(a, b, false);
+        check_covers_covered_by(a, b, false);
+        check_overlaps(a, b, true);
+        check_touches(a, b, false);
+    }
+
+    #[test]
+    fn test_polygons_overlap_at_nodes() {
+        let a = "POLYGON ((1 5, 5 5, 5 1, 1 1, 1 5))";
+        let b = "POLYGON ((7 3, 5 1, 3 3, 5 5, 7 3))";
+        check_intersects_disjoint(a, b, true);
+        check_contains_within(a, b, false);
+        check_covers_covered_by(a, b, false);
+        check_overlaps(a, b, true);
+        check_touches(a, b, false);
+    }
+
+    #[test]
+    fn test_polygons_contained_at_nodes() {
+        let a = "POLYGON ((1 5, 5 5, 6 2, 1 1, 1 5))";
+        let b = "POLYGON ((1 1, 5 5, 6 2, 1 1))";
+        check_contains_within(a, b, true);
+        check_covers_covered_by(a, b, true);
+        check_overlaps(a, b, false);
+        check_touches(a, b, false);
+    }
+
+    #[test]
+    fn test_polygons_nested_with_hole() {
+        let a = "POLYGON ((40 60, 420 60, 420 320, 40 320, 40 60), (200 140, 160 220, 260 200, 200 140))";
+        let b = "POLYGON ((80 100, 360 100, 360 280, 80 280, 80 100))";
+        check_contains_within(a, b, false);
+        check_contains_within(b, a, false);
+        check_pred(pred::contains(), a, b, false);
+    }
+
+    #[test]
+    fn test_polygons_overlapping_with_boundary_inside() {
+        let a = "POLYGON ((100 60, 140 100, 100 140, 60 100, 100 60))";
+        let b = "MULTIPOLYGON (((80 40, 120 40, 120 80, 80 80, 80 40)), ((120 80, 160 80, 160 120, 120 120, 120 80)), ((80 120, 120 120, 120 160, 80 160, 80 120)), ((40 80, 80 80, 80 120, 40 120, 40 80)))";
+        check_relate(a, b, "21210F212");
+        check_intersects_disjoint(a, b, true);
+        check_contains_within(a, b, false);
+        check_contains_within(b, a, false);
+        check_covers_covered_by(a, b, false);
+        check_overlaps(a, b, true);
+        check_touches(a, b, false);
+    }
+
+    #[test]
+    fn test_polygons_overlap_very_narrow() {
+        let a = "POLYGON ((120 100, 120 200, 200 200, 200 100, 120 100))";
+        let b = "POLYGON ((100 100, 100000 110, 100000 100, 100 100))";
+        check_relate(a, b, "212111212");
+        check_intersects_disjoint(a, b, true);
+        check_contains_within(a, b, false);
+        check_contains_within(b, a, false);
+    }
+
+    #[test]
+    fn test_validate_relate_aa_86() {
+        let a = "POLYGON ((170 120, 300 120, 250 70, 120 70, 170 120))";
+        let b = "POLYGON ((150 150, 410 150, 280 20, 20 20, 150 150), (170 120, 330 120, 260 50, 100 50, 170 120))";
+        check_intersects_disjoint(a, b, true);
+        check_contains_within(a, b, false);
+        check_covers_covered_by(a, b, false);
+        check_overlaps(a, b, false);
+        check_pred(pred::within(), a, b, false);
+        check_touches(a, b, true);
+    }
+
+    #[test]
+    fn test_validate_relate_aa_97() {
+        let a = "POLYGON ((330 150, 200 110, 150 150, 280 190, 330 150))";
+        let b = "MULTIPOLYGON (((140 110, 260 110, 170 20, 50 20, 140 110)), ((300 270, 420 270, 340 190, 220 190, 300 270)))";
+        check_intersects_disjoint(a, b, true);
+        check_contains_within(a, b, false);
+        check_covers_covered_by(a, b, false);
+        check_overlaps(a, b, false);
+        check_pred(pred::within(), a, b, false);
+        check_touches(a, b, true);
+    }
+
+    #[test]
+    fn test_adjacent_polygons() {
+        let a = "POLYGON ((1 9, 6 9, 6 1, 1 1, 1 9))";
+        let b = "POLYGON ((9 9, 9 4, 6 4, 6 9, 9 9))";
+        check_relate_matches(a, b, intersection_matrix_pattern::ADJACENT, true);
+    }
+
+    #[test]
+    fn test_adjacent_polygons_touching_at_point() {
+        let a = "POLYGON ((1 9, 6 9, 6 1, 1 1, 1 9))";
+        let b = "POLYGON ((9 9, 9 4, 6 4, 7 9, 9 9))";
+        check_relate_matches(a, b, intersection_matrix_pattern::ADJACENT, false);
+    }
+
+    #[test]
+    fn test_adjacent_polygons_overlappping() {
+        let a = "POLYGON ((1 9, 6 9, 6 1, 1 1, 1 9))";
+        let b = "POLYGON ((9 9, 9 4, 6 4, 5 9, 9 9))";
+        check_relate_matches(a, b, intersection_matrix_pattern::ADJACENT, false);
+    }
+
+    #[test]
+    fn test_contains_properly_polygon_contained() {
+        let a = "POLYGON ((1 9, 9 9, 9 1, 1 1, 1 9))";
+        let b = "POLYGON ((2 8, 5 8, 5 5, 2 5, 2 8))";
+        check_relate_matches(a, b, intersection_matrix_pattern::CONTAINS_PROPERLY, true);
+    }
+
+    #[test]
+    fn test_contains_properly_polygon_touching() {
+        let a = "POLYGON ((1 9, 9 9, 9 1, 1 1, 1 9))";
+        let b = "POLYGON ((9 1, 5 1, 5 5, 9 5, 9 1))";
+        check_relate_matches(a, b, intersection_matrix_pattern::CONTAINS_PROPERLY, false);
+    }
+
+    #[test]
+    fn test_contains_properly_polygons_overlapping() {
+        let a = "GEOMETRYCOLLECTION (POLYGON ((1 9, 6 9, 6 4, 1 4, 1 9)), POLYGON ((2 4, 6 7, 9 1, 2 4)))";
+        let b = "POLYGON ((5 5, 6 5, 6 4, 5 4, 5 5))";
+        check_relate_matches(a, b, intersection_matrix_pattern::CONTAINS_PROPERLY, true);
+    }
+
+    //================  Repeated Points  ==============
+
+    #[test]
+    fn test_repeated_point_ll() {
+        let a = "LINESTRING(0 0, 5 5, 5 5, 5 5, 9 9)";
+        let b = "LINESTRING(0 9, 5 5, 5 5, 5 5, 9 0)";
+        check_relate(a, b, "0F1FF0102");
+        check_intersects_disjoint(a, b, true);
+    }
+
+    #[test]
+    fn test_repeated_point_aa() {
+        let a = "POLYGON ((1 9, 9 7, 9 1, 1 3, 1 9))";
+        let b = "POLYGON ((1 3, 1 3, 1 3, 3 7, 9 7, 9 7, 1 3))";
+        check_relate(a, b, "212F01FF2");
+    }
+
+    //================  EMPTY geometries  ==============
+
+    // geo cannot represent POINT EMPTY, so it is omitted from the JTS
+    // list of empty fixtures.
+    const EMPTIES: [&str; 6] = [
+        "LINESTRING EMPTY",
+        "POLYGON EMPTY",
+        "MULTIPOINT EMPTY",
+        "MULTILINESTRING EMPTY",
+        "MULTIPOLYGON EMPTY",
+        "GEOMETRYCOLLECTION EMPTY",
+    ];
+
+    #[test]
+    fn test_empty_empty() {
+        for a in EMPTIES {
+            for b in EMPTIES {
+                check_relate(a, b, "FFFFFFFF2");
+                // Empty geometries are all topologically equal.
+                check_equals(a, b, true);
+
+                check_intersects_disjoint(a, b, false);
+                check_contains_within(a, b, false);
+            }
+        }
+    }
+
+    #[test]
+    fn test_empty_non_empty() {
+        let non_empty_point = "POINT (1 1)";
+        let non_empty_line = "LINESTRING (1 1, 2 2)";
+        let non_empty_polygon = "POLYGON ((1 1, 1 2, 2 1, 1 1))";
+
+        for empty in EMPTIES {
+            check_relate(empty, non_empty_point, "FFFFFF0F2");
+            check_relate(non_empty_point, empty, "FF0FFFFF2");
+
+            check_relate(empty, non_empty_line, "FFFFFF102");
+            check_relate(non_empty_line, empty, "FF1FF0FF2");
+
+            check_relate(empty, non_empty_polygon, "FFFFFF212");
+            check_relate(non_empty_polygon, empty, "FF2FF1FF2");
+
+            check_equals(empty, non_empty_point, false);
+            check_equals(empty, non_empty_line, false);
+            check_equals(empty, non_empty_polygon, false);
+
+            check_intersects_disjoint(empty, non_empty_point, false);
+            check_intersects_disjoint(empty, non_empty_line, false);
+            check_intersects_disjoint(empty, non_empty_polygon, false);
+
+            check_contains_within(empty, non_empty_point, false);
+            check_contains_within(empty, non_empty_line, false);
+            check_contains_within(empty, non_empty_polygon, false);
+
+            check_contains_within(non_empty_point, empty, false);
+            check_contains_within(non_empty_line, empty, false);
+            check_contains_within(non_empty_polygon, empty, false);
+        }
+    }
+
+    //================  Prepared Relate  ==============
+
+    #[test]
+    fn test_prepared_aa() {
+        let a = "POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))";
+        let b = "POLYGON((0.5 0.5, 1.5 0.5, 1.5 1.5, 0.5 1.5, 0.5 0.5))";
+        check_prepared(a, b);
+    }
+
+    #[test]
+    fn test_prepared_pa() {
+        let a = "POINT (5 5)";
+        let b = "POLYGON ((1 9, 9 9, 9 1, 1 1, 1 9))";
+        check_prepared(a, b);
+        check_prepared(b, a);
+
+        // See https://github.com/libgeos/geos/issues/1275 (not a bug, but
+        // a good test to have). The transposed pattern is written out
+        // directly.
+        check_prepared_matches(a, b, "T*****FF*");
+        check_prepared_matches(b, a, "T*F**F***");
+    }
+}

--- a/geo/src/algorithm/relate/relateng/topology_computer.rs
+++ b/geo/src/algorithm/relate/relateng/topology_computer.rs
@@ -21,18 +21,18 @@ use super::topology_predicate::{InputIndex, TopologyPredicate};
 
 const MSG_GEOMETRY_DIMENSION_UNEXPECTED: &str = "Unexpected combination of geometry dimensions";
 
-pub(crate) struct TopologyComputer<'r, 'a, F: GeoFloat> {
+pub(crate) struct TopologyComputer<'r, 'a, 'b, F: GeoFloat> {
     predicate: &'r mut dyn TopologyPredicate<F>,
     geom_a: &'r RelateGeometry<'a, F>,
-    geom_b: &'r RelateGeometry<'a, F>,
+    geom_b: &'r RelateGeometry<'b, F>,
     node_map: BTreeMap<NodeKey<F>, NodeSections<F>>,
 }
 
-impl<'r, 'a, F: GeoFloat> TopologyComputer<'r, 'a, F> {
+impl<'r, 'a, 'b, F: GeoFloat> TopologyComputer<'r, 'a, 'b, F> {
     pub fn new(
         predicate: &'r mut dyn TopologyPredicate<F>,
         geom_a: &'r RelateGeometry<'a, F>,
-        geom_b: &'r RelateGeometry<'a, F>,
+        geom_b: &'r RelateGeometry<'b, F>,
     ) -> Self {
         let mut computer = Self {
             predicate,
@@ -96,7 +96,7 @@ impl<'r, 'a, F: GeoFloat> TopologyComputer<'r, 'a, F> {
                 );
             }
             Dimensions::OneDimensional => {
-                if self.geometry(geom_non_empty).has_boundary() {
+                if self.geometry_has_boundary(geom_non_empty) {
                     self.update_dim_for(
                         geom_non_empty,
                         CoordPos::OnBoundary,
@@ -129,16 +129,26 @@ impl<'r, 'a, F: GeoFloat> TopologyComputer<'r, 'a, F> {
         }
     }
 
-    fn geometry(&self, input: InputIndex) -> &RelateGeometry<'a, F> {
+    fn geometry_has_boundary(&self, input: InputIndex) -> bool {
         match input {
-            InputIndex::A => self.geom_a,
-            InputIndex::B => self.geom_b,
+            InputIndex::A => self.geom_a.has_boundary(),
+            InputIndex::B => self.geom_b.has_boundary(),
+        }
+    }
+
+    fn geometry_is_empty(&self, input: InputIndex) -> bool {
+        match input {
+            InputIndex::A => self.geom_a.is_empty(),
+            InputIndex::B => self.geom_b.is_empty(),
         }
     }
 
     /// The type-based dimension of an input.
     pub fn dimension(&self, input: InputIndex) -> Dimensions {
-        self.geometry(input).dimension()
+        match input {
+            InputIndex::A => self.geom_a.dimension(),
+            InputIndex::B => self.geom_b.dimension(),
+        }
     }
 
     /// Whether the input geometries require self-noding for correct
@@ -266,7 +276,7 @@ impl<'r, 'a, F: GeoFloat> TopologyComputer<'r, 'a, F> {
         sections.add_node_section(ns1);
     }
 
-    pub fn add_point_on_point_interior(&mut self, _pt: Coord<F>) {
+    pub fn add_point_on_point_interior(&mut self) {
         self.update_dim(
             CoordPos::Inside,
             CoordPos::Inside,
@@ -274,7 +284,7 @@ impl<'r, 'a, F: GeoFloat> TopologyComputer<'r, 'a, F> {
         );
     }
 
-    pub fn add_point_on_point_exterior(&mut self, source: InputIndex, _pt: Coord<F>) {
+    pub fn add_point_on_point_exterior(&mut self, source: InputIndex) {
         self.update_dim_for(
             source,
             CoordPos::Inside,
@@ -299,7 +309,7 @@ impl<'r, 'a, F: GeoFloat> TopologyComputer<'r, 'a, F> {
         );
 
         // An empty geometry has no points to infer entries from.
-        if self.geometry(source.other()).is_empty() {
+        if self.geometry_is_empty(source.other()) {
             return;
         }
 
@@ -352,7 +362,7 @@ impl<'r, 'a, F: GeoFloat> TopologyComputer<'r, 'a, F> {
         );
 
         // An empty geometry has no points to infer entries from.
-        if self.geometry(source.other()).is_empty() {
+        if self.geometry_is_empty(source.other()) {
             return;
         }
 

--- a/geo/src/algorithm/relate/relateng/topology_computer.rs
+++ b/geo/src/algorithm/relate/relateng/topology_computer.rs
@@ -1,0 +1,671 @@
+//! Accumulates topological information from point, line-end, area-vertex
+//! and edge-intersection interactions between the two input geometries,
+//! updating the predicate as evaluation proceeds.
+//!
+//! Port of JTS `TopologyComputer`.
+
+use std::collections::BTreeMap;
+
+use crate::algorithm::polygon_node_topology::is_crossing;
+use crate::coordinate_position::CoordPos;
+use crate::dimensions::Dimensions;
+use crate::relate::geomgraph::Direction;
+use crate::relate::geomgraph::node_map::NodeKey;
+use crate::{Coord, GeoFloat};
+
+use super::node_section::NodeSection;
+use super::node_sections::NodeSections;
+use super::relate_geometry::RelateGeometry;
+use super::relate_node::RelateNode;
+use super::topology_predicate::{InputIndex, TopologyPredicate};
+
+const MSG_GEOMETRY_DIMENSION_UNEXPECTED: &str = "Unexpected combination of geometry dimensions";
+
+pub(crate) struct TopologyComputer<'r, 'a, F: GeoFloat> {
+    predicate: &'r mut dyn TopologyPredicate<F>,
+    geom_a: &'r RelateGeometry<'a, F>,
+    geom_b: &'r RelateGeometry<'a, F>,
+    node_map: BTreeMap<NodeKey<F>, NodeSections<F>>,
+}
+
+impl<'r, 'a, F: GeoFloat> TopologyComputer<'r, 'a, F> {
+    pub fn new(
+        predicate: &'r mut dyn TopologyPredicate<F>,
+        geom_a: &'r RelateGeometry<'a, F>,
+        geom_b: &'r RelateGeometry<'a, F>,
+    ) -> Self {
+        let mut computer = Self {
+            predicate,
+            geom_a,
+            geom_b,
+            node_map: BTreeMap::new(),
+        };
+        computer.init_exterior_dims();
+        computer
+    }
+
+    /// Determines a-priori partial exterior topology based on the real
+    /// dimensions of the inputs.
+    fn init_exterior_dims(&mut self) {
+        let dim_real_a = self.geom_a.dimension_real();
+        let dim_real_b = self.geom_b.dimension_real();
+        use Dimensions::{Empty, OneDimensional, TwoDimensional, ZeroDimensional};
+
+        if dim_real_a == ZeroDimensional && dim_real_b == OneDimensional {
+            // For the P/L case, the point exterior intersects the line
+            // interior.
+            self.update_dim(CoordPos::Outside, CoordPos::Inside, OneDimensional);
+        } else if dim_real_a == OneDimensional && dim_real_b == ZeroDimensional {
+            self.update_dim(CoordPos::Inside, CoordPos::Outside, OneDimensional);
+        } else if dim_real_a == ZeroDimensional && dim_real_b == TwoDimensional {
+            // For the P/A case, the area interior and boundary intersect
+            // the point exterior.
+            self.update_dim(CoordPos::Outside, CoordPos::Inside, TwoDimensional);
+            self.update_dim(CoordPos::Outside, CoordPos::OnBoundary, OneDimensional);
+        } else if dim_real_a == TwoDimensional && dim_real_b == ZeroDimensional {
+            self.update_dim(CoordPos::Inside, CoordPos::Outside, TwoDimensional);
+            self.update_dim(CoordPos::OnBoundary, CoordPos::Outside, OneDimensional);
+        } else if dim_real_a == OneDimensional && dim_real_b == TwoDimensional {
+            self.update_dim(CoordPos::Outside, CoordPos::Inside, TwoDimensional);
+        } else if dim_real_a == TwoDimensional && dim_real_b == OneDimensional {
+            self.update_dim(CoordPos::Inside, CoordPos::Outside, TwoDimensional);
+        } else if dim_real_a == Empty || dim_real_b == Empty {
+            // Cases where one geometry is empty.
+            if dim_real_a != Empty {
+                self.init_exterior_empty(InputIndex::A);
+            }
+            if dim_real_b != Empty {
+                self.init_exterior_empty(InputIndex::B);
+            }
+        }
+    }
+
+    /// Seeds the matrix entries of a non-empty geometry against an empty
+    /// one (everything of the non-empty geometry lies in the exterior of
+    /// the empty one).
+    fn init_exterior_empty(&mut self, geom_non_empty: InputIndex) {
+        // The type-based dimension, as in JTS.
+        let dim_non_empty = self.dimension(geom_non_empty);
+        match dim_non_empty {
+            Dimensions::ZeroDimensional => {
+                self.update_dim_for(
+                    geom_non_empty,
+                    CoordPos::Inside,
+                    CoordPos::Outside,
+                    Dimensions::ZeroDimensional,
+                );
+            }
+            Dimensions::OneDimensional => {
+                if self.geometry(geom_non_empty).has_boundary() {
+                    self.update_dim_for(
+                        geom_non_empty,
+                        CoordPos::OnBoundary,
+                        CoordPos::Outside,
+                        Dimensions::ZeroDimensional,
+                    );
+                }
+                self.update_dim_for(
+                    geom_non_empty,
+                    CoordPos::Inside,
+                    CoordPos::Outside,
+                    Dimensions::OneDimensional,
+                );
+            }
+            Dimensions::TwoDimensional => {
+                self.update_dim_for(
+                    geom_non_empty,
+                    CoordPos::OnBoundary,
+                    CoordPos::Outside,
+                    Dimensions::OneDimensional,
+                );
+                self.update_dim_for(
+                    geom_non_empty,
+                    CoordPos::Inside,
+                    CoordPos::Outside,
+                    Dimensions::TwoDimensional,
+                );
+            }
+            Dimensions::Empty => {}
+        }
+    }
+
+    fn geometry(&self, input: InputIndex) -> &RelateGeometry<'a, F> {
+        match input {
+            InputIndex::A => self.geom_a,
+            InputIndex::B => self.geom_b,
+        }
+    }
+
+    /// The type-based dimension of an input.
+    pub fn dimension(&self, input: InputIndex) -> Dimensions {
+        self.geometry(input).dimension()
+    }
+
+    /// Whether the input geometries require self-noding for correct
+    /// evaluation of the predicate.
+    ///
+    /// Self-noding is required for geometries which may have self-crossing
+    /// linework, or lines lying in the boundary of an area. It causes the
+    /// coordinates of nodes created by crossing segments to be computed
+    /// explicitly, so node locations match in situations where a
+    /// self-crossing and a mutual crossing occur at the same logical
+    /// location (the canonical example being a self-crossing line tested
+    /// against a segment identical to one of the crossed segments).
+    ///
+    /// Requiring self-noding prevents cached-index reuse, so the cases are
+    /// kept limited: A inputs which may self-cross, and B inputs which are
+    /// mixed area/line collections (a linear B does not require it when A
+    /// is polygonal; JTS PR #1099).
+    pub fn is_self_noding_required(&self) -> bool {
+        if !self.predicate.requires_self_noding() {
+            return false;
+        }
+        if self.geom_a.is_self_noding_required() {
+            return true;
+        }
+        // If B is a mixed collection with areas and lines, full noding is
+        // required.
+        self.geom_b.has_area_and_line()
+    }
+
+    pub fn is_exterior_check_required(&self, input: InputIndex) -> bool {
+        self.predicate.requires_exterior_check(input)
+    }
+
+    fn update_dim(&mut self, loc_a: CoordPos, loc_b: CoordPos, dimension: Dimensions) {
+        self.predicate.update_dimension(loc_a, loc_b, dimension);
+    }
+
+    /// Updates an entry with the locations given in the order (source,
+    /// target); the source input determines the matrix orientation.
+    fn update_dim_for(
+        &mut self,
+        source: InputIndex,
+        loc1: CoordPos,
+        loc2: CoordPos,
+        dimension: Dimensions,
+    ) {
+        match source {
+            InputIndex::A => self.update_dim(loc1, loc2, dimension),
+            // The locations are ordered B/A, so swap them.
+            InputIndex::B => self.update_dim(loc2, loc1, dimension),
+        }
+    }
+
+    pub fn is_result_known(&self) -> bool {
+        self.predicate.is_known()
+    }
+
+    pub fn result(&self) -> bool {
+        self.predicate.value()
+    }
+
+    /// Finalises the evaluation.
+    pub fn finish(&mut self) {
+        self.predicate.finish();
+    }
+
+    /// Records an intersection between segments of the inputs: updates
+    /// direct topology for A/B interactions and accumulates the node
+    /// sections for later node evaluation.
+    pub fn add_intersection(&mut self, a: NodeSection<F>, b: NodeSection<F>) {
+        if !a.is_same_geometry(&b) {
+            self.update_intersection_ab(&a, &b);
+        }
+        // Add the edges to the node, to allow full topology evaluation
+        // later.
+        self.add_node_sections(a, b);
+    }
+
+    fn update_intersection_ab(&mut self, a: &NodeSection<F>, b: &NodeSection<F>) {
+        if NodeSection::is_area_area(a, b) {
+            self.update_area_area_cross(a, b);
+        }
+        self.update_node_location(a, b);
+    }
+
+    /// Updates topology for an A/B area-area crossing node. Sections cross
+    /// at a node if the intersection is proper (in the interior of both
+    /// segments), or otherwise if the linework on either side of the node
+    /// crosses. In these situations the area interiors intersect in
+    /// dimension 2.
+    fn update_area_area_cross(&mut self, a: &NodeSection<F>, b: &NodeSection<F>) {
+        let is_proper = NodeSection::is_proper_pair(a, b);
+        if is_proper
+            || is_crossing(
+                a.node_pt(),
+                a.vertex(0).expect("area section has both vertices"),
+                a.vertex(1).expect("area section has both vertices"),
+                b.vertex(0).expect("area section has both vertices"),
+                b.vertex(1).expect("area section has both vertices"),
+            )
+        {
+            self.update_dim(
+                CoordPos::Inside,
+                CoordPos::Inside,
+                Dimensions::TwoDimensional,
+            );
+        }
+    }
+
+    /// Updates topology for the point location of an A/B edge intersection
+    /// node.
+    fn update_node_location(&mut self, a: &NodeSection<F>, b: &NodeSection<F>) {
+        let pt = a.node_pt();
+        let loc_a = self.geom_a.locate_node(pt, a.polygonal_id());
+        let loc_b = self.geom_b.locate_node(pt, b.polygonal_id());
+        self.update_dim(loc_a, loc_b, Dimensions::ZeroDimensional);
+    }
+
+    fn add_node_sections(&mut self, ns0: NodeSection<F>, ns1: NodeSection<F>) {
+        let sections = self
+            .node_map
+            .entry(NodeKey(ns0.node_pt()))
+            .or_insert_with(|| NodeSections::new(ns0.node_pt()));
+        sections.add_node_section(ns0);
+        sections.add_node_section(ns1);
+    }
+
+    pub fn add_point_on_point_interior(&mut self, _pt: Coord<F>) {
+        self.update_dim(
+            CoordPos::Inside,
+            CoordPos::Inside,
+            Dimensions::ZeroDimensional,
+        );
+    }
+
+    pub fn add_point_on_point_exterior(&mut self, source: InputIndex, _pt: Coord<F>) {
+        self.update_dim_for(
+            source,
+            CoordPos::Inside,
+            CoordPos::Outside,
+            Dimensions::ZeroDimensional,
+        );
+    }
+
+    pub fn add_point_on_geometry(
+        &mut self,
+        source: InputIndex,
+        loc_target: CoordPos,
+        dim_target: Dimensions,
+        _pt: Coord<F>,
+    ) {
+        // Update the entry for the point interior.
+        self.update_dim_for(
+            source,
+            CoordPos::Inside,
+            loc_target,
+            Dimensions::ZeroDimensional,
+        );
+
+        // An empty geometry has no points to infer entries from.
+        if self.geometry(source.other()).is_empty() {
+            return;
+        }
+
+        match dim_target {
+            Dimensions::ZeroDimensional => {}
+            Dimensions::OneDimensional => {
+                // Because zero-length lines are handled, a point lying in
+                // the exterior of the line target may imply either P or L
+                // for the exterior interaction, so nothing further can be
+                // inferred.
+            }
+            Dimensions::TwoDimensional => {
+                // If a point intersects an area target, then the area
+                // interior and boundary must extend beyond the point and
+                // thus interact with its exterior.
+                self.update_dim_for(
+                    source,
+                    CoordPos::Outside,
+                    CoordPos::Inside,
+                    Dimensions::TwoDimensional,
+                );
+                self.update_dim_for(
+                    source,
+                    CoordPos::Outside,
+                    CoordPos::OnBoundary,
+                    Dimensions::OneDimensional,
+                );
+            }
+            Dimensions::Empty => unreachable!("{}", MSG_GEOMETRY_DIMENSION_UNEXPECTED),
+        }
+    }
+
+    /// Adds topology for a line end. The line end point must be
+    /// "significant": not contained in an area if the source is a
+    /// mixed-dimension collection.
+    pub fn add_line_end_on_geometry(
+        &mut self,
+        source: InputIndex,
+        loc_line_end: CoordPos,
+        loc_target: CoordPos,
+        dim_target: Dimensions,
+        pt: Coord<F>,
+    ) {
+        // Record topology at the line end point.
+        self.update_dim_for(
+            source,
+            loc_line_end,
+            loc_target,
+            Dimensions::ZeroDimensional,
+        );
+
+        // An empty geometry has no points to infer entries from.
+        if self.geometry(source.other()).is_empty() {
+            return;
+        }
+
+        // Line and area targets may have additional topology.
+        match dim_target {
+            Dimensions::ZeroDimensional => {}
+            Dimensions::OneDimensional => {
+                self.add_line_end_on_line(source, loc_line_end, loc_target, pt);
+            }
+            Dimensions::TwoDimensional => {
+                self.add_line_end_on_area(source, loc_line_end, loc_target, pt);
+            }
+            Dimensions::Empty => unreachable!("{}", MSG_GEOMETRY_DIMENSION_UNEXPECTED),
+        }
+    }
+
+    fn add_line_end_on_line(
+        &mut self,
+        source: InputIndex,
+        _loc_line_end: CoordPos,
+        loc_line: CoordPos,
+        _pt: Coord<F>,
+    ) {
+        // When a line end is in the exterior of a line, some length of the
+        // source line interior is also in the target line exterior. This
+        // holds for zero-length lines as well.
+        if loc_line == CoordPos::Outside {
+            self.update_dim_for(
+                source,
+                CoordPos::Inside,
+                CoordPos::Outside,
+                Dimensions::OneDimensional,
+            );
+        }
+    }
+
+    fn add_line_end_on_area(
+        &mut self,
+        source: InputIndex,
+        _loc_line_end: CoordPos,
+        loc_area: CoordPos,
+        _pt: Coord<F>,
+    ) {
+        if loc_area != CoordPos::OnBoundary {
+            // When a line end is in an area interior or exterior, some
+            // length of the source line interior, and the exterior of the
+            // line, is also in that location of the target. This assumes
+            // the line end is not also in an area of a mixed-dimension
+            // collection.
+            self.update_dim_for(
+                source,
+                CoordPos::Inside,
+                loc_area,
+                Dimensions::OneDimensional,
+            );
+            self.update_dim_for(
+                source,
+                CoordPos::Outside,
+                loc_area,
+                Dimensions::TwoDimensional,
+            );
+        }
+    }
+
+    /// Adds topology for an area vertex interaction with a target geometry
+    /// element. Assumes the target element has the highest dimension of
+    /// those the point lies on (the semantic provided by the point
+    /// locator).
+    ///
+    /// In a GeometryCollection containing overlapping or adjacent
+    /// polygons, the area vertex location may be interior instead of
+    /// boundary.
+    pub fn add_area_vertex(
+        &mut self,
+        source: InputIndex,
+        loc_area: CoordPos,
+        loc_target: CoordPos,
+        dim_target: Dimensions,
+        pt: Coord<F>,
+    ) {
+        if loc_target == CoordPos::Outside {
+            self.update_dim_for(
+                source,
+                CoordPos::Inside,
+                CoordPos::Outside,
+                Dimensions::TwoDimensional,
+            );
+            // If the area vertex is on the boundary, further topology can
+            // be deduced from the neighbourhood around the boundary
+            // vertex. This is always the case for polygonal geometries;
+            // for collections the vertex may be on the boundary or in the
+            // interior (of overlapping or adjacent polygons).
+            if loc_area == CoordPos::OnBoundary {
+                self.update_dim_for(
+                    source,
+                    CoordPos::OnBoundary,
+                    CoordPos::Outside,
+                    Dimensions::OneDimensional,
+                );
+                self.update_dim_for(
+                    source,
+                    CoordPos::Outside,
+                    CoordPos::Outside,
+                    Dimensions::TwoDimensional,
+                );
+            }
+            return;
+        }
+        match dim_target {
+            Dimensions::ZeroDimensional => self.add_area_vertex_on_point(source, loc_area, pt),
+            Dimensions::OneDimensional => {
+                self.add_area_vertex_on_line(source, loc_area, loc_target, pt)
+            }
+            Dimensions::TwoDimensional => {
+                self.add_area_vertex_on_area(source, loc_area, loc_target, pt)
+            }
+            Dimensions::Empty => unreachable!("{}", MSG_GEOMETRY_DIMENSION_UNEXPECTED),
+        }
+    }
+
+    /// An area vertex (in the interior or on the boundary) intersecting a
+    /// point. Because the largest-dimension intersecting target was
+    /// determined, the point is not part of any other target element, so
+    /// its neighbourhood is in the target exterior.
+    fn add_area_vertex_on_point(&mut self, source: InputIndex, loc_area: CoordPos, _pt: Coord<F>) {
+        // The vertex location intersects the point.
+        self.update_dim_for(
+            source,
+            loc_area,
+            CoordPos::Inside,
+            Dimensions::ZeroDimensional,
+        );
+        // The area interior intersects the point's exterior neighbourhood.
+        self.update_dim_for(
+            source,
+            CoordPos::Inside,
+            CoordPos::Outside,
+            Dimensions::TwoDimensional,
+        );
+        // If the area vertex is on the boundary, the area boundary and
+        // exterior also intersect the point's exterior neighbourhood.
+        if loc_area == CoordPos::OnBoundary {
+            self.update_dim_for(
+                source,
+                CoordPos::OnBoundary,
+                CoordPos::Outside,
+                Dimensions::OneDimensional,
+            );
+            self.update_dim_for(
+                source,
+                CoordPos::Outside,
+                CoordPos::Outside,
+                Dimensions::TwoDimensional,
+            );
+        }
+    }
+
+    /// An area vertex intersecting a line: all that is known is the
+    /// point intersection (the line may or may not be collinear with the
+    /// area boundary or intersect the area interior); full topology is
+    /// determined later by node analysis.
+    fn add_area_vertex_on_line(
+        &mut self,
+        source: InputIndex,
+        loc_area: CoordPos,
+        loc_target: CoordPos,
+        _pt: Coord<F>,
+    ) {
+        self.update_dim_for(source, loc_area, loc_target, Dimensions::ZeroDimensional);
+        if loc_area == CoordPos::Inside {
+            // The area interior intersects the line's exterior
+            // neighbourhood.
+            self.update_dim_for(
+                source,
+                CoordPos::Inside,
+                CoordPos::Outside,
+                Dimensions::TwoDimensional,
+            );
+        }
+    }
+
+    fn add_area_vertex_on_area(
+        &mut self,
+        source: InputIndex,
+        loc_area: CoordPos,
+        loc_target: CoordPos,
+        _pt: Coord<F>,
+    ) {
+        if loc_target == CoordPos::OnBoundary {
+            if loc_area == CoordPos::OnBoundary {
+                // B/B topology is fully computed later by node analysis.
+                self.update_dim_for(
+                    source,
+                    CoordPos::OnBoundary,
+                    CoordPos::OnBoundary,
+                    Dimensions::ZeroDimensional,
+                );
+            } else {
+                // The area vertex is in the interior.
+                self.update_dim_for(
+                    source,
+                    CoordPos::Inside,
+                    CoordPos::Inside,
+                    Dimensions::TwoDimensional,
+                );
+                self.update_dim_for(
+                    source,
+                    CoordPos::Inside,
+                    CoordPos::OnBoundary,
+                    Dimensions::OneDimensional,
+                );
+                self.update_dim_for(
+                    source,
+                    CoordPos::Inside,
+                    CoordPos::Outside,
+                    Dimensions::TwoDimensional,
+                );
+            }
+        } else {
+            // The target location is interior or exterior.
+            self.update_dim_for(
+                source,
+                CoordPos::Inside,
+                loc_target,
+                Dimensions::TwoDimensional,
+            );
+            // If the area vertex is on the boundary, further topology can
+            // be deduced from the neighbourhood around the boundary
+            // vertex (see add_area_vertex).
+            if loc_area == CoordPos::OnBoundary {
+                self.update_dim_for(
+                    source,
+                    CoordPos::OnBoundary,
+                    loc_target,
+                    Dimensions::OneDimensional,
+                );
+                self.update_dim_for(
+                    source,
+                    CoordPos::Outside,
+                    loc_target,
+                    Dimensions::TwoDimensional,
+                );
+            }
+        }
+    }
+
+    /// Evaluates the accumulated intersection nodes: builds each node with
+    /// interaction between the inputs, finishes its edge topology, and
+    /// reads the edge locations into the matrix.
+    pub fn evaluate_nodes(&mut self) {
+        let Self {
+            predicate,
+            geom_a,
+            geom_b,
+            node_map,
+        } = self;
+        for sections in node_map.values_mut() {
+            if sections.has_interaction_ab() {
+                evaluate_node(*predicate, geom_a, geom_b, sections);
+                if predicate.is_known() {
+                    return;
+                }
+            }
+        }
+    }
+}
+
+fn evaluate_node<F: GeoFloat>(
+    predicate: &mut dyn TopologyPredicate<F>,
+    geom_a: &RelateGeometry<'_, F>,
+    geom_b: &RelateGeometry<'_, F>,
+    sections: &mut NodeSections<F>,
+) {
+    let p = sections.coordinate();
+    let mut node = sections.create_node();
+    // The node must have edges for its own geometry, but may also lie in
+    // the interior of an overlapping polygon of a collection.
+    let is_area_interior_a = geom_a.is_node_in_area(p, sections.polygonal_id(InputIndex::A));
+    let is_area_interior_b = geom_b.is_node_in_area(p, sections.polygonal_id(InputIndex::B));
+    node.finish(is_area_interior_a, is_area_interior_b);
+    evaluate_node_edges(predicate, geom_a, geom_b, &node);
+}
+
+fn evaluate_node_edges<F: GeoFloat>(
+    predicate: &mut dyn TopologyPredicate<F>,
+    geom_a: &RelateGeometry<'_, F>,
+    geom_b: &RelateGeometry<'_, F>,
+    node: &RelateNode<F>,
+) {
+    let is_area_area = geom_a.dimension() == Dimensions::TwoDimensional
+        && geom_b.dimension() == Dimensions::TwoDimensional;
+    for e in node.edges() {
+        let loc = |input, dir| {
+            e.location(input, dir)
+                .expect("finished node edges have all locations")
+        };
+        // Side updates are only needed for the area/area case.
+        if is_area_area {
+            predicate.update_dimension(
+                loc(InputIndex::A, Direction::Left),
+                loc(InputIndex::B, Direction::Left),
+                Dimensions::TwoDimensional,
+            );
+            predicate.update_dimension(
+                loc(InputIndex::A, Direction::Right),
+                loc(InputIndex::B, Direction::Right),
+                Dimensions::TwoDimensional,
+            );
+        }
+        predicate.update_dimension(
+            loc(InputIndex::A, Direction::On),
+            loc(InputIndex::B, Direction::On),
+            Dimensions::OneDimensional,
+        );
+    }
+}


### PR DESCRIPTION
Part 4 of 5 of the RelateNG port. Based on #1589. This PR ports the topology computer, the edge-phase intersectors and the driver, together with the ported JTS test suites. It also upgrades line_intersection to the JTS double-double intersection computation and adds a regression test for #1585.

Commits:
- Port RelateNG TopologyComputer
- Port RelateNG edge-phase intersectors on rstar segment index
- Upgrade line_intersection to JTS double-double intersection computation
- Port RelateNG driver with RelateNGTest suite and issue 1585 regression test
- Port RelateNG robustness, GeometryCollection and boundary-rule test suites

Stack: #1587 → #1588 → #1589 → #1590 → #1591
