### PR TITLE
RelateNG port 6: cache prepared point-locator state

### DIFF
--- a/geo-benches/src/prepared_geometry.rs
+++ b/geo-benches/src/prepared_geometry.rs
@@ -1,7 +1,28 @@
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use geo::PreparedGeometry;
 use geo::algorithm::Relate;
-use geo_types::MultiPolygon;
+use geo_types::{Coord, LineString, MultiLineString, MultiPolygon, Point, Rect};
+
+/// `members` short line strings of `points` coordinates each, laid out on
+/// a grid: a linear geometry whose prepared point-locator state (per-line
+/// envelopes, boundary points) is large relative to one evaluation.
+fn grid_multi_line_string(members: usize, points: usize) -> MultiLineString<f64> {
+    let side = (members as f64).sqrt().ceil() as usize;
+    let lines = (0..members)
+        .map(|i| {
+            let (gx, gy) = ((i % side) as f64 * 10.0, (i / side) as f64 * 10.0);
+            LineString::from(
+                (0..points)
+                    .map(|k| Coord {
+                        x: gx + k as f64 * (8.0 / points as f64),
+                        y: gy + (k % 2) as f64,
+                    })
+                    .collect::<Vec<_>>(),
+            )
+        })
+        .collect();
+    MultiLineString::new(lines)
+}
 
 fn criterion_benchmark(c: &mut Criterion) {
     let plot_polygons: MultiPolygon = geo_test_fixtures::nl_plots_wgs84();
@@ -71,6 +92,28 @@ fn criterion_benchmark(c: &mut Criterion) {
             assert_eq!(non_intersects, 27782);
         });
     });
+
+    // A linear A geometry: the point-locator state is rebuilt per call
+    // unless prepared.
+    let mls = grid_multi_line_string(1_000, 10);
+    let prepared_mls = PreparedGeometry::from(&mls);
+    let point = Point::new(4.0, 5.0);
+    let polygon = Rect::new(Coord { x: 3.0, y: 4.0 }, Coord { x: 5.0, y: 6.0 }).to_polygon();
+    c.bench_function("relate prepared multilinestring with point", |bencher| {
+        bencher.iter(|| black_box(prepared_mls.relate(&point).is_intersects()));
+    });
+    c.bench_function("relate unprepared multilinestring with point", |bencher| {
+        bencher.iter(|| black_box(mls.relate(&point).is_intersects()));
+    });
+    c.bench_function("relate prepared multilinestring with polygon", |bencher| {
+        bencher.iter(|| black_box(prepared_mls.relate(&polygon).is_intersects()));
+    });
+    c.bench_function(
+        "relate unprepared multilinestring with polygon",
+        |bencher| {
+            bencher.iter(|| black_box(mls.relate(&polygon).is_intersects()));
+        },
+    );
 
     let mut slow_group = c.benchmark_group("unprepared polygons");
     slow_group.sample_size(10);

--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -10,6 +10,7 @@
   - <https://github.com/georust/geo/issues/1585>
   - BREAKING: the `Relate` trait gains a required `geometry_cow` method (the trait is not practically implementable outside geo, since `GeometryGraph` has no public constructor).
   - DEPRECATED: `Relate::geometry_graph` and the `geo::relate::GeometryGraph` re-export; the graph-based engine is no longer used by `relate` and will be removed in a future release.
+  - `PreparedGeometry` also reuses the per-line envelopes, linear boundary points and adjacent-edge locator of linear and mixed geometries, so a repeated `relate` against a prepared linear geometry costs a walk of its elements rather than of its coordinates.
 - `line_intersection::line_intersection` now computes intersection points with double-double extended-precision arithmetic, matching current JTS (`CGAlgorithmsDD.intersection`). Computed points can differ from previous releases by roughly one ULP; the new values match JTS exactly.
   - <https://github.com/locationtech/jts/pull/989>
 - `Contains<Point>` / `Contains<Coord>` for `GeometryCollection` and `MultiLineString` now use the union semantics of the collection, consistent with `relate` and JTS: a point on the shared boundary of two adjacent polygon elements, or an endpoint shared by two line elements, lies in the interior of their union and is contained. Previously the check was member-wise and reported such points as not contained.

