### PR TITLE
Remove redundant references in format arguments

### DIFF
--- a/geo/src/algorithm/relate/geomgraph/edge_end.rs
+++ b/geo/src/algorithm/relate/geomgraph/edge_end.rs
@@ -40,7 +40,7 @@ impl<F: GeoFloat> fmt::Debug for EdgeEndKey<F> {
         f.debug_struct("EdgeEndKey")
             .field(
                 "coords",
-                &format!("{:?} -> {:?}", &self.coord_0, &self.coord_1),
+                &format!("{:?} -> {:?}", self.coord_0, self.coord_1),
             )
             .field("quadrant", &self.quadrant)
             .finish()

--- a/geo/src/algorithm/relate/geomgraph/intersection_matrix.rs
+++ b/geo/src/algorithm/relate/geomgraph/intersection_matrix.rs
@@ -258,7 +258,7 @@ impl std::fmt::Debug for IntersectionMatrix {
             .collect::<Vec<&str>>()
             .join("");
 
-        write!(f, "IntersectionMatrix({})", &text)
+        write!(f, "IntersectionMatrix({text})")
     }
 }
 

--- a/geo/src/algorithm/relate/geomgraph/label.rs
+++ b/geo/src/algorithm/relate/geomgraph/label.rs
@@ -23,7 +23,7 @@ impl fmt::Debug for Label {
         write!(
             f,
             "Label {{ A: {:?}, B: {:?} }}",
-            &self.geometry_topologies[0], &self.geometry_topologies[1]
+            self.geometry_topologies[0], self.geometry_topologies[1]
         )
     }
 }

--- a/geo/src/algorithm/relate/relate_operation.rs
+++ b/geo/src/algorithm/relate/relate_operation.rs
@@ -133,7 +133,7 @@ where
 
         debug!(
             "before update_intersection_matrix: {:?}",
-            &intersection_matrix
+            intersection_matrix
         );
         Self::update_intersection_matrix(
             &isolated_edge_labels,

--- a/jts-test-runner/src/runner.rs
+++ b/jts-test-runner/src/runner.rs
@@ -670,13 +670,13 @@ impl TestRunner {
             for (case_idx, mut case) in run.cases.into_iter().enumerate() {
                 if let Some(desc_filter) = &self.desc_filter {
                     if case.desc.as_str().contains(desc_filter) {
-                        debug!("filter matched case: {}", &case.desc);
+                        debug!("filter matched case: {}", case.desc);
                     } else {
-                        debug!("filter skipped case: {}", &case.desc);
+                        debug!("filter skipped case: {}", case.desc);
                         continue;
                     }
                 } else {
-                    debug!("parsing case {}:", &case.desc);
+                    debug!("parsing case {}:", case.desc);
                 }
                 let tests = std::mem::take(&mut case.tests);
                 for (test_idx, test) in tests.into_iter().enumerate() {


### PR DESCRIPTION
Format macros take their arguments by reference, so the explicit & is redundant. Clippy 1.97 (when we switch to it) flags these sites via useless_borrows_in_formatting, warn-by-default; fixing them now keeps the lint job green when CI's clippy catches up.

Done using Fable 5.

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
