### PR TITLE
Add explicit tolerances to geodesic tests

### DIFF
--- a/geo/src/algorithm/line_measures/metric_spaces/geodesic.rs
+++ b/geo/src/algorithm/line_measures/metric_spaces/geodesic.rs
@@ -511,7 +511,11 @@ mod tests {
                 assert_eq!(route.len(), 13);
                 assert_eq!(route[0], start);
                 assert_eq!(route.last().unwrap(), &end);
-                assert_relative_eq!(route[1], Point::new(17.878754355562464, 24.466667836189565));
+                assert_relative_eq!(
+                    route[1],
+                    Point::new(17.878754355562464, 24.466667836189565),
+                    epsilon = 1e-9
+                );
             }
 
             #[test]
@@ -523,7 +527,11 @@ mod tests {
                     .points_along_line(start, end, max_dist, false)
                     .collect::<Vec<_>>();
                 assert_eq!(route.len(), 11);
-                assert_relative_eq!(route[0], Point::new(17.878754355562464, 24.466667836189565));
+                assert_relative_eq!(
+                    route[0],
+                    Point::new(17.878754355562464, 24.466667836189565),
+                    epsilon = 1e-9
+                );
             }
         }
     }
@@ -539,6 +547,10 @@ mod tests {
         let mars_flattening = 0.00589;
         let mars_geoid = GeodesicMeasure::new(mars_equatorial_radius, mars_flattening);
 
-        assert_relative_eq!(70684.36315529353, mars_geoid.distance(start, finish));
+        assert_relative_eq!(
+            70684.36315529353,
+            mars_geoid.distance(start, finish),
+            epsilon = 1e-9
+        );
     }
 }


### PR DESCRIPTION
Three assertions in the geodesic tests used the default tolerance of `assert_relative_eq!`. The expected values were computed on glibc 2.31, and on glibc 2.36 (the default in bookworm) the libm results differ by a few ULP.

This surfaced in georust/docker-images#56, which moves the CI images from Debian bullseye (glibc 2.31) to bookworm (glibc 2.36).

Done in conjunction with Fable.

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---