--- a/geo/src/algorithm/indexed/prepared_geometry.rs
+++ b/geo/src/algorithm/indexed/prepared_geometry.rs
@@ -11,11 +11,12 @@ use std::fmt::{Debug, Formatter};
 use crate::dimensions::Dimensions;
 use rstar::RTreeNum;
 
-/// A `PreparedGeometry` caches the spatial indexes that topological
-/// comparisons use: a segment [R-tree](https://en.wikipedia.org/wiki/R-tree),
-/// per-polygon point-in-area locators, and the set of unique points.
-/// The indexes are built on the first comparison that needs them and are
-/// reused by later comparisons, so a `PreparedGeometry` can be more
+/// A `PreparedGeometry` caches the spatial indexes and derived state that
+/// topological comparisons use: a segment
+/// [R-tree](https://en.wikipedia.org/wiki/R-tree), per-polygon
+/// point-in-area locators, per-line envelopes and boundary points, and the
+/// set of unique points. They are built on the first comparison that needs
+/// them and are reused by later comparisons, so a `PreparedGeometry` can be more
 /// efficient than a plain `Geometry` when it is compared many times.
 ///
 /// ```
@@ -43,8 +44,7 @@ where
     /// `Relate::geometry_graph`.
     geometry_graph: OnceCell<GeometryGraph<'a, F>>,
     /// The RelateNG caches reused across `relate` calls: the geometry
-    /// metadata, segment index, per-element area locators, and unique
-    /// points.
+    /// metadata, segment index, point-locator state, and unique points.
     relate_state: PreparedRelateState<F>,
 }
 

--- a/geo/src/algorithm/relate/relateng/linear_boundary.rs
+++ b/geo/src/algorithm/relate/relateng/linear_boundary.rs
@@ -16,6 +16,7 @@ fn is_in_boundary_mod2(degree: usize) -> bool {
     degree % 2 == 1
 }
 
