### PR TITLE
RelateNG port 5/5: switch-over and integration

### DIFF
--- a/geo-benches/src/relate.rs
+++ b/geo-benches/src/relate.rs
@@ -1,5 +1,6 @@
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
-use geo::algorithm::{Relate, Rotate, Translate};
+use geo::PreparedGeometry;
+use geo::algorithm::{Contains, Relate, Rotate, Translate};
 use geo::geometry::{LineString, Polygon};
 
 fn criterion_benchmark(c: &mut Criterion) {
@@ -83,6 +84,25 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         bencher.iter(|| {
             criterion::black_box(norway.relate(&translated_norway));
+        });
+    });
+
+    c.bench_function("prepared relate repeated", |bencher| {
+        let norway = Polygon::new(geo_test_fixtures::norway_main::<f64>(), vec![]);
+        let rotated_norway = norway.rotate_around_center(20.0);
+        let prepared = PreparedGeometry::from(&norway);
+
+        bencher.iter(|| {
+            criterion::black_box(prepared.relate(&rotated_norway));
+        });
+    });
+
+    c.bench_function("contains via short-circuit predicate", |bencher| {
+        let norway = Polygon::new(geo_test_fixtures::norway_main::<f64>(), vec![]);
+        let rotated_norway = norway.rotate_around_center(20.0);
+
+        bencher.iter(|| {
+            criterion::black_box(norway.contains(&rotated_norway));
         });
     });
 }

--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -12,6 +12,8 @@
   - DEPRECATED: `Relate::geometry_graph` and the `geo::relate::GeometryGraph` re-export; the graph-based engine is no longer used by `relate` and will be removed in a future release.
 - `line_intersection::line_intersection` now computes intersection points with double-double extended-precision arithmetic, matching current JTS (`CGAlgorithmsDD.intersection`). Computed points can differ from previous releases by roughly one ULP; the new values match JTS exactly.
   - <https://github.com/locationtech/jts/pull/989>
+- `Contains<Point>` / `Contains<Coord>` for `GeometryCollection` and `MultiLineString` now use the union semantics of the collection, consistent with `relate` and JTS: a point on the shared boundary of two adjacent polygon elements, or an endpoint shared by two line elements, lies in the interior of their union and is contained. Previously the check was member-wise and reported such points as not contained.
+  - BREAKING: these impls (and the delegating impls on `Geometry`) now require `T: GeoFloat` instead of `T: GeoNum` (`CoordNum` for `MultiLineString`), because the evaluation goes through the relate engine. Point containment for integer coordinates remains available on the non-collection geometry types.
 - Add simply connected interior validation for polygons. Polygons with holes that touch at vertices in ways that disconnect the interior (e.g., two holes sharing 2+ vertices, or cycles of holes each sharing a vertex) are now detected as invalid via `Validation::is_valid()`. This aligns with OGC Simple Features and matches PostGIS behavior.
 - BREAKING: adds the `InvalidPolygon::InteriorNotSimplyConnected` error variant.
   - <https://github.com/georust/geo/pull/1472>

--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -6,6 +6,12 @@
 
 - Add `Intersects<Coord>` and `Intersects<Point>` implementations for `IntervalTreeMultiPolygon`. Unlike the existing `Contains` impls, these return `true` for points on the polygon's boundary.
 
+- The `Relate` trait and the predicates derived from it (`Contains`, `Within`, `Covers`, `ContainsProperly` where they delegate to relate) are now evaluated by RelateNG, a port of the JTS next-generation relate engine (JTS 1.20 / GEOS 3.13, including post-release fixes). RelateNG evaluates the DE-9IM matrix from local robust segment tests without building a noded topology graph. This fixes a class of robustness failures where a constructed intersection point that is not exactly representable produced incorrect matrices, and adds full support for GeometryCollections (union semantics), which the previous engine rejected for overlapping polygons. Relate on interacting polygon pairs is substantially faster; named predicates short-circuit as soon as their value is known; `PreparedGeometry` caches the relate segment index and point locators across calls.
+  - <https://github.com/georust/geo/issues/1585>
+  - BREAKING: the `Relate` trait gains a required `geometry_cow` method (the trait is not practically implementable outside geo, since `GeometryGraph` has no public constructor).
+  - DEPRECATED: `Relate::geometry_graph` and the `geo::relate::GeometryGraph` re-export; the graph-based engine is no longer used by `relate` and will be removed in a future release.
+- `line_intersection::line_intersection` now computes intersection points with double-double extended-precision arithmetic, matching current JTS (`CGAlgorithmsDD.intersection`). Computed points can differ from previous releases by roughly one ULP; the new values match JTS exactly.
+  - <https://github.com/locationtech/jts/pull/989>
 - Add simply connected interior validation for polygons. Polygons with holes that touch at vertices in ways that disconnect the interior (e.g., two holes sharing 2+ vertices, or cycles of holes each sharing a vertex) are now detected as invalid via `Validation::is_valid()`. This aligns with OGC Simple Features and matches PostGIS behavior.
 - BREAKING: adds the `InvalidPolygon::InteriorNotSimplyConnected` error variant.
   - <https://github.com/georust/geo/pull/1472>

--- a/geo/src/algorithm/contains/geometry.rs
+++ b/geo/src/algorithm/contains/geometry.rs
@@ -1,11 +1,11 @@
 use super::Contains;
+use crate::GeoFloat;
 use crate::geometry::*;
 use crate::geometry_delegate_impl;
-use crate::{GeoFloat, GeoNum};
 
 impl<T> Contains<Coord<T>> for Geometry<T>
 where
-    T: GeoNum,
+    T: GeoFloat,
 {
     fn contains(&self, coord: &Coord<T>) -> bool {
         self.contains(&Point::from(*coord))
@@ -14,7 +14,7 @@ where
 
 impl<T> Contains<Point<T>> for Geometry<T>
 where
-    T: GeoNum,
+    T: GeoFloat,
 {
     geometry_delegate_impl! {
         fn contains(&self, point: &Point<T>) -> bool;

--- a/geo/src/algorithm/contains/geometry_collection.rs
+++ b/geo/src/algorithm/contains/geometry_collection.rs
@@ -1,19 +1,29 @@
 use super::{Contains, impl_contains_from_relate, impl_contains_geometry_for};
+use crate::GeoFloat;
+use crate::algorithm::relate::relateng::relate_point_locator::{Mode, RelatePointLocator};
+use crate::coordinate_position::CoordPos;
 use crate::geometry::*;
-use crate::{GeoFloat, GeoNum};
+use crate::geometry_cow::GeometryCow;
 
 impl<T> Contains<Coord<T>> for GeometryCollection<T>
 where
-    T: GeoNum,
+    T: GeoFloat,
 {
+    /// Point containment uses the union semantics of the collection, as
+    /// `relate` does: a point on the shared boundary of two adjacent
+    /// polygon elements lies in the interior of their union and is
+    /// contained. A member-wise check cannot express this, so the
+    /// evaluation goes through the relate engine.
     fn contains(&self, coord: &Coord<T>) -> bool {
-        self.iter().any(|geometry| geometry.contains(coord))
+        // A point is contained exactly when it lies in the interior.
+        RelatePointLocator::new(&GeometryCow::from(self), Mode::Simple).locate(*coord)
+            == CoordPos::Inside
     }
 }
 
 impl<T> Contains<Point<T>> for GeometryCollection<T>
 where
-    T: GeoNum,
+    T: GeoFloat,
 {
     fn contains(&self, point: &Point<T>) -> bool {
         self.contains(&point.0)

--- a/geo/src/algorithm/contains/line_string.rs
+++ b/geo/src/algorithm/contains/line_string.rs
@@ -1,8 +1,11 @@
 use super::{Contains, impl_contains_from_relate, impl_contains_geometry_for};
 use crate::algorithm::kernels::Kernel;
+use crate::algorithm::relate::relateng::relate_point_locator::{Mode, RelatePointLocator};
+use crate::coordinate_position::CoordPos;
 use crate::dimensions::Dimensions;
 use crate::geometry::*;
-use crate::{CoordNum, GeoFloat, GeoNum, HasDimensions, Intersects, Orientation};
+use crate::geometry_cow::GeometryCow;
+use crate::{GeoFloat, GeoNum, HasDimensions, Intersects, Orientation};
 
 // ┌────────────────────────────────┐
 // │ Implementations for LineString │
@@ -152,21 +155,25 @@ impl_contains_geometry_for!(MultiLineString<T>);
 
 impl<T> Contains<Coord<T>> for MultiLineString<T>
 where
-    T: CoordNum,
-    LineString<T>: Contains<Coord<T>>,
+    T: GeoFloat,
 {
+    /// Point containment uses the union semantics of the collection, as
+    /// `relate` does (the Mod-2 boundary rule): an endpoint shared by two
+    /// members lies in the interior of their union and is contained. A
+    /// member-wise check cannot express this.
     fn contains(&self, coord: &Coord<T>) -> bool {
-        self.iter().any(|ls| ls.contains(coord))
+        // A point is contained exactly when it lies in the interior.
+        RelatePointLocator::new(&GeometryCow::from(self), Mode::Simple).locate(*coord)
+            == CoordPos::Inside
     }
 }
 
 impl<T> Contains<Point<T>> for MultiLineString<T>
 where
-    T: CoordNum,
-    LineString<T>: Contains<Point<T>>,
+    T: GeoFloat,
 {
     fn contains(&self, rhs: &Point<T>) -> bool {
-        self.iter().any(|ls| ls.contains(rhs))
+        self.contains(&rhs.0)
     }
 }
 

--- a/geo/src/algorithm/contains/mod.rs
+++ b/geo/src/algorithm/contains/mod.rs
@@ -63,17 +63,13 @@ mod triangle;
 
 macro_rules! impl_contains_from_relate {
     ($for:ty,  [$($target:ty),*]) => {
-        $(
-            impl<T> Contains<$target> for $for
-            where
-                T: GeoFloat
-            {
-                fn contains(&self, target: &$target) -> bool {
-                    use $crate::algorithm::Relate;
-                    self.relate(target).is_contains()
-                }
-            }
-        )*
+        $crate::algorithm::relate::relateng::impl_predicate_from_relate!(
+            Contains,
+            contains,
+            $crate::algorithm::relate::relateng::relate_predicate::contains(),
+            $for,
+            [$($target),*]
+        );
     };
 }
 pub(crate) use impl_contains_from_relate;

--- a/geo/src/algorithm/contains/mod.rs
+++ b/geo/src/algorithm/contains/mod.rs
@@ -110,6 +110,7 @@ mod test {
     use crate::Relate;
     use crate::indexed::IntervalTreeMultiPolygon;
     use crate::line_string;
+    use crate::wkt;
     use crate::{Coord, Line, LineString, MultiPolygon, Point, Polygon, Rect, Triangle, coord};
 
     #[test]
@@ -1004,5 +1005,36 @@ mod test {
         let _ = multi_poly.contains(&multi_point);
         let _ = multi_poly.contains(&multi_ls);
         let _ = multi_poly.contains(&multi_poly);
+    }
+
+    // Point containment for collections uses the union semantics of the
+    // collection, as `relate` does: a point shared by two members can be
+    // interior to their union although it is on the boundary of each.
+    #[test]
+    fn multi_line_string_contains_shared_endpoint() {
+        let mls = wkt!(MULTILINESTRING((0. 0., 1. 0.), (1. 0., 2. 0.)));
+        let shared = Point::new(1., 0.);
+        let end = Point::new(2., 0.);
+        let interior = Point::new(0.5, 0.);
+        let off = Point::new(0.5, 1.);
+        assert!(mls.contains(&shared));
+        assert_eq!(mls.contains(&shared), mls.relate(&shared).is_contains());
+        assert!(!mls.contains(&end));
+        assert!(mls.contains(&interior));
+        assert!(!mls.contains(&off));
+        assert!(mls.contains(&shared.0));
+    }
+
+    #[test]
+    fn geometry_collection_contains_shared_polygon_edge() {
+        let gc = wkt!(GEOMETRYCOLLECTION(
+            POLYGON((0. 0., 1. 0., 1. 1., 0. 1., 0. 0.)),
+            POLYGON((1. 0., 2. 0., 2. 1., 1. 1., 1. 0.))
+        ));
+        let shared = Point::new(1., 0.5);
+        let outer = Point::new(0., 0.5);
+        assert!(gc.contains(&shared));
+        assert_eq!(gc.contains(&shared), gc.relate(&shared).is_contains());
+        assert!(!gc.contains(&outer));
     }
 }

--- a/geo/src/algorithm/contains_properly/mod.rs
+++ b/geo/src/algorithm/contains_properly/mod.rs
@@ -58,17 +58,13 @@ mod triangle;
 
 macro_rules! impl_contains_properly_from_relate {
     ($for:ty,  [$($target:ty),*]) => {
-        $(
-            impl<T> ContainsProperly<$target> for $for
-            where
-                T: GeoFloat
-            {
-                fn contains_properly(&self, target: &$target) -> bool {
-                    use $crate::algorithm::Relate;
-                    self.relate(target).is_contains_properly()
-                }
-            }
-        )*
+        $crate::algorithm::relate::relateng::impl_predicate_from_relate!(
+            ContainsProperly,
+            contains_properly,
+            $crate::algorithm::relate::relateng::relate_predicate::contains_properly(),
+            $for,
+            [$($target),*]
+        );
     };
 }
 use impl_contains_properly_from_relate;

--- a/geo/src/algorithm/covers/mod.rs
+++ b/geo/src/algorithm/covers/mod.rs
@@ -57,17 +57,13 @@ pub(crate) mod geometry_collection;
 
 macro_rules! impl_covers_from_relate {
     ($for:ty,  [$($target:ty),*]) => {
-        $(
-            impl<T> Covers<$target> for $for
-            where
-                T: GeoFloat
-            {
-                fn covers(&self, target: &$target) -> bool {
-                    use $crate::algorithm::Relate;
-                    self.relate(target).is_covers()
-                }
-            }
-        )*
+        $crate::algorithm::relate::relateng::impl_predicate_from_relate!(
+            Covers,
+            covers,
+            $crate::algorithm::relate::relateng::relate_predicate::covers(),
+            $for,
+            [$($target),*]
+        );
     };
 }
 pub(crate) use impl_covers_from_relate;

--- a/geo/src/algorithm/indexed/mod.rs
+++ b/geo/src/algorithm/indexed/mod.rs
@@ -1,4 +1,4 @@
-/// Geometries that are backed by an [R*-tree](https://en.wikipedia.org/wiki/R*-tree) spatial index for faster bulk operations
+/// Geometries that cache spatial indexes for faster repeated topological comparisons
 pub mod prepared_geometry;
 pub use prepared_geometry::PreparedGeometry;
 

--- a/geo/src/algorithm/indexed/prepared_geometry.rs
+++ b/geo/src/algorithm/indexed/prepared_geometry.rs
@@ -127,6 +127,10 @@ where
     fn geometry_graph(&self, arg_index: usize) -> GeometryGraph<'_, F> {
         self.geometry_graph.clone_for_arg_index(arg_index)
     }
+
+    fn geometry_cow(&self) -> GeometryCow<'_, F> {
+        self.geometry_graph.geometry().reborrow()
+    }
 }
 
 #[cfg(test)]

--- a/geo/src/algorithm/indexed/prepared_geometry.rs
+++ b/geo/src/algorithm/indexed/prepared_geometry.rs
@@ -5,6 +5,7 @@ use crate::relate::relateng::relate_ng::{PreparedRelateState, RelateNG};
 use crate::{BoundingRect, GeometryCow, HasDimensions};
 use crate::{GeoFloat, Relate};
 
+use std::cell::OnceCell;
 use std::fmt::{Debug, Formatter};
 
 use crate::dimensions::Dimensions;
@@ -37,10 +38,13 @@ where
     F: GeoFloat + RTreeNum,
 {
     pub(crate) geometry: G,
-    pub(crate) geometry_graph: GeometryGraph<'a, F>,
-    pub(crate) bounding_rect: Option<Rect<F>>,
-    /// The RelateNG caches reused across `relate` calls: the segment
-    /// index, per-element area locators, and unique points.
+    geometry_cow: GeometryCow<'a, F>,
+    /// The legacy noded graph, built on the first call of the deprecated
+    /// `Relate::geometry_graph`.
+    geometry_graph: OnceCell<GeometryGraph<'a, F>>,
+    /// The RelateNG caches reused across `relate` calls: the geometry
+    /// metadata, segment index, per-element area locators, and unique
+    /// points.
     relate_state: PreparedRelateState<F>,
 }
 
@@ -50,13 +54,13 @@ where
     F: GeoFloat + RTreeNum,
 {
     fn clone(&self) -> Self {
-        // The relate caches are rebuildable; a clone starts with fresh
-        // (empty) ones.
+        // The caches are rebuildable; a clone starts with fresh (empty)
+        // ones.
         Self {
             geometry: self.geometry.clone(),
-            geometry_graph: self.geometry_graph.clone(),
-            bounding_rect: self.bounding_rect,
-            relate_state: PreparedRelateState::new(),
+            geometry_cow: self.geometry_cow.clone(),
+            geometry_graph: OnceCell::new(),
+            relate_state: PreparedRelateState::default(),
         }
     }
 }
@@ -89,13 +93,11 @@ where
     F: GeoFloat,
     T: Clone + Into<GeometryCow<'a, F>>,
 {
-    let geometry_graph = GeometryGraph::new(0, geometry.clone().into());
-    let bounding_rect = geometry_graph.geometry().bounding_rect();
     PreparedGeometry {
+        geometry_cow: geometry.clone().into(),
         geometry,
-        geometry_graph,
-        bounding_rect,
-        relate_state: PreparedRelateState::new(),
+        geometry_graph: OnceCell::new(),
+        relate_state: PreparedRelateState::default(),
     }
 }
 
@@ -120,7 +122,7 @@ where
     type Output = Option<Rect<F>>;
 
     fn bounding_rect(&self) -> Option<Rect<F>> {
-        self.bounding_rect
+        self.relate_state.meta(&self.geometry_cow).envelope()
     }
 }
 
@@ -130,15 +132,15 @@ where
     G: Into<GeometryCow<'a, F>>,
 {
     fn is_empty(&self) -> bool {
-        self.geometry_graph.geometry().is_empty()
+        self.geometry_cow.is_empty()
     }
 
     fn dimensions(&self) -> Dimensions {
-        self.geometry_graph.geometry().dimensions()
+        self.geometry_cow.dimensions()
     }
 
     fn boundary_dimensions(&self) -> Dimensions {
-        self.geometry_graph.geometry().boundary_dimensions()
+        self.geometry_cow.boundary_dimensions()
     }
 }
 
@@ -147,15 +149,17 @@ where
     F: GeoFloat,
     G: Into<GeometryCow<'a, F>>,
 {
-    /// Efficiently builds a [`GeometryGraph`] which can then be used for topological
-    /// computations.
+    /// Returns a copy of the cached [`GeometryGraph`], which is built on
+    /// the first call.
     #[allow(deprecated)]
     fn geometry_graph(&self, arg_index: usize) -> GeometryGraph<'_, F> {
-        self.geometry_graph.clone_for_arg_index(arg_index)
+        self.geometry_graph
+            .get_or_init(|| GeometryGraph::new(0, self.geometry_cow.clone()))
+            .clone_for_arg_index(arg_index)
     }
 
     fn geometry_cow(&self) -> GeometryCow<'_, F> {
-        self.geometry_graph.geometry().reborrow()
+        self.geometry_cow.reborrow()
     }
 
     /// Relates against the B geometry with the cached prepared state: the
@@ -163,7 +167,7 @@ where
     /// once and reused across calls.
     fn relate(&self, other: &impl Relate<F>) -> IntersectionMatrix {
         let cow = self.geometry_cow();
-        let engine = RelateNG::with_state(&cow, &self.relate_state);
+        let engine = RelateNG::prepared(&cow, &self.relate_state);
         engine.evaluate_matrix(&other.geometry_cow())
     }
 }
@@ -229,14 +233,8 @@ mod tests {
         let prepared = PreparedGeometry::from(&a);
         for _pass in 0..2 {
             for b in &bs {
-                assert_eq!(
-                    format!("{:?}", prepared.relate(b)),
-                    format!("{:?}", a.relate(b)),
-                );
-                assert_eq!(
-                    format!("{:?}", b.relate(&prepared)),
-                    format!("{:?}", b.relate(&a)),
-                );
+                assert_eq!(prepared.relate(b), a.relate(b));
+                assert_eq!(b.relate(&prepared), b.relate(&a));
             }
         }
     }

--- a/geo/src/algorithm/indexed/prepared_geometry.rs
+++ b/geo/src/algorithm/indexed/prepared_geometry.rs
@@ -1,5 +1,7 @@
 use crate::geometry::*;
+use crate::relate::IntersectionMatrix;
 use crate::relate::geomgraph::GeometryGraph;
+use crate::relate::relateng::relate_ng::{PreparedRelateState, RelateNG};
 use crate::{BoundingRect, GeometryCow, HasDimensions};
 use crate::{GeoFloat, Relate};
 
@@ -8,9 +10,12 @@ use std::fmt::{Debug, Formatter};
 use crate::dimensions::Dimensions;
 use rstar::RTreeNum;
 
-/// A `PreparedGeometry` is backed by an R*-tree spatial index and
-/// can be more efficient than a plain Geometry when performing
-/// multiple topological comparisons against the `PreparedGeometry`.
+/// A `PreparedGeometry` caches the spatial indexes that topological
+/// comparisons use: a segment [R-tree](https://en.wikipedia.org/wiki/R-tree),
+/// per-polygon point-in-area locators, and the set of unique points.
+/// The indexes are built on the first comparison that needs them and are
+/// reused by later comparisons, so a `PreparedGeometry` can be more
+/// efficient than a plain `Geometry` when it is compared many times.
 ///
 /// ```
 /// use geo::{Relate, PreparedGeometry, wkt};
@@ -26,7 +31,6 @@ use rstar::RTreeNum;
 /// assert!(prepared_polygon.relate(&contained_line).is_contains());
 ///
 /// ```
-#[derive(Clone)]
 pub struct PreparedGeometry<'a, G, F = f64>
 where
     G: Into<GeometryCow<'a, F>>,
@@ -35,6 +39,26 @@ where
     pub(crate) geometry: G,
     pub(crate) geometry_graph: GeometryGraph<'a, F>,
     pub(crate) bounding_rect: Option<Rect<F>>,
+    /// The RelateNG caches reused across `relate` calls: the segment
+    /// index, per-element area locators, and unique points.
+    relate_state: PreparedRelateState<F>,
+}
+
+impl<'a, G, F> Clone for PreparedGeometry<'a, G, F>
+where
+    G: Into<GeometryCow<'a, F>> + Clone,
+    F: GeoFloat + RTreeNum,
+{
+    fn clone(&self) -> Self {
+        // The relate caches are rebuildable; a clone starts with fresh
+        // (empty) ones.
+        Self {
+            geometry: self.geometry.clone(),
+            geometry_graph: self.geometry_graph.clone(),
+            bounding_rect: self.bounding_rect,
+            relate_state: PreparedRelateState::new(),
+        }
+    }
 }
 
 impl<'a, G, F> Debug for PreparedGeometry<'a, G, F>
@@ -71,6 +95,7 @@ where
         geometry,
         geometry_graph,
         bounding_rect,
+        relate_state: PreparedRelateState::new(),
     }
 }
 
@@ -131,6 +156,15 @@ where
     fn geometry_cow(&self) -> GeometryCow<'_, F> {
         self.geometry_graph.geometry().reborrow()
     }
+
+    /// Relates against the B geometry with the cached prepared state: the
+    /// A-side segment index, area locators and unique points are built
+    /// once and reused across calls.
+    fn relate(&self, other: &impl Relate<F>) -> IntersectionMatrix {
+        let cow = self.geometry_cow();
+        let engine = RelateNG::with_state(&cow, &self.relate_state);
+        engine.evaluate_matrix(&other.geometry_cow())
+    }
 }
 
 #[cfg(test)]
