### PR TITLE
Fix sweep line assertion failure across the signed-zero boundary

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- FIX: the sweep line no longer trips its `intervals_overlap` debug assertion when a segment's maximum `x` is `-0.0` and another segment begins at `+0.0`. This panicked `interior_point()` (and other sweep-based algorithms) in debug builds on polygons that `Validation::is_valid()` accepts.
+  - <https://github.com/georust/geo/issues/1578>
 - BREAKING: `GeoNum` (and therefore `GeoFloat`) now requires `Send + Sync`. This lets algorithms behind the `multithreading` feature share coordinates across threads without per-algorithm bounds. All supported primitive scalar types already satisfy the bound; only downstream `GeoNum` implementations on non-thread-safe types are affected.
 
 - Add `Intersects<Coord>` and `Intersects<Point>` implementations for `IntervalTreeMultiPolygon`. Unlike the existing `Contains` impls, these return `true` for points on the polygon's boundary.

--- a/geo/src/algorithm/interior_point.rs
+++ b/geo/src/algorithm/interior_point.rs
@@ -929,4 +929,38 @@ mod test {
         );
         let _ = poly.interior_point();
     }
+
+    #[test]
+    fn polygon_with_negative_zero_coordinate_does_not_panic() {
+        // Regression for https://github.com/georust/geo/issues/1578: an edge whose
+        // maximum `x` is `-0.0` tripped the sweep line's `intervals_overlap` assertion,
+        // even though `-0.0` and `+0.0` are the same position.
+        let poly = Polygon::new(
+            LineString::from(vec![
+                (-5.0, 0.0),
+                (-0.0, 5.0),
+                (0.0, 10.0),
+                (5.0, 0.0),
+                (-5.0, 0.0),
+            ]),
+            vec![],
+        );
+
+        let interior_point = poly.interior_point().unwrap();
+        assert!(poly.contains(&interior_point));
+
+        // Replacing `-0.0` with `+0.0` describes the very same polygon, so it must
+        // produce the very same interior point.
+        let positive_zero = Polygon::new(
+            LineString::from(vec![
+                (-5.0, 0.0),
+                (0.0, 5.0),
+                (0.0, 10.0),
+                (5.0, 0.0),
+                (-5.0, 0.0),
+            ]),
+            vec![],
+        );
+        assert_eq!(interior_point, positive_zero.interior_point().unwrap());
+    }
 }

--- a/geo/src/algorithm/sweep/mod.rs
+++ b/geo/src/algorithm/sweep/mod.rs
@@ -272,9 +272,15 @@ impl<C: Cross> SweepLineIndex<C> {
 /// Helper function to check if two intervals overlap on the `x`-axis
 ///
 /// This determines which segments might geometrically intersect during the sweep.
-/// We use `total_cmp` for robust floating-point comparisons to handle edge cases
-/// involving very close values.
+///
+/// The comparisons here are the IEEE operators rather than [`total_cmp`], because they
+/// are asking about *position*: `-0.0` and `+0.0` denote the same point on the `x`-axis,
+/// and a segment ending at `-0.0` does overlap one beginning at `+0.0`. `total_cmp` is
+/// used where a *total order* is genuinely required — sorting the intervals, and picking
+/// each segment's endpoints in [`SweepLineIndex::new`] — and signed zero is the only case
+/// where finite values make the two disagree.
+///
+/// [`total_cmp`]: f64::total_cmp
 fn intervals_overlap<C: Cross>(s0: &SweepLineInterval<C>, s1: &SweepLineInterval<C>) -> bool {
-    s0.inserted_x.total_cmp(&s1.inserted_x).is_le()
-        && s0.deleted_x.total_cmp(&s1.inserted_x).is_ge()
+    s0.inserted_x <= s1.inserted_x && s0.deleted_x >= s1.inserted_x
 }

--- a/geo/src/algorithm/sweep/tests.rs
+++ b/geo/src/algorithm/sweep/tests.rs
@@ -165,6 +165,27 @@ fn sweep_line_interval_ordering_holds_for_signed_zero() {
     }
 }
 
+/// A segment whose maximum `x` is `-0.0` must still be swept against a segment
+/// starting at `+0.0`: the two coordinates denote the same position.
+///
+/// See <https://github.com/georust/geo/issues/1578>.
+#[test]
+fn sweep_spans_signed_zero_boundary() {
+    // The first segment is deleted at `-0.0`, the second inserted at `+0.0`.
+    let segments = vec![
+        Line::from([(-1.0, 0.0), (-0.0, 0.0)]),
+        Line::from([(0.0, 0.0), (1.0, 0.0)]),
+    ];
+    verify_intersections(&segments);
+
+    // Same shape, but the shared endpoint is a genuine crossing rather than a touch.
+    let segments = vec![
+        Line::from([(-1.0, -1.0), (-0.0, 1.0)]),
+        Line::from([(0.0, -1.0), (1.0, 1.0)]),
+    ];
+    verify_intersections(&segments);
+}
+
 #[test]
 fn test_iterator_behavior() {
     let input = vec![


### PR DESCRIPTION
Closes #1578.

`Intersections` guards its inner loop with the IEEE comparison `overlapping_interval.inserted_x > current_interval.deleted_x`, but `intervals_overlap` — asserted immediately afterwards — compared the same values with `total_cmp`. Signed zero is the one place where finite values make those two orderings disagree: `(-0.0).total_cmp(&0.0)` is `Less`, while IEEE treats them as equal.

A segment whose maximum x is `-0.0`, followed by a segment inserted at `+0.0`, therefore passes the guard and then fails the assertion, even though the two coordinates denote the same position. `interior_point()` panics in debug builds on a polygon that `Validation::is_valid()` accepts:

    POLYGON((-5 0, -0 5, 0 10, 5 0, -5 0))

This is the case @urschrei identified in #1578 as still reachable after #1554; the original reporter's polygon now passes.

`intervals_overlap` now uses the IEEE operators, matching the guard. `total_cmp` is kept where a total order is actually required — sorting the intervals, and choosing each segment's endpoints in `SweepLineIndex::new`. Tightening the guard instead would be wrong: it would make genuine intersections be missed in release builds, where the assertion is compiled out. The doc comment on `intervals_overlap` is rewritten, since its claim about handling "very close values" did not describe what the function did.

Both new tests go through the existing `verify_intersections` brute-force comparison, so they check that the sweep finds the right intersections, not merely that it does not panic.

Two things worth stating plainly: this is a debug-mode panic rather than a silent wrong answer — release mode falls through to the full `line_intersection` check and stays correct. And the fixed assertion is now close to tautological given the guard; its remaining value is catching a future regression in the sort order.

An LLM agent was used for this change: it ran a property-test battery over the predicate and `relate` invariants to locate the defect, reproduced it, wrote the fix and the two regression tests, and drafted this description. The change has been reviewed and I am accountable for it.

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