+#[derive(Clone)]
 pub(crate) struct LinearBoundary<F: GeoFloat> {
     vertex_degree: BTreeMap<NodeKey<F>, usize>,
     has_boundary: bool,

--- a/geo/src/algorithm/relate/relateng/relate_ng.rs
+++ b/geo/src/algorithm/relate/relateng/relate_ng.rs
@@ -28,7 +28,7 @@ use super::edge_segment_intersector::{
 };
 use super::im_predicate::RelateMatrixPredicate;
 use super::relate_geometry::{GeometryMeta, RelateGeometry};
-use super::relate_point_locator::{Mode, Polygonal};
+use super::relate_point_locator::{Mode, Polygonal, PreparedLocatorCache};
 use super::topology_computer::TopologyComputer;
 use super::topology_predicate::{
     InputIndex, TopologyPredicate, envelope_covers, envelopes_intersect,
@@ -61,8 +61,8 @@ pub(crate) fn eval<F: GeoFloat>(
 pub(crate) struct PreparedRelateState<F: GeoFloat> {
     /// The A-side segment index, built over all A edges on first use.
     edge_mutual_int: OnceCell<MutualSegmentSetIntersector<F>>,
-    /// The per-polygonal-element area locators of A.
-    area_locators: super::relate_point_locator::SharedAreaLocators<F>,
+    /// The point-locator state of A that costs a coordinate walk.
+    locator_cache: PreparedLocatorCache<F>,
     /// The unique points of A (for the P/P fast path).
     unique_points:
         OnceCell<std::collections::BTreeSet<crate::relate::geomgraph::node_map::NodeKey<F>>>,
@@ -74,7 +74,7 @@ impl<F: GeoFloat> Default for PreparedRelateState<F> {
     fn default() -> Self {
         Self {
             edge_mutual_int: OnceCell::new(),
-            area_locators: OnceCell::new(),
+            locator_cache: PreparedLocatorCache::default(),
             unique_points: OnceCell::new(),
             meta: OnceCell::new(),
         }
@@ -113,7 +113,7 @@ impl<'a, F: GeoFloat> RelateNG<'a, F> {
         Self {
             geom_a: RelateGeometry::with_meta(
                 a,
-                Mode::Prepared(&state.area_locators),
+                Mode::Prepared(&state.locator_cache),
                 *state.meta(a),
             ),
             state,

--- a/geo/src/algorithm/relate/relateng/relate_point_locator.rs
+++ b/geo/src/algorithm/relate/relateng/relate_point_locator.rs
@@ -175,21 +175,22 @@ impl<'a, F: GeoFloat> GeometryElements<'a, F> {
         self.points.insert(NodeKey(p));
     }
 
+    // Envelopes are filled in by the locator, which may take them from
+    // the prepared cache instead of walking the coordinates.
     fn add_line(&mut self, line: &'a LineString<F>) {
         if line.0.is_empty() {
             return;
         }
         self.lines.push(LineElement {
-            env: line.bounding_rect(),
             line: Cow::Borrowed(line),
+            env: None,
         });
     }
 
     fn add_line_segment(&mut self, start: Coord<F>, end: Coord<F>) {
-        let line = LineString::new(vec![start, end]);
         self.lines.push(LineElement {
-            env: line.bounding_rect(),
-            line: Cow::Owned(line),
+            line: Cow::Owned(LineString::new(vec![start, end])),
+            env: None,
         });
     }
 
@@ -222,11 +223,36 @@ impl<'a, F: GeoFloat> GeometryElements<'a, F> {
     }
 }
 
-/// A cache of the per-polygonal-element area indexes of a geometry, owned
-/// by prepared state and shared across evaluations. The outer cell is
-/// initialised on first use to one cell per polygonal element, in document
-/// order.
-pub(crate) type SharedAreaLocators<F> = OnceCell<Vec<OnceCell<IntervalTreeMultiPolygon<F>>>>;
+/// The parts of a point locator that cost a walk of the geometry's
+/// coordinates, owned by prepared state and reused by every locator
+/// constructed over the same geometry. Each part is built on first use.
+/// Per-element entries are in document order, so they line up with the
+/// elements a locator extracts from the same geometry.
+///
+/// The locator itself borrows the geometry and so cannot be stored next
+/// to it in a prepared geometry; with this cache a per-evaluation locator
+/// costs a walk of the elements rather than of the coordinates.
+pub(crate) struct PreparedLocatorCache<F: GeoFloat> {
+    /// The envelope of each linear element.
+    line_envelopes: OnceCell<Vec<Option<Rect<F>>>>,
+    /// The boundary points of the linear elements; `None` when there are
+    /// no linear elements.
+    line_boundary: OnceCell<Option<LinearBoundary<F>>>,
+    /// One area index cell per polygonal element.
+    area_locators: OnceCell<Vec<OnceCell<IntervalTreeMultiPolygon<F>>>>,
+    adj_edge_locator: OnceCell<AdjacentEdgeLocator<F>>,
+}
+
+impl<F: GeoFloat> Default for PreparedLocatorCache<F> {
+    fn default() -> Self {
+        Self {
+            line_envelopes: OnceCell::new(),
+            line_boundary: OnceCell::new(),
+            area_locators: OnceCell::new(),
+            adj_edge_locator: OnceCell::new(),
+        }
+    }
+}
 
 /// How an input geometry is evaluated.
 #[derive(Clone, Copy)]
@@ -235,9 +261,9 @@ pub(crate) enum Mode<'a, F: GeoFloat> {
     /// the edge index is filtered to the opposing envelope.
     Simple,
     /// Repeated evaluations against the same geometry: point-in-area
-    /// location is indexed, with the per-element indexes stored in state
-    /// that outlives the evaluation.
-    Prepared(&'a SharedAreaLocators<F>),
+    /// location is indexed, and the locator state that costs a coordinate
+    /// walk is taken from a cache that outlives the evaluation.
+    Prepared(&'a PreparedLocatorCache<F>),
 }
 
 impl<F: GeoFloat> Mode<'_, F> {
@@ -249,43 +275,56 @@ impl<F: GeoFloat> Mode<'_, F> {
 pub(crate) struct RelatePointLocator<'a, F: GeoFloat> {
     is_empty: bool,
     elements: GeometryElements<'a, F>,
-    line_boundary: Option<LinearBoundary<F>>,
+    /// Owned in simple mode, borrowed from the cache in prepared mode.
+    line_boundary: Cow<'a, Option<LinearBoundary<F>>>,
     /// Prepared mode: the lazily built index per polygonal element.
     poly_locators: Option<&'a [OnceCell<IntervalTreeMultiPolygon<F>>]>,
-    adj_edge_locator: OnceCell<AdjacentEdgeLocator<F>>,
+    /// Prepared mode: the cached adjacent-edge locator cell.
+    shared_adj_edge_locator: Option<&'a OnceCell<AdjacentEdgeLocator<F>>>,
+    /// Simple mode: the adjacent-edge locator cell.
+    own_adj_edge_locator: OnceCell<AdjacentEdgeLocator<F>>,
 }
 
 impl<'a, F: GeoFloat> RelatePointLocator<'a, F> {
-    /// In prepared mode the shared area locators must belong to the same
-    /// geometry.
+    /// In prepared mode the cache must belong to the same geometry.
     pub fn new(geom: &'a GeometryCow<'a, F>, mode: Mode<'a, F>) -> Self {
-        let elements = GeometryElements::extract(geom);
+        let mut elements = GeometryElements::extract(geom);
         let is_empty = elements.is_empty();
-        let line_boundary = if elements.lines.is_empty() {
-            None
-        } else {
-            Some(LinearBoundary::new(
-                elements.lines.iter().map(|l| l.line.as_ref()),
-            ))
-        };
-        let poly_locators = match mode {
-            Mode::Simple => None,
-            Mode::Prepared(shared) => Some(
-                shared
-                    .get_or_init(|| {
-                        (0..elements.polygonals.len())
-                            .map(|_| OnceCell::new())
-                            .collect()
-                    })
-                    .as_slice(),
-            ),
+        let lines = &mut elements.lines;
+        let (line_boundary, poly_locators, shared_adj_edge_locator) = match mode {
+            Mode::Simple => {
+                for elem in lines.iter_mut() {
+                    elem.env = elem.line.bounding_rect();
+                }
+                (Cow::Owned(line_boundary(lines)), None, None)
+            }
+            Mode::Prepared(cache) => {
+                let envs = cache
+                    .line_envelopes
+                    .get_or_init(|| lines.iter().map(|l| l.line.bounding_rect()).collect());
+                for (elem, env) in lines.iter_mut().zip(envs) {
+                    elem.env = *env;
+                }
+                let boundary = cache.line_boundary.get_or_init(|| line_boundary(lines));
+                let cells = cache.area_locators.get_or_init(|| {
+                    (0..elements.polygonals.len())
+                        .map(|_| OnceCell::new())
+                        .collect()
+                });
+                (
+                    Cow::Borrowed(boundary),
+                    Some(cells.as_slice()),
+                    Some(&cache.adj_edge_locator),
+                )
+            }
         };
         Self {
             is_empty,
             elements,
             line_boundary,
             poly_locators,
-            adj_edge_locator: OnceCell::new(),
+            shared_adj_edge_locator,
+            own_adj_edge_locator: OnceCell::new(),
         }
     }
 
@@ -297,11 +336,13 @@ impl<'a, F: GeoFloat> RelatePointLocator<'a, F> {
         self.elements.polygonals()
     }
 
+    fn line_boundary(&self) -> Option<&LinearBoundary<F>> {
+        Option::as_ref(&self.line_boundary)
+    }
+
     /// Whether the linear components have any boundary points.
     pub fn has_boundary(&self) -> bool {
-        self.line_boundary
-            .as_ref()
-            .is_some_and(|lb| lb.has_boundary())
+        self.line_boundary().is_some_and(|lb| lb.has_boundary())
     }
 
     pub fn locate(&self, p: Coord<F>) -> CoordPos {
@@ -321,10 +362,7 @@ impl<'a, F: GeoFloat> RelatePointLocator<'a, F> {
             }
         }
         // Not in an area, so return the line end location.
-        let is_boundary = self
-            .line_boundary
-            .as_ref()
-            .is_some_and(|lb| lb.is_boundary(p));
+        let is_boundary = self.line_boundary().is_some_and(|lb| lb.is_boundary(p));
         if is_boundary {
             DimensionLocation::LineBoundary
         } else {
@@ -404,11 +442,7 @@ impl<'a, F: GeoFloat> RelatePointLocator<'a, F> {
     }
 
     fn locate_on_lines(&self, p: Coord<F>, is_node: bool) -> CoordPos {
-        if self
-            .line_boundary
-            .as_ref()
-            .is_some_and(|lb| lb.is_boundary(p))
-        {
+        if self.line_boundary().is_some_and(|lb| lb.is_boundary(p)) {
             return CoordPos::OnBoundary;
         }
         // A node must be on a line, in the interior.
@@ -462,7 +496,8 @@ impl<'a, F: GeoFloat> RelatePointLocator<'a, F> {
             // The point lies on more than one polygon boundary: determine
             // the effective location from the adjacent edges.
             let adj_locator = self
-                .adj_edge_locator
+                .shared_adj_edge_locator
+                .unwrap_or(&self.own_adj_edge_locator)
                 .get_or_init(|| AdjacentEdgeLocator::new(&self.elements.polygonals));
             adj_locator.locate(p)
         } else {
@@ -487,6 +522,15 @@ impl<'a, F: GeoFloat> RelatePointLocator<'a, F> {
                 .containment_parity(p),
             None => polygonal.coordinate_position(p),
         }
+    }
+}
+
+/// The boundary of the linear elements; `None` when there are none.
+fn line_boundary<F: GeoFloat>(lines: &[LineElement<'_, F>]) -> Option<LinearBoundary<F>> {
+    if lines.is_empty() {
+        None
+    } else {
+        Some(LinearBoundary::new(lines.iter().map(|l| l.line.as_ref())))
     }
 }
 
@@ -521,10 +565,13 @@ mod tests {
         let locator = RelatePointLocator::new(&cow, Mode::Simple);
         assert_eq!(locator.locate_with_dim(Coord { x, y }), expected);
         // Not in JTS: the prepared (indexed) mode must agree with the
-        // simple mode.
-        let shared = SharedAreaLocators::default();
-        let prepared = RelatePointLocator::new(&cow, Mode::Prepared(&shared));
+        // simple mode, both when the cache is empty and when a second
+        // locator reuses the cache filled by the first.
+        let cache = PreparedLocatorCache::default();
+        let prepared = RelatePointLocator::new(&cow, Mode::Prepared(&cache));
         assert_eq!(prepared.locate_with_dim(Coord { x, y }), expected);
+        let reused = RelatePointLocator::new(&cow, Mode::Prepared(&cache));
+        assert_eq!(reused.locate_with_dim(Coord { x, y }), expected);
     }
 
     fn check_line_end_dim_location(


### PR DESCRIPTION
Part 6 of the RelateNG port. Based on #1591. A `RelatePointLocator` borrows the geometry, so a `PreparedGeometry` cannot store one; this PR moves the locator state that costs a walk of the coordinates (per-line envelopes, the `LinearBoundary`, the area index cells and the `AdjacentEdgeLocator`) into a `PreparedLocatorCache` in the prepared state, built on first use. A per-evaluation locator then costs a walk of the elements only.

For a 1000-member MultiLineString: locator construction 250 µs → 3 µs; full-matrix relate against a point 268 µs → 119 µs (the remainder is the line-end phase, which is O(elements)); a short-circuiting predicate 4 µs. Adds a bench for this shape to `geo-benches`.

Commits:
- Cache prepared point-locator state across relate evaluations

Stack: #1587 → #1588 → #1589 → #1590 → #1591 → #1598 → #1599