@@ -177,6 +211,33 @@ mod tests {
         let prepared_1 = PreparedGeometry::from(&p1);
         assert!(prepared_1.relate(&p2).is_contains());
         assert!(p2.relate(&prepared_1).is_within());
+    }
+
+    // Not in JTS: repeated relate calls reuse the cached prepared state
+    // (segment index, area locators, unique points) and must produce
+    // results identical to unprepared evaluation, in both argument
+    // positions and against multiple B geometries.
+    #[test]
+    fn repeated_relates_reuse_cached_state() {
+        let a = wkt!(POLYGON((0.0 0.0, 10.0 0.0, 10.0 10.0, 0.0 10.0, 0.0 0.0)));
+        let bs = [
+            wkt!(POLYGON((2.0 2.0, 4.0 2.0, 4.0 4.0, 2.0 4.0, 2.0 2.0))),
+            wkt!(POLYGON((8.0 8.0, 12.0 8.0, 12.0 12.0, 8.0 12.0, 8.0 8.0))),
+            wkt!(POLYGON((20.0 20.0, 22.0 20.0, 22.0 22.0, 20.0 22.0, 20.0 20.0))),
+        ];
+        let prepared = PreparedGeometry::from(&a);
+        for _pass in 0..2 {
+            for b in &bs {
+                assert_eq!(
+                    format!("{:?}", prepared.relate(b)),
+                    format!("{:?}", a.relate(b)),
+                );
+                assert_eq!(
+                    format!("{:?}", b.relate(&prepared)),
+                    format!("{:?}", b.relate(&a)),
+                );
+            }
+        }
     }
 
     #[test]

--- a/geo/src/algorithm/indexed/prepared_geometry.rs
+++ b/geo/src/algorithm/indexed/prepared_geometry.rs
@@ -149,6 +149,7 @@ where
 {
     /// Efficiently builds a [`GeometryGraph`] which can then be used for topological
     /// computations.
+    #[allow(deprecated)]
     fn geometry_graph(&self, arg_index: usize) -> GeometryGraph<'_, F> {
         self.geometry_graph.clone_for_arg_index(arg_index)
     }
@@ -241,6 +242,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn swap_arg_index() {
         let poly = polygon![(x: 0.0, y: 0.0), (x: 2.0, y: 0.0), (x: 1.0, y: 1.0)];
         let prepared_geom = PreparedGeometry::from(&poly);

--- a/geo/src/algorithm/relate/mod.rs
+++ b/geo/src/algorithm/relate/mod.rs
@@ -1,6 +1,5 @@
 pub(crate) use edge_end_builder::EdgeEndBuilder;
 pub use geomgraph::intersection_matrix::IntersectionMatrix;
-use relate_operation::RelateOperation;
 
 use crate::geometry::*;
 #[deprecated(
@@ -11,8 +10,13 @@ pub use crate::indexed::PreparedGeometry;
 pub use crate::relate::geomgraph::GeometryGraph;
 use crate::{BoundingRect, GeoFloat, GeometryCow, HasDimensions};
 
+// The legacy graph-based engine is kept in-tree (still reachable through
+// `Relate::geometry_graph` and `PreparedGeometry`) until a future breaking
+// release removes it; `relate` itself now evaluates through `relateng`.
+#[allow(dead_code)]
 mod edge_end_builder;
 pub(crate) mod geomgraph;
+#[allow(dead_code)]
 mod relate_operation;
 pub(crate) mod relateng;
 
@@ -62,17 +66,23 @@ pub(crate) mod relateng;
 pub trait Relate<F: GeoFloat>: BoundingRect<F> + HasDimensions {
     /// Returns a noded topology graph for the geometry.
     ///
+    /// Used by the legacy graph-based relate engine; `relate` itself no
+    /// longer calls this.
+    ///
     /// # Params
     ///
     /// `idx`: 0 or 1, designating A or B (respectively) in the role this geometry plays
     ///        in the relation. e.g. in `a.relate(b)`
     fn geometry_graph(&self, idx: usize) -> GeometryGraph<'_, F>;
 
+    /// Returns a borrowed view of the geometry for relate evaluation.
+    fn geometry_cow(&self) -> GeometryCow<'_, F>;
+
     fn relate(&self, other: &impl Relate<F>) -> IntersectionMatrix
     where
         Self: Sized,
     {
-        RelateOperation::new(self, other).compute_intersection_matrix()
+        relateng::relate_ng::relate(&self.geometry_cow(), &other.geometry_cow())
     }
 }
 
@@ -82,6 +92,10 @@ macro_rules! relate_impl {
             impl<F: GeoFloat> Relate<F> for $t {
                 fn geometry_graph(&self, arg_index: usize) -> GeometryGraph<'_, F> {
                     $crate::relate::GeometryGraph::new(arg_index, GeometryCow::from(self))
+                }
+
+                fn geometry_cow(&self) -> GeometryCow<'_, F> {
+                    GeometryCow::from(self)
                 }
             }
             impl<F: GeoFloat> From<$t> for PreparedGeometry<'static, $t, F> {

--- a/geo/src/algorithm/relate/mod.rs
+++ b/geo/src/algorithm/relate/mod.rs
@@ -7,6 +7,10 @@ use crate::geometry::*;
     note = "PreparedGeometry has moved to geo::indexed::PreparedGeometry"
 )]
 pub use crate::indexed::PreparedGeometry;
+#[deprecated(
+    since = "0.34.0",
+    note = "part of the legacy graph-based relate engine, superseded by RelateNG; will be removed in a future release"
+)]
 pub use crate::relate::geomgraph::GeometryGraph;
 use crate::{BoundingRect, GeoFloat, GeometryCow, HasDimensions};
 
@@ -16,7 +20,7 @@ use crate::{BoundingRect, GeoFloat, GeometryCow, HasDimensions};
 #[allow(dead_code)]
 mod edge_end_builder;
 pub(crate) mod geomgraph;
-#[allow(dead_code)]
+#[allow(dead_code, deprecated)]
 mod relate_operation;
 pub(crate) mod relateng;
 
@@ -73,7 +77,14 @@ pub trait Relate<F: GeoFloat>: BoundingRect<F> + HasDimensions {
     ///
     /// `idx`: 0 or 1, designating A or B (respectively) in the role this geometry plays
     ///        in the relation. e.g. in `a.relate(b)`
-    fn geometry_graph(&self, idx: usize) -> GeometryGraph<'_, F>;
+    #[deprecated(
+        since = "0.34.0",
+        note = "part of the legacy graph-based relate engine, superseded by RelateNG; will be removed in a future release"
+    )]
+    #[allow(deprecated)]
+    fn geometry_graph(&self, idx: usize) -> GeometryGraph<'_, F> {
+        GeometryGraph::new(idx, self.geometry_cow())
+    }
 
     /// Returns a borrowed view of the geometry for relate evaluation.
     fn geometry_cow(&self) -> GeometryCow<'_, F>;
@@ -90,10 +101,6 @@ macro_rules! relate_impl {
     ($($t:ty ,)*) => {
         $(
             impl<F: GeoFloat> Relate<F> for $t {
-                fn geometry_graph(&self, arg_index: usize) -> GeometryGraph<'_, F> {
-                    $crate::relate::GeometryGraph::new(arg_index, GeometryCow::from(self))
-                }
-
                 fn geometry_cow(&self) -> GeometryCow<'_, F> {
                     GeometryCow::from(self)
                 }

--- a/geo/src/algorithm/relate/relateng/edge_segment_intersector.rs
+++ b/geo/src/algorithm/relate/relateng/edge_segment_intersector.rs
@@ -238,6 +238,7 @@ mod tests {
     // interior/interior intersection via node evaluation.
     use super::super::im_predicate::RelateMatrixPredicate;
     use super::super::relate_geometry::RelateGeometry;
+    use super::super::relate_point_locator::Mode;
     use super::super::topology_computer::TopologyComputer;
     use super::super::topology_predicate::InputIndex;
     use super::*;
@@ -252,8 +253,8 @@ mod tests {
         let b = wkt!(LINESTRING (0. 2., 2. 0.));
         let cow_a = GeometryCow::from(&a);
         let cow_b = GeometryCow::from(&b);
-        let geom_a = RelateGeometry::new(&cow_a);
-        let geom_b = RelateGeometry::new(&cow_b);
+        let geom_a = RelateGeometry::new(&cow_a, Mode::Simple);
+        let geom_b = RelateGeometry::new(&cow_b, Mode::Simple);
 
         let mut predicate = RelateMatrixPredicate::new();
         {
@@ -281,8 +282,8 @@ mod tests {
         let b = wkt!(LINESTRING (0. 2., 2. 0.));
         let cow_a = GeometryCow::from(&a);
         let cow_b = GeometryCow::from(&b);
-        let geom_a = RelateGeometry::new(&cow_a);
-        let geom_b = RelateGeometry::new(&cow_b);
+        let geom_a = RelateGeometry::new(&cow_a, Mode::Simple);
+        let geom_b = RelateGeometry::new(&cow_b, Mode::Simple);
 
         let mut predicate = RelateMatrixPredicate::new();
         {

--- a/geo/src/algorithm/relate/relateng/mod.rs
+++ b/geo/src/algorithm/relate/relateng/mod.rs
@@ -15,9 +15,6 @@
 //! trait and the predicate traits built on it. The boundary node rule is
 //! Mod-2 (the OGC SFS rule), matching the rest of the crate.
 
-// Parts of the module are consumed only by later commits in the port.
-#![allow(dead_code)]
-
 pub(crate) mod adjacent_edge_locator;
 pub(crate) mod dimension_location;
 pub(crate) mod edge_segment_intersector;

--- a/geo/src/algorithm/relate/relateng/mod.rs
+++ b/geo/src/algorithm/relate/relateng/mod.rs
@@ -11,13 +11,11 @@
 //! GeometryCollections with union semantics, and allows named predicates to
 //! short-circuit as soon as their value is known.
 //!
-//! The module is crate-private while the port is in progress; see
-//! RELATENG_PLAN.md at the workspace root for the implementation plan and
-//! progress log. The boundary node rule is Mod-2 (the OGC SFS rule),
-//! matching the rest of the crate.
+//! The module is crate-private; the public entry points are the `Relate`
+//! trait and the predicate traits built on it. The boundary node rule is
+//! Mod-2 (the OGC SFS rule), matching the rest of the crate.
 
-// The module is consumed incrementally as the port proceeds; the allowance
-// is removed when the RelateNG driver lands.
+// Parts of the module are consumed only by later commits in the port.
 #![allow(dead_code)]
 
 pub(crate) mod adjacent_edge_locator;
@@ -40,3 +38,27 @@ pub(crate) mod topology_predicate;
 
 #[cfg(test)]
 mod tests;
+
+/// Implements a predicate trait for `$for` against each `$target` type by
+/// evaluating a RelateNG predicate, which short-circuits as soon as its
+/// value is known (unlike computing the full matrix).
+macro_rules! impl_predicate_from_relate {
+    ($trait:ident, $method:ident, $predicate:expr, $for:ty, [$($target:ty),*]) => {
+        $(
+            impl<T> $trait<$target> for $for
+            where
+                T: GeoFloat
+            {
+                fn $method(&self, target: &$target) -> bool {
+                    use $crate::algorithm::Relate;
+                    $crate::algorithm::relate::relateng::relate_ng::eval(
+                        &self.geometry_cow(),
+                        &target.geometry_cow(),
+                        &mut $predicate,
+                    )
+                }
+            }
+        )*
+    };
+}
+pub(crate) use impl_predicate_from_relate;

--- a/geo/src/algorithm/relate/relateng/relate_geometry.rs
+++ b/geo/src/algorithm/relate/relateng/relate_geometry.rs
@@ -23,18 +23,18 @@ use crate::dimensions::{Dimensions, HasDimensions};
 use crate::geometry_cow::GeometryCow;
 use crate::relate::geomgraph::node_map::NodeKey;
 use crate::winding_order::Winding;
-use crate::{Coord, GeoFloat, Geometry, Intersects, LineString, MultiPolygon, Polygon, Rect};
+use crate::{Coord, GeoFloat, Intersects, LineString, MultiPolygon, Polygon, Rect};
 
 use super::dimension_location::DimensionLocation;
-use super::relate_point_locator::{RelatePointLocator, SharedAreaLocators};
+use super::relate_point_locator::{LineElement, Mode, Polygonal, RelatePointLocator};
 use super::relate_segment_string::RelateSegmentString;
 use super::topology_predicate::InputIndex;
 
-pub(crate) struct RelateGeometry<'a, F: GeoFloat> {
-    geom: &'a GeometryCow<'a, F>,
-    is_prepared: bool,
-    /// Prepared mode: per-element area locators shared across evaluations.
-    shared_area_locators: Option<&'a SharedAreaLocators<F>>,
+/// The metadata of a relate input that costs a walk of its coordinates:
+/// the envelope and the dimension analysis. A prepared geometry computes
+/// it once and reuses it across evaluations.
+#[derive(Clone, Copy)]
+pub(crate) struct GeometryMeta<F: GeoFloat> {
     env: Option<Rect<F>>,
     geom_dim: Dimensions,
     has_points: bool,
@@ -42,124 +42,131 @@ pub(crate) struct RelateGeometry<'a, F: GeoFloat> {
     has_areas: bool,
     is_line_zero_len: bool,
     is_geom_empty: bool,
+}
+
+impl<F: GeoFloat> GeometryMeta<F> {
+    pub fn of(geom: &GeometryCow<'_, F>) -> Self {
+        let is_geom_empty = geom.is_empty();
+        let mut analysis = DimensionAnalysis {
+            // The type-based dimension, which counts empty elements.
+            dim: type_dimension(geom),
+            has_points: false,
+            has_lines: false,
+            has_areas: false,
+        };
+        if !is_geom_empty {
+            analysis.analyze(geom);
+        }
+        let geom_dim = analysis.dim;
+        Self {
+            env: geom.bounding_rect(),
+            geom_dim,
+            has_points: analysis.has_points,
+            has_lines: analysis.has_lines,
+            has_areas: analysis.has_areas,
+            is_line_zero_len: geom_dim == Dimensions::OneDimensional && is_zero_length(geom),
+            is_geom_empty,
+        }
+    }
+
+    /// The geometry envelope; `None` for an empty geometry.
+    pub fn envelope(&self) -> Option<Rect<F>> {
+        self.env
+    }
+}
+
+pub(crate) struct RelateGeometry<'a, F: GeoFloat> {
+    geom: &'a GeometryCow<'a, F>,
+    mode: Mode<'a, F>,
+    meta: GeometryMeta<F>,
     unique_points: OnceCell<BTreeSet<NodeKey<F>>>,
     locator: OnceCell<RelatePointLocator<'a, F>>,
 }
 
 impl<'a, F: GeoFloat> RelateGeometry<'a, F> {
-    pub fn new(geom: &'a GeometryCow<'a, F>) -> Self {
-        Self::new_full(geom, false, None)
+    pub fn new(geom: &'a GeometryCow<'a, F>, mode: Mode<'a, F>) -> Self {
+        Self::with_meta(geom, mode, GeometryMeta::of(geom))
     }
 
-    pub fn new_with_prepared(geom: &'a GeometryCow<'a, F>, is_prepared: bool) -> Self {
-        Self::new_full(geom, is_prepared, None)
-    }
-
-    /// A prepared instance whose area locators are stored in shared state
-    /// that outlives it, for reuse across evaluations.
-    pub fn new_prepared_shared(
+    /// An instance over metadata computed earlier for the same geometry.
+    pub fn with_meta(
         geom: &'a GeometryCow<'a, F>,
-        shared_area_locators: &'a SharedAreaLocators<F>,
+        mode: Mode<'a, F>,
+        meta: GeometryMeta<F>,
     ) -> Self {
-        Self::new_full(geom, true, Some(shared_area_locators))
-    }
-
-    fn new_full(
-        geom: &'a GeometryCow<'a, F>,
-        is_prepared: bool,
-        shared_area_locators: Option<&'a SharedAreaLocators<F>>,
-    ) -> Self {
-        let is_geom_empty = geom.is_empty();
-        // The type-based dimension, which counts empty elements.
-        let mut geom_dim = type_dimension_cow(geom);
-        let mut has_points = false;
-        let mut has_lines = false;
-        let mut has_areas = false;
-        if !is_geom_empty {
-            analyze_dimensions_cow(
-                geom,
-                &mut geom_dim,
-                &mut has_points,
-                &mut has_lines,
-                &mut has_areas,
-            );
-        }
-        let is_line_zero_len = geom_dim == Dimensions::OneDimensional && is_zero_length_cow(geom);
         Self {
             geom,
-            is_prepared,
-            shared_area_locators,
-            env: geom.bounding_rect(),
-            geom_dim,
-            has_points,
-            has_lines,
-            has_areas,
-            is_line_zero_len,
-            is_geom_empty,
+            mode,
+            meta,
             unique_points: OnceCell::new(),
             locator: OnceCell::new(),
         }
     }
 
-    pub fn geometry(&self) -> &'a GeometryCow<'a, F> {
-        self.geom
-    }
-
     pub fn is_prepared(&self) -> bool {
-        self.is_prepared
+        self.mode.is_prepared()
     }
 
     /// The geometry envelope; `None` for an empty geometry (the JTS null
     /// envelope).
     pub fn envelope(&self) -> Option<Rect<F>> {
-        self.env
+        self.meta.env
     }
 
     /// The type-based dimension of the geometry.
     pub fn dimension(&self) -> Dimensions {
-        self.geom_dim
+        self.meta.geom_dim
     }
 
     pub fn has_dimension(&self, dim: Dimensions) -> bool {
         match dim {
-            Dimensions::ZeroDimensional => self.has_points,
-            Dimensions::OneDimensional => self.has_lines,
-            Dimensions::TwoDimensional => self.has_areas,
+            Dimensions::ZeroDimensional => self.meta.has_points,
+            Dimensions::OneDimensional => self.meta.has_lines,
+            Dimensions::TwoDimensional => self.meta.has_areas,
             Dimensions::Empty => false,
         }
     }
 
     pub fn has_area_and_line(&self) -> bool {
-        self.has_areas && self.has_lines
+        self.meta.has_areas && self.meta.has_lines
     }
 
     /// The actual non-empty dimension of the geometry. Zero-length
     /// linestrings are treated as points; an empty geometry has dimension
     /// `Empty`.
     pub fn dimension_real(&self) -> Dimensions {
-        if self.is_geom_empty {
+        if self.meta.is_geom_empty {
             return Dimensions::Empty;
         }
-        if self.geom_dim == Dimensions::OneDimensional && self.is_line_zero_len {
+        if self.meta.geom_dim == Dimensions::OneDimensional && self.meta.is_line_zero_len {
             return Dimensions::ZeroDimensional;
         }
-        if self.has_areas {
+        if self.meta.has_areas {
             return Dimensions::TwoDimensional;
         }
-        if self.has_lines {
+        if self.meta.has_lines {
             return Dimensions::OneDimensional;
         }
         Dimensions::ZeroDimensional
     }
 
     pub fn has_edges(&self) -> bool {
-        self.has_lines || self.has_areas
+        self.meta.has_lines || self.meta.has_areas
     }
 
     fn locator(&self) -> &RelatePointLocator<'a, F> {
-        self.locator.get_or_init(|| {
-            RelatePointLocator::new_full(self.geom, self.is_prepared, self.shared_area_locators)
-        })
+        self.locator
+            .get_or_init(|| RelatePointLocator::new(self.geom, self.mode))
+    }
+
+    /// The non-empty linear elements, in document order.
+    pub fn lines(&self) -> &[LineElement<'a, F>] {
+        self.locator().lines()
+    }
+
+    /// The non-empty polygonal elements, in document order.
+    pub fn polygonals(&self) -> &[Polygonal<'a, F>] {
+        self.locator().polygonals()
     }
 
     /// Whether a node point lies in the interior of the geometry's area,
@@ -167,10 +174,27 @@ impl<'a, F: GeoFloat> RelateGeometry<'a, F> {
     /// for nodes of a geometry inside an overlapping polygon of a
     /// GeometryCollection.
     pub fn is_node_in_area(&self, node_pt: Coord<F>, parent_polygonal_id: Option<usize>) -> bool {
-        let dim_loc = self
-            .locator()
-            .locate_node_with_dim(node_pt, parent_polygonal_id);
+        let dim_loc = self.locate_node_with_dim(node_pt, parent_polygonal_id);
         dim_loc == DimensionLocation::AreaInterior
+    }
+
+    /// Locates a node point, hoisting the locator's own O(1) fast paths so
+    /// the locator is not built when they decide the answer: an empty
+    /// geometry has only exterior, and a node of a purely polygonal
+    /// geometry is always on its boundary. The conditions mirror
+    /// `RelatePointLocator::locate_with_dim_impl` exactly.
+    fn locate_node_with_dim(
+        &self,
+        pt: Coord<F>,
+        parent_polygonal_id: Option<usize>,
+    ) -> DimensionLocation {
+        if self.meta.is_geom_empty {
+            return DimensionLocation::Exterior;
+        }
+        if self.is_polygonal() {
+            return DimensionLocation::AreaBoundary;
+        }
+        self.locator().locate_node_with_dim(pt, parent_polygonal_id)
     }
 
     pub fn locate_line_end_with_dim(&self, p: Coord<F>) -> DimensionLocation {
@@ -188,11 +212,19 @@ impl<'a, F: GeoFloat> RelateGeometry<'a, F> {
     }
 
     pub fn locate_node(&self, pt: Coord<F>, parent_polygonal_id: Option<usize>) -> CoordPos {
-        self.locator().locate_node(pt, parent_polygonal_id)
+        self.locate_node_with_dim(pt, parent_polygonal_id)
+            .location()
     }
 
     pub fn locate_with_dim(&self, pt: Coord<F>) -> DimensionLocation {
-        self.locator().locate_with_dim(pt)
+        // Envelope fast rejection: a point outside the (cached) envelope is
+        // exterior without a locator walk. This restores the performance of
+        // full-matrix evaluation on envelope-disjoint inputs, where every
+        // point-phase locate lands here.
+        match self.meta.env {
+            Some(env) if env.intersects(&pt) => self.locator().locate_with_dim(pt),
+            _ => DimensionLocation::Exterior,
+        }
     }
 
     /// Whether the geometry requires self-noding for correct evaluation of
@@ -211,10 +243,10 @@ impl<'a, F: GeoFloat> RelateGeometry<'a, F> {
             GeometryCow::GeometryCollection(gc) => {
                 // A collection with a single polygonal element does not
                 // need noding; neither does one with only points.
-                if self.has_areas && gc.0.len() == 1 {
+                if self.meta.has_areas && gc.0.len() == 1 {
                     return false;
                 }
-                self.has_areas || self.has_lines
+                self.meta.has_areas || self.meta.has_lines
             }
             // A single Line segment cannot self-cross, but is treated as a
             // LineString for consistency with JTS.
@@ -239,7 +271,7 @@ impl<'a, F: GeoFloat> RelateGeometry<'a, F> {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.is_geom_empty
+        self.meta.is_geom_empty
     }
 
     pub fn has_boundary(&self) -> bool {
@@ -260,7 +292,7 @@ impl<'a, F: GeoFloat> RelateGeometry<'a, F> {
     /// the result across evaluations.
     pub fn compute_unique_points(&self) -> BTreeSet<NodeKey<F>> {
         let mut set = BTreeSet::new();
-        collect_component_coords_cow(self.geom, &mut |c| {
+        collect_component_coords(self.geom, &mut |c| {
             set.insert(NodeKey(c));
         });
         set
@@ -270,7 +302,7 @@ impl<'a, F: GeoFloat> RelateGeometry<'a, F> {
     /// higher-dimension element of the geometry.
     pub fn effective_points(&self) -> Vec<Coord<F>> {
         let mut pts = Vec::new();
-        collect_point_coords_cow(self.geom, &mut |c| pts.push(c));
+        collect_point_coords(self.geom, &mut |c| pts.push(c));
 
         if pts.is_empty() || self.dimension_real() <= Dimensions::ZeroDimensional {
             return pts;
@@ -299,7 +331,7 @@ impl<'a, F: GeoFloat> RelateGeometry<'a, F> {
             polygonal_count: 0,
             seg_strings: Vec::new(),
         };
-        extractor.extract_cow(self.geom);
+        extractor.extract(self.geom);
         extractor.seg_strings
     }
 }
@@ -313,10 +345,14 @@ struct SegmentStringExtractor<'e, F: GeoFloat> {
 }
 
 impl<F: GeoFloat> SegmentStringExtractor<'_, F> {
-    fn extract_cow(&mut self, geom: &GeometryCow<'_, F>) {
+    fn extract(&mut self, geom: &GeometryCow<'_, F>) {
         match geom {
             GeometryCow::Point(_) | GeometryCow::MultiPoint(_) => {}
-            GeometryCow::Line(l) => self.extract_line_coords(vec![l.start, l.end]),
+            GeometryCow::Line(l) => {
+                if self.env_intersects(Some(l.bounding_rect())) {
+                    self.push_line(vec![l.start, l.end]);
+                }
+            }
             GeometryCow::LineString(ls) => self.extract_line(ls),
             GeometryCow::Polygon(p) => self.extract_polygon(p),
             GeometryCow::MultiLineString(mls) => {
@@ -329,45 +365,20 @@ impl<F: GeoFloat> SegmentStringExtractor<'_, F> {
             GeometryCow::Triangle(t) => self.extract_polygon(&t.to_polygon()),
             GeometryCow::GeometryCollection(gc) => {
                 for g in &gc.0 {
-                    self.extract_geometry(g);
-                }
-            }
-        }
-    }
-
-    fn extract_geometry(&mut self, geom: &Geometry<F>) {
-        match geom {
-            Geometry::Point(_) | Geometry::MultiPoint(_) => {}
-            Geometry::Line(l) => self.extract_line_coords(vec![l.start, l.end]),
-            Geometry::LineString(ls) => self.extract_line(ls),
-            Geometry::Polygon(p) => self.extract_polygon(p),
-            Geometry::MultiLineString(mls) => {
-                for ls in &mls.0 {
-                    self.extract_line(ls);
-                }
-            }
-            Geometry::MultiPolygon(mp) => self.extract_multi_polygon(mp),
-            Geometry::Rect(r) => self.extract_polygon(&r.to_polygon()),
-            Geometry::Triangle(t) => self.extract_polygon(&t.to_polygon()),
-            Geometry::GeometryCollection(gc) => {
-                for g in &gc.0 {
-                    self.extract_geometry(g);
+                    self.extract(&GeometryCow::from(g));
                 }
             }
         }
     }
 
     fn extract_line(&mut self, line: &LineString<F>) {
-        if line.0.is_empty() {
+        if line.0.is_empty() || !self.env_intersects(line.bounding_rect()) {
             return;
         }
-        self.extract_line_coords(line.0.clone());
+        self.push_line(line.0.clone());
     }
 
-    fn extract_line_coords(&mut self, coords: Vec<Coord<F>>) {
-        if !self.env_intersects_coords(&coords) {
-            return;
-        }
+    fn push_line(&mut self, coords: Vec<Coord<F>>) {
         self.element_id += 1;
         self.seg_strings.push(RelateSegmentString::create_line(
             coords,
@@ -378,7 +389,7 @@ impl<F: GeoFloat> SegmentStringExtractor<'_, F> {
 
     /// A polygon which is a direct element (its own polygonal element).
     fn extract_polygon(&mut self, polygon: &Polygon<F>) {
-        if polygon.exterior().0.is_empty() {
+        if polygon.is_empty() {
             return;
         }
         self.polygonal_count += 1;
@@ -389,13 +400,13 @@ impl<F: GeoFloat> SegmentStringExtractor<'_, F> {
     /// A MultiPolygon is one polygonal element; its member polygons share
     /// its id.
     fn extract_multi_polygon(&mut self, mp: &MultiPolygon<F>) {
-        if mp.0.iter().all(|p| p.exterior().0.is_empty()) {
+        if mp.is_empty() {
             return;
         }
         self.polygonal_count += 1;
         let polygonal_id = self.polygonal_count - 1;
         for polygon in &mp.0 {
-            if polygon.exterior().0.is_empty() {
+            if polygon.is_empty() {
                 continue;
             }
             self.extract_polygon_rings(polygon, polygonal_id);
@@ -403,7 +414,7 @@ impl<F: GeoFloat> SegmentStringExtractor<'_, F> {
     }
 
     fn extract_polygon_rings(&mut self, polygon: &Polygon<F>, polygonal_id: usize) {
-        if !self.env_intersects_coords(&polygon.exterior().0) {
+        if !self.env_intersects(polygon.exterior().bounding_rect()) {
             // The shell envelope contains the whole polygon.
             return;
         }
@@ -415,10 +426,7 @@ impl<F: GeoFloat> SegmentStringExtractor<'_, F> {
     }
 
     fn extract_ring(&mut self, ring: &LineString<F>, ring_id: i32, polygonal_id: usize) {
-        if ring.0.is_empty() {
-            return;
-        }
-        if !self.env_intersects_coords(&ring.0) {
+        if ring.0.is_empty() || !self.env_intersects(ring.bounding_rect()) {
             return;
         }
         // Orient the points if required: shells CW, holes CCW.
@@ -433,28 +441,16 @@ impl<F: GeoFloat> SegmentStringExtractor<'_, F> {
         ));
     }
 
-    fn env_intersects_coords(&self, coords: &[Coord<F>]) -> bool {
-        let Some(env) = self.env else {
-            return true;
-        };
-        let Some(coords_env) = coords_bounding_rect(coords) else {
-            return false;
-        };
-        env.intersects(&coords_env)
+    /// Whether an element with the given envelope passes the extraction
+    /// filter. Without a filter every element passes; with one, an empty
+    /// element (no envelope) is rejected.
+    fn env_intersects(&self, elem_env: Option<Rect<F>>) -> bool {
+        match (self.env, elem_env) {
+            (None, _) => true,
+            (Some(env), Some(elem_env)) => env.intersects(&elem_env),
+            (Some(_), None) => false,
+        }
     }
-}
-
-fn coords_bounding_rect<F: GeoFloat>(coords: &[Coord<F>]) -> Option<Rect<F>> {
-    let (first, rest) = coords.split_first()?;
-    let mut min = *first;
-    let mut max = *first;
-    for c in rest {
-        min.x = min.x.min(c.x);
-        min.y = min.y.min(c.y);
-        max.x = max.x.max(c.x);
-        max.y = max.y.max(c.y);
-    }
-    Some(Rect::new(min, max))
 }
 
 /// A copy of the ring's coordinates, oriented CW (for shells) or CCW (for
@@ -475,7 +471,7 @@ pub(crate) fn oriented_ring_coords<F: GeoFloat>(
 /// The type-based dimension of the geometry: empty geometries and empty
 /// collection members count with their type's dimension (JTS
 /// `Geometry.getDimension`).
-fn type_dimension_cow<F: GeoFloat>(geom: &GeometryCow<'_, F>) -> Dimensions {
+fn type_dimension<F: GeoFloat>(geom: &GeometryCow<'_, F>) -> Dimensions {
     match geom {
         GeometryCow::Point(_) | GeometryCow::MultiPoint(_) => Dimensions::ZeroDimensional,
         GeometryCow::Line(_) | GeometryCow::LineString(_) | GeometryCow::MultiLineString(_) => {
@@ -487,129 +483,72 @@ fn type_dimension_cow<F: GeoFloat>(geom: &GeometryCow<'_, F>) -> Dimensions {
         | GeometryCow::Triangle(_) => Dimensions::TwoDimensional,
         GeometryCow::GeometryCollection(gc) => {
             gc.0.iter()
-                .map(type_dimension_geom)
+                .map(|g| type_dimension(&GeometryCow::from(g)))
                 .max()
                 .unwrap_or(Dimensions::Empty)
         }
     }
 }
 
-fn type_dimension_geom<F: GeoFloat>(geom: &Geometry<F>) -> Dimensions {
-    match geom {
-        Geometry::Point(_) | Geometry::MultiPoint(_) => Dimensions::ZeroDimensional,
-        Geometry::Line(_) | Geometry::LineString(_) | Geometry::MultiLineString(_) => {
-            Dimensions::OneDimensional
-        }
-        Geometry::Polygon(_)
-        | Geometry::MultiPolygon(_)
-        | Geometry::Rect(_)
-        | Geometry::Triangle(_) => Dimensions::TwoDimensional,
-        Geometry::GeometryCollection(gc) => {
-            gc.0.iter()
-                .map(type_dimension_geom)
-                .max()
-                .unwrap_or(Dimensions::Empty)
-        }
-    }
+/// The dimension analysis of a geometry: the dimension raised to that of
+/// the highest non-empty element, and which dimensions have non-empty
+/// elements (JTS `RelateGeometry.analyzeDimensions`).
+struct DimensionAnalysis {
+    dim: Dimensions,
+    has_points: bool,
+    has_lines: bool,
+    has_areas: bool,
 }
 
-/// Computes the per-dimension presence flags over the non-empty elements,
-/// raising the dimension to at least the highest non-empty element's (JTS
-/// `RelateGeometry.analyzeDimensions`). For non-collection inputs the
-/// dimension is set outright, as in JTS.
-fn analyze_dimensions_cow<F: GeoFloat>(
-    geom: &GeometryCow<'_, F>,
-    geom_dim: &mut Dimensions,
-    has_points: &mut bool,
-    has_lines: &mut bool,
-    has_areas: &mut bool,
-) {
-    match geom {
-        GeometryCow::Point(_) | GeometryCow::MultiPoint(_) => {
-            *has_points = true;
-            *geom_dim = Dimensions::ZeroDimensional;
+impl DimensionAnalysis {
+    fn found(&mut self, dim: Dimensions) {
+        match dim {
+            Dimensions::ZeroDimensional => self.has_points = true,
+            Dimensions::OneDimensional => self.has_lines = true,
+            Dimensions::TwoDimensional => self.has_areas = true,
+            Dimensions::Empty => {}
         }
-        GeometryCow::Line(_) | GeometryCow::LineString(_) | GeometryCow::MultiLineString(_) => {
-            *has_lines = true;
-            *geom_dim = Dimensions::OneDimensional;
-        }
-        GeometryCow::Polygon(_)
-        | GeometryCow::MultiPolygon(_)
-        | GeometryCow::Rect(_)
-        | GeometryCow::Triangle(_) => {
-            *has_areas = true;
-            *geom_dim = Dimensions::TwoDimensional;
-        }
-        GeometryCow::GeometryCollection(gc) => {
-            for g in &gc.0 {
-                analyze_dimensions_geom(g, geom_dim, has_points, has_lines, has_areas);
-            }
+        if self.dim < dim {
+            self.dim = dim;
         }
     }
-}
 
-fn analyze_dimensions_geom<F: GeoFloat>(
-    geom: &Geometry<F>,
-    geom_dim: &mut Dimensions,
-    has_points: &mut bool,
-    has_lines: &mut bool,
-    has_areas: &mut bool,
-) {
-    let raise = |geom_dim: &mut Dimensions, dim: Dimensions| {
-        if *geom_dim < dim {
-            *geom_dim = dim;
-        }
-    };
-    match geom {
-        Geometry::Point(_) => {
-            *has_points = true;
-            raise(geom_dim, Dimensions::ZeroDimensional);
-        }
-        Geometry::MultiPoint(mp) => {
-            if !mp.0.is_empty() {
-                *has_points = true;
-                raise(geom_dim, Dimensions::ZeroDimensional);
+    fn analyze<F: GeoFloat>(&mut self, geom: &GeometryCow<'_, F>) {
+        match geom {
+            GeometryCow::Point(_) => self.found(Dimensions::ZeroDimensional),
+            GeometryCow::MultiPoint(mp) => {
+                if !mp.0.is_empty() {
+                    self.found(Dimensions::ZeroDimensional);
+                }
             }
-        }
-        Geometry::Line(_) => {
-            *has_lines = true;
-            raise(geom_dim, Dimensions::OneDimensional);
-        }
-        Geometry::LineString(ls) => {
-            if !ls.0.is_empty() {
-                *has_lines = true;
-                raise(geom_dim, Dimensions::OneDimensional);
-            }
-        }
-        Geometry::MultiLineString(mls) => {
-            for ls in &mls.0 {
+            GeometryCow::Line(_) => self.found(Dimensions::OneDimensional),
+            GeometryCow::LineString(ls) => {
                 if !ls.0.is_empty() {
-                    *has_lines = true;
-                    raise(geom_dim, Dimensions::OneDimensional);
+                    self.found(Dimensions::OneDimensional);
                 }
             }
-        }
-        Geometry::Polygon(p) => {
-            if !p.exterior().0.is_empty() {
-                *has_areas = true;
-                raise(geom_dim, Dimensions::TwoDimensional);
-            }
-        }
-        Geometry::MultiPolygon(mp) => {
-            for p in &mp.0 {
-                if !p.exterior().0.is_empty() {
-                    *has_areas = true;
-                    raise(geom_dim, Dimensions::TwoDimensional);
+            GeometryCow::MultiLineString(mls) => {
+                if mls.0.iter().any(|ls| !ls.0.is_empty()) {
+                    self.found(Dimensions::OneDimensional);
                 }
             }
-        }
-        Geometry::Rect(_) | Geometry::Triangle(_) => {
-            *has_areas = true;
-            raise(geom_dim, Dimensions::TwoDimensional);
-        }
-        Geometry::GeometryCollection(gc) => {
-            for g in &gc.0 {
-                analyze_dimensions_geom(g, geom_dim, has_points, has_lines, has_areas);
+            GeometryCow::Polygon(p) => {
+                if !p.is_empty() {
+                    self.found(Dimensions::TwoDimensional);
+                }
+            }
+            GeometryCow::MultiPolygon(mp) => {
+                if !mp.is_empty() {
+                    self.found(Dimensions::TwoDimensional);
+                }
+            }
+            GeometryCow::Rect(_) | GeometryCow::Triangle(_) => {
+                self.found(Dimensions::TwoDimensional)
+            }
+            GeometryCow::GeometryCollection(gc) => {
+                for g in &gc.0 {
+                    self.analyze(&GeometryCow::from(g));
+                }
             }
         }
     }
@@ -617,22 +556,14 @@ fn analyze_dimensions_geom<F: GeoFloat>(
 
 /// Tests if all linear elements are zero-length. For efficiency the test
 /// avoids computing actual length.
-fn is_zero_length_cow<F: GeoFloat>(geom: &GeometryCow<'_, F>) -> bool {
+fn is_zero_length<F: GeoFloat>(geom: &GeometryCow<'_, F>) -> bool {
     match geom {
         GeometryCow::Line(l) => l.start == l.end,
         GeometryCow::LineString(ls) => is_zero_length_line(ls),
         GeometryCow::MultiLineString(mls) => mls.0.iter().all(is_zero_length_line),
-        GeometryCow::GeometryCollection(gc) => gc.0.iter().all(is_zero_length_geom),
-        _ => true,
-    }
-}
-
-fn is_zero_length_geom<F: GeoFloat>(geom: &Geometry<F>) -> bool {
-    match geom {
-        Geometry::Line(l) => l.start == l.end,
-        Geometry::LineString(ls) => is_zero_length_line(ls),
-        Geometry::MultiLineString(mls) => mls.0.iter().all(is_zero_length_line),
-        Geometry::GeometryCollection(gc) => gc.0.iter().all(is_zero_length_geom),
+        GeometryCow::GeometryCollection(gc) => {
+            gc.0.iter().all(|g| is_zero_length(&GeometryCow::from(g)))
+        }
         _ => true,
     }
 }
@@ -650,10 +581,7 @@ fn is_zero_length_line<F: GeoFloat>(line: &LineString<F>) -> bool {
 /// point and line component of the geometry, in document order (the JTS
 /// `ComponentCoordinateExtracter` semantic). Polygonal components are not
 /// visited; the callers only use this for zero-dimensional geometries.
-fn collect_component_coords_cow<F: GeoFloat>(
-    geom: &GeometryCow<'_, F>,
-    f: &mut impl FnMut(Coord<F>),
-) {
+fn collect_component_coords<F: GeoFloat>(geom: &GeometryCow<'_, F>, f: &mut impl FnMut(Coord<F>)) {
     match geom {
         GeometryCow::Point(p) => f(p.0),
         GeometryCow::Line(l) => f(l.start),
@@ -676,37 +604,7 @@ fn collect_component_coords_cow<F: GeoFloat>(
         }
         GeometryCow::GeometryCollection(gc) => {
             for g in &gc.0 {
-                collect_component_coords_geom(g, f);
-            }
-        }
-        _ => {}
-    }
-}
-
-fn collect_component_coords_geom<F: GeoFloat>(geom: &Geometry<F>, f: &mut impl FnMut(Coord<F>)) {
-    match geom {
-        Geometry::Point(p) => f(p.0),
-        Geometry::Line(l) => f(l.start),
-        Geometry::LineString(ls) => {
-            if let Some(&c) = ls.0.first() {
-                f(c);
-            }
-        }
-        Geometry::MultiPoint(mp) => {
-            for p in &mp.0 {
-                f(p.0);
-            }
-        }
-        Geometry::MultiLineString(mls) => {
-            for ls in &mls.0 {
-                if let Some(&c) = ls.0.first() {
-                    f(c);
-                }
-            }
-        }
-        Geometry::GeometryCollection(gc) => {
-            for g in &gc.0 {
-                collect_component_coords_geom(g, f);
+                collect_component_coords(&GeometryCow::from(g), f);
             }
         }
         _ => {}
@@ -715,7 +613,7 @@ fn collect_component_coords_geom<F: GeoFloat>(geom: &Geometry<F>, f: &mut impl F
 
 /// Applies `f` to the coordinate of every point element of the geometry,
 /// in document order.
-fn collect_point_coords_cow<F: GeoFloat>(geom: &GeometryCow<'_, F>, f: &mut impl FnMut(Coord<F>)) {
+fn collect_point_coords<F: GeoFloat>(geom: &GeometryCow<'_, F>, f: &mut impl FnMut(Coord<F>)) {
     match geom {
         GeometryCow::Point(p) => f(p.0),
         GeometryCow::MultiPoint(mp) => {
@@ -725,24 +623,7 @@ fn collect_point_coords_cow<F: GeoFloat>(geom: &GeometryCow<'_, F>, f: &mut impl
         }
         GeometryCow::GeometryCollection(gc) => {
             for g in &gc.0 {
-                collect_point_coords_geom(g, f);
-            }
-        }
-        _ => {}
-    }
-}
-
-fn collect_point_coords_geom<F: GeoFloat>(geom: &Geometry<F>, f: &mut impl FnMut(Coord<F>)) {
-    match geom {
-        Geometry::Point(p) => f(p.0),
-        Geometry::MultiPoint(mp) => {
-            for p in &mp.0 {
-                f(p.0);
-            }
-        }
-        Geometry::GeometryCollection(gc) => {
-            for g in &gc.0 {
-                collect_point_coords_geom(g, f);
+                collect_point_coords(&GeometryCow::from(g), f);
             }
         }
         _ => {}
@@ -756,7 +637,7 @@ mod tests {
     use crate::wkt;
 
     fn relate_geom_dims(geom: &GeometryCow<'_, f64>) -> (Dimensions, Dimensions) {
-        let rgeom = RelateGeometry::new(geom);
+        let rgeom = RelateGeometry::new(geom, Mode::Simple);
         (rgeom.dimension(), rgeom.dimension_real())
     }
 
@@ -764,7 +645,7 @@ mod tests {
     fn test_unique_points() {
         let geom = wkt!(MULTIPOINT(0. 0., 5. 5., 5. 0., 0. 0.));
         let cow = GeometryCow::from(&geom);
-        let rgeom = RelateGeometry::new(&cow);
+        let rgeom = RelateGeometry::new(&cow, Mode::Simple);
         assert_eq!(rgeom.unique_points().len(), 3, "Unique pts size");
     }
 
@@ -772,7 +653,7 @@ mod tests {
     fn test_boundary() {
         let geom = wkt!(MULTILINESTRING ((0. 0., 9. 9.), (9. 9., 5. 1.)));
         let cow = GeometryCow::from(&geom);
-        let rgeom = RelateGeometry::new(&cow);
+        let rgeom = RelateGeometry::new(&cow, Mode::Simple);
         assert!(rgeom.has_boundary(), "hasBoundary");
     }
 
@@ -784,7 +665,7 @@ mod tests {
             POINT (6. 5.)
         ));
         let cow = GeometryCow::from(&geom);
-        let rgeom = RelateGeometry::new(&cow);
+        let rgeom = RelateGeometry::new(&cow, Mode::Simple);
         assert!(rgeom.has_dimension(Dimensions::ZeroDimensional), "dim 0");
         assert!(rgeom.has_dimension(Dimensions::OneDimensional), "dim 1");
         assert!(rgeom.has_dimension(Dimensions::TwoDimensional), "dim 2");
@@ -844,7 +725,7 @@ mod tests {
             POLYGON ((20. 20., 22. 20., 22. 22., 20. 22., 20. 20.))
         ));
         let cow = GeometryCow::from(&gc);
-        let rgeom = RelateGeometry::new(&cow);
+        let rgeom = RelateGeometry::new(&cow, Mode::Simple);
 
         // Filter to the last polygon only: its section id must still be 2.
         let env = Rect::new(Coord { x: 19., y: 19. }, Coord { x: 23., y: 23. });

--- a/geo/src/algorithm/relate/relateng/relate_geometry.rs
+++ b/geo/src/algorithm/relate/relateng/relate_geometry.rs
@@ -26,13 +26,15 @@ use crate::winding_order::Winding;
 use crate::{Coord, GeoFloat, Geometry, Intersects, LineString, MultiPolygon, Polygon, Rect};
 
 use super::dimension_location::DimensionLocation;
-use super::relate_point_locator::RelatePointLocator;
+use super::relate_point_locator::{RelatePointLocator, SharedAreaLocators};
 use super::relate_segment_string::RelateSegmentString;
 use super::topology_predicate::InputIndex;
 
 pub(crate) struct RelateGeometry<'a, F: GeoFloat> {
     geom: &'a GeometryCow<'a, F>,
     is_prepared: bool,
+    /// Prepared mode: per-element area locators shared across evaluations.
+    shared_area_locators: Option<&'a SharedAreaLocators<F>>,
     env: Option<Rect<F>>,
     geom_dim: Dimensions,
     has_points: bool,
@@ -46,10 +48,27 @@ pub(crate) struct RelateGeometry<'a, F: GeoFloat> {
 
 impl<'a, F: GeoFloat> RelateGeometry<'a, F> {
     pub fn new(geom: &'a GeometryCow<'a, F>) -> Self {
-        Self::new_with_prepared(geom, false)
+        Self::new_full(geom, false, None)
     }
 
     pub fn new_with_prepared(geom: &'a GeometryCow<'a, F>, is_prepared: bool) -> Self {
+        Self::new_full(geom, is_prepared, None)
+    }
+
+    /// A prepared instance whose area locators are stored in shared state
+    /// that outlives it, for reuse across evaluations.
+    pub fn new_prepared_shared(
+        geom: &'a GeometryCow<'a, F>,
+        shared_area_locators: &'a SharedAreaLocators<F>,
+    ) -> Self {
+        Self::new_full(geom, true, Some(shared_area_locators))
+    }
+
+    fn new_full(
+        geom: &'a GeometryCow<'a, F>,
+        is_prepared: bool,
+        shared_area_locators: Option<&'a SharedAreaLocators<F>>,
+    ) -> Self {
         let is_geom_empty = geom.is_empty();
         // The type-based dimension, which counts empty elements.
         let mut geom_dim = type_dimension_cow(geom);
@@ -69,6 +88,7 @@ impl<'a, F: GeoFloat> RelateGeometry<'a, F> {
         Self {
             geom,
             is_prepared,
+            shared_area_locators,
             env: geom.bounding_rect(),
             geom_dim,
             has_points,
@@ -137,8 +157,9 @@ impl<'a, F: GeoFloat> RelateGeometry<'a, F> {
     }
 
     fn locator(&self) -> &RelatePointLocator<'a, F> {
-        self.locator
-            .get_or_init(|| RelatePointLocator::new_with_prepared(self.geom, self.is_prepared))
+        self.locator.get_or_init(|| {
+            RelatePointLocator::new_full(self.geom, self.is_prepared, self.shared_area_locators)
+        })
     }
 
     /// Whether a node point lies in the interior of the geometry's area,
@@ -231,13 +252,18 @@ impl<'a, F: GeoFloat> RelateGeometry<'a, F> {
     /// coordinate is included. Cached for reuse in prepared mode. Only
     /// used for geometries with real dimension 0.
     pub fn unique_points(&self) -> &BTreeSet<NodeKey<F>> {
-        self.unique_points.get_or_init(|| {
-            let mut set = BTreeSet::new();
-            collect_component_coords_cow(self.geom, &mut |c| {
-                set.insert(NodeKey(c));
-            });
-            set
-        })
+        self.unique_points
+            .get_or_init(|| self.compute_unique_points())
+    }
+
+    /// Computes the unique points without caching; prepared state caches
+    /// the result across evaluations.
+    pub fn compute_unique_points(&self) -> BTreeSet<NodeKey<F>> {
+        let mut set = BTreeSet::new();
+        collect_component_coords_cow(self.geom, &mut |c| {
+            set.insert(NodeKey(c));
+        });
+        set
     }
 
     /// The point-element coordinates that are not covered by a

--- a/geo/src/algorithm/relate/relateng/relate_ng.rs
+++ b/geo/src/algorithm/relate/relateng/relate_ng.rs
@@ -51,30 +51,79 @@ pub(crate) fn eval<F: GeoFloat>(
     RelateNG::new(a).evaluate(b, predicate)
 }
 
+/// The A-side caches of a prepared relate evaluation. The state is fully
+/// owned (segment strings own their coordinates, the area indexes are
+/// owned), so it can live in a `PreparedGeometry` and be shared into
+/// per-call engines without borrowing the geometry.
+pub(crate) struct PreparedRelateState<F: GeoFloat> {
+    /// The A-side segment index, built over all A edges on first use.
+    edge_mutual_int: OnceCell<MutualSegmentSetIntersector<F>>,
+    /// The per-polygonal-element area locators of A.
+    area_locators: super::relate_point_locator::SharedAreaLocators<F>,
+    /// The unique points of A (for the P/P fast path).
+    unique_points:
+        OnceCell<std::collections::BTreeSet<crate::relate::geomgraph::node_map::NodeKey<F>>>,
+}
+
+impl<F: GeoFloat> PreparedRelateState<F> {
+    pub fn new() -> Self {
+        Self {
+            edge_mutual_int: OnceCell::new(),
+            area_locators: OnceCell::new(),
+            unique_points: OnceCell::new(),
+        }
+    }
+}
+
+/// The state used by an engine instance: owned for one-shot and
+/// self-contained prepared use, or borrowed from a `PreparedGeometry`.
+enum StateHolder<'a, F: GeoFloat> {
+    Owned(PreparedRelateState<F>),
+    Shared(&'a PreparedRelateState<F>),
+}
+
+impl<F: GeoFloat> StateHolder<'_, F> {
+    fn get(&self) -> &PreparedRelateState<F> {
+        match self {
+            StateHolder::Owned(state) => state,
+            StateHolder::Shared(state) => state,
+        }
+    }
+}
+
 pub(crate) struct RelateNG<'a, F: GeoFloat> {
     geom_a: RelateGeometry<'a, F>,
-    /// The cached A-side segment index. In prepared mode it is built over
-    /// all A edges and reused across evaluations; otherwise it is built
-    /// filtered to the first evaluation's envelope (a non-prepared
-    /// instance is single-use, as in JTS).
-    edge_mutual_int: OnceCell<MutualSegmentSetIntersector<F>>,
+    /// In prepared mode the A-side segment index is built over all A edges
+    /// and reused across evaluations; otherwise it is built filtered to
+    /// the first evaluation's envelope (a non-prepared instance is
+    /// single-use, as in JTS).
+    state: StateHolder<'a, F>,
 }
 
 impl<'a, F: GeoFloat> RelateNG<'a, F> {
     pub fn new(a: &'a GeometryCow<'a, F>) -> Self {
-        Self::new_with_prepared(a, false)
+        Self {
+            geom_a: RelateGeometry::new_with_prepared(a, false),
+            state: StateHolder::Owned(PreparedRelateState::new()),
+        }
     }
 
     /// Creates an instance with cached spatial indexes, for repeated
     /// evaluations against the same A geometry.
     pub fn prepare(a: &'a GeometryCow<'a, F>) -> Self {
-        Self::new_with_prepared(a, true)
+        Self {
+            geom_a: RelateGeometry::new_with_prepared(a, true),
+            state: StateHolder::Owned(PreparedRelateState::new()),
+        }
     }
 
-    fn new_with_prepared(a: &'a GeometryCow<'a, F>, is_prepared: bool) -> Self {
+    /// An engine over shared prepared state that outlives this instance
+    /// (the `PreparedGeometry` case): heavy indexes are stored in the
+    /// state and reused by every engine constructed over it.
+    pub fn with_state(a: &'a GeometryCow<'a, F>, state: &'a PreparedRelateState<F>) -> Self {
         Self {
-            geom_a: RelateGeometry::new_with_prepared(a, is_prepared),
-            edge_mutual_int: OnceCell::new(),
+            geom_a: RelateGeometry::new_prepared_shared(a, &state.area_locators),
+            state: StateHolder::Shared(state),
         }
     }
 
@@ -172,7 +221,13 @@ impl<'a, F: GeoFloat> RelateNG<'a, F> {
         geom_b: &RelateGeometry<'_, F>,
         computer: &mut TopologyComputer<'_, '_, '_, F>,
     ) {
-        let pts_a = self.geom_a.unique_points();
+        // The A-side unique points live in the (possibly shared) state so
+        // prepared use computes them once.
+        let pts_a = self
+            .state
+            .get()
+            .unique_points
+            .get_or_init(|| self.geom_a.compute_unique_points());
         let pts_b = geom_b.unique_points();
 
         let mut num_b_in_a = 0;
@@ -217,7 +272,7 @@ impl<'a, F: GeoFloat> RelateNG<'a, F> {
         } else {
             // In prepared mode the A edge index is reused across
             // evaluations.
-            let mutual = self.edge_mutual_int.get_or_init(|| {
+            let mutual = self.state.get().edge_mutual_int.get_or_init(|| {
                 let env_extract = if self.geom_a.is_prepared() {
                     None
                 } else {

--- a/geo/src/algorithm/relate/relateng/relate_ng.rs
+++ b/geo/src/algorithm/relate/relateng/relate_ng.rs
@@ -17,17 +17,18 @@ use std::cell::OnceCell;
 
 use crate::bounding_rect::BoundingRect;
 use crate::coordinate_position::CoordPos;
-use crate::dimensions::Dimensions;
+use crate::dimensions::{Dimensions, HasDimensions};
 use crate::geometry_cow::GeometryCow;
 use crate::rect_ops::RectOps;
 use crate::relate::IntersectionMatrix;
-use crate::{Coord, GeoFloat, Geometry, Line, LineString, Polygon, Rect};
+use crate::{Coord, GeoFloat, LineString, Rect};
 
 use super::edge_segment_intersector::{
     EdgeSegmentIntersector, MutualSegmentSetIntersector, intersect_all,
 };
 use super::im_predicate::RelateMatrixPredicate;
-use super::relate_geometry::RelateGeometry;
+use super::relate_geometry::{GeometryMeta, RelateGeometry};
+use super::relate_point_locator::{Mode, Polygonal};
 use super::topology_computer::TopologyComputer;
 use super::topology_predicate::{
     InputIndex, TopologyPredicate, envelope_covers, envelopes_intersect,
@@ -38,7 +39,8 @@ pub(crate) fn relate<F: GeoFloat>(
     a: &GeometryCow<'_, F>,
     b: &GeometryCow<'_, F>,
 ) -> IntersectionMatrix {
-    RelateNG::new(a).evaluate_matrix(b)
+    let state = PreparedRelateState::default();
+    RelateNG::new(a, &state).evaluate_matrix(b)
 }
 
 /// Evaluates a topological predicate for a pair of geometries, with
@@ -48,7 +50,8 @@ pub(crate) fn eval<F: GeoFloat>(
     b: &GeometryCow<'_, F>,
     predicate: &mut dyn TopologyPredicate<F>,
 ) -> bool {
-    RelateNG::new(a).evaluate(b, predicate)
+    let state = PreparedRelateState::default();
+    RelateNG::new(a, &state).evaluate(b, predicate)
 }
 
 /// The A-side caches of a prepared relate evaluation. The state is fully
@@ -63,67 +66,57 @@ pub(crate) struct PreparedRelateState<F: GeoFloat> {
     /// The unique points of A (for the P/P fast path).
     unique_points:
         OnceCell<std::collections::BTreeSet<crate::relate::geomgraph::node_map::NodeKey<F>>>,
+    /// The envelope and dimension analysis of A.
+    meta: OnceCell<GeometryMeta<F>>,
 }
 
-impl<F: GeoFloat> PreparedRelateState<F> {
-    pub fn new() -> Self {
+impl<F: GeoFloat> Default for PreparedRelateState<F> {
+    fn default() -> Self {
         Self {
             edge_mutual_int: OnceCell::new(),
             area_locators: OnceCell::new(),
             unique_points: OnceCell::new(),
+            meta: OnceCell::new(),
         }
     }
 }
 
-/// The state used by an engine instance: owned for one-shot and
-/// self-contained prepared use, or borrowed from a `PreparedGeometry`.
-enum StateHolder<'a, F: GeoFloat> {
-    Owned(PreparedRelateState<F>),
-    Shared(&'a PreparedRelateState<F>),
-}
-
-impl<F: GeoFloat> StateHolder<'_, F> {
-    fn get(&self) -> &PreparedRelateState<F> {
-        match self {
-            StateHolder::Owned(state) => state,
-            StateHolder::Shared(state) => state,
-        }
+impl<F: GeoFloat> PreparedRelateState<F> {
+    /// The metadata of the A geometry, computed on first use.
+    pub fn meta(&self, a: &GeometryCow<'_, F>) -> &GeometryMeta<F> {
+        self.meta.get_or_init(|| GeometryMeta::of(a))
     }
 }
 
 pub(crate) struct RelateNG<'a, F: GeoFloat> {
     geom_a: RelateGeometry<'a, F>,
-    /// In prepared mode the A-side segment index is built over all A edges
-    /// and reused across evaluations; otherwise it is built filtered to
-    /// the first evaluation's envelope (a non-prepared instance is
-    /// single-use, as in JTS).
-    state: StateHolder<'a, F>,
+    /// The A-side caches. In prepared mode the segment index is built over
+    /// all A edges and reused across evaluations; otherwise it is built
+    /// filtered to the first evaluation's envelope, so a non-prepared
+    /// instance is single-use, as in JTS.
+    state: &'a PreparedRelateState<F>,
 }
 
 impl<'a, F: GeoFloat> RelateNG<'a, F> {
-    pub fn new(a: &'a GeometryCow<'a, F>) -> Self {
+    /// An engine for a single evaluation.
+    pub fn new(a: &'a GeometryCow<'a, F>, state: &'a PreparedRelateState<F>) -> Self {
         Self {
-            geom_a: RelateGeometry::new_with_prepared(a, false),
-            state: StateHolder::Owned(PreparedRelateState::new()),
+            geom_a: RelateGeometry::new(a, Mode::Simple),
+            state,
         }
     }
 
-    /// Creates an instance with cached spatial indexes, for repeated
-    /// evaluations against the same A geometry.
-    pub fn prepare(a: &'a GeometryCow<'a, F>) -> Self {
+    /// An engine for repeated evaluations against the same A geometry:
+    /// the indexes are stored in the state and reused by every engine
+    /// constructed over it.
+    pub fn prepared(a: &'a GeometryCow<'a, F>, state: &'a PreparedRelateState<F>) -> Self {
         Self {
-            geom_a: RelateGeometry::new_with_prepared(a, true),
-            state: StateHolder::Owned(PreparedRelateState::new()),
-        }
-    }
-
-    /// An engine over shared prepared state that outlives this instance
-    /// (the `PreparedGeometry` case): heavy indexes are stored in the
-    /// state and reused by every engine constructed over it.
-    pub fn with_state(a: &'a GeometryCow<'a, F>, state: &'a PreparedRelateState<F>) -> Self {
-        Self {
-            geom_a: RelateGeometry::new_prepared_shared(a, &state.area_locators),
-            state: StateHolder::Shared(state),
+            geom_a: RelateGeometry::with_meta(
+                a,
+                Mode::Prepared(&state.area_locators),
+                *state.meta(a),
+            ),
+            state,
         }
     }
 
@@ -140,12 +133,15 @@ impl<'a, F: GeoFloat> RelateNG<'a, F> {
         b: &GeometryCow<'_, F>,
         predicate: &mut dyn TopologyPredicate<F>,
     ) -> bool {
+        // The B wrapper is built first so the envelope gate reuses its
+        // cached envelope instead of walking B's coordinates twice (JTS
+        // gets the gate's envelope for free from the Geometry cache).
+        let geom_b = RelateGeometry::new(b, Mode::Simple);
+
         // Fast envelope checks.
-        if !self.has_required_envelope_interaction(b, predicate) {
+        if !self.has_required_envelope_interaction(geom_b.envelope(), predicate) {
             return false;
         }
-
-        let geom_b = RelateGeometry::new(b);
 
         let dim_a = self.geom_a.dimension_real();
         let dim_b = geom_b.dimension_real();
@@ -191,10 +187,9 @@ impl<'a, F: GeoFloat> RelateNG<'a, F> {
 
     fn has_required_envelope_interaction(
         &self,
-        b: &GeometryCow<'_, F>,
+        env_b: Option<Rect<F>>,
         predicate: &dyn TopologyPredicate<F>,
     ) -> bool {
-        let env_b = b.bounding_rect();
         let env_a = self.geom_a.envelope();
         let mut is_interacts = false;
         if predicate.requires_covers(InputIndex::A) {
@@ -225,7 +220,6 @@ impl<'a, F: GeoFloat> RelateNG<'a, F> {
         // prepared use computes them once.
         let pts_a = self
             .state
-            .get()
             .unique_points
             .get_or_init(|| self.geom_a.compute_unique_points());
         let pts_b = geom_b.unique_points();
@@ -272,7 +266,7 @@ impl<'a, F: GeoFloat> RelateNG<'a, F> {
         } else {
             // In prepared mode the A edge index is reused across
             // evaluations.
-            let mutual = self.state.get().edge_mutual_int.get_or_init(|| {
+            let mutual = self.state.edge_mutual_int.get_or_init(|| {
                 let env_extract = if self.geom_a.is_prepared() {
                     None
                 } else {
@@ -356,8 +350,8 @@ fn compute_point<F: GeoFloat>(
 ) {
     let loc_dim_target = geom_target.locate_with_dim(pt);
     let loc_target = loc_dim_target.location();
-    let dim_target = loc_dim_target.dimension_with_exterior(computer.dimension(other(input)));
-    computer.add_point_on_geometry(input, loc_target, dim_target, pt);
+    let dim_target = loc_dim_target.dimension_with_exterior(computer.dimension(input.other()));
+    computer.add_point_on_geometry(input, loc_target, dim_target);
 }
 
 fn compute_line_ends<F: GeoFloat>(
@@ -376,44 +370,25 @@ fn compute_line_ends<F: GeoFloat>(
     let mut has_interior_exterior_intersection = false;
     let mut has_boundary_exterior_intersection = false;
 
-    for elem in linear_elements(geom.geometry()) {
-        let (e0, e1, is_closed, elem_env) = match elem {
-            LinearElement::LineString(ls) => {
-                let first = ls.0[0];
-                let last = ls.0[ls.0.len() - 1];
-                (first, last, ls.is_closed(), ls.bounding_rect())
-            }
-            LinearElement::Line(l) => (
-                l.start,
-                l.end,
-                l.start == l.end,
-                Some(Rect::new(l.start, l.end)),
-            ),
-        };
+    for elem in geom.lines() {
+        let coords = &elem.line.0;
+        let e0 = coords[0];
+        let e1 = coords[coords.len() - 1];
 
         // Once intersections with the target exterior are recorded for
         // both interior and boundary line ends, skip further
         // known-exterior line components.
         if has_interior_exterior_intersection
             && has_boundary_exterior_intersection
-            && !envelopes_intersect(elem_env, geom_target.envelope())
+            && !envelopes_intersect(elem.env, geom_target.envelope())
         {
             continue;
         }
 
-        let loc0 = compute_line_end(geom, input, e0, geom_target, computer);
-        match loc0 {
-            Some(CoordPos::Inside) => has_interior_exterior_intersection = true,
-            Some(CoordPos::OnBoundary) => has_boundary_exterior_intersection = true,
-            _ => {}
-        }
-        if computer.is_result_known() {
-            return true;
-        }
-
-        if !is_closed {
-            let loc1 = compute_line_end(geom, input, e1, geom_target, computer);
-            match loc1 {
+        // A closed line has a single end point.
+        let ends: &[Coord<F>] = if e0 == e1 { &[e0] } else { &[e0, e1] };
+        for &pt in ends {
+            match compute_line_end(geom, input, pt, geom_target, computer) {
                 Some(CoordPos::Inside) => has_interior_exterior_intersection = true,
                 Some(CoordPos::OnBoundary) => has_boundary_exterior_intersection = true,
                 _ => {}
@@ -446,8 +421,8 @@ fn compute_line_end<F: GeoFloat>(
 
     let loc_dim_target = geom_target.locate_with_dim(pt);
     let loc_target = loc_dim_target.location();
-    let dim_target = loc_dim_target.dimension_with_exterior(computer.dimension(other(input)));
-    computer.add_line_end_on_geometry(input, loc_line_end, loc_target, dim_target, pt);
+    let dim_target = loc_dim_target.dimension_with_exterior(computer.dimension(input.other()));
+    computer.add_line_end_on_geometry(input, loc_line_end, loc_target, dim_target);
     if loc_target == CoordPos::Outside {
         return Some(loc_line_end);
     }
@@ -471,9 +446,8 @@ fn compute_area_vertex<F: GeoFloat>(
 
     let mut has_exterior_intersection = false;
 
-    for elem in area_elements(geom.geometry()) {
-        let polygon = elem.polygon();
-        if polygon.exterior().0.is_empty() {
+    for polygon in geom.polygonals().iter().flat_map(Polygonal::polygons) {
+        if polygon.is_empty() {
             continue;
         }
         // Once an intersection with the target exterior is recorded, skip
@@ -515,131 +489,9 @@ fn compute_area_vertex_on_ring<F: GeoFloat>(
     let loc_area = geom.locate_area_vertex(pt);
     let loc_dim_target = geom_target.locate_with_dim(pt);
     let loc_target = loc_dim_target.location();
-    let dim_target = loc_dim_target.dimension_with_exterior(computer.dimension(other(input)));
-    computer.add_area_vertex(input, loc_area, loc_target, dim_target, pt);
+    let dim_target = loc_dim_target.dimension_with_exterior(computer.dimension(input.other()));
+    computer.add_area_vertex(input, loc_area, loc_target, dim_target);
     loc_target == CoordPos::Outside
-}
-
-fn other(input: InputIndex) -> InputIndex {
-    match input {
-        InputIndex::A => InputIndex::B,
-        InputIndex::B => InputIndex::A,
-    }
-}
-
-/// The linear elements of a geometry (LineStrings and Lines), in document
-/// order, skipping empty ones.
-enum LinearElement<'g, F: GeoFloat> {
-    LineString(&'g LineString<F>),
-    Line(&'g Line<F>),
-}
-
-fn linear_elements<'g, F: GeoFloat>(geom: &'g GeometryCow<'g, F>) -> Vec<LinearElement<'g, F>> {
-    let mut elems = Vec::new();
-    match geom {
-        GeometryCow::Line(l) => elems.push(LinearElement::Line(l)),
-        GeometryCow::LineString(ls) => {
-            if !ls.0.is_empty() {
-                elems.push(LinearElement::LineString(ls));
-            }
-        }
-        GeometryCow::MultiLineString(mls) => {
-            for ls in &mls.0 {
-                if !ls.0.is_empty() {
-                    elems.push(LinearElement::LineString(ls));
-                }
-            }
-        }
-        GeometryCow::GeometryCollection(gc) => {
-            for g in &gc.0 {
-                collect_linear_elements(g, &mut elems);
-            }
-        }
-        _ => {}
-    }
-    elems
-}
-
-fn collect_linear_elements<'g, F: GeoFloat>(
-    geom: &'g Geometry<F>,
-    elems: &mut Vec<LinearElement<'g, F>>,
-) {
-    match geom {
-        Geometry::Line(l) => elems.push(LinearElement::Line(l)),
-        Geometry::LineString(ls) => {
-            if !ls.0.is_empty() {
-                elems.push(LinearElement::LineString(ls));
-            }
-        }
-        Geometry::MultiLineString(mls) => {
-            for ls in &mls.0 {
-                if !ls.0.is_empty() {
-                    elems.push(LinearElement::LineString(ls));
-                }
-            }
-        }
-        Geometry::GeometryCollection(gc) => {
-            for g in &gc.0 {
-                collect_linear_elements(g, elems);
-            }
-        }
-        _ => {}
-    }
-}
-
-/// The polygonal elements of a geometry, in document order. Rect and
-/// Triangle elements are converted to owned polygons.
-enum AreaElement<'g, F: GeoFloat> {
-    Polygon(&'g Polygon<F>),
-    Owned(Polygon<F>),
-}
-
-impl<F: GeoFloat> AreaElement<'_, F> {
-    fn polygon(&self) -> &Polygon<F> {
-        match self {
-            AreaElement::Polygon(p) => p,
-            AreaElement::Owned(p) => p,
-        }
-    }
-}
-
-fn area_elements<'g, F: GeoFloat>(geom: &'g GeometryCow<'g, F>) -> Vec<AreaElement<'g, F>> {
-    let mut elems = Vec::new();
-    match geom {
-        GeometryCow::Polygon(p) => elems.push(AreaElement::Polygon(p)),
-        GeometryCow::MultiPolygon(mp) => {
-            elems.extend(mp.0.iter().map(AreaElement::Polygon));
-        }
-        GeometryCow::Rect(r) => elems.push(AreaElement::Owned(r.to_polygon())),
-        GeometryCow::Triangle(t) => elems.push(AreaElement::Owned(t.to_polygon())),
-        GeometryCow::GeometryCollection(gc) => {
-            for g in &gc.0 {
-                collect_area_elements(g, &mut elems);
-            }
-        }
-        _ => {}
-    }
-    elems
-}
-
-fn collect_area_elements<'g, F: GeoFloat>(
-    geom: &'g Geometry<F>,
-    elems: &mut Vec<AreaElement<'g, F>>,
-) {
-    match geom {
-        Geometry::Polygon(p) => elems.push(AreaElement::Polygon(p)),
-        Geometry::MultiPolygon(mp) => {
-            elems.extend(mp.0.iter().map(AreaElement::Polygon));
-        }
-        Geometry::Rect(r) => elems.push(AreaElement::Owned(r.to_polygon())),
-        Geometry::Triangle(t) => elems.push(AreaElement::Owned(t.to_polygon())),
-        Geometry::GeometryCollection(gc) => {
-            for g in &gc.0 {
-                collect_area_elements(g, elems);
-            }
-        }
-        _ => {}
-    }
 }
 
 #[cfg(test)]
@@ -661,7 +513,7 @@ mod tests {
         let cow_m0 = GeometryCow::from(&m0);
 
         let im = relate(&cow_mls, &cow_m0);
-        assert_eq!(format!("{im:?}"), "IntersectionMatrix(1F1F00FF2)");
+        assert_eq!(im, "1F1F00FF2".parse().unwrap());
         assert!(im.is_contains());
 
         let mut contains = super::super::relate_predicate::contains();

--- a/geo/src/algorithm/relate/relateng/relate_point_locator.rs
+++ b/geo/src/algorithm/relate/relateng/relate_point_locator.rs
@@ -205,6 +205,32 @@ impl<'a, F: GeoFloat> GeometryElements<'a, F> {
     }
 }
 
+/// A cache of the per-polygonal-element area indexes of a geometry, owned
+/// by prepared state and shared across evaluations. The outer cell is
+/// initialised on first use to one cell per polygonal element, in document
+/// order.
+pub(crate) type SharedAreaLocators<F> = OnceCell<Vec<OnceCell<IntervalTreeMultiPolygon<F>>>>;
+
+/// The per-element area locator cells: owned by this locator, or borrowed
+/// from prepared state that outlives it.
+enum AreaLocators<'a, F: GeoFloat> {
+    Own(Vec<OnceCell<IntervalTreeMultiPolygon<F>>>),
+    Shared(&'a [OnceCell<IntervalTreeMultiPolygon<F>>]),
+}
+
+impl<F: GeoFloat> AreaLocators<'_, F> {
+    fn cells(&self) -> &[OnceCell<IntervalTreeMultiPolygon<F>>] {
+        match self {
+            AreaLocators::Own(cells) => cells,
+            AreaLocators::Shared(cells) => cells,
+        }
+    }
+}
+
+fn new_locator_cells<F: GeoFloat>(count: usize) -> Vec<OnceCell<IntervalTreeMultiPolygon<F>>> {
+    (0..count).map(|_| OnceCell::new()).collect()
+}
+
 pub(crate) struct RelatePointLocator<'a, F: GeoFloat> {
     is_prepared: bool,
     is_empty: bool,
@@ -213,7 +239,7 @@ pub(crate) struct RelatePointLocator<'a, F: GeoFloat> {
     line_envelopes: Vec<Option<Rect<F>>>,
     line_boundary: Option<LinearBoundary<F>>,
     /// Prepared mode: lazily built index per polygonal element.
-    poly_locators: Vec<OnceCell<IntervalTreeMultiPolygon<F>>>,
+    poly_locators: AreaLocators<'a, F>,
     adj_edge_locator: OnceCell<AdjacentEdgeLocator<F>>,
 }
 
@@ -223,6 +249,17 @@ impl<'a, F: GeoFloat> RelatePointLocator<'a, F> {
     }
 
     pub fn new_with_prepared(geom: &'a GeometryCow<'a, F>, is_prepared: bool) -> Self {
+        Self::new_full(geom, is_prepared, None)
+    }
+
+    /// Full constructor. When `shared_locators` is given, the per-element
+    /// area indexes are stored in (and reused from) that cache, which must
+    /// belong to the same geometry.
+    pub fn new_full(
+        geom: &'a GeometryCow<'a, F>,
+        is_prepared: bool,
+        shared_locators: Option<&'a SharedAreaLocators<F>>,
+    ) -> Self {
         let elements = GeometryElements::extract(geom);
         let is_empty = elements.is_empty();
         let line_envelopes = elements.lines.iter().map(|l| l.bounding_rect()).collect();
@@ -233,11 +270,13 @@ impl<'a, F: GeoFloat> RelatePointLocator<'a, F> {
                 elements.lines.iter().map(|l| l.as_ref()),
             ))
         };
-        let poly_locators = elements
-            .polygonals
-            .iter()
-            .map(|_| OnceCell::new())
-            .collect();
+        let n_polygonals = elements.polygonals.len();
+        let poly_locators = match shared_locators {
+            Some(shared) => {
+                AreaLocators::Shared(shared.get_or_init(|| new_locator_cells(n_polygonals)))
+            }
+            None => AreaLocators::Own(new_locator_cells(n_polygonals)),
+        };
         Self {
             is_prepared,
             is_empty,
@@ -438,7 +477,7 @@ impl<'a, F: GeoFloat> RelatePointLocator<'a, F> {
         }
         let polygonal = &self.elements.polygonals[index];
         if self.is_prepared {
-            self.poly_locators[index]
+            self.poly_locators.cells()[index]
                 .get_or_init(|| polygonal.build_index())
                 .containment_parity(p)
         } else {

--- a/geo/src/algorithm/relate/relateng/relate_point_locator.rs
+++ b/geo/src/algorithm/relate/relateng/relate_point_locator.rs
@@ -25,6 +25,7 @@ use std::collections::BTreeSet;
 
 use crate::bounding_rect::BoundingRect;
 use crate::coordinate_position::{CoordPos, CoordinatePosition};
+use crate::dimensions::HasDimensions;
 use crate::geometry_cow::GeometryCow;
 use crate::indexed::IntervalTreeMultiPolygon;
 use crate::relate::geomgraph::node_map::NodeKey;
@@ -45,10 +46,10 @@ pub(crate) enum Polygonal<'a, F: GeoFloat> {
 }
 
 impl<'a, F: GeoFloat> Polygonal<'a, F> {
-    pub fn polygons(&self) -> Box<dyn Iterator<Item = &Polygon<F>> + '_> {
+    pub fn polygons(&self) -> &[Polygon<F>] {
         match self {
-            Polygonal::Polygon(p) => Box::new(std::iter::once(p.as_ref())),
-            Polygonal::MultiPolygon(mp) => Box::new(mp.0.iter()),
+            Polygonal::Polygon(p) => std::slice::from_ref(p.as_ref()),
+            Polygonal::MultiPolygon(mp) => &mp.0,
         }
     }
 
@@ -82,12 +83,19 @@ impl<'a, F: GeoFloat> Polygonal<'a, F> {
     }
 }
 
+/// A linear element of the input geometry, with its envelope cached for
+/// fast rejection. A Line input is promoted to a two-point LineString.
+pub(crate) struct LineElement<'a, F: GeoFloat> {
+    pub line: Cow<'a, LineString<F>>,
+    pub env: Option<Rect<F>>,
+}
+
 /// The elements of an input geometry, decomposed for point location:
 /// unique point coordinates, linear components, and polygonal components,
 /// in document order.
 pub(crate) struct GeometryElements<'a, F: GeoFloat> {
     points: BTreeSet<NodeKey<F>>,
-    lines: Vec<Cow<'a, LineString<F>>>,
+    lines: Vec<LineElement<'a, F>>,
     polygonals: Vec<Polygonal<'a, F>>,
     is_polygonal_input: bool,
 }
@@ -133,6 +141,9 @@ impl<'a, F: GeoFloat> GeometryElements<'a, F> {
         elements
     }
 
+    /// Collection members are walked over `Geometry` rather than a
+    /// borrowed `GeometryCow` view so that the element borrows keep the
+    /// input lifetime.
     fn extract_geometry(&mut self, geom: &'a Geometry<F>) {
         match geom {
             Geometry::Point(p) => self.add_point(p.0),
@@ -168,16 +179,22 @@ impl<'a, F: GeoFloat> GeometryElements<'a, F> {
         if line.0.is_empty() {
             return;
         }
-        self.lines.push(Cow::Borrowed(line));
+        self.lines.push(LineElement {
+            env: line.bounding_rect(),
+            line: Cow::Borrowed(line),
+        });
     }
 
     fn add_line_segment(&mut self, start: Coord<F>, end: Coord<F>) {
-        self.lines
-            .push(Cow::Owned(LineString::new(vec![start, end])));
+        let line = LineString::new(vec![start, end]);
+        self.lines.push(LineElement {
+            env: line.bounding_rect(),
+            line: Cow::Owned(line),
+        });
     }
 
     fn add_polygon(&mut self, polygon: &'a Polygon<F>) {
-        if polygon.exterior().0.is_empty() {
+        if polygon.is_empty() {
             return;
         }
         self.polygonals
@@ -190,7 +207,7 @@ impl<'a, F: GeoFloat> GeometryElements<'a, F> {
     }
 
     fn add_multi_polygon(&mut self, mp: &'a MultiPolygon<F>) {
-        if mp.0.iter().all(|p| p.exterior().0.is_empty()) {
+        if mp.is_empty() {
             return;
         }
         self.polygonals.push(Polygonal::MultiPolygon(mp));
@@ -211,81 +228,73 @@ impl<'a, F: GeoFloat> GeometryElements<'a, F> {
 /// order.
 pub(crate) type SharedAreaLocators<F> = OnceCell<Vec<OnceCell<IntervalTreeMultiPolygon<F>>>>;
 
-/// The per-element area locator cells: owned by this locator, or borrowed
-/// from prepared state that outlives it.
-enum AreaLocators<'a, F: GeoFloat> {
-    Own(Vec<OnceCell<IntervalTreeMultiPolygon<F>>>),
-    Shared(&'a [OnceCell<IntervalTreeMultiPolygon<F>>]),
+/// How an input geometry is evaluated.
+#[derive(Clone, Copy)]
+pub(crate) enum Mode<'a, F: GeoFloat> {
+    /// A single evaluation: point-in-area location scans the rings, and
+    /// the edge index is filtered to the opposing envelope.
+    Simple,
+    /// Repeated evaluations against the same geometry: point-in-area
+    /// location is indexed, with the per-element indexes stored in state
+    /// that outlives the evaluation.
+    Prepared(&'a SharedAreaLocators<F>),
 }
 
-impl<F: GeoFloat> AreaLocators<'_, F> {
-    fn cells(&self) -> &[OnceCell<IntervalTreeMultiPolygon<F>>] {
-        match self {
-            AreaLocators::Own(cells) => cells,
-            AreaLocators::Shared(cells) => cells,
-        }
+impl<F: GeoFloat> Mode<'_, F> {
+    pub fn is_prepared(self) -> bool {
+        matches!(self, Mode::Prepared(_))
     }
 }
 
-fn new_locator_cells<F: GeoFloat>(count: usize) -> Vec<OnceCell<IntervalTreeMultiPolygon<F>>> {
-    (0..count).map(|_| OnceCell::new()).collect()
-}
-
 pub(crate) struct RelatePointLocator<'a, F: GeoFloat> {
-    is_prepared: bool,
     is_empty: bool,
     elements: GeometryElements<'a, F>,
-    /// Cached envelope per line, for fast rejection.
-    line_envelopes: Vec<Option<Rect<F>>>,
     line_boundary: Option<LinearBoundary<F>>,
-    /// Prepared mode: lazily built index per polygonal element.
-    poly_locators: AreaLocators<'a, F>,
+    /// Prepared mode: the lazily built index per polygonal element.
+    poly_locators: Option<&'a [OnceCell<IntervalTreeMultiPolygon<F>>]>,
     adj_edge_locator: OnceCell<AdjacentEdgeLocator<F>>,
 }
 
 impl<'a, F: GeoFloat> RelatePointLocator<'a, F> {
-    pub fn new(geom: &'a GeometryCow<'a, F>) -> Self {
-        Self::new_with_prepared(geom, false)
-    }
-
-    pub fn new_with_prepared(geom: &'a GeometryCow<'a, F>, is_prepared: bool) -> Self {
-        Self::new_full(geom, is_prepared, None)
-    }
-
-    /// Full constructor. When `shared_locators` is given, the per-element
-    /// area indexes are stored in (and reused from) that cache, which must
-    /// belong to the same geometry.
-    pub fn new_full(
-        geom: &'a GeometryCow<'a, F>,
-        is_prepared: bool,
-        shared_locators: Option<&'a SharedAreaLocators<F>>,
-    ) -> Self {
+    /// In prepared mode the shared area locators must belong to the same
+    /// geometry.
+    pub fn new(geom: &'a GeometryCow<'a, F>, mode: Mode<'a, F>) -> Self {
         let elements = GeometryElements::extract(geom);
         let is_empty = elements.is_empty();
-        let line_envelopes = elements.lines.iter().map(|l| l.bounding_rect()).collect();
         let line_boundary = if elements.lines.is_empty() {
             None
         } else {
             Some(LinearBoundary::new(
-                elements.lines.iter().map(|l| l.as_ref()),
+                elements.lines.iter().map(|l| l.line.as_ref()),
             ))
         };
-        let n_polygonals = elements.polygonals.len();
-        let poly_locators = match shared_locators {
-            Some(shared) => {
-                AreaLocators::Shared(shared.get_or_init(|| new_locator_cells(n_polygonals)))
-            }
-            None => AreaLocators::Own(new_locator_cells(n_polygonals)),
+        let poly_locators = match mode {
+            Mode::Simple => None,
+            Mode::Prepared(shared) => Some(
+                shared
+                    .get_or_init(|| {
+                        (0..elements.polygonals.len())
+                            .map(|_| OnceCell::new())
+                            .collect()
+                    })
+                    .as_slice(),
+            ),
         };
         Self {
-            is_prepared,
             is_empty,
             elements,
-            line_envelopes,
             line_boundary,
             poly_locators,
             adj_edge_locator: OnceCell::new(),
         }
+    }
+
+    pub fn lines(&self) -> &[LineElement<'a, F>] {
+        &self.elements.lines
+    }
+
+    pub fn polygonals(&self) -> &[Polygonal<'a, F>] {
+        self.elements.polygonals()
     }
 
     /// Whether the linear components have any boundary points.
@@ -326,10 +335,6 @@ impl<'a, F: GeoFloat> RelatePointLocator<'a, F> {
     /// Locates a point which is known to be a node of the geometry (a
     /// vertex or on an edge). `parent_polygonal_id` identifies the
     /// polygonal element the point is a node of, if any.
-    pub fn locate_node(&self, p: Coord<F>, parent_polygonal_id: Option<usize>) -> CoordPos {
-        self.locate_node_with_dim(p, parent_polygonal_id).location()
-    }
-
     pub fn locate_node_with_dim(
         &self,
         p: Coord<F>,
@@ -411,10 +416,10 @@ impl<'a, F: GeoFloat> RelatePointLocator<'a, F> {
             return CoordPos::Inside;
         }
 
-        for (line, env) in self.elements.lines.iter().zip(&self.line_envelopes) {
+        for elem in &self.elements.lines {
             // Every line has to be checked, since any or all may contain
             // the point.
-            let loc = Self::locate_on_line(p, line, env);
+            let loc = Self::locate_on_line(p, &elem.line, &elem.env);
             if loc != CoordPos::Outside {
                 return loc;
             }
@@ -476,12 +481,11 @@ impl<'a, F: GeoFloat> RelatePointLocator<'a, F> {
             return CoordPos::OnBoundary;
         }
         let polygonal = &self.elements.polygonals[index];
-        if self.is_prepared {
-            self.poly_locators.cells()[index]
+        match self.poly_locators {
+            Some(cells) => cells[index]
                 .get_or_init(|| polygonal.build_index())
-                .containment_parity(p)
-        } else {
-            polygonal.coordinate_position(p)
+                .containment_parity(p),
+            None => polygonal.coordinate_position(p),
         }
     }
 }
@@ -514,11 +518,12 @@ mod tests {
         expected: DimensionLocation,
     ) {
         let cow = GeometryCow::from(gc);
-        let locator = RelatePointLocator::new(&cow);
+        let locator = RelatePointLocator::new(&cow, Mode::Simple);
         assert_eq!(locator.locate_with_dim(Coord { x, y }), expected);
         // Not in JTS: the prepared (indexed) mode must agree with the
         // simple mode.
-        let prepared = RelatePointLocator::new_with_prepared(&cow, true);
+        let shared = SharedAreaLocators::default();
+        let prepared = RelatePointLocator::new(&cow, Mode::Prepared(&shared));
         assert_eq!(prepared.locate_with_dim(Coord { x, y }), expected);
     }
 
@@ -529,14 +534,19 @@ mod tests {
         expected: DimensionLocation,
     ) {
         let cow = GeometryCow::from(gc);
-        let locator = RelatePointLocator::new(&cow);
+        let locator = RelatePointLocator::new(&cow, Mode::Simple);
         assert_eq!(locator.locate_line_end_with_dim(Coord { x, y }), expected);
     }
 
     fn check_node_location(gc: &GeometryCollection<f64>, x: f64, y: f64, expected: CoordPos) {
         let cow = GeometryCow::from(gc);
-        let locator = RelatePointLocator::new(&cow);
-        assert_eq!(locator.locate_node(Coord { x, y }, None), expected);
+        let locator = RelatePointLocator::new(&cow, Mode::Simple);
+        assert_eq!(
+            locator
+                .locate_node_with_dim(Coord { x, y }, None)
+                .location(),
+            expected
+        );
     }
 
     #[test]

--- a/geo/src/algorithm/relate/relateng/relate_point_locator.rs
+++ b/geo/src/algorithm/relate/relateng/relate_point_locator.rs
@@ -52,11 +52,24 @@ impl<'a, F: GeoFloat> Polygonal<'a, F> {
         }
     }
 
-    /// Simple-mode location: the unindexed mod-2 locator.
+    /// Simple-mode location, with JTS `SimplePointInAreaLocator` member
+    /// semantics: the first non-exterior member location wins. The
+    /// `CoordinatePosition` impl for `MultiPolygon` is deliberately not
+    /// used: it applies the mod-2 rule across member boundaries, so a
+    /// point where two members touch would be classified exterior instead
+    /// of on the boundary.
     fn coordinate_position(&self, coord: Coord<F>) -> CoordPos {
         match self {
             Polygonal::Polygon(p) => p.coordinate_position(&coord),
-            Polygonal::MultiPolygon(mp) => mp.coordinate_position(&coord),
+            Polygonal::MultiPolygon(mp) => {
+                for polygon in &mp.0 {
+                    let loc = polygon.coordinate_position(&coord);
+                    if loc != CoordPos::Outside {
+                        return loc;
+                    }
+                }
+                CoordPos::Outside
+            }
         }
     }
 

--- a/geo/src/algorithm/relate/relateng/tests.rs
+++ b/geo/src/algorithm/relate/relateng/tests.rs
@@ -14,7 +14,7 @@ use crate::geometry_cow::GeometryCow;
 use crate::relate::IntersectionMatrix;
 
 use super::im_predicate::RelateMatrixPredicate;
-use super::relate_ng::{self, RelateNG};
+use super::relate_ng::{self, PreparedRelateState, RelateNG};
 use super::relate_predicate as pred;
 use super::relate_predicate::intersection_matrix_pattern;
 use super::topology_predicate::TopologyPredicate;
@@ -98,7 +98,8 @@ fn check_prepared(wkta: &str, wktb: &str) {
     let b = read(wktb);
     let ca = GeometryCow::from(&a);
     let cb = GeometryCow::from(&b);
-    let prep_a = RelateNG::prepare(&ca);
+    let state = PreparedRelateState::default();
+    let prep_a = RelateNG::prepared(&ca, &state);
 
     macro_rules! check {
         ($factory:expr, $name:literal) => {
@@ -138,7 +139,8 @@ fn check_prepared_matches(wkta: &str, wktb: &str, pattern: &str) {
     let b = read(wktb);
     let ca = GeometryCow::from(&a);
     let cb = GeometryCow::from(&b);
-    let prep_a = RelateNG::prepare(&ca);
+    let state = PreparedRelateState::default();
+    let prep_a = RelateNG::prepared(&ca, &state);
 
     let mut p1 = pred::matches(pattern).expect("valid pattern");
     let mut p2 = pred::matches(pattern).expect("valid pattern");
@@ -1364,5 +1366,36 @@ mod relate_ng_boundary_node_rule_test {
         let a = "POLYGON EMPTY";
         let b = "MULTILINESTRING ((0 0, 0 1), (0 1, 1 1, 1 0, 0 0))";
         check_relate(a, b, "FFFFFF1F2");
+    }
+}
+
+// Not from JTS: pins the full matrices of envelope-disjoint pairs, which
+// are served by the envelope fast-rejection path in
+// `RelateGeometry::locate_with_dim`.
+mod envelope_disjoint_matrix {
+    use super::*;
+
+    #[test]
+    fn test_polygons_envelope_disjoint() {
+        let a = "POLYGON ((0 0, 4 0, 4 4, 0 4, 0 0))";
+        let b = "POLYGON ((10 10, 14 10, 14 14, 10 14, 10 10))";
+        check_relate(a, b, "FF2FF1212");
+        check_intersects_disjoint(a, b, false);
+    }
+
+    #[test]
+    fn test_lines_envelope_disjoint() {
+        let a = "LINESTRING (0 0, 4 4)";
+        let b = "LINESTRING (10 10, 14 14)";
+        check_relate(a, b, "FF1FF0102");
+        check_intersects_disjoint(a, b, false);
+    }
+
+    #[test]
+    fn test_polygon_line_envelope_disjoint() {
+        let a = "POLYGON ((0 0, 4 0, 4 4, 0 4, 0 0))";
+        let b = "LINESTRING (10 10, 14 14)";
+        check_relate(a, b, "FF2FF1102");
+        check_relate(b, a, "FF1FF0212");
     }
 }

--- a/geo/src/algorithm/relate/relateng/topology_computer.rs
+++ b/geo/src/algorithm/relate/relateng/topology_computer.rs
@@ -6,12 +6,12 @@
 
 use std::collections::BTreeMap;
 
+use crate::GeoFloat;
 use crate::algorithm::polygon_node_topology::is_crossing;
 use crate::coordinate_position::CoordPos;
 use crate::dimensions::Dimensions;
 use crate::relate::geomgraph::Direction;
 use crate::relate::geomgraph::node_map::NodeKey;
-use crate::{Coord, GeoFloat};
 
 use super::node_section::NodeSection;
 use super::node_sections::NodeSections;
@@ -298,7 +298,6 @@ impl<'r, 'a, 'b, F: GeoFloat> TopologyComputer<'r, 'a, 'b, F> {
         source: InputIndex,
         loc_target: CoordPos,
         dim_target: Dimensions,
-        _pt: Coord<F>,
     ) {
         // Update the entry for the point interior.
         self.update_dim_for(
@@ -351,7 +350,6 @@ impl<'r, 'a, 'b, F: GeoFloat> TopologyComputer<'r, 'a, 'b, F> {
         loc_line_end: CoordPos,
         loc_target: CoordPos,
         dim_target: Dimensions,
-        pt: Coord<F>,
     ) {
         // Record topology at the line end point.
         self.update_dim_for(
@@ -370,22 +368,16 @@ impl<'r, 'a, 'b, F: GeoFloat> TopologyComputer<'r, 'a, 'b, F> {
         match dim_target {
             Dimensions::ZeroDimensional => {}
             Dimensions::OneDimensional => {
-                self.add_line_end_on_line(source, loc_line_end, loc_target, pt);
+                self.add_line_end_on_line(source, loc_target);
             }
             Dimensions::TwoDimensional => {
-                self.add_line_end_on_area(source, loc_line_end, loc_target, pt);
+                self.add_line_end_on_area(source, loc_target);
             }
             Dimensions::Empty => unreachable!("{}", MSG_GEOMETRY_DIMENSION_UNEXPECTED),
         }
     }
 
-    fn add_line_end_on_line(
-        &mut self,
-        source: InputIndex,
-        _loc_line_end: CoordPos,
-        loc_line: CoordPos,
-        _pt: Coord<F>,
-    ) {
+    fn add_line_end_on_line(&mut self, source: InputIndex, loc_line: CoordPos) {
         // When a line end is in the exterior of a line, some length of the
         // source line interior is also in the target line exterior. This
         // holds for zero-length lines as well.
@@ -399,13 +391,7 @@ impl<'r, 'a, 'b, F: GeoFloat> TopologyComputer<'r, 'a, 'b, F> {
         }
     }
 
-    fn add_line_end_on_area(
-        &mut self,
-        source: InputIndex,
-        _loc_line_end: CoordPos,
-        loc_area: CoordPos,
-        _pt: Coord<F>,
-    ) {
+    fn add_line_end_on_area(&mut self, source: InputIndex, loc_area: CoordPos) {
         if loc_area != CoordPos::OnBoundary {
             // When a line end is in an area interior or exterior, some
             // length of the source line interior, and the exterior of the
@@ -441,7 +427,6 @@ impl<'r, 'a, 'b, F: GeoFloat> TopologyComputer<'r, 'a, 'b, F> {
         loc_area: CoordPos,
         loc_target: CoordPos,
         dim_target: Dimensions,
-        pt: Coord<F>,
     ) {
         if loc_target == CoordPos::Outside {
             self.update_dim_for(
@@ -472,12 +457,12 @@ impl<'r, 'a, 'b, F: GeoFloat> TopologyComputer<'r, 'a, 'b, F> {
             return;
         }
         match dim_target {
-            Dimensions::ZeroDimensional => self.add_area_vertex_on_point(source, loc_area, pt),
+            Dimensions::ZeroDimensional => self.add_area_vertex_on_point(source, loc_area),
             Dimensions::OneDimensional => {
-                self.add_area_vertex_on_line(source, loc_area, loc_target, pt)
+                self.add_area_vertex_on_line(source, loc_area, loc_target)
             }
             Dimensions::TwoDimensional => {
-                self.add_area_vertex_on_area(source, loc_area, loc_target, pt)
+                self.add_area_vertex_on_area(source, loc_area, loc_target)
             }
             Dimensions::Empty => unreachable!("{}", MSG_GEOMETRY_DIMENSION_UNEXPECTED),
         }
@@ -487,7 +472,7 @@ impl<'r, 'a, 'b, F: GeoFloat> TopologyComputer<'r, 'a, 'b, F> {
     /// point. Because the largest-dimension intersecting target was
     /// determined, the point is not part of any other target element, so
     /// its neighbourhood is in the target exterior.
-    fn add_area_vertex_on_point(&mut self, source: InputIndex, loc_area: CoordPos, _pt: Coord<F>) {
+    fn add_area_vertex_on_point(&mut self, source: InputIndex, loc_area: CoordPos) {
         // The vertex location intersects the point.
         self.update_dim_for(
             source,
@@ -529,7 +514,6 @@ impl<'r, 'a, 'b, F: GeoFloat> TopologyComputer<'r, 'a, 'b, F> {
         source: InputIndex,
         loc_area: CoordPos,
         loc_target: CoordPos,
-        _pt: Coord<F>,
     ) {
         self.update_dim_for(source, loc_area, loc_target, Dimensions::ZeroDimensional);
         if loc_area == CoordPos::Inside {
@@ -549,7 +533,6 @@ impl<'r, 'a, 'b, F: GeoFloat> TopologyComputer<'r, 'a, 'b, F> {
         source: InputIndex,
         loc_area: CoordPos,
         loc_target: CoordPos,
-        _pt: Coord<F>,
     ) {
         if loc_target == CoordPos::OnBoundary {
             if loc_area == CoordPos::OnBoundary {

--- a/geo/src/geometry_cow.rs
+++ b/geo/src/geometry_cow.rs
@@ -27,6 +27,29 @@ where
     Triangle(Cow<'a, Triangle<T>>),
 }
 
+impl<T: CoordNum> GeometryCow<'_, T> {
+    /// A borrowed view of this `GeometryCow`, without cloning owned
+    /// contents.
+    pub(crate) fn reborrow(&self) -> GeometryCow<'_, T> {
+        match self {
+            GeometryCow::Point(g) => GeometryCow::Point(Cow::Borrowed(g.as_ref())),
+            GeometryCow::Line(g) => GeometryCow::Line(Cow::Borrowed(g.as_ref())),
+            GeometryCow::LineString(g) => GeometryCow::LineString(Cow::Borrowed(g.as_ref())),
+            GeometryCow::Polygon(g) => GeometryCow::Polygon(Cow::Borrowed(g.as_ref())),
+            GeometryCow::MultiPoint(g) => GeometryCow::MultiPoint(Cow::Borrowed(g.as_ref())),
+            GeometryCow::MultiLineString(g) => {
+                GeometryCow::MultiLineString(Cow::Borrowed(g.as_ref()))
+            }
+            GeometryCow::MultiPolygon(g) => GeometryCow::MultiPolygon(Cow::Borrowed(g.as_ref())),
+            GeometryCow::GeometryCollection(g) => {
+                GeometryCow::GeometryCollection(Cow::Borrowed(g.as_ref()))
+            }
+            GeometryCow::Rect(g) => GeometryCow::Rect(Cow::Borrowed(g.as_ref())),
+            GeometryCow::Triangle(g) => GeometryCow::Triangle(Cow::Borrowed(g.as_ref())),
+        }
+    }
+}
+
 impl<'a, T: CoordNum> From<&'a Geometry<T>> for GeometryCow<'a, T> {
     fn from(geometry: &'a Geometry<T>) -> Self {
         match geometry {

--- a/jts-test-runner/resources/testxml/general/TestRelateAA.xml
+++ b/jts-test-runner/resources/testxml/general/TestRelateAA.xml
@@ -1,5 +1,4 @@
 <run>
-  <precisionModel scale="1.0" offsetx="0.0" offsety="0.0"/>
 
 <case>
   <desc>AA disjoint</desc>
@@ -99,7 +98,7 @@
       (120 140, 260 140, 260 260, 120 260, 120 140))
   </b>
 <test>
-  <op name="relate" arg3="212101212" arg1="A" arg2="B">true</op>
+  <op name="relate" arg3="212101212" arg1="A" arg2="B"> true  </op>
 </test>
 <test>  <op name="intersects" arg1="A" arg2="B">   true   </op></test>
 <test>  <op name="contains" arg1="A" arg2="B">   false   </op></test>
@@ -230,6 +229,20 @@
 </test>
 <test>  <op name="intersects" arg1="A" arg2="B">   true   </op></test>
 <test>  <op name="contains" arg1="A" arg2="B">   false   </op></test>
+</case>
+
+<case>
+  <desc>A/mA A-shells overlapping B-shell at A-vertex</desc>
+  <a>
+    POLYGON ((100 60, 140 100, 100 140, 60 100, 100 60))
+  </a>
+  <b>
+    MULTIPOLYGON (((80 40, 120 40, 120 80, 80 80, 80 40)), ((120 80, 160 80, 160 120, 120 120, 120 80)), ((80 120, 120 120, 120 160, 80 160, 80 120)), ((40 80, 80 80, 80 120, 40 120, 40 80)))
+  </b>
+<test>
+  <op name="relate" arg3="21210F212" arg1="A" arg2="B">    true  </op>
+</test>
+<test>  <op name="intersects" arg1="A" arg2="B">   true   </op></test>
 </case>
 
 </run>

--- a/jts-test-runner/resources/testxml/general/TestRelateLA.xml
+++ b/jts-test-runner/resources/testxml/general/TestRelateLA.xml
@@ -1,5 +1,4 @@
 <run>
-  <precisionModel scale="1.0" offsetx="0.0" offsety="0.0"/>
 
 <case>
   <desc>LA - intersection at NV: {A-Bdy, A-Int} = {B-Bdy, B-Int}</desc>
@@ -184,6 +183,32 @@
   </b>
   <test>
     <op name="relate" arg1="A" arg2="B" arg3="101FFF212">true</op>
+  </test>
+</case>
+
+<case>
+<desc>LA - closed line / empty polygon</desc>
+  <a>
+    LINESTRING(110 60, 20 150, 200 150, 110 60)
+  </a>
+  <b>
+    POLYGON EMPTY
+  </b>
+  <test>
+    <op name="relate" arg1="A" arg2="B" arg3="FF1FFFFF2">true</op>
+  </test>
+</case>
+
+<case>
+<desc>LA - closed multiline / empty polygon</desc>
+  <a>
+    MULTILINESTRING ((0 0, 0 1), (0 1, 1 1, 1 0, 0 0))
+  </a>
+  <b>
+    POLYGON EMPTY
+  </b>
+  <test>
+    <op name="relate" arg1="A" arg2="B" arg3="FF1FFFFF2">true</op>
   </test>
 </case>
 

--- a/jts-test-runner/resources/testxml/general/TestRelateLL.xml
+++ b/jts-test-runner/resources/testxml/general/TestRelateLL.xml
@@ -1,5 +1,4 @@
 <run>
-  <precisionModel scale="1.0" offsetx="0.0" offsety="0.0"/>
 
 <case>
   <desc>LL - disjoint, non-overlapping envelopes</desc>
@@ -62,7 +61,7 @@
 </case>
 
 <case>
-  <desc>Line vs line - pointwise equal short</desc>
+  <desc>Line vs line - pointwise equal</desc>
   <a>
     LINESTRING(20 20, 80 80)
   </a>
@@ -307,5 +306,89 @@
   </test>
 </case>
 
+<case>
+<desc>LL - closed multiline / empty line</desc>
+  <a>
+    MULTILINESTRING ((0 0, 0 1), (0 1, 1 1, 1 0, 0 0))
+  </a>
+  <b>
+    LINESTRING EMPTY
+  </b>
+  <test>
+    <op name="relate" arg1="A" arg2="B" arg3="FF1FFFFF2">true</op>
+  </test>
+</case>
+
+<case>
+<desc>LL - test intersection node computation (see https://github.com/locationtech/jts/issues/396)</desc>
+  <a>
+    LINESTRING (1 0, 0 2, 0 0, 2 2)
+  </a>
+  <b>
+    LINESTRING (0 0, 2 2)
+  </b>
+  <test>
+    <op name="relate" arg1="A" arg2="B" arg3="101F00FF2">true</op>
+  </test>
+  <test><op name="contains"   arg1="A" arg2="B"> true  </op></test>
+  <test><op name="coveredBy"  arg1="A" arg2="B"> false </op></test>
+  <test><op name="covers"     arg1="A" arg2="B"> true  </op></test>
+  <test><op name="crosses"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="disjoint"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="equalsTopo" arg1="A" arg2="B"> false </op></test>
+  <test><op name="intersects" arg1="A" arg2="B"> true  </op></test>
+  <test><op name="overlaps"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="touches"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="within"     arg1="A" arg2="B"> false </op></test>
+</case>
+
+<case>
+<desc>LL - test intersection node computation (see https://github.com/libgeos/geos/issues/933)</desc>
+  <a>
+    MULTILINESTRING ((0 0, 1 1), (0.5 0.5, 1 0.1, -1 0.1))
+  </a>
+  <b>
+    LINESTRING (0 0, 1 1)
+  </b>
+  <test>
+    <op name="relate" arg1="A" arg2="B" arg3="1F1000FF2">true</op>
+  </test>
+  <test><op name="contains"   arg1="A" arg2="B"> true  </op></test>
+  <test><op name="coveredBy"  arg1="A" arg2="B"> false </op></test>
+  <test><op name="covers"     arg1="A" arg2="B"> true  </op></test>
+  <test><op name="crosses"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="disjoint"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="equalsTopo" arg1="A" arg2="B"> false </op></test>
+  <test><op name="intersects" arg1="A" arg2="B"> true  </op></test>
+  <test><op name="overlaps"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="touches"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="within"     arg1="A" arg2="B"> false </op></test>
+</case>
+
+<case>
+  <desc>LmL - topographically equal with no boundary</desc>
+  <a>
+    LINESTRING(0 0, 0 50, 50 50, 50 0, 0 0)
+  </a>
+  <b>
+    MULTILINESTRING((0 0, 0 50), (0 50, 50 50), (50 50, 50 0), (50 0, 0 0))
+  </b>
+<test>
+  <op name="relate" arg3="1FFFFFFF2" arg1="A" arg2="B"> true </op>
+</test>
+</case>
+
+<case>
+  <desc>LmL - equal with boundary intersection</desc>
+  <a>
+    LINESTRING(0 0, 60 0, 60 60, 60 0, 120 0)
+  </a>
+  <b>
+    MULTILINESTRING((0 0, 60 0), (60 0, 120 0), (60 0, 60 60))
+  </b>
+<test>
+  <op name="relate" arg3="10FF0FFF2" arg1="A" arg2="B"> true </op>
+</test>
+</case>
 
 </run>

--- a/jts-test-runner/resources/testxml/general/TestRelatePA.xml
+++ b/jts-test-runner/resources/testxml/general/TestRelatePA.xml
@@ -1,5 +1,4 @@
 <run>
-  <precisionModel scale="1.0" offsetx="0.0" offsety="0.0"/>
 
 <case>
   <desc>PA - disjoint</desc>
@@ -15,6 +14,16 @@
     true
   </op>
 </test>
+<test><op name="contains"   arg1="A" arg2="B"> false </op></test>
+<test><op name="coveredBy"  arg1="A" arg2="B"> false </op></test>
+<test><op name="covers"     arg1="A" arg2="B"> false </op></test>
+<test><op name="crosses"    arg1="A" arg2="B"> false </op></test>
+<test><op name="disjoint"   arg1="A" arg2="B"> true  </op></test>
+<test><op name="equalsTopo" arg1="A" arg2="B"> false </op></test>
+<test><op name="intersects" arg1="A" arg2="B"> false </op></test>
+<test><op name="overlaps"   arg1="A" arg2="B"> false </op></test>
+<test><op name="touches"    arg1="A" arg2="B"> false </op></test>
+<test><op name="within"     arg1="A" arg2="B"> false </op></test>
 </case>
 
 <case>
@@ -31,6 +40,16 @@
     true
   </op>
 </test>
+<test><op name="contains"   arg1="A" arg2="B"> false </op></test>
+<test><op name="coveredBy"  arg1="A" arg2="B"> false </op></test>
+<test><op name="covers"     arg1="A" arg2="B"> false </op></test>
+<test><op name="crosses"    arg1="A" arg2="B"> true  </op></test>
+<test><op name="disjoint"   arg1="A" arg2="B"> false </op></test>
+<test><op name="equalsTopo" arg1="A" arg2="B"> false </op></test>
+<test><op name="intersects" arg1="A" arg2="B"> true  </op></test>
+<test><op name="overlaps"   arg1="A" arg2="B"> false </op></test>
+<test><op name="touches"    arg1="A" arg2="B"> false </op></test>
+<test><op name="within"     arg1="A" arg2="B"> false </op></test>
 </case>
 
 <case>
@@ -39,14 +58,23 @@
     MULTIPOINT((0 20), (20 20))
   </a>
   <b>
-    POLYGON(
-      (20 40, 20 0, 60 0, 60 40, 20 40))
+    POLYGON((20 40, 20 0, 60 0, 60 40, 20 40))
   </b>
 <test>
   <op name="relate" arg3="F00FFF212" arg1="A" arg2="B">
     true
   </op>
 </test>
+<test><op name="contains"   arg1="A" arg2="B"> false </op></test>
+<test><op name="coveredBy"  arg1="A" arg2="B"> false </op></test>
+<test><op name="covers"     arg1="A" arg2="B"> false </op></test>
+<test><op name="crosses"    arg1="A" arg2="B"> false </op></test>
+<test><op name="disjoint"   arg1="A" arg2="B"> false </op></test>
+<test><op name="equalsTopo" arg1="A" arg2="B"> false </op></test>
+<test><op name="intersects" arg1="A" arg2="B"> true  </op></test>
+<test><op name="overlaps"   arg1="A" arg2="B"> false </op></test>
+<test><op name="touches"    arg1="A" arg2="B"> true  </op></test>
+<test><op name="within"     arg1="A" arg2="B"> false </op></test>
 </case>
 
 <case>
@@ -55,14 +83,23 @@
     MULTIPOINT((20 20), (40 20))
   </a>
   <b>
-    POLYGON(
-      (20 40, 20 0, 60 0, 60 40, 20 40))
+    POLYGON((20 40, 20 0, 60 0, 60 40, 20 40))
   </b>
 <test>
   <op name="relate" arg3="00FFFF212" arg1="A" arg2="B">
     true
   </op>
 </test>
+<test><op name="contains"   arg1="A" arg2="B"> false </op></test>
+<test><op name="coveredBy"  arg1="A" arg2="B"> true  </op></test>
+<test><op name="covers"     arg1="A" arg2="B"> false </op></test>
+<test><op name="crosses"    arg1="A" arg2="B"> false </op></test>
+<test><op name="disjoint"   arg1="A" arg2="B"> false </op></test>
+<test><op name="equalsTopo" arg1="A" arg2="B"> false </op></test>
+<test><op name="intersects" arg1="A" arg2="B"> true  </op></test>
+<test><op name="overlaps"   arg1="A" arg2="B"> false </op></test>
+<test><op name="touches"    arg1="A" arg2="B"> false </op></test>
+<test><op name="within"     arg1="A" arg2="B"> true  </op></test>
 </case>
 
 <case>
@@ -71,14 +108,23 @@
     MULTIPOINT((80 260), (140 260), (180 260))
   </a>
   <b>
-    POLYGON(
-      (40 320, 140 320, 140 200, 40 200, 40 320))
+    POLYGON((40 320, 140 320, 140 200, 40 200, 40 320))
   </b>
 <test>
   <op name="relate" arg3="000FFF212" arg1="A" arg2="B">
     true
   </op>
 </test>
+<test><op name="contains"   arg1="A" arg2="B"> false </op></test>
+<test><op name="coveredBy"  arg1="A" arg2="B"> false </op></test>
+<test><op name="covers"     arg1="A" arg2="B"> false </op></test>
+<test><op name="crosses"    arg1="A" arg2="B"> true  </op></test>
+<test><op name="disjoint"   arg1="A" arg2="B"> false </op></test>
+<test><op name="equalsTopo" arg1="A" arg2="B"> false </op></test>
+<test><op name="intersects" arg1="A" arg2="B"> true  </op></test>
+<test><op name="overlaps"   arg1="A" arg2="B"> false </op></test>
+<test><op name="touches"    arg1="A" arg2="B"> false </op></test>
+<test><op name="within"     arg1="A" arg2="B"> false </op></test>
 </case>
 
 <case>
@@ -98,6 +144,141 @@
     true
   </op>
 </test>
+<test><op name="contains"   arg1="A" arg2="B"> false </op></test>
+<test><op name="coveredBy"  arg1="A" arg2="B"> true  </op></test>
+<test><op name="covers"     arg1="A" arg2="B"> false </op></test>
+<test><op name="crosses"    arg1="A" arg2="B"> false </op></test>
+<test><op name="disjoint"   arg1="A" arg2="B"> false </op></test>
+<test><op name="equalsTopo" arg1="A" arg2="B"> false </op></test>
+<test><op name="intersects" arg1="A" arg2="B"> true  </op></test>
+<test><op name="overlaps"   arg1="A" arg2="B"> false </op></test>
+<test><op name="touches"    arg1="A" arg2="B"> true  </op></test>
+<test><op name="within"     arg1="A" arg2="B"> false </op></test>
+</case>
+
+<case>
+  <desc>mPA - empty MultiPoint element for A</desc>
+  <a>
+    MULTIPOINT(EMPTY,(0 0))
+  </a>
+  <b>
+    POLYGON ((1 0,0 1,-1 0,0 -1, 1 0))
+  </b>
+<test>
+  <op name="relate" arg3="0FFFFF212" arg1="A" arg2="B">
+    true
+  </op>
+</test>
+<test><op name="contains"   arg1="A" arg2="B"> false </op></test>
+<test><op name="coveredBy"  arg1="A" arg2="B"> true  </op></test>
+<test><op name="covers"     arg1="A" arg2="B"> false </op></test>
+<test><op name="crosses"    arg1="A" arg2="B"> false </op></test>
+<test><op name="disjoint"   arg1="A" arg2="B"> false </op></test>
+<test><op name="equalsTopo" arg1="A" arg2="B"> false </op></test>
+<test><op name="intersects" arg1="A" arg2="B"> true  </op></test>
+<test><op name="overlaps"   arg1="A" arg2="B"> false </op></test>
+<test><op name="touches"    arg1="A" arg2="B"> false </op></test>
+<test><op name="within"     arg1="A" arg2="B"> true  </op></test>
+</case>
+
+<case>
+  <desc>mPA - empty MultiPoint element for A, on boundary of B</desc>
+  <a>
+    MULTIPOINT(EMPTY,(1 0))
+  </a>
+  <b>
+    POLYGON ((1 0,0 1,-1 0,0 -1, 1 0))
+  </b>
+<test>
+  <op name="relate" arg3="F0FFFF212" arg1="A" arg2="B">
+    true
+  </op>
+</test>
+<test><op name="contains"   arg1="A" arg2="B"> false </op></test>
+<test><op name="coveredBy"  arg1="A" arg2="B"> true  </op></test>
+<test><op name="covers"     arg1="A" arg2="B"> false </op></test>
+<test><op name="crosses"    arg1="A" arg2="B"> false </op></test>
+<test><op name="disjoint"   arg1="A" arg2="B"> false </op></test>
+<test><op name="equalsTopo" arg1="A" arg2="B"> false </op></test>
+<test><op name="intersects" arg1="A" arg2="B"> true  </op></test>
+<test><op name="overlaps"   arg1="A" arg2="B"> false </op></test>
+<test><op name="touches"    arg1="A" arg2="B"> true </op></test>
+<test><op name="within"     arg1="A" arg2="B"> false  </op></test>
+</case>
+
+<case>
+  <desc>mPA - empty MultiPoint element for B</desc>
+  <a>
+    POLYGON ((1 0,0 1,-1 0,0 -1, 1 0))
+  </a>
+  <b>
+    MULTIPOINT(EMPTY,(0 0))
+  </b>
+<test>
+  <op name="relate" arg3="0F2FF1FF2" arg1="A" arg2="B">
+    true
+  </op>
+</test>
+<test><op name="contains"   arg1="A" arg2="B"> true </op></test>
+<test><op name="coveredBy"  arg1="A" arg2="B"> false  </op></test>
+<test><op name="covers"     arg1="A" arg2="B"> true </op></test>
+<test><op name="crosses"    arg1="A" arg2="B"> false </op></test>
+<test><op name="disjoint"   arg1="A" arg2="B"> false </op></test>
+<test><op name="equalsTopo" arg1="A" arg2="B"> false </op></test>
+<test><op name="intersects" arg1="A" arg2="B"> true  </op></test>
+<test><op name="overlaps"   arg1="A" arg2="B"> false </op></test>
+<test><op name="touches"    arg1="A" arg2="B"> false </op></test>
+<test><op name="within"     arg1="A" arg2="B"> false  </op></test>
+</case>
+
+<case>
+  <desc>mPA - empty MultiPoint element for B, on boundary of A</desc>
+  <a>
+    POLYGON ((1 0,0 1,-1 0,0 -1, 1 0))
+  </a>
+  <b>
+    MULTIPOINT(EMPTY,(1 0))
+  </b>
+<test>
+  <op name="relate" arg3="FF20F1FF2" arg1="A" arg2="B">
+    true
+  </op>
+</test>
+<test><op name="contains"   arg1="A" arg2="B"> false </op></test>
+<test><op name="coveredBy"  arg1="A" arg2="B"> false  </op></test>
+<test><op name="covers"     arg1="A" arg2="B"> true </op></test>
+<test><op name="crosses"    arg1="A" arg2="B"> false </op></test>
+<test><op name="disjoint"   arg1="A" arg2="B"> false </op></test>
+<test><op name="equalsTopo" arg1="A" arg2="B"> false </op></test>
+<test><op name="intersects" arg1="A" arg2="B"> true  </op></test>
+<test><op name="overlaps"   arg1="A" arg2="B"> false </op></test>
+<test><op name="touches"    arg1="A" arg2="B"> true </op></test>
+<test><op name="within"     arg1="A" arg2="B"> false  </op></test>
+</case>
+
+<case>
+  <desc>PmA - empty MultiPolygon element</desc>
+  <a>
+    POINT(0 0)
+  </a>
+  <b>
+    MULTIPOLYGON (EMPTY, ((1 0,0 1,-1 0,0 -1, 1 0)))
+  </b>
+<test>
+  <op name="relate" arg3="0FFFFF212" arg1="A" arg2="B">
+    true
+  </op>
+</test>
+<test><op name="contains"   arg1="A" arg2="B"> false </op></test>
+<test><op name="coveredBy"  arg1="A" arg2="B"> true  </op></test>
+<test><op name="covers"     arg1="A" arg2="B"> false </op></test>
+<test><op name="crosses"    arg1="A" arg2="B"> false </op></test>
+<test><op name="disjoint"   arg1="A" arg2="B"> false </op></test>
+<test><op name="equalsTopo" arg1="A" arg2="B"> false </op></test>
+<test><op name="intersects" arg1="A" arg2="B"> true  </op></test>
+<test><op name="overlaps"   arg1="A" arg2="B"> false </op></test>
+<test><op name="touches"    arg1="A" arg2="B"> false </op></test>
+<test><op name="within"     arg1="A" arg2="B"> true  </op></test>
 </case>
 
 </run>

--- a/jts-test-runner/resources/testxml/general/TestRelatePL.xml
+++ b/jts-test-runner/resources/testxml/general/TestRelatePL.xml
@@ -1,5 +1,4 @@
 <run>
-  <precisionModel scale="1.0" offsetx="0.0" offsety="0.0"/>
 
 <case>
   <desc>PL - disjoint</desc>

--- a/jts-test-runner/resources/testxml/general/TestRelatePP.xml
+++ b/jts-test-runner/resources/testxml/general/TestRelatePP.xml
@@ -1,5 +1,4 @@
 <run>
-  <precisionModel scale="1.0" offsetx="0.0" offsety="0.0"/>
 
 <case>
   <desc>same point</desc>

--- a/jts-test-runner/resources/testxml/misc/TestRelateGC.xml
+++ b/jts-test-runner/resources/testxml/misc/TestRelateGC.xml
@@ -1,0 +1,623 @@
+<run>
+
+<case>
+  <desc>GC:L/GC:PL - a line with the same line in a collection with an empty polygon</desc>
+  <a>
+    LINESTRING(0 0, 1 1)
+  </a>
+  <b>
+    GEOMETRYCOLLECTION(POLYGON EMPTY, LINESTRING(0 0, 1 1))
+  </b>
+  <test><op name="relate" arg3="1FFF0FFF2" arg1="A" arg2="B"> true </op></test>
+  <test><op name="contains"   arg1="A" arg2="B"> true </op></test>
+  <test><op name="coveredBy"  arg1="A" arg2="B"> true </op></test>
+  <test><op name="covers"     arg1="A" arg2="B"> true </op></test>
+  <test><op name="crosses"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="disjoint"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="equalsTopo" arg1="A" arg2="B"> true </op></test>
+  <test><op name="intersects" arg1="A" arg2="B"> true </op></test>
+  <test><op name="overlaps"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="touches"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="within"     arg1="A" arg2="B"> true </op></test>
+</case>
+
+<case>
+  <desc>A/GC:mP</desc>
+  <a>
+    POLYGON((-60 -50,-70 -50,-60 -40,-60 -50))
+  </a>
+  <b>
+    GEOMETRYCOLLECTION(MULTIPOINT((-60 -50),(-63 -49)))
+  </b>
+  <test><op name="relate" arg3="0F20F1FF2" arg1="A" arg2="B"> true </op></test>
+  <test><op name="contains"   arg1="A" arg2="B"> true </op></test>
+  <test><op name="coveredBy"  arg1="A" arg2="B"> false </op></test>
+  <test><op name="covers"     arg1="A" arg2="B"> true </op></test>
+  <test><op name="crosses"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="disjoint"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="equalsTopo" arg1="A" arg2="B"> false </op></test>
+  <test><op name="intersects" arg1="A" arg2="B"> true </op></test>
+  <test><op name="overlaps"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="touches"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="within"     arg1="A" arg2="B"> false </op></test>
+</case>
+
+<case>
+  <desc>A/GC:mP with empty MultiPoint elements</desc>
+  <a>
+    POLYGON ((3 7, 7 7, 7 3, 3 3, 3 7))
+  </a>
+  <b>
+    GEOMETRYCOLLECTION (MULTIPOINT (EMPTY, (5 5)), LINESTRING (1 9, 4 9))
+  </b>
+  <test><op name="relate" arg3="0F2FF1102" arg1="A" arg2="B"> true </op></test>
+  <test><op name="contains"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="coveredBy"  arg1="A" arg2="B"> false </op></test>
+  <test><op name="covers"     arg1="A" arg2="B"> false </op></test>
+  <test><op name="crosses"    arg1="A" arg2="B"> true </op></test>
+  <test><op name="disjoint"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="equalsTopo" arg1="A" arg2="B"> false </op></test>
+  <test><op name="intersects" arg1="A" arg2="B"> true </op></test>
+  <test><op name="overlaps"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="touches"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="within"     arg1="A" arg2="B"> false </op></test>
+</case>
+
+<case>
+  <desc>mA/GC:PL</desc>
+  <a>
+    MULTIPOLYGON (((0 0, 3 0, 3 3, 0 3, 0 0)))
+  </a>
+  <b>
+    GEOMETRYCOLLECTION ( LINESTRING (1 2, 1 1), POINT (0 0))
+  </b>
+  <test><op name="relate" arg3="1020F1FF2" arg1="A" arg2="B"> true </op></test>
+  <test><op name="contains"   arg1="A" arg2="B"> true </op></test>
+  <test><op name="coveredBy"  arg1="A" arg2="B"> false </op></test>
+  <test><op name="covers"     arg1="A" arg2="B"> true </op></test>
+  <test><op name="crosses"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="disjoint"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="equalsTopo" arg1="A" arg2="B"> false </op></test>
+  <test><op name="intersects" arg1="A" arg2="B"> true </op></test>
+  <test><op name="overlaps"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="touches"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="within"     arg1="A" arg2="B"> false </op></test>
+</case>
+
+<case>
+  <desc>GC:PL/A</desc>
+  <a>
+    GEOMETRYCOLLECTION (POINT (7 1), LINESTRING (6 5, 6 4))
+  </a>
+  <b>
+    POLYGON ((7 1, 1 3, 3 9, 7 1))
+  </b>
+  <test><op name="relate" arg3="F01FF0212" arg1="A" arg2="B"> true </op></test>
+  <test><op name="contains"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="coveredBy"  arg1="A" arg2="B"> false </op></test>
+  <test><op name="covers"     arg1="A" arg2="B"> false </op></test>
+  <test><op name="crosses"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="disjoint"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="equalsTopo" arg1="A" arg2="B"> false </op></test>
+  <test><op name="intersects" arg1="A" arg2="B"> true </op></test>
+  <test><op name="overlaps"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="touches"    arg1="A" arg2="B"> true </op></test>
+  <test><op name="within"     arg1="A" arg2="B"> false </op></test>
+</case>
+
+<case>
+  <desc>P/GC:PL - point on boundary of GC with line and point</desc>
+  <a>
+    POINT(0 0)
+  </a>
+  <b>
+    GEOMETRYCOLLECTION(POINT(0 0), LINESTRING(0 0, 1 0))
+  </b>
+  <test><op name="relate" arg3="F0FFFF102" arg1="A" arg2="B"> true </op></test>
+  <test><op name="contains"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="coveredBy"  arg1="A" arg2="B"> true </op></test>
+  <test><op name="covers"     arg1="A" arg2="B"> false </op></test>
+  <test><op name="crosses"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="disjoint"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="equalsTopo" arg1="A" arg2="B"> false </op></test>
+  <test><op name="intersects" arg1="A" arg2="B"> true </op></test>
+  <test><op name="overlaps"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="touches"    arg1="A" arg2="B"> true </op></test>
+  <test><op name="within"     arg1="A" arg2="B"> false </op></test>
+</case>
+
+
+<case>
+  <desc>L/GC:A - line in interior of GC of overlapping polygons</desc>
+  <a>
+    LINESTRING (3 7, 7 3)
+  </a>
+  <b>
+    GEOMETRYCOLLECTION (POLYGON ((1 9, 7 9, 7 3, 1 3, 1 9)), POLYGON ((9 1, 3 1, 3 7, 9 7, 9 1)))
+  </b>
+  <test><op name="relate" arg3="1FF0FF212" arg1="A" arg2="B"> true </op></test>
+  <test><op name="contains"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="coveredBy"  arg1="A" arg2="B"> true </op></test>
+  <test><op name="covers"     arg1="A" arg2="B"> false </op></test>
+  <test><op name="crosses"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="disjoint"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="equalsTopo" arg1="A" arg2="B"> false </op></test>
+  <test><op name="intersects" arg1="A" arg2="B"> true </op></test>
+  <test><op name="overlaps"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="touches"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="within"     arg1="A" arg2="B"> true </op></test>
+</case>
+
+<case>
+  <desc>P/GC:A - point on common boundaries of 2 adjacent polygons</desc>
+  <a>
+    POINT (4 3)
+  </a>
+  <b>
+    GEOMETRYCOLLECTION (POLYGON ((1 1, 1 6, 4 6, 4 1, 1 1)), POLYGON ((9 1, 4 1, 4 6, 9 6, 9 1)))
+  </b>
+  <test><op name="relate" arg3="0FFFFF212" arg1="A" arg2="B"> true </op></test>
+  <test><op name="contains"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="coveredBy"  arg1="A" arg2="B"> true </op></test>
+  <test><op name="covers"     arg1="A" arg2="B"> false </op></test>
+  <test><op name="crosses"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="disjoint"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="equalsTopo" arg1="A" arg2="B"> false </op></test>
+  <test><op name="intersects" arg1="A" arg2="B"> true </op></test>
+  <test><op name="overlaps"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="touches"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="within"     arg1="A" arg2="B"> true </op></test>
+</case>
+
+<case>
+  <desc>P/GC:A - point on common node of 3 adjacent polygons</desc>
+  <a>
+    POINT (5 4)
+  </a>
+  <b>
+    GEOMETRYCOLLECTION (POLYGON ((1 6, 5 4, 4 1, 1 6)), POLYGON ((4 1, 5 4, 9 6, 4 1)), POLYGON ((1 6, 9 6, 5 4, 1 6)))
+  </b>
+  <test><op name="relate" arg3="0FFFFF212" arg1="A" arg2="B"> true </op></test>
+  <test><op name="contains"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="coveredBy"  arg1="A" arg2="B"> true </op></test>
+  <test><op name="covers"     arg1="A" arg2="B"> false </op></test>
+  <test><op name="crosses"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="disjoint"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="equalsTopo" arg1="A" arg2="B"> false </op></test>
+  <test><op name="intersects" arg1="A" arg2="B"> true </op></test>
+  <test><op name="overlaps"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="touches"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="within"     arg1="A" arg2="B"> true </op></test>
+</case>
+
+<case>
+  <desc>P/GC:A - point on common node of 6 adjacent polygons, with holes at node</desc>
+  <a>
+    POINT (6 6)
+  </a>
+  <b>
+GEOMETRYCOLLECTION (POLYGON ((1 9, 5 9, 6 6, 1 5, 1 9), (2 6, 4 8, 6 6, 2 6)), POLYGON ((2 6, 4 8, 6 6, 2 6)), POLYGON ((9 9, 9 5, 6 6, 5 9, 9 9)), POLYGON ((9 1, 5 1, 6 6, 9 5, 9 1), (7 2, 6 6, 8 3, 7 2)), POLYGON ((7 2, 6 6, 8 3, 7 2)), POLYGON ((1 1, 1 5, 6 6, 5 1, 1 1)))
+  </b>
+  <test><op name="relate" arg3="0FFFFF212" arg1="A" arg2="B"> true </op></test>
+  <test><op name="contains"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="coveredBy"  arg1="A" arg2="B"> true </op></test>
+  <test><op name="covers"     arg1="A" arg2="B"> false </op></test>
+  <test><op name="crosses"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="disjoint"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="equalsTopo" arg1="A" arg2="B"> false </op></test>
+  <test><op name="intersects" arg1="A" arg2="B"> true </op></test>
+  <test><op name="overlaps"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="touches"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="within"     arg1="A" arg2="B"> true </op></test>
+</case>
+
+<case>
+  <desc>P/GC:A - point on common node of 5 adjacent polygons, with holes at node and one not filled</desc>
+  <a>
+    POINT (6 6)
+  </a>
+  <b>
+GEOMETRYCOLLECTION (POLYGON ((1 9, 5 9, 6 6, 1 5, 1 9), (2 6, 4 8, 6 6, 2 6)), POLYGON ((2 6, 4 8, 6 6, 2 6)), POLYGON ((9 9, 9 5, 6 6, 5 9, 9 9)), POLYGON ((9 1, 5 1, 6 6, 9 5, 9 1), (7 2, 6 6, 8 3, 7 2)), POLYGON ((1 1, 1 5, 6 6, 5 1, 1 1)))
+  </b>
+  <test><op name="relate" arg3="F0FFFF212" arg1="A" arg2="B"> true </op></test>
+  <test><op name="contains"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="coveredBy"  arg1="A" arg2="B"> true </op></test>
+  <test><op name="covers"     arg1="A" arg2="B"> false </op></test>
+  <test><op name="crosses"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="disjoint"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="equalsTopo" arg1="A" arg2="B"> false </op></test>
+  <test><op name="intersects" arg1="A" arg2="B"> true </op></test>
+  <test><op name="overlaps"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="touches"    arg1="A" arg2="B"> true </op></test>
+  <test><op name="within"     arg1="A" arg2="B"> false </op></test>
+</case>
+
+<case>
+  <desc>L/GC:A - line on common boundaries of adjacent polygons</desc>
+  <a>
+    LINESTRING (4 5, 4 2)
+  </a>
+  <b>
+    GEOMETRYCOLLECTION (POLYGON ((1 1, 1 6, 4 6, 4 1, 1 1)), POLYGON ((9 1, 4 1, 4 6, 9 6, 9 1)))
+  </b>
+  <test><op name="relate" arg3="1FF0FF212" arg1="A" arg2="B"> true </op></test>
+  <test><op name="contains"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="coveredBy"  arg1="A" arg2="B"> true </op></test>
+  <test><op name="covers"     arg1="A" arg2="B"> false </op></test>
+  <test><op name="crosses"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="disjoint"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="equalsTopo" arg1="A" arg2="B"> false </op></test>
+  <test><op name="intersects" arg1="A" arg2="B"> true </op></test>
+  <test><op name="overlaps"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="touches"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="within"     arg1="A" arg2="B"> true </op></test>
+</case>
+
+<case>
+  <desc>L/GC:A - line on exterior boundaries of GC of overlapping polygons</desc>
+  <a>
+    LINESTRING (2 6, 8 6)
+  </a>
+  <b>
+    GEOMETRYCOLLECTION (POLYGON ((1 1, 1 6, 6 6, 6 1, 1 1)), POLYGON ((9 1, 4 1, 4 6, 9 6, 9 1)))
+  </b>
+  <test><op name="relate" arg3="F1FF0F212" arg1="A" arg2="B"> true </op></test>
+  <test><op name="contains"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="coveredBy"  arg1="A" arg2="B"> true </op></test>
+  <test><op name="covers"     arg1="A" arg2="B"> false </op></test>
+  <test><op name="crosses"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="disjoint"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="equalsTopo" arg1="A" arg2="B"> false </op></test>
+  <test><op name="intersects" arg1="A" arg2="B"> true </op></test>
+  <test><op name="overlaps"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="touches"    arg1="A" arg2="B"> true </op></test>
+  <test><op name="within"     arg1="A" arg2="B"> false </op></test>
+</case>
+
+<case>
+  <desc>GC:L/GC:A - lines covers boundaries of overlapping polygons</desc>
+  <a>
+    GEOMETRYCOLLECTION (LINESTRING (2 6, 9 6, 9 1, 7 1), LINESTRING (8 1, 1 1, 1 6, 7 6))
+  </a>
+  <b>
+    GEOMETRYCOLLECTION (POLYGON ((1 1, 1 6, 6 6, 6 1, 1 1)), POLYGON ((9 1, 4 1, 4 6, 9 6, 9 1)))
+  </b>
+  <test><op name="relate" arg3="F1FF0F2F2" arg1="A" arg2="B"> true </op></test>
+  <test><op name="contains"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="coveredBy"  arg1="A" arg2="B"> true </op></test>
+  <test><op name="covers"     arg1="A" arg2="B"> false </op></test>
+  <test><op name="crosses"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="disjoint"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="equalsTopo" arg1="A" arg2="B"> false </op></test>
+  <test><op name="intersects" arg1="A" arg2="B"> true </op></test>
+  <test><op name="overlaps"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="touches"    arg1="A" arg2="B"> true </op></test>
+  <test><op name="within"     arg1="A" arg2="B"> false </op></test>
+</case>
+
+<case>
+  <desc>GC:A/GC:A - adjacent polygons contained by adjacent polygons</desc>
+  <a>
+    GEOMETRYCOLLECTION (POLYGON ((2 2, 2 5, 4 5, 4 2, 2 2)), POLYGON ((8 2, 4 3, 4 4, 8 5, 8 2)))
+  </a>
+  <b>
+    GEOMETRYCOLLECTION (POLYGON ((1 1, 1 6, 4 6, 4 1, 1 1)), POLYGON ((9 1, 4 1, 4 6, 9 6, 9 1)))
+  </b>
+  <test><op name="relate" arg3="2FF1FF212" arg1="A" arg2="B"> true </op></test>
+  <test><op name="contains"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="coveredBy"  arg1="A" arg2="B"> true </op></test>
+  <test><op name="covers"     arg1="A" arg2="B"> false </op></test>
+  <test><op name="crosses"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="disjoint"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="equalsTopo" arg1="A" arg2="B"> false </op></test>
+  <test><op name="intersects" arg1="A" arg2="B"> true </op></test>
+  <test><op name="overlaps"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="touches"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="within"     arg1="A" arg2="B"> true </op></test>
+</case>
+
+<case>
+  <desc>GC:A/P - adjacent polygons contain point at interior node</desc>
+  <a>
+    GEOMETRYCOLLECTION (POLYGON ((5 5, 2 9, 9 9, 9 5, 5 5)), POLYGON ((3 1, 5 5, 9 5, 9 1, 3 1)), POLYGON ((1 9, 2 9, 5 5, 3 1, 1 1, 1 9)))
+  </a>
+  <b>
+    POINT (5 5)
+  </b>
+  <test><op name="relate" arg3="0F2FF1FF2" arg1="A" arg2="B"> true </op></test>
+  <test><op name="contains"   arg1="A" arg2="B"> true </op></test>
+  <test><op name="coveredBy"  arg1="A" arg2="B"> false </op></test>
+  <test><op name="covers"     arg1="A" arg2="B"> true </op></test>
+  <test><op name="crosses"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="disjoint"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="equalsTopo" arg1="A" arg2="B"> false </op></test>
+  <test><op name="intersects" arg1="A" arg2="B"> true </op></test>
+  <test><op name="overlaps"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="touches"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="within"     arg1="A" arg2="B"> false </op></test>
+</case>
+
+<case>
+  <desc>GC:A/P - adjacent polygons contain point on interior edge</desc>
+  <a>
+    GEOMETRYCOLLECTION (POLYGON ((5 5, 2 9, 9 9, 9 5, 5 5)), POLYGON ((3 1, 5 5, 9 5, 9 1, 3 1)), POLYGON ((1 9, 2 9, 5 5, 3 1, 1 1, 1 9)))
+  </a>
+  <b>
+    POINT (7 5)
+  </b>
+  <test><op name="relate" arg3="0F2FF1FF2" arg1="A" arg2="B"> true </op></test>
+  <test><op name="contains"   arg1="A" arg2="B"> true </op></test>
+  <test><op name="coveredBy"  arg1="A" arg2="B"> false </op></test>
+  <test><op name="covers"     arg1="A" arg2="B"> true </op></test>
+  <test><op name="crosses"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="disjoint"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="equalsTopo" arg1="A" arg2="B"> false </op></test>
+  <test><op name="intersects" arg1="A" arg2="B"> true </op></test>
+  <test><op name="overlaps"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="touches"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="within"     arg1="A" arg2="B"> false </op></test>
+</case>
+
+<case>
+  <desc>GC:A/P - adjacent polygons cover point on exterior node</desc>
+  <a>
+    GEOMETRYCOLLECTION (POLYGON ((5 5, 2 9, 9 9, 9 5, 5 5)), POLYGON ((3 1, 5 5, 9 5, 9 1, 3 1)), POLYGON ((1 9, 2 9, 5 5, 3 1, 1 1, 1 9)))
+  </a>
+  <b>
+    POINT (9 5)
+  </b>
+  <test><op name="relate" arg3="FF20F1FF2" arg1="A" arg2="B"> true </op></test>
+  <test><op name="contains"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="coveredBy"  arg1="A" arg2="B"> false </op></test>
+  <test><op name="covers"     arg1="A" arg2="B"> true </op></test>
+  <test><op name="crosses"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="disjoint"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="equalsTopo" arg1="A" arg2="B"> false </op></test>
+  <test><op name="intersects" arg1="A" arg2="B"> true </op></test>
+  <test><op name="overlaps"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="touches"    arg1="A" arg2="B"> true </op></test>
+  <test><op name="within"     arg1="A" arg2="B"> false </op></test>
+</case>
+
+<case>
+  <desc>GC:A/L - adjacent polygons contain line touching interior node</desc>
+  <a>
+    GEOMETRYCOLLECTION (POLYGON ((5 5, 2 9, 9 9, 9 5, 5 5)), POLYGON ((3 1, 5 5, 9 5, 9 1, 3 1)), POLYGON ((1 9, 2 9, 5 5, 3 1, 1 1, 1 9)))
+  </a>
+  <b>
+    LINESTRING (5 5, 7 7)
+  </b>
+  <test><op name="relate" arg3="102FF1FF2" arg1="A" arg2="B"> true </op></test>
+  <test><op name="contains"   arg1="A" arg2="B"> true </op></test>
+  <test><op name="coveredBy"  arg1="A" arg2="B"> false </op></test>
+  <test><op name="covers"     arg1="A" arg2="B"> true </op></test>
+  <test><op name="crosses"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="disjoint"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="equalsTopo" arg1="A" arg2="B"> false </op></test>
+  <test><op name="intersects" arg1="A" arg2="B"> true </op></test>
+  <test><op name="overlaps"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="touches"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="within"     arg1="A" arg2="B"> false </op></test>
+</case>
+
+<case>
+  <desc>GC:A/L - adjacent polygons contain line along interior edge to boundary</desc>
+  <a>
+    GEOMETRYCOLLECTION (POLYGON ((5 5, 2 9, 9 9, 9 5, 5 5)), POLYGON ((3 1, 5 5, 9 5, 9 1, 3 1)), POLYGON ((1 9, 2 9, 5 5, 3 1, 1 1, 1 9)))
+  </a>
+  <b>
+    LINESTRING (5 5, 9 5)
+  </b>
+  <test><op name="relate" arg3="102F01FF2" arg1="A" arg2="B"> true </op></test>
+  <test><op name="contains"   arg1="A" arg2="B"> true </op></test>
+  <test><op name="coveredBy"  arg1="A" arg2="B"> false </op></test>
+  <test><op name="covers"     arg1="A" arg2="B"> true </op></test>
+  <test><op name="crosses"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="disjoint"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="equalsTopo" arg1="A" arg2="B"> false </op></test>
+  <test><op name="intersects" arg1="A" arg2="B"> true </op></test>
+  <test><op name="overlaps"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="touches"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="within"     arg1="A" arg2="B"> false </op></test>
+</case>
+
+<case>
+  <desc>GC:A/GC:PL - adjacent polygons contain line and point</desc>
+  <a>
+    GEOMETRYCOLLECTION (POLYGON ((5 5, 2 9, 9 9, 9 5, 5 5)), POLYGON ((3 1, 5 5, 9 5, 9 1, 3 1)), POLYGON ((1 9, 2 9, 5 5, 3 1, 1 1, 1 9)))
+  </a>
+  <b>
+    GEOMETRYCOLLECTION (POINT (5 5), LINESTRING (5 7, 7 7))
+  </b>
+  <test><op name="relate" arg3="102FF1FF2" arg1="A" arg2="B"> true </op></test>
+  <test><op name="contains"   arg1="A" arg2="B"> true </op></test>
+  <test><op name="coveredBy"  arg1="A" arg2="B"> false </op></test>
+  <test><op name="covers"     arg1="A" arg2="B"> true </op></test>
+  <test><op name="crosses"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="disjoint"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="equalsTopo" arg1="A" arg2="B"> false </op></test>
+  <test><op name="intersects" arg1="A" arg2="B"> true </op></test>
+  <test><op name="overlaps"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="touches"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="within"     arg1="A" arg2="B"> false </op></test>
+</case>
+
+<case>
+  <desc>GC:A/A - adjacent polygons containing polygon with endpoint inside</desc>
+  <a>
+    GEOMETRYCOLLECTION (POLYGON ((5 5, 2 9, 9 9, 9 5, 5 5)), POLYGON ((3 1, 5 5, 9 5, 9 1, 3 1)), POLYGON ((1 9, 2 9, 5 5, 3 1, 1 1, 1 9)))
+  </a>
+  <b>
+    POLYGON ((3 7, 7 7, 7 3, 3 3, 3 7))
+  </b>
+  <test><op name="relate" arg3="212FF1FF2" arg1="A" arg2="B"> true </op></test>
+  <test><op name="contains"   arg1="A" arg2="B"> true </op></test>
+  <test><op name="coveredBy"  arg1="A" arg2="B"> false </op></test>
+  <test><op name="covers"     arg1="A" arg2="B"> true </op></test>
+  <test><op name="crosses"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="disjoint"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="equalsTopo" arg1="A" arg2="B"> false </op></test>
+  <test><op name="intersects" arg1="A" arg2="B"> true </op></test>
+  <test><op name="overlaps"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="touches"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="within"     arg1="A" arg2="B"> false </op></test>
+</case>
+
+<case>
+  <desc>GC:A/A - adjacent polygons overlapping polygon with shell outside and hole inside</desc>
+  <a>
+    GEOMETRYCOLLECTION (POLYGON ((5 5, 2 9, 9 9, 9 5, 5 5)), POLYGON ((3 1, 5 5, 9 5, 9 1, 3 1)), POLYGON ((1 9, 2 9, 5 5, 3 1, 1 1, 1 9)))
+  </a>
+  <b>
+    POLYGON ((0 10, 10 10, 10 0, 0 0, 0 10), (2 8, 8 8, 8 2, 2 2, 2 8))
+  </b>
+  <test><op name="relate" arg3="2121FF212" arg1="A" arg2="B"> true </op></test>
+  <test><op name="contains"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="coveredBy"  arg1="A" arg2="B"> false </op></test>
+  <test><op name="covers"     arg1="A" arg2="B"> false </op></test>
+  <test><op name="crosses"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="disjoint"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="equalsTopo" arg1="A" arg2="B"> false </op></test>
+  <test><op name="intersects" arg1="A" arg2="B"> true </op></test>
+  <test><op name="overlaps"   arg1="A" arg2="B"> true </op></test>
+  <test><op name="touches"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="within"     arg1="A" arg2="B"> false </op></test>
+</case>
+
+<case>
+  <desc>GC:A/GC:A - overlapping polygons equal to overlapping polygons</desc>
+  <a>
+    GEOMETRYCOLLECTION (POLYGON ((1 6, 9 6, 9 2, 1 2, 1 6)), POLYGON ((9 1, 1 1, 1 5, 9 5, 9 1)))
+  </a>
+  <b>
+    GEOMETRYCOLLECTION (POLYGON ((1 1, 1 6, 6 6, 6 1, 1 1)), POLYGON ((9 1, 4 1, 4 6, 9 6, 9 1)))
+  </b>
+  <test><op name="relate" arg3="2FFF1FFF2" arg1="A" arg2="B"> true </op></test>
+  <test><op name="contains"   arg1="A" arg2="B"> true </op></test>
+  <test><op name="coveredBy"  arg1="A" arg2="B"> true </op></test>
+  <test><op name="covers"     arg1="A" arg2="B"> true </op></test>
+  <test><op name="crosses"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="disjoint"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="equalsTopo" arg1="A" arg2="B"> true </op></test>
+  <test><op name="intersects" arg1="A" arg2="B"> true </op></test>
+  <test><op name="overlaps"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="touches"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="within"     arg1="A" arg2="B"> true </op></test>
+</case>
+
+<case>
+  <desc>GC:A/GC:A - overlapping polygons contained by overlapping polygons</desc>
+  <a>
+    GEOMETRYCOLLECTION (POLYGON ((4 4, 6 4, 6 3, 4 3, 4 4)), POLYGON ((2 5, 8 5, 8 2, 2 2, 2 5)))
+  </a>
+  <b>
+    GEOMETRYCOLLECTION (POLYGON ((1 1, 1 6, 6 6, 6 1, 1 1)), POLYGON ((9 1, 4 1, 4 6, 9 6, 9 1)))
+  </b>
+  <test><op name="relate" arg3="2FF1FF212" arg1="A" arg2="B"> true </op></test>
+  <test><op name="contains"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="coveredBy"  arg1="A" arg2="B"> true </op></test>
+  <test><op name="covers"     arg1="A" arg2="B"> false </op></test>
+  <test><op name="crosses"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="disjoint"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="equalsTopo" arg1="A" arg2="B"> false </op></test>
+  <test><op name="intersects" arg1="A" arg2="B"> true </op></test>
+  <test><op name="overlaps"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="touches"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="within"     arg1="A" arg2="B"> true </op></test>
+</case>
+
+
+<case>
+  <desc>A/GC:A - polygon equal to nested overlapping polygons</desc>
+  <a>
+    POLYGON ((1 9, 9 9, 9 1, 1 1, 1 9))
+  </a>
+  <b>
+    GEOMETRYCOLLECTION (
+      POLYGON ((1 1, 1 5, 5 5, 5 1, 1 1)), 
+      GEOMETRYCOLLECTION( 
+          POLYGON ((1 5, 5 9, 9 9, 9 5, 5 1, 1 5)),
+          MULTIPOLYGON (((1 9, 5 9, 5 5, 1 5, 1 9)), ((9 1, 5 1, 5 5, 9 5, 9 1)))
+      )
+    )
+  </b>
+  <test><op name="relate" arg3="2FFF1FFF2" arg1="A" arg2="B"> true </op></test>
+  <test><op name="contains"   arg1="A" arg2="B"> true </op></test>
+  <test><op name="coveredBy"  arg1="A" arg2="B"> true </op></test>
+  <test><op name="covers"     arg1="A" arg2="B"> true </op></test>
+  <test><op name="crosses"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="disjoint"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="equalsTopo" arg1="A" arg2="B"> true </op></test>
+  <test><op name="intersects" arg1="A" arg2="B"> true </op></test>
+  <test><op name="overlaps"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="touches"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="within"     arg1="A" arg2="B"> true </op></test>
+</case>
+
+<case>
+  <desc>GC:AmP/A - polygon with overlapping points equal to polygon </desc>
+  <a>
+    GEOMETRYCOLLECTION (POLYGON((0 0, 10 0, 10 10, 0 10, 0 0)),
+      MULTIPOINT(0 2, 0 5))
+  </a>
+  <b>
+    POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))
+  </b>
+  <test><op name="relate" arg3="2FFF1FFF2" arg1="A" arg2="B"> true </op></test>
+  <test><op name="contains"   arg1="A" arg2="B"> true </op></test>
+  <test><op name="coveredBy"  arg1="A" arg2="B"> true </op></test>
+  <test><op name="covers"     arg1="A" arg2="B"> true </op></test>
+  <test><op name="crosses"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="disjoint"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="equalsTopo" arg1="A" arg2="B"> true </op></test>
+  <test><op name="intersects" arg1="A" arg2="B"> true </op></test>
+  <test><op name="overlaps"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="touches"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="within"     arg1="A" arg2="B"> true </op></test>
+  
+  <test><op name="contains"   arg1="B" arg2="A"> true </op></test>
+  <test><op name="coveredBy"  arg1="B" arg2="A"> true </op></test>
+  <test><op name="covers"     arg1="B" arg2="A"> true </op></test>
+  <test><op name="crosses"    arg1="B" arg2="A"> false </op></test>
+  <test><op name="disjoint"   arg1="B" arg2="A"> false </op></test>
+  <test><op name="equalsTopo" arg1="B" arg2="A"> true </op></test>
+  <test><op name="intersects" arg1="B" arg2="A"> true </op></test>
+  <test><op name="overlaps"   arg1="B" arg2="A"> false </op></test>
+  <test><op name="touches"    arg1="B" arg2="A"> false </op></test>
+  <test><op name="within"     arg1="B" arg2="A"> true </op></test>
+</case>
+
+<case>
+  <desc>GC:AL/A - polygon with line in boundary and interior equal to polygon </desc>
+  <a>
+    GEOMETRYCOLLECTION (POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0)), 
+      LINESTRING (0 2, 0 5, 5 5))
+  </a>
+  <b>
+    POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))
+  </b>
+  <test><op name="relate" arg3="2FFF1FFF2" arg1="A" arg2="B"> true </op></test>
+  <test><op name="contains"   arg1="A" arg2="B"> true </op></test>
+  <test><op name="coveredBy"  arg1="A" arg2="B"> true </op></test>
+  <test><op name="covers"     arg1="A" arg2="B"> true </op></test>
+  <test><op name="crosses"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="disjoint"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="equalsTopo" arg1="A" arg2="B"> true </op></test>
+  <test><op name="intersects" arg1="A" arg2="B"> true </op></test>
+  <test><op name="overlaps"   arg1="A" arg2="B"> false </op></test>
+  <test><op name="touches"    arg1="A" arg2="B"> false </op></test>
+  <test><op name="within"     arg1="A" arg2="B"> true </op></test>
+  
+  <test><op name="contains"   arg1="B" arg2="A"> true </op></test>
+  <test><op name="coveredBy"  arg1="B" arg2="A"> true </op></test>
+  <test><op name="covers"     arg1="B" arg2="A"> true </op></test>
+  <test><op name="crosses"    arg1="B" arg2="A"> false </op></test>
+  <test><op name="disjoint"   arg1="B" arg2="A"> false </op></test>
+  <test><op name="equalsTopo" arg1="B" arg2="A"> true </op></test>
+  <test><op name="intersects" arg1="B" arg2="A"> true </op></test>
+  <test><op name="overlaps"   arg1="B" arg2="A"> false </op></test>
+  <test><op name="touches"    arg1="B" arg2="A"> false </op></test>
+  <test><op name="within"     arg1="B" arg2="A"> true </op></test>
+</case>
+
+</run>

--- a/jts-test-runner/src/input.rs
+++ b/jts-test-runner/src/input.rs
@@ -48,14 +48,28 @@ pub(crate) struct Case {
     #[serde(default)]
     pub(crate) desc: String,
 
-    #[serde(deserialize_with = "wkt::deserialize_wkt")]
-    pub(crate) a: Geometry,
+    #[serde(deserialize_with = "deserialize_lenient_geometry", default)]
+    pub(crate) a: Option<Geometry>,
 
-    #[serde(deserialize_with = "deserialize_opt_geometry", default)]
+    #[serde(deserialize_with = "deserialize_lenient_geometry", default)]
     pub(crate) b: Option<Geometry>,
 
     #[serde(rename = "test", default)]
     pub(crate) tests: Vec<Test>,
+}
+
+impl Case {
+    fn a(&self) -> Result<&Geometry> {
+        self.a
+            .as_ref()
+            .ok_or_else(|| "geometry A is not representable in geo".into())
+    }
+
+    fn b(&self) -> Result<&Geometry> {
+        self.b
+            .as_ref()
+            .ok_or_else(|| "no geometry b in case".into())
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -277,9 +291,25 @@ pub(crate) enum Operation {
     },
 }
 
+/// Resolves the (arg1, arg2) references of a binary predicate op to the
+/// case geometries, supporting both (A, B) and the swapped (B, A) order
+/// used by some fixtures.
+fn binary_args<'c>(case: &'c Case, arg1: &str, arg2: &str) -> Result<(&'c Geometry, &'c Geometry)> {
+    let a = case.a()?;
+    let b = case.b()?;
+    match (arg1.to_uppercase().as_str(), arg2.to_uppercase().as_str()) {
+        ("A", "B") => Ok((a, b)),
+        ("B", "A") => Ok((b, a)),
+        (arg1, arg2) => Err(format!("unsupported op arguments: {arg1}, {arg2}").into()),
+    }
+}
+
 impl OperationInput {
     pub(crate) fn into_operation(self, case: &Case) -> Result<Operation> {
-        let geometry = &case.a;
+        let geometry = case
+            .a
+            .as_ref()
+            .ok_or("geometry A is not representable in geo")?;
         match self {
             Self::BufferInput(BufferInput {
                 arg1,
@@ -307,79 +337,59 @@ impl OperationInput {
                     expected: convex_hull_input.expected,
                 })
             }
-            Self::EqualsTopoInput(equals_topo_input) => {
-                assert_eq!("A", equals_topo_input.arg1);
-                assert_eq!("B", equals_topo_input.arg2);
-                assert!(
-                    case.b.is_some(),
-                    "equalsTopo test case must contain geometry b"
-                );
+            Self::EqualsTopoInput(input) => {
+                let (first, second) = binary_args(case, &input.arg1, &input.arg2)?;
                 Ok(Operation::EqualsTopo {
-                    a: geometry.clone(),
-                    b: case.b.clone().expect("no geometry b in case"),
-                    expected: equals_topo_input.expected,
+                    a: first.clone(),
+                    b: second.clone(),
+                    expected: input.expected,
                 })
             }
             Self::IntersectsInput(input) => {
-                assert_eq!("A", input.arg1);
-                assert_eq!("B", input.arg2);
-                assert!(
-                    case.b.is_some(),
-                    "intersects test case must contain geometry b"
-                );
+                let (first, second) = binary_args(case, &input.arg1, &input.arg2)?;
                 Ok(Operation::Intersects {
-                    subject: geometry.clone(),
-                    clip: case.b.clone().expect("no geometry b in case"),
+                    subject: first.clone(),
+                    clip: second.clone(),
                     expected: input.expected,
                 })
             }
             Self::RelateInput(input) => {
-                assert_eq!("A", input.arg1);
-                assert_eq!("B", input.arg2);
-                assert!(case.b.is_some(), "relate test case must contain geometry b");
+                let (first, second) = binary_args(case, &input.arg1, &input.arg2)?;
                 Ok(Operation::Relate {
-                    a: geometry.clone(),
-                    b: case.b.clone().expect("no geometry b in case"),
+                    a: first.clone(),
+                    b: second.clone(),
                     expected: input.expected,
                 })
             }
             Self::ContainsInput(input) => {
-                assert_eq!("A", input.arg1);
-                assert_eq!("B", input.arg2);
+                let (first, second) = binary_args(case, &input.arg1, &input.arg2)?;
                 Ok(Operation::Contains {
-                    subject: geometry.clone(),
-                    target: case.b.clone().expect("no geometry b in case"),
+                    subject: first.clone(),
+                    target: second.clone(),
                     expected: input.expected,
                 })
             }
             Self::CoversInput(input) => {
-                assert_eq!("A", input.arg1);
-                assert_eq!("B", input.arg2);
+                let (first, second) = binary_args(case, &input.arg1, &input.arg2)?;
                 Ok(Operation::Covers {
-                    subject: geometry.clone(),
-                    target: case.b.clone().expect("no geometry b in case"),
+                    subject: first.clone(),
+                    target: second.clone(),
                     expected: input.expected,
                 })
             }
             Self::WithinInput(input) => {
-                assert_eq!("A", input.arg1);
-                assert_eq!("B", input.arg2);
+                let (first, second) = binary_args(case, &input.arg1, &input.arg2)?;
                 Ok(Operation::Within {
-                    subject: geometry.clone(),
-                    target: case.b.clone().expect("no geometry b in case"),
+                    subject: first.clone(),
+                    target: second.clone(),
                     expected: input.expected,
                 })
             }
             Self::UnionInput(input) => {
-                validate_boolean_op(
-                    &input.arg1,
-                    &input.arg2,
-                    geometry,
-                    case.b.as_ref().expect("no geometry b in case"),
-                )?;
+                validate_boolean_op(&input.arg1, &input.arg2, geometry, case.b()?)?;
                 Ok(Operation::BooleanOp {
                     a: geometry.clone(),
-                    b: case.b.clone().expect("no geometry b in case"),
+                    b: case.b()?.clone(),
                     op: BoolOp::Union,
                     expected: input.expected,
                 })
@@ -389,7 +399,7 @@ impl OperationInput {
                 assert_eq!("B", input.arg2);
 
                 // Clipping a line string in geo is like a Line x Poly Intersection in JTS
-                match (geometry, case.b.as_ref().expect("no geometry b in case")) {
+                match (geometry, case.b()?) {
                     (
                         Geometry::LineString(_) | Geometry::MultiLineString(_),
                         Geometry::Polygon(_) | Geometry::MultiPolygon(_),
@@ -400,31 +410,26 @@ impl OperationInput {
                     ) => {
                         return Ok(Operation::ClipOp {
                             a: geometry.clone(),
-                            b: case.b.clone().expect("no geometry b in case"),
+                            b: case.b()?.clone(),
                             invert: false,
                             expected: input.expected,
                         });
                     }
                     _ => {
-                        validate_boolean_op(
-                            &input.arg1,
-                            &input.arg2,
-                            geometry,
-                            case.b.as_ref().expect("no geometry b in case"),
-                        )?;
+                        validate_boolean_op(&input.arg1, &input.arg2, geometry, case.b()?)?;
                     }
                 };
 
                 Ok(Operation::BooleanOp {
                     a: geometry.clone(),
-                    b: case.b.clone().expect("no geometry b in case"),
+                    b: case.b()?.clone(),
                     op: BoolOp::Intersection,
                     expected: input.expected,
                 })
             }
             Self::DifferenceInput(input) => {
                 // Clipping a line string in geo is like a Line x Poly Intersection in JTS
-                match (geometry, case.b.as_ref().expect("no geometry b in case")) {
+                match (geometry, case.b()?) {
                     (
                         Geometry::LineString(_) | Geometry::MultiLineString(_),
                         Geometry::Polygon(_) | Geometry::MultiPolygon(_),
@@ -435,37 +440,27 @@ impl OperationInput {
                     ) => {
                         return Ok(Operation::ClipOp {
                             a: geometry.clone(),
-                            b: case.b.clone().expect("no geometry b in case"),
+                            b: case.b()?.clone(),
                             invert: true,
                             expected: input.expected,
                         });
                     }
                     _ => {
-                        validate_boolean_op(
-                            &input.arg1,
-                            &input.arg2,
-                            geometry,
-                            case.b.as_ref().expect("no geometry b in case"),
-                        )?;
+                        validate_boolean_op(&input.arg1, &input.arg2, geometry, case.b()?)?;
                     }
                 };
                 Ok(Operation::BooleanOp {
                     a: geometry.clone(),
-                    b: case.b.clone().expect("no geometry b in case"),
+                    b: case.b()?.clone(),
                     op: BoolOp::Difference,
                     expected: input.expected,
                 })
             }
             Self::SymDifferenceInput(input) => {
-                validate_boolean_op(
-                    &input.arg1,
-                    &input.arg2,
-                    geometry,
-                    case.b.as_ref().expect("no geometry b in case"),
-                )?;
+                validate_boolean_op(&input.arg1, &input.arg2, geometry, case.b()?)?;
                 Ok(Operation::BooleanOp {
                     a: geometry.clone(),
-                    b: case.b.clone().expect("no geometry b in case"),
+                    b: case.b()?.clone(),
                     op: BoolOp::Xor,
                     expected: input.expected,
                 })
@@ -474,6 +469,10 @@ impl OperationInput {
             OperationInput::IsValidInput(input) => match input.arg1.as_str() {
                 "A" => Ok(Operation::IsValidOp {
                     subject: geometry.clone(),
+                    expected: input.expected,
+                }),
+                "B" => Ok(Operation::IsValidOp {
+                    subject: case.b()?.clone(),
                     expected: input.expected,
                 }),
                 _ => todo!("Handle {}", input.arg1),
@@ -498,16 +497,29 @@ fn validate_boolean_op(arg1: &str, arg2: &str, a: &Geometry<f64>, b: &Geometry<f
     Ok(())
 }
 
-pub fn deserialize_opt_geometry<'de, D>(
+/// Deserialises an optional WKT geometry, treating WKT that cannot be
+/// represented as a geo geometry (for example a MultiPoint with an EMPTY
+/// point element) as absent instead of failing the whole file. Cases with
+/// an absent geometry are skipped per test, with a log message, rather
+/// than silently dropping every case in the file.
+pub fn deserialize_lenient_geometry<'de, D>(
     deserializer: D,
 ) -> std::result::Result<Option<Geometry>, D::Error>
 where
     D: Deserializer<'de>,
 {
-    #[derive(Debug, Deserialize)]
-    struct Wrapper(#[serde(deserialize_with = "wkt::deserialize_wkt")] Geometry);
+    use wkt::TryFromWkt;
 
-    Option::<Wrapper>::deserialize(deserializer).map(|opt_wrapped| opt_wrapped.map(|w| w.0))
+    let raw = Option::<String>::deserialize(deserializer)?;
+    Ok(
+        raw.and_then(|wkt_str| match Geometry::try_from_wkt_str(&wkt_str) {
+            Ok(geometry) => Some(geometry),
+            Err(e) => {
+                log::warn!("geometry not representable in geo, skipping its cases: {e}: {wkt_str}");
+                None
+            }
+        }),
+    )
 }
 
 pub fn deserialize_from_str<'de, T, D>(deserializer: D) -> std::result::Result<T, D::Error>

--- a/jts-test-runner/src/lib.rs
+++ b/jts-test-runner/src/lib.rs
@@ -136,7 +136,7 @@ mod tests {
         //
         // We'll need to increase this number as more tests are added, but it should never be
         // decreased.
-        let expected_test_count: usize = 11725;
+        let expected_test_count: usize = 12461;
         let actual_test_count = runner.unexpected_failures().len() + runner.successes().len();
         match actual_test_count.cmp(&expected_test_count) {
             Ordering::Less => {

--- a/jts-test-runner/src/runner.rs
+++ b/jts-test-runner/src/runner.rs
@@ -18,6 +18,7 @@ use geo::{ConvexHull, GeoNum};
 const GENERAL_TEST_XML: Dir = include_dir!("$CARGO_MANIFEST_DIR/resources/testxml/general");
 const VALIDATE_TEST_XML: Dir = include_dir!("$CARGO_MANIFEST_DIR/resources/testxml/validate");
 const MISC_TEST_XML: Dir = include_dir!("$CARGO_MANIFEST_DIR/resources/testxml/misc");
+const ROBUST_TEST_XML: Dir = include_dir!("$CARGO_MANIFEST_DIR/resources/testxml/robust");
 
 #[derive(Debug, Default, Clone)]
 pub struct TestRunner {
@@ -58,9 +59,91 @@ impl TestRunner {
             expected_failures: vec![
                 // Degenerate case we don't yet handle: buffering a collapsed (flat) polygon
                 TestId {
-                    file_name: "TestBuffer.xml".to_string(),
+                    file_name: "general/TestBuffer.xml".to_string(),
                     case_idx: 6,
                     test_idx: 1,
+                },
+                // GEOS ticket 841: the fixture expects `contains` = false
+                // because the DECIMAL point (0.95, 0.05) lies on the
+                // triangle's hypotenuse. After f64 parsing the point lies
+                // strictly inside (0.95_f64 rounds below 0.95), so exact
+                // arithmetic on the parsed doubles answers true. The
+                // fixture documents a limitation of float parsing, not of
+                // the relate engine.
+                TestId {
+                    file_name: "robust/TestRobustRelateFloat.xml".to_string(),
+                    case_idx: 0,
+                    test_idx: 0,
+                },
+                // "OLD robustness failure (works with snapping)" overlay
+                // cases: JTS passes these only via its snap-rounding
+                // fallback. i_overlay's integer-grid overlay produces the
+                // same slivers with quantised vertices (cases 0 and 1) or
+                // collapses a hairline sliver to empty (case 4). The same
+                // three cases appear in two fixture files.
+                TestId {
+                    file_name: "robust/TestRobustOverlayFloat.xml".to_string(),
+                    case_idx: 0,
+                    test_idx: 0,
+                },
+                TestId {
+                    file_name: "robust/TestRobustOverlayFloat.xml".to_string(),
+                    case_idx: 1,
+                    test_idx: 0,
+                },
+                TestId {
+                    file_name: "robust/TestRobustOverlayFloat.xml".to_string(),
+                    case_idx: 4,
+                    test_idx: 0,
+                },
+                TestId {
+                    file_name: "robust/overlay/TestOverlay-misc-3.xml".to_string(),
+                    case_idx: 0,
+                    test_idx: 0,
+                },
+                TestId {
+                    file_name: "robust/overlay/TestOverlay-misc-3.xml".to_string(),
+                    case_idx: 1,
+                    test_idx: 0,
+                },
+                TestId {
+                    file_name: "robust/overlay/TestOverlay-misc-3.xml".to_string(),
+                    case_idx: 4,
+                    test_idx: 0,
+                },
+                // The following files were previously skipped in their
+                // entirety, because a single unparseable case (e.g. POINT
+                // EMPTY) failed the whole-file deserialisation. Lenient
+                // per-case parsing now runs their remaining cases, which
+                // exposes these pre-existing gaps:
+                //
+                // geo has no LinearRing type: LINEARRING WKT parses as a
+                // LineString, and a self-intersecting LineString is valid,
+                // so the linear-ring bowtie cannot be reported invalid.
+                TestId {
+                    file_name: "general/TestValid.xml".to_string(),
+                    case_idx: 0,
+                    test_idx: 0,
+                },
+                // geo's polygon validation does not flag a collapsed
+                // (zero-area, collinear) ring as invalid.
+                TestId {
+                    file_name: "general/TestValid.xml".to_string(),
+                    case_idx: 17,
+                    test_idx: 0,
+                },
+                // i_overlay output differs from the JTS expectation in
+                // sliver-precision cases (near-degenerate geometry;
+                // vertices differ at the precision limit).
+                TestId {
+                    file_name: "misc/TestOverlay.xml".to_string(),
+                    case_idx: 0,
+                    test_idx: 0,
+                },
+                TestId {
+                    file_name: "robust/overlay/TestOverlay-pg-list.xml".to_string(),
+                    case_idx: 0,
+                    test_idx: 0,
                 },
             ],
             ..Self::default()
@@ -641,10 +724,18 @@ impl TestRunner {
             "**/*.xml".to_string()
         };
 
-        for entry in GENERAL_TEST_XML
-            .find(&filename_filter)?
-            .chain(VALIDATE_TEST_XML.find(&filename_filter)?)
-            .chain(MISC_TEST_XML.find(&filename_filter)?)
+        let corpora: [(&str, &Dir); 4] = [
+            ("general", &GENERAL_TEST_XML),
+            ("validate", &VALIDATE_TEST_XML),
+            ("misc", &MISC_TEST_XML),
+            ("robust", &ROBUST_TEST_XML),
+        ];
+        for (corpus, entry) in corpora
+            .iter()
+            .map(|(name, dir)| Ok((*name, dir.find(&filename_filter)?)))
+            .collect::<Result<Vec<_>>>()?
+            .into_iter()
+            .flat_map(|(name, entries)| entries.map(move |e| (name, e)))
         {
             let file = match entry {
                 DirEntry::Dir(_) => {
@@ -682,12 +773,10 @@ impl TestRunner {
                 for (test_idx, test) in tests.into_iter().enumerate() {
                     let description = case.desc.clone();
 
-                    let test_file_name = file
-                        .path()
-                        .file_name()
-                        .expect("file from include_dir unexpectedly missing name")
-                        .to_string_lossy()
-                        .to_string();
+                    // Qualify with the corpus directory: bare file
+                    // names are ambiguous (e.g. TestValid.xml exists in
+                    // both general/ and misc/).
+                    let test_file_name = format!("{}/{}", corpus, file.path().display());
 
                     let test_id = TestId {
                         file_name: test_file_name.clone(),
@@ -718,8 +807,13 @@ impl TestRunner {
                             }
                         }
                         Err(e) => {
-                            debug!("skipping unsupported operation: {e}");
-                            continue;
+                            cases.push(TestCase {
+                                description,
+                                test_id,
+                                operation: Operation::Unsupported {
+                                    reason: e.to_string(),
+                                },
+                            });
                         }
                     }
                 }


### PR DESCRIPTION
Part 5 of 5 of the RelateNG port. Based on #1590. This PR switches the default relate engine to RelateNG, reworks PreparedGeometry on cached RelateNG prepared state, and deprecates the legacy relate graph API.

Commits:
- Switch Relate::relate to the RelateNG engine
- Rework PreparedGeometry on cached RelateNG prepared state
- Wire Contains/Covers/ContainsProperly through short-circuiting RelateNG predicates; add benches
- Deprecate legacy relate graph API; add CHANGES entries and bench results
- Restore envelope-disjoint relate performance via envelope fast paths
- Use union semantics for GeometryCollection point containment
- Enable robust and GC XML corpora; make jts-test-runner parsing per-case lenient

Stack: #1587 → #1588 → #1589 → #1590 → #1591
