### PR TITLE
Add Hegel tests for geo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/Cargo.lock
 .idea
 .dir-locals.el
+.hegel/

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -48,7 +48,7 @@ rand_pcg = "0.10.1"
 [dev-dependencies]
 approx = ">= 0.4.0, < 0.6.0"
 geo-test-fixtures = { path = "../geo-test-fixtures" }
-hegeltest = "0.35.0"
+hegel = { package = "hegeltest", version = "0.35.0" }
 jts-test-runner = { path = "../jts-test-runner" }
 pretty_env_logger = "0.4"
 wkt = "0.14.0"

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -48,6 +48,7 @@ rand_pcg = "0.10.1"
 [dev-dependencies]
 approx = ">= 0.4.0, < 0.6.0"
 geo-test-fixtures = { path = "../geo-test-fixtures" }
+hegeltest = "0.35.0"
 jts-test-runner = { path = "../jts-test-runner" }
 pretty_env_logger = "0.4"
 wkt = "0.14.0"

--- a/geo/src/algorithm/affine_ops.rs
+++ b/geo/src/algorithm/affine_ops.rs
@@ -643,3 +643,236 @@ mod tests {
         assert_eq!(point.affine_transform(&composed), Point::new(8., 0.));
     }
 }
+
+#[cfg(test)]
+mod hegel_props {
+    use super::{AffineOps, AffineTransform};
+    use crate::utils::pbt_gens::{coords, geometries, star_polygons};
+    use crate::{Coord, MapCoords};
+    use hegel::generators::{self, Generator, PrintableGenerator};
+
+    /// Transforms built from the four documented constructors and their
+    /// `compose`-based mutators. Generating transforms this way rather than
+    /// from six arbitrary matrix entries keeps them in the range of shapes
+    /// callers actually build, and keeps `det` well away from zero for the
+    /// inverse property.
+    fn transforms() -> impl PrintableGenerator<AffineTransform<f64>> {
+        hegel::compose!(|tc| {
+            let mut transform = AffineTransform::identity();
+            let steps = tc.draw_silent(generators::integers::<usize>().max_value(4));
+            for _ in 0..steps {
+                let origin = tc.draw_silent(coords(1e3));
+                let factor = || {
+                    tc.draw_silent(hegel::one_of!(
+                        generators::floats::<f64>().min_value(0.25).max_value(4.0),
+                        generators::floats::<f64>().min_value(-4.0).max_value(-0.25),
+                    ))
+                };
+                transform = match tc.draw_silent(generators::integers::<u8>().max_value(3)) {
+                    0 => {
+                        let offset = tc.draw_silent(coords(1e3));
+                        transform.translated(offset.x, offset.y)
+                    }
+                    1 => transform.scaled(factor(), factor(), origin),
+                    2 => transform.rotated(
+                        tc.draw_silent(
+                            generators::floats::<f64>()
+                                .min_value(-360.0)
+                                .max_value(360.0),
+                        ),
+                        origin,
+                    ),
+                    _ => transform.skewed(
+                        tc.draw_silent(
+                            generators::floats::<f64>().min_value(-45.0).max_value(45.0),
+                        ),
+                        tc.draw_silent(
+                            generators::floats::<f64>().min_value(-45.0).max_value(45.0),
+                        ),
+                        origin,
+                    ),
+                };
+            }
+            transform
+        })
+        .print_as_debug()
+    }
+
+    fn assert_coords_close(actual: Coord<f64>, expected: Coord<f64>, scale: f64) {
+        let tolerance = 1e-9 * scale;
+        assert!(
+            (actual.x - expected.x).abs() <= tolerance
+                && (actual.y - expected.y).abs() <= tolerance,
+            "{actual:?} differs from {expected:?} by more than {tolerance}"
+        );
+    }
+
+    // `compose` is documented as cumulative — "the new transform is *added* to
+    // the existing transform" — and `test_compose` above pins the order:
+    // applying `a` then `b` equals applying `a.compose(&b)`.
+    #[hegel::test]
+    fn composing_transforms_matches_applying_them_in_turn(tc: hegel::TestCase) {
+        let (first, second) = (tc.draw(transforms()), tc.draw(transforms()));
+        let coord = tc.draw(coords(1e3));
+        let stepwise = second.apply(first.apply(coord));
+        let composed = first.compose(&second).apply(coord);
+        assert_coords_close(
+            composed,
+            stepwise,
+            stepwise.x.abs().max(stepwise.y.abs()).max(1.0),
+        );
+    }
+
+    // "Composing a transform with its inverse yields the identity matrix". The
+    // matrix entries are only equal up to rounding, so the check is that the
+    // round trip returns each coordinate rather than that the matrices match
+    // exactly.
+    #[hegel::test]
+    fn composing_a_transform_with_its_inverse_is_the_identity(tc: hegel::TestCase) {
+        let transform = tc.draw(transforms());
+        let coord = tc.draw(coords(1e3));
+        let inverse = transform
+            .inverse()
+            .expect("transforms built from these constructors have non-zero determinant");
+        // `inverse` only promises `None` for an exactly zero determinant, so a
+        // nearly singular transform round-trips with an error set by its
+        // condition number. The slack below scales with that; it protects the
+        // test's tolerance rather than granting the library room to be wrong.
+        let determinant = transform.a() * transform.e() - transform.b() * transform.d();
+        let norm = transform
+            .a()
+            .abs()
+            .max(transform.b().abs())
+            .max(transform.d().abs())
+            .max(transform.e().abs());
+        let condition = (norm * norm / determinant.abs()).max(1.0);
+        assert_coords_close(
+            transform.compose(&inverse).apply(coord),
+            coord,
+            coord.x.abs().max(coord.y.abs()).max(1.0) * condition,
+        );
+    }
+
+    #[hegel::test]
+    fn compose_many_folds_compose(tc: hegel::TestCase) {
+        let parts: Vec<AffineTransform<f64>> = tc.draw(generators::vecs(transforms()).max_size(4));
+        let folded = parts
+            .iter()
+            .fold(AffineTransform::identity(), |acc, next| acc.compose(next));
+        assert_eq!(AffineTransform::identity().compose_many(&parts), folded);
+    }
+
+    // The identity matrix leaves coordinates alone, and `Default` is documented
+    // as the identity.
+    #[hegel::test]
+    fn the_identity_transform_leaves_coords_untouched(tc: hegel::TestCase) {
+        let coord = tc.draw(coords(1e300));
+        assert_eq!(
+            AffineTransform::<f64>::default(),
+            AffineTransform::identity()
+        );
+        assert_eq!(AffineTransform::identity().apply(coord), coord);
+    }
+
+    // "The equations for transforming coordinates `(x, y) -> (x', y')` are
+    // given as follows: `x' = ax + by + xoff`, `y' = dx + ey + yoff`."
+    #[hegel::test]
+    fn apply_follows_the_documented_equations(tc: hegel::TestCase) {
+        let transform = tc.draw(transforms());
+        let coord = tc.draw(coords(1e3));
+        assert_eq!(
+            transform.apply(coord),
+            crate::coord! {
+                x: transform.a() * coord.x + transform.b() * coord.y + transform.xoff(),
+                y: transform.d() * coord.x + transform.e() * coord.y + transform.yoff(),
+            }
+        );
+    }
+
+    // The six accessors name the six values `new` takes, so rebuilding a
+    // transform from them must reproduce it.
+    #[hegel::test]
+    fn a_transform_rebuilds_from_its_accessors(tc: hegel::TestCase) {
+        let transform = tc.draw(transforms());
+        assert_eq!(
+            AffineTransform::new(
+                transform.a(),
+                transform.b(),
+                transform.xoff(),
+                transform.d(),
+                transform.e(),
+                transform.yoff(),
+            ),
+            transform
+        );
+    }
+
+    // The past-participle methods are documented to *add* a transform to the
+    // existing one, while the present-tense constructors create a fresh one:
+    // `t.scaled(..)` is therefore `t.compose(&scale(..))`.
+    #[hegel::test]
+    fn the_mutating_methods_compose_the_constructed_transform(tc: hegel::TestCase) {
+        let transform = tc.draw(transforms());
+        let origin = tc.draw(coords(1e3));
+        let offset = tc.draw(coords(1e3));
+        let degrees = tc.draw(
+            generators::floats::<f64>()
+                .min_value(-360.0)
+                .max_value(360.0),
+        );
+        assert_eq!(
+            transform.translated(offset.x, offset.y),
+            transform.compose(&AffineTransform::translate(offset.x, offset.y))
+        );
+        assert_eq!(
+            transform.scaled(2.0, 3.0, origin),
+            transform.compose(&AffineTransform::scale(2.0, 3.0, origin))
+        );
+        assert_eq!(
+            transform.rotated(degrees, origin),
+            transform.compose(&AffineTransform::rotate(degrees, origin))
+        );
+        assert_eq!(
+            transform.skewed(10.0, 20.0, origin),
+            transform.compose(&AffineTransform::skew(10.0, 20.0, origin))
+        );
+    }
+
+    // `affine_transform` applies the transform "immutably, outputting a new
+    // geometry", `affine_transform_mut` applies it in place; both are the same
+    // operation.
+    #[hegel::test]
+    fn the_mutable_and_immutable_forms_agree(tc: hegel::TestCase) {
+        let geometry = tc.draw(geometries(1e3));
+        let transform = tc.draw(transforms());
+        let mut in_place = geometry.clone();
+        in_place.affine_transform_mut(&transform);
+        assert_eq!(geometry.affine_transform(&transform), in_place);
+    }
+
+    // `AffineOps` is blanket-implemented through `map_coords` of
+    // `transform.apply`, so the two routes must produce identical geometries.
+    #[hegel::test]
+    fn affine_transform_maps_apply_over_the_coords(tc: hegel::TestCase) {
+        let polygon = tc.draw(star_polygons());
+        let transform = tc.draw(transforms());
+        assert_eq!(
+            polygon.affine_transform(&transform),
+            polygon.map_coords(|c| transform.apply(c))
+        );
+    }
+
+    // `rotate` fixes its origin: the matrix offsets are chosen so that the
+    // pivot maps to itself.
+    #[hegel::test]
+    fn rotation_fixes_its_origin(tc: hegel::TestCase) {
+        let origin = tc.draw(coords(1e3));
+        let degrees = tc.draw(
+            generators::floats::<f64>()
+                .min_value(-360.0)
+                .max_value(360.0),
+        );
+        let rotated = AffineTransform::rotate(degrees, origin).apply(origin);
+        assert_coords_close(rotated, origin, origin.x.abs().max(origin.y.abs()).max(1.0));
+    }
+}

--- a/geo/src/algorithm/affine_ops.rs
+++ b/geo/src/algorithm/affine_ops.rs
@@ -647,7 +647,7 @@ mod tests {
 #[cfg(test)]
 mod hegel_props {
     use super::{AffineOps, AffineTransform};
-    use crate::utils::pbt_gens::{coords, geometries, star_polygons};
+    use crate::utils::hegel_gens::{coords, geometries, star_polygons};
     use crate::{Coord, MapCoords};
     use hegel::generators::{self, Generator, PrintableGenerator};
 

--- a/geo/src/algorithm/area.rs
+++ b/geo/src/algorithm/area.rs
@@ -574,7 +574,9 @@ mod test {
 
 #[cfg(test)]
 mod hegel_props {
-    use crate::utils::pbt_gens::{coords, polygons_with_holes, star_polygons};
+    use crate::utils::hegel_gens::{
+        coords, disjoint_multi_polygons, polygons_with_holes, star_polygons,
+    };
     use crate::{Area, LineString, MapCoords, Polygon, Translate};
 
     // Planar area does not depend on where the origin is. `sum_line_determinants`
@@ -640,7 +642,7 @@ mod hegel_props {
     // the signed or unsigned areas of the individual polygons".
     #[hegel::test]
     fn multi_polygon_area_sums_its_members(tc: hegel::TestCase) {
-        let multi_polygon = tc.draw(crate::utils::pbt_gens::disjoint_multi_polygons());
+        let multi_polygon = tc.draw(disjoint_multi_polygons());
         let expected: f64 = multi_polygon.iter().map(|p| p.unsigned_area()).sum();
         assert_eq!(multi_polygon.unsigned_area(), expected);
     }

--- a/geo/src/algorithm/area.rs
+++ b/geo/src/algorithm/area.rs
@@ -571,3 +571,95 @@ mod test {
         );
     }
 }
+
+#[cfg(test)]
+mod hegel_props {
+    use crate::utils::pbt_gens::{coords, polygons_with_holes, star_polygons};
+    use crate::{Area, LineString, MapCoords, Polygon, Translate};
+
+    // Planar area does not depend on where the origin is. `sum_line_determinants`
+    // shifts each ring by its first coordinate for exactly this reason, and
+    // `area_polygon_numerical_stability` above pins one instance of it.
+    #[hegel::test]
+    fn signed_area_is_invariant_under_translation(tc: hegel::TestCase) {
+        let polygon = tc.draw(star_polygons());
+        let offset = tc.draw(coords(1e8));
+        let area = polygon.signed_area();
+        let translated = polygon.translate(offset.x, offset.y).signed_area();
+        // The shift moves each coordinate onto a coarser part of the f64 grid,
+        // so the determinant sum loses about `ulp(offset)` per vertex scaled by
+        // the polygon extent. This tolerance sizes that loss; it is not slack
+        // for a logic error, which would move the area by whole regions.
+        let tol =
+            1e-9 * area.abs() + 64.0 * f64::EPSILON * offset.x.abs().max(offset.y.abs()) * 2e3;
+        assert!(
+            (translated - area).abs() <= tol,
+            "area moved from {area} to {translated} under translation by {offset:?}"
+        );
+    }
+
+    // The `Area` doc example reverses a ring and shows `signed_area` going from
+    // 30. to -30. while `unsigned_area` stays 30.
+    #[hegel::test]
+    fn reversing_a_ring_negates_its_signed_area(tc: hegel::TestCase) {
+        let polygon = tc.draw(star_polygons());
+        let reversed = Polygon::new(
+            LineString::new(polygon.exterior().0.iter().rev().copied().collect()),
+            vec![],
+        );
+        // The two summations visit the same terms in opposite order, so they
+        // may round differently.
+        assert_relative_eq!(
+            reversed.signed_area(),
+            -polygon.signed_area(),
+            max_relative = 1e-9
+        );
+    }
+
+    #[hegel::test]
+    fn unsigned_area_is_the_magnitude_of_signed_area(tc: hegel::TestCase) {
+        let polygon = tc.draw(polygons_with_holes());
+        assert_eq!(polygon.unsigned_area(), polygon.signed_area().abs());
+    }
+
+    // A polygon's area is its exterior less its holes. The generator's holes are
+    // disjoint and strictly inside the exterior, so measuring each ring on its
+    // own gives an independent oracle; the sign convention comes from the note
+    // on the `Polygon` impl that "the sign of the output is the same as that of
+    // the exterior shell".
+    #[hegel::test]
+    fn polygon_area_is_its_exterior_less_its_holes(tc: hegel::TestCase) {
+        let polygon = tc.draw(polygons_with_holes());
+        let ring_area = |ring: &LineString<f64>| Polygon::new(ring.clone(), vec![]).unsigned_area();
+        let expected =
+            ring_area(polygon.exterior()) - polygon.interiors().iter().map(ring_area).sum::<f64>();
+        assert_relative_eq!(polygon.unsigned_area(), expected, max_relative = 1e-9);
+    }
+
+    // The `MultiPolygon` impl is documented as "a straight-forward summation of
+    // the signed or unsigned areas of the individual polygons".
+    #[hegel::test]
+    fn multi_polygon_area_sums_its_members(tc: hegel::TestCase) {
+        let multi_polygon = tc.draw(crate::utils::pbt_gens::disjoint_multi_polygons());
+        let expected: f64 = multi_polygon.iter().map(|p| p.unsigned_area()).sum();
+        assert_eq!(multi_polygon.unsigned_area(), expected);
+    }
+
+    // Area is quadratic in a uniform coordinate scaling: every determinant
+    // summed by `sum_line_determinants` picks up a factor of `factor^2`.
+    #[hegel::test]
+    fn scaling_coordinates_scales_area_by_the_square_of_the_factor(tc: hegel::TestCase) {
+        let polygon = tc.draw(star_polygons());
+        let factor = tc.draw(
+            hegel::generators::floats::<f64>()
+                .min_value(0.1)
+                .max_value(10.0),
+        );
+        let scaled = polygon.map_coords(|c| (c.x * factor, c.y * factor).into());
+        assert_relative_eq!(
+            scaled.unsigned_area(),
+            polygon.unsigned_area() * factor * factor,
+            max_relative = 1e-9
+        );
+    }
+}

--- a/geo/src/algorithm/bool_ops/tests.rs
+++ b/geo/src/algorithm/bool_ops/tests.rs
@@ -625,7 +625,7 @@ mod hegel_props {
 
     // Exterior rings of boolean-op output are counter-clockwise and interior
     // rings clockwise — the invariant `i_overlay_integration::test_winding_order`
-    // pins for georust/geo#1309.
+    // pins for #1309.
     #[hegel::test]
     fn union_output_rings_follow_the_standard_winding(tc: hegel::TestCase) {
         let a = tc.draw(star_polygons());

--- a/geo/src/algorithm/bool_ops/tests.rs
+++ b/geo/src/algorithm/bool_ops/tests.rs
@@ -483,3 +483,158 @@ mod ogc_compliance {
         );
     }
 }
+
+/// Hegel property tests for `BooleanOps`.
+///
+/// The trait describes its operations as "set operations on geometries
+/// considered as a subset of the 2-D plane", well-defined on valid geometries,
+/// so the set-algebra identities on areas must hold. Inputs are the star-shaped
+/// and hole-bearing polygons from `crate::utils::pbt_gens`, which
+/// `Validation` accepts.
+mod hegel_props {
+    use super::{BooleanOps, unary_union};
+    use crate::utils::pbt_gens::{monotone_line_strings, polygons_with_holes, star_polygons};
+    use crate::{Area, Euclidean, Length, MultiLineString, MultiPolygon, OpType, Polygon, Winding};
+
+    /// Every boolean operation snaps its inputs onto a discrete integer grid
+    /// scaled to their combined extent, so an area derived from op output
+    /// carries an error whose magnitude is relative to the magnitude of the
+    /// input — this is the error model spelled out in the comment inside
+    /// `test_unary_union_errors` above, which compares at `max_relative = 1e-5`
+    /// after offsetting by the input area. These properties reuse it. A logic
+    /// error moves areas by whole regions, far outside this band.
+    fn assert_area_eq(actual: f64, expected: f64, scale: f64, context: &str) {
+        let tolerance = 1e-5 * scale;
+        assert!(
+            (actual - expected).abs() <= tolerance,
+            "{context}: {actual} vs {expected}, off by more than {tolerance}"
+        );
+    }
+
+    #[hegel::test]
+    fn union_with_self_preserves_area(tc: hegel::TestCase) {
+        let a = tc.draw(star_polygons());
+        let area = a.unsigned_area();
+        assert_area_eq(a.union(&a).unsigned_area(), area, area, "area(A union A)");
+    }
+
+    #[hegel::test]
+    fn difference_with_self_is_empty(tc: hegel::TestCase) {
+        let a = tc.draw(star_polygons());
+        let area = a.unsigned_area();
+        assert_area_eq(
+            a.difference(&a).unsigned_area(),
+            0.0,
+            area,
+            "area(A minus A)",
+        );
+    }
+
+    #[hegel::test]
+    fn union_and_intersection_satisfy_inclusion_exclusion(tc: hegel::TestCase) {
+        let a = tc.draw(star_polygons());
+        let b = tc.draw(star_polygons());
+        let inputs = a.unsigned_area() + b.unsigned_area();
+        assert_area_eq(
+            a.union(&b).unsigned_area() + a.intersection(&b).unsigned_area(),
+            inputs,
+            inputs,
+            "area(A union B) + area(A cap B)",
+        );
+    }
+
+    // The union is partitioned by the intersection and the two differences. All
+    // four quantities come from op output, so input snapping affects both sides
+    // of the comparison alike.
+    #[hegel::test]
+    fn intersection_and_differences_partition_the_union(tc: hegel::TestCase) {
+        let a = tc.draw(star_polygons());
+        let b = tc.draw(star_polygons());
+        let union = a.union(&b).unsigned_area();
+        let parts = a.intersection(&b).unsigned_area()
+            + a.difference(&b).unsigned_area()
+            + b.difference(&a).unsigned_area();
+        assert_area_eq(parts, union, union, "the three parts of A union B");
+    }
+
+    // `xor` returns "the regions that are in either `self` or `other`, but not
+    // in both".
+    #[hegel::test]
+    fn xor_is_the_union_less_the_intersection(tc: hegel::TestCase) {
+        let a = tc.draw(star_polygons());
+        let b = tc.draw(star_polygons());
+        let union = a.union(&b).unsigned_area();
+        let expected = union - a.intersection(&b).unsigned_area();
+        assert_area_eq(a.xor(&b).unsigned_area(), expected, union, "area(A xor B)");
+    }
+
+    // `unary_union` is documented as an efficient union "of many adjacent /
+    // overlapping geometries", so it must agree with folding `union` over the
+    // same inputs. The discrepancy is measured as the area of the symmetric
+    // difference of the two results, exactly as `test_unary_union_errors` does.
+    #[hegel::test]
+    fn unary_union_agrees_with_a_folded_union(tc: hegel::TestCase) {
+        let polygons: Vec<Polygon<f64>> = tc.draw(
+            hegel::generators::vecs(star_polygons())
+                .min_size(1)
+                .max_size(5),
+        );
+        let mut folded = MultiPolygon::empty();
+        for polygon in &polygons {
+            folded = folded.union(polygon);
+        }
+        let combined = unary_union(polygons.iter());
+        let scale: f64 = polygons.iter().map(|p| p.unsigned_area()).sum();
+        assert_area_eq(
+            combined.xor(&folded).unsigned_area(),
+            0.0,
+            scale,
+            "area(unary_union xor folded union)",
+        );
+    }
+
+    // `intersection`, `union`, `xor` and `difference` are each documented as
+    // `boolean_op` with the corresponding `OpType`, using the default
+    // `FillRule::EvenOdd`.
+    #[hegel::test]
+    fn boolean_op_matches_the_named_operations(tc: hegel::TestCase) {
+        let a = tc.draw(polygons_with_holes());
+        let b = tc.draw(polygons_with_holes());
+        assert_eq!(a.boolean_op(&b, OpType::Intersection), a.intersection(&b));
+        assert_eq!(a.boolean_op(&b, OpType::Union), a.union(&b));
+        assert_eq!(a.boolean_op(&b, OpType::Difference), a.difference(&b));
+        assert_eq!(a.boolean_op(&b, OpType::Xor), a.xor(&b));
+    }
+
+    // `clip` "Returns the portion of `ls` that lies within `self` ... if
+    // `invert` is false, and the difference (`ls - self`) otherwise", so the two
+    // halves must together account for the whole input length. The input is
+    // x-monotone: clipping is a set operation, so a line string that retraces
+    // itself loses the duplicated length and the identity would not apply.
+    #[hegel::test]
+    fn clipping_a_line_string_splits_its_length_in_two(tc: hegel::TestCase) {
+        let polygon = tc.draw(star_polygons());
+        let lines = MultiLineString::new(vec![tc.draw(monotone_line_strings(2e3, 8))]);
+        let inside = Euclidean.length(&polygon.clip(&lines, false));
+        let outside = Euclidean.length(&polygon.clip(&lines, true));
+        let total = Euclidean.length(&lines);
+        // Clipping cuts at snapped intersection points, so the two pieces are
+        // shorter or longer by the snapping error at each cut.
+        assert_relative_eq!(inside + outside, total, max_relative = 1e-5, epsilon = 1e-6);
+    }
+
+    // Exterior rings of boolean-op output are counter-clockwise and interior
+    // rings clockwise — the invariant `i_overlay_integration::test_winding_order`
+    // pins for georust/geo#1309.
+    #[hegel::test]
+    fn union_output_rings_follow_the_standard_winding(tc: hegel::TestCase) {
+        let a = tc.draw(star_polygons());
+        let b = tc.draw(star_polygons());
+        for polygon in a.union(&b) {
+            assert!(polygon.exterior().is_ccw());
+            for interior in polygon.interiors() {
+                assert!(interior.is_cw());
+            }
+        }
+    }
+}

--- a/geo/src/algorithm/bool_ops/tests.rs
+++ b/geo/src/algorithm/bool_ops/tests.rs
@@ -489,11 +489,11 @@ mod ogc_compliance {
 /// The trait describes its operations as "set operations on geometries
 /// considered as a subset of the 2-D plane", well-defined on valid geometries,
 /// so the set-algebra identities on areas must hold. Inputs are the star-shaped
-/// and hole-bearing polygons from `crate::utils::pbt_gens`, which
+/// and hole-bearing polygons from `crate::utils::hegel_gens`, which
 /// `Validation` accepts.
 mod hegel_props {
     use super::{BooleanOps, unary_union};
-    use crate::utils::pbt_gens::{monotone_line_strings, polygons_with_holes, star_polygons};
+    use crate::utils::hegel_gens::{monotone_line_strings, polygons_with_holes, star_polygons};
     use crate::{Area, Euclidean, Length, MultiLineString, MultiPolygon, OpType, Polygon, Winding};
 
     /// Every boolean operation snaps its inputs onto a discrete integer grid

--- a/geo/src/algorithm/bounding_rect.rs
+++ b/geo/src/algorithm/bounding_rect.rs
@@ -421,7 +421,7 @@ mod test {
 
 #[cfg(test)]
 mod hegel_props {
-    use crate::utils::pbt_gens::geometries;
+    use crate::utils::hegel_gens::geometries;
     use crate::{BoundingRect, CoordsIter, Geometry};
 
     // The crate documents the result as "the axis-aligned bounding rectangle of

--- a/geo/src/algorithm/bounding_rect.rs
+++ b/geo/src/algorithm/bounding_rect.rs
@@ -418,3 +418,80 @@ mod test {
         );
     }
 }
+
+#[cfg(test)]
+mod hegel_props {
+    use crate::utils::pbt_gens::geometries;
+    use crate::{BoundingRect, CoordsIter, Geometry};
+
+    // The crate documents the result as "the axis-aligned bounding rectangle of
+    // a geometry", so every coordinate must lie within it and each of the four
+    // bounds must be attained by some coordinate — otherwise the rectangle is
+    // not the bounding one. The oracle iterates exterior coords because the
+    // `Polygon` and `MultiPolygon` impls deliberately ignore interior rings.
+    #[hegel::test]
+    fn bounding_rect_is_the_tightest_rect_covering_every_coord(tc: hegel::TestCase) {
+        let geometry = tc.draw(geometries(1e12));
+        let Some(rect) = geometry.bounding_rect() else {
+            return;
+        };
+        let coords: Vec<_> = geometry.exterior_coords_iter().collect();
+        for coord in &coords {
+            assert!(
+                (rect.min().x..=rect.max().x).contains(&coord.x)
+                    && (rect.min().y..=rect.max().y).contains(&coord.y),
+                "{coord:?} lies outside {rect:?}"
+            );
+        }
+        assert!(coords.iter().any(|c| c.x == rect.min().x));
+        assert!(coords.iter().any(|c| c.x == rect.max().x));
+        assert!(coords.iter().any(|c| c.y == rect.min().y));
+        assert!(coords.iter().any(|c| c.y == rect.max().y));
+    }
+
+    // The `Output` type is `Option<Rect>` exactly for the geometries that can be
+    // empty, and `None` is only used when a geometry contributes no coordinates.
+    #[hegel::test]
+    fn bounding_rect_is_none_only_for_geometries_without_coords(tc: hegel::TestCase) {
+        let geometry = tc.draw(geometries(1e12));
+        assert_eq!(
+            geometry.bounding_rect().is_none(),
+            geometry.exterior_coords_iter().count() == 0
+        );
+    }
+
+    // A `Coord`'s bounding rect is documented to "have zero width and zero
+    // height", so merging it into the geometry's own rect must be a no-op.
+    #[hegel::test]
+    fn bounding_rect_covers_the_bounding_rect_of_each_coord(tc: hegel::TestCase) {
+        let geometry = tc.draw(geometries(1e12));
+        let Some(rect) = geometry.bounding_rect() else {
+            return;
+        };
+        for coord in geometry.exterior_coords_iter() {
+            let coord_rect = coord.bounding_rect();
+            assert_eq!(coord_rect.min(), coord_rect.max());
+            assert_eq!(super::bounding_rect_merge(rect, coord_rect), rect);
+        }
+    }
+
+    // Wrapping a geometry in the `Geometry` enum changes nothing about it, so the
+    // delegating impl must produce the same rectangle.
+    #[hegel::test]
+    fn wrapping_in_the_geometry_enum_preserves_the_bounding_rect(tc: hegel::TestCase) {
+        let geometry = tc.draw(geometries(1e12));
+        let expected = match &geometry {
+            Geometry::Point(g) => Some(g.bounding_rect()),
+            Geometry::Line(g) => Some(g.bounding_rect()),
+            Geometry::LineString(g) => g.bounding_rect(),
+            Geometry::Polygon(g) => g.bounding_rect(),
+            Geometry::MultiPoint(g) => g.bounding_rect(),
+            Geometry::MultiLineString(g) => g.bounding_rect(),
+            Geometry::MultiPolygon(g) => g.bounding_rect(),
+            Geometry::GeometryCollection(g) => g.bounding_rect(),
+            Geometry::Rect(g) => Some(g.bounding_rect()),
+            Geometry::Triangle(g) => Some(g.bounding_rect()),
+        };
+        assert_eq!(geometry.bounding_rect(), expected);
+    }
+}

--- a/geo/src/algorithm/centroid.rs
+++ b/geo/src/algorithm/centroid.rs
@@ -1165,3 +1165,93 @@ mod test {
         assert_eq!(centroid.y(), 2.0);
     }
 }
+
+#[cfg(test)]
+mod hegel_props {
+    use crate::utils::pbt_gens::{convex_polygons, coords, disjoint_multi_polygons, star_polygons};
+    use crate::{Area, BoundingRect, Centroid, Contains, Intersects, Translate};
+
+    // Translating a shape moves its centroid by the same offset. The polygon
+    // implementation shifts each ring by its first coordinate to keep this true
+    // far from the origin — see `centroid_polygon_numerical_stability` above.
+    #[hegel::test]
+    fn centroid_is_translation_equivariant(tc: hegel::TestCase) {
+        let polygon = tc.draw(star_polygons());
+        let offset = tc.draw(coords(1e8));
+        let centroid = polygon
+            .centroid()
+            .expect("star polygons have positive area");
+        let translated = polygon
+            .translate(offset.x, offset.y)
+            .centroid()
+            .expect("translation preserves positive area");
+        // The offset dominates the residual: shifting coordinates by up to 1e8
+        // costs about `ulp(1e8)` each, and the area-weighted mean amplifies that
+        // by the ratio of extent to area. The slack sizes that cost rather than
+        // granting the library room for a wrong answer.
+        let scale = offset.x.abs().max(offset.y.abs()).max(1.0);
+        let tol = 1024.0 * f64::EPSILON * scale;
+        assert!(
+            (translated.x() - (centroid.x() + offset.x)).abs() <= tol
+                && (translated.y() - (centroid.y() + offset.y)).abs() <= tol,
+            "centroid {centroid:?} translated by {offset:?} gave {translated:?}"
+        );
+    }
+
+    // "The geometric centroid of a convex object always lies in the object" —
+    // the `Centroid` trait docs. The generator's exteriors are cyclic polygons,
+    // hence convex.
+    #[hegel::test]
+    fn the_centroid_of_a_convex_polygon_lies_inside_it(tc: hegel::TestCase) {
+        let polygon = tc.draw(convex_polygons());
+        let centroid = polygon.centroid().expect("convex polygons have area");
+        assert!(
+            polygon.contains(&centroid),
+            "centroid {centroid:?} is not inside {polygon:?}"
+        );
+    }
+
+    // The centroid is an average of points of the geometry, so it cannot fall
+    // outside the geometry's bounding rectangle.
+    #[hegel::test]
+    fn centroid_lies_within_the_bounding_rect(tc: hegel::TestCase) {
+        let multi_polygon = tc.draw(disjoint_multi_polygons());
+        let centroid = multi_polygon.centroid().expect("members have area");
+        let rect = multi_polygon
+            .bounding_rect()
+            .expect("members have coordinates");
+        assert!(
+            rect.intersects(&centroid),
+            "centroid {centroid:?} lies outside bounding rect {rect:?}"
+        );
+    }
+
+    // A `MultiPolygon`'s centroid is documented as "the mean of the centroids of
+    // its polygons, weighted by the area of the polygons".
+    #[hegel::test]
+    fn multi_polygon_centroid_is_the_area_weighted_mean_of_member_centroids(tc: hegel::TestCase) {
+        let multi_polygon = tc.draw(disjoint_multi_polygons());
+        let mut weight = 0.0;
+        let (mut x, mut y) = (0.0, 0.0);
+        for polygon in multi_polygon.iter() {
+            let area = polygon.unsigned_area();
+            let centroid = polygon.centroid().expect("members have area");
+            weight += area;
+            x += area * centroid.x();
+            y += area * centroid.y();
+        }
+        let centroid = multi_polygon.centroid().expect("members have area");
+        assert_relative_eq!(
+            centroid.x(),
+            x / weight,
+            max_relative = 1e-9,
+            epsilon = 1e-9
+        );
+        assert_relative_eq!(
+            centroid.y(),
+            y / weight,
+            max_relative = 1e-9,
+            epsilon = 1e-9
+        );
+    }
+}

--- a/geo/src/algorithm/centroid.rs
+++ b/geo/src/algorithm/centroid.rs
@@ -1168,7 +1168,9 @@ mod test {
 
 #[cfg(test)]
 mod hegel_props {
-    use crate::utils::pbt_gens::{convex_polygons, coords, disjoint_multi_polygons, star_polygons};
+    use crate::utils::hegel_gens::{
+        convex_polygons, coords, disjoint_multi_polygons, star_polygons,
+    };
     use crate::{Area, BoundingRect, Centroid, Contains, Intersects, Translate};
 
     // Translating a shape moves its centroid by the same offset. The polygon

--- a/geo/src/algorithm/chaikin_smoothing.rs
+++ b/geo/src/algorithm/chaikin_smoothing.rs
@@ -268,7 +268,7 @@ mod test {
 #[cfg(test)]
 mod hegel_props {
     use super::ChaikinSmoothing;
-    use crate::utils::pbt_gens::{monotone_line_strings, star_polygons};
+    use crate::utils::hegel_gens::{monotone_line_strings, star_polygons};
     use crate::{Euclidean, Length};
     use hegel::generators;
 

--- a/geo/src/algorithm/chaikin_smoothing.rs
+++ b/geo/src/algorithm/chaikin_smoothing.rs
@@ -264,3 +264,66 @@ mod test {
         );
     }
 }
+
+#[cfg(test)]
+mod hegel_props {
+    use super::ChaikinSmoothing;
+    use crate::utils::pbt_gens::{monotone_line_strings, star_polygons};
+    use crate::{Euclidean, Length};
+    use hegel::generators;
+
+    fn iterations(tc: &hegel::TestCase) -> usize {
+        tc.draw(generators::integers::<usize>().min_value(1).max_value(4))
+    }
+
+    // "This implementation preserves the start and end vertices of an open
+    // linestring". The generator's x values strictly increase, so the string is
+    // open.
+    #[hegel::test]
+    fn smoothing_preserves_the_ends_of_an_open_line_string(tc: hegel::TestCase) {
+        let line_string = tc.draw(monotone_line_strings(1e3, 12));
+        let smoothed = line_string.chaikin_smoothing(iterations(&tc));
+        assert_eq!(smoothed.0.first(), line_string.0.first());
+        assert_eq!(smoothed.0.last(), line_string.0.last());
+    }
+
+    // "Each iteration of the smoothing doubles the number of vertices of the
+    // geometry": an open string of n coordinates yields the 2(n-1) midpoints
+    // plus its two retained ends.
+    #[hegel::test]
+    fn each_iteration_doubles_an_open_line_strings_vertices(tc: hegel::TestCase) {
+        let line_string = tc.draw(monotone_line_strings(1e3, 12));
+        let n = line_string.0.len();
+        assert_eq!(line_string.chaikin_smoothing(1).0.len(), 2 * n);
+    }
+
+    // Every new vertex is a convex combination of two neighbours, so smoothing
+    // cannot leave the convex hull of the input — in particular it cannot
+    // lengthen a closed ring's perimeter.
+    #[hegel::test]
+    fn smoothing_a_ring_never_lengthens_it(tc: hegel::TestCase) {
+        let ring = tc.draw(star_polygons()).exterior().clone();
+        let smoothed = ring.chaikin_smoothing(iterations(&tc));
+        let before = Euclidean.length(&ring);
+        let after = Euclidean.length(&smoothed);
+        assert!(
+            after <= before * (1.0 + 1e-9),
+            "smoothing lengthened the ring: {before} -> {after}"
+        );
+    }
+
+    // Smoothing "smoothes the corner between start and end of a closed
+    // linestring", so a closed ring comes back closed.
+    #[hegel::test]
+    fn smoothing_keeps_a_closed_ring_closed(tc: hegel::TestCase) {
+        let ring = tc.draw(star_polygons()).exterior().clone();
+        assert!(ring.chaikin_smoothing(iterations(&tc)).is_closed());
+    }
+
+    // Zero iterations is no smoothing at all.
+    #[hegel::test]
+    fn zero_iterations_leaves_the_geometry_alone(tc: hegel::TestCase) {
+        let line_string = tc.draw(monotone_line_strings(1e3, 12));
+        assert_eq!(line_string.chaikin_smoothing(0), line_string);
+    }
+}

--- a/geo/src/algorithm/closest_point.rs
+++ b/geo/src/algorithm/closest_point.rs
@@ -349,7 +349,7 @@ mod tests {
 #[cfg(test)]
 mod hegel_props {
     use super::ClosestPoint;
-    use crate::utils::pbt_gens::{coords, grid_coords, monotone_line_strings, star_polygons};
+    use crate::utils::hegel_gens::{coords, grid_coords, monotone_line_strings, star_polygons};
     use crate::{Closest, Distance, Euclidean, Point};
 
     // `SinglePoint` is "exactly one place on this object which is closest to the

--- a/geo/src/algorithm/closest_point.rs
+++ b/geo/src/algorithm/closest_point.rs
@@ -345,3 +345,82 @@ mod tests {
         assert_eq!(result, Closest::Intersection(point!(x: 10.5, y: 10.5)));
     }
 }
+
+#[cfg(test)]
+mod hegel_props {
+    use super::ClosestPoint;
+    use crate::utils::pbt_gens::{coords, grid_coords, monotone_line_strings, star_polygons};
+    use crate::{Closest, Distance, Euclidean, Point};
+
+    // `SinglePoint` is "exactly one place on this object which is closest to the
+    // point", so the distance to it must be the distance to the geometry, which
+    // `best_of_two` itself measures with `Euclidean.distance`.
+    #[hegel::test]
+    fn the_closest_point_on_a_line_string_realises_the_distance(tc: hegel::TestCase) {
+        let line_string = tc.draw(monotone_line_strings(1e3, 10));
+        let point = Point::from(tc.draw(coords(2e3)));
+        let expected = Euclidean.distance(&point, &line_string);
+        match line_string.closest_point(&point) {
+            Closest::SinglePoint(closest) | Closest::Intersection(closest) => {
+                assert_relative_eq!(
+                    Euclidean.distance(&point, &closest),
+                    expected,
+                    max_relative = 1e-9,
+                    epsilon = 1e-9
+                );
+            }
+            Closest::Indeterminate => {}
+        }
+    }
+
+    // "The point actually intersects with the object", so an `Intersection`
+    // result must be at zero distance.
+    #[hegel::test]
+    fn an_intersection_result_is_at_zero_distance(tc: hegel::TestCase) {
+        let polygon = tc.draw(star_polygons());
+        let point = Point::from(tc.draw(coords(2e3)));
+        if let Closest::Intersection(closest) = polygon.closest_point(&point) {
+            assert_eq!(Euclidean.distance(&point, &closest), 0.0);
+        }
+    }
+
+    // A two-coordinate `LineString` traces exactly one segment, so it must
+    // answer as that `Line` does — the relation
+    // `line_string_with_single_element_behaves_like_line` above checks for one
+    // input. Coordinates come from the integer grid: a segment shorter than
+    // about 1e-161 makes both sides return a NaN point, pinned by
+    // `closest_point_on_a_tiny_segment_is_not_a_number` below.
+    #[hegel::test]
+    fn a_two_coord_line_string_agrees_with_the_line_it_traces(tc: hegel::TestCase) {
+        let start = tc.draw(grid_coords());
+        let end = tc.draw(grid_coords());
+        let point = Point::from(tc.draw(grid_coords()));
+        let line = crate::Line::new(start, end);
+        let line_string = crate::LineString::new(vec![start, end]);
+        assert_eq!(
+            line_string.closest_point(&point),
+            line.closest_point(&point)
+        );
+    }
+
+    // KNOWN FAILURE, georust/geo#1604 (open): `Line::closest_point` projects onto
+    // the segment by dividing by its squared length, which underflows to zero
+    // once the segment is shorter than about 1e-161, so the returned point is
+    // `NaN`. The zero-length case is special-cased to `Indeterminate`; a
+    // segment that is merely tiny is not, and `Intersection` promises a point
+    // that "actually intersects with the object".
+    #[test]
+    #[ignore = "geo#1604: Line::closest_point returns a NaN point for a tiny segment"]
+    fn closest_point_on_a_tiny_segment_is_not_a_number() {
+        let line: crate::Line<f64> = crate::Line::new(
+            crate::coord! { x: 0.0, y: 0.0 },
+            crate::coord! { x: 0.0, y: 1e-200 },
+        );
+        match line.closest_point(&Point::new(0.0, 0.0)) {
+            Closest::SinglePoint(p) | Closest::Intersection(p) => {
+                assert!(p.x().is_finite() && p.y().is_finite(), "got {p:?}");
+            }
+            Closest::Indeterminate => {}
+        }
+    }
+}

--- a/geo/src/algorithm/closest_point.rs
+++ b/geo/src/algorithm/closest_point.rs
@@ -403,14 +403,14 @@ mod hegel_props {
         );
     }
 
-    // KNOWN FAILURE, georust/geo#1604 (open): `Line::closest_point` projects onto
+    // KNOWN FAILURE, #1604 (open): `Line::closest_point` projects onto
     // the segment by dividing by its squared length, which underflows to zero
     // once the segment is shorter than about 1e-161, so the returned point is
     // `NaN`. The zero-length case is special-cased to `Indeterminate`; a
     // segment that is merely tiny is not, and `Intersection` promises a point
     // that "actually intersects with the object".
     #[test]
-    #[ignore = "geo#1604: Line::closest_point returns a NaN point for a tiny segment"]
+    #[ignore = "#1604: Line::closest_point returns a NaN point for a tiny segment"]
     fn closest_point_on_a_tiny_segment_is_not_a_number() {
         let line: crate::Line<f64> = crate::Line::new(
             crate::coord! { x: 0.0, y: 0.0 },

--- a/geo/src/algorithm/concave_hull.rs
+++ b/geo/src/algorithm/concave_hull.rs
@@ -886,7 +886,7 @@ mod tests {
 #[cfg(test)]
 mod hegel_props {
     use super::{ConcaveHull, ConcaveHullOptions};
-    use crate::utils::pbt_gens::grid_coords;
+    use crate::utils::hegel_gens::grid_coords;
     use crate::{Area, ConvexHull, Coord, Intersects, MultiPoint, Point};
     use hegel::generators::{self, PrintableGenerator};
 

--- a/geo/src/algorithm/concave_hull.rs
+++ b/geo/src/algorithm/concave_hull.rs
@@ -882,3 +882,72 @@ mod tests {
         }
     }
 }
+
+#[cfg(test)]
+mod hegel_props {
+    use super::{ConcaveHull, ConcaveHullOptions};
+    use crate::utils::pbt_gens::grid_coords;
+    use crate::{Area, ConvexHull, Coord, Intersects, MultiPoint, Point};
+    use hegel::generators::{self, PrintableGenerator};
+
+    fn point_sets() -> impl PrintableGenerator<Vec<Coord<f64>>> {
+        generators::vecs(grid_coords()).min_size(3).max_size(32)
+    }
+
+    fn multi_point(coords: &[Coord<f64>]) -> MultiPoint<f64> {
+        MultiPoint::new(coords.iter().copied().map(Point::from).collect())
+    }
+
+    // "Returns a polygon which covers a geometry" — the property
+    // `test_all_points_in_hull` above checks for one fixture.
+    #[hegel::test]
+    fn the_concave_hull_covers_every_input_point(tc: hegel::TestCase) {
+        let coords = tc.draw(point_sets());
+        let concavity = tc.draw(generators::floats::<f64>().min_value(0.5).max_value(1e3));
+        let hull = multi_point(&coords).concave_hull_with_options(ConcaveHullOptions {
+            concavity,
+            length_threshold: 0.0,
+        });
+        for coord in &coords {
+            assert!(
+                hull.intersects(coord),
+                "{coord:?} is not covered by {hull:?}"
+            );
+        }
+    }
+
+    // "Infinity would result in a convex hull": no edge is ever short enough to
+    // drill into, so the starting convex hull is returned unchanged.
+    #[hegel::test]
+    fn an_infinite_concavity_gives_the_convex_hull(tc: hegel::TestCase) {
+        let coords = tc.draw(point_sets());
+        let points = multi_point(&coords);
+        let hull = points.concave_hull_with_options(ConcaveHullOptions {
+            concavity: f64::INFINITY,
+            length_threshold: 0.0,
+        });
+        assert_eq!(hull.exterior(), points.convex_hull().exterior());
+    }
+
+    // The concave hull "does so while trying to further minimize its area by
+    // constructing edges such that the exterior of the polygon incorporates
+    // points that would be interior points in a convex hull", so it never
+    // covers more than the convex hull.
+    #[hegel::test]
+    fn the_concave_hull_is_no_larger_than_the_convex_hull(tc: hegel::TestCase) {
+        let coords = tc.draw(point_sets());
+        let points = multi_point(&coords);
+        let concavity = tc.draw(generators::floats::<f64>().min_value(0.5).max_value(1e3));
+        let concave = points
+            .concave_hull_with_options(ConcaveHullOptions {
+                concavity,
+                length_threshold: 0.0,
+            })
+            .unsigned_area();
+        let convex = points.convex_hull().unsigned_area();
+        assert!(
+            concave <= convex * (1.0 + 1e-9) + 1e-9,
+            "concave hull area {concave} exceeds the convex hull area {convex}"
+        );
+    }
+}

--- a/geo/src/algorithm/contains/mod.rs
+++ b/geo/src/algorithm/contains/mod.rs
@@ -1010,3 +1010,379 @@ mod test {
         let _ = multi_poly.contains(&multi_poly);
     }
 }
+
+#[cfg(test)]
+mod hegel_props {
+    use crate::coordinate_position::CoordPos;
+    use crate::utils::pbt_gens::{coords, disjoint_multi_polygons, polygons_with_holes};
+    use crate::{
+        Contains, ContainsProperly, Coord, CoordinatePosition, Covers, Geometry, Intersects, Line,
+        LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon, Rect, Relate,
+        Triangle, Within, coord,
+    };
+    use hegel::generators::{self, Generator, PrintableGenerator};
+
+    /// Geometries on the integer grid `[-4, 4]^2` that `Validation` accepts.
+    ///
+    /// Small integer coordinates make the geometries interact constantly and
+    /// keep the kernel's arithmetic exact. Validity is by construction:
+    /// endpoints of a `Line` are distinct, a `LineString` has at least two
+    /// distinct coordinates, a `Triangle`'s vertices are not collinear, and
+    /// polygons are built from rectangles and triangles.
+    ///
+    /// `Relate` documents only two preconditions — no `NaN` coordinates, and
+    /// no geometry collection with overlapping polygons — but degenerate
+    /// geometry reaches assertions inside it, so the domain here stays with
+    /// what the crate's own validity model admits. The reproducers at the end
+    /// of this module pin what happens outside it.
+    fn relatable_geometries() -> impl PrintableGenerator<Geometry<f64>> {
+        fn grid(tc: &hegel::TestCase) -> Coord<f64> {
+            let component = || generators::integers::<i8>().min_value(-4).max_value(4);
+            let (x, y) = tc.draw_silent(generators::tuples!(component(), component()));
+            coord! { x: x as f64, y: y as f64 }
+        }
+        fn distinct_pair(tc: &hegel::TestCase) -> (Coord<f64>, Coord<f64>) {
+            let a = grid(tc);
+            let mut b = grid(tc);
+            if a == b {
+                b.x += 1.0;
+            }
+            (a, b)
+        }
+        // Rects with a zero-width or zero-height extent are degenerate, and
+        // `Relate` mislabels them — see `relate_mislabels_a_degenerate_rect`.
+        fn rect(tc: &hegel::TestCase) -> Rect<f64> {
+            let a = grid(tc);
+            let mut b = grid(tc);
+            if b.x == a.x {
+                b.x += 1.0;
+            }
+            if b.y == a.y {
+                b.y += 1.0;
+            }
+            Rect::new(a, b)
+        }
+        // Paths are x-monotone, hence simple: `Relate` mislabels a
+        // self-intersecting line string that contains one of its own segments —
+        // see `relate_mislabels_a_self_intersecting_line_string`.
+        fn path(tc: &hegel::TestCase) -> LineString<f64> {
+            let n = tc.draw_silent(generators::integers::<usize>().min_value(2).max_value(6));
+            let mut x = -4.0;
+            LineString::new(
+                (0..n)
+                    .map(|_| {
+                        let coord = coord! { x: x, y: grid(tc).y };
+                        x += tc.draw_silent(generators::integers::<i8>().min_value(1).max_value(2))
+                            as f64;
+                        coord
+                    })
+                    .collect(),
+            )
+        }
+        fn triangle(tc: &hegel::TestCase) -> Triangle<f64> {
+            let (a, b) = distinct_pair(tc);
+            let mut c = grid(tc);
+            let collinear = robust::orient2d(
+                robust::Coord { x: a.x, y: a.y },
+                robust::Coord { x: b.x, y: b.y },
+                robust::Coord { x: c.x, y: c.y },
+            ) == 0.0;
+            if collinear {
+                c.x += b.y - a.y;
+                c.y += a.x - b.x;
+            }
+            Triangle::new(a, b, c)
+        }
+        hegel::one_of!(
+            hegel::compose!(|tc| { Geometry::Point(grid(tc).into()) }),
+            hegel::compose!(|tc| {
+                Geometry::MultiPoint(MultiPoint::new(
+                    (0..tc.draw_silent(generators::integers::<usize>().max_value(4)))
+                        .map(|_| grid(tc).into())
+                        .collect(),
+                ))
+            }),
+            hegel::compose!(|tc| {
+                let (a, b) = distinct_pair(tc);
+                Geometry::Line(Line::new(a, b))
+            }),
+            hegel::compose!(|tc| { Geometry::LineString(path(tc)) }),
+            hegel::compose!(|tc| {
+                Geometry::MultiLineString(MultiLineString::new(
+                    (0..tc.draw_silent(generators::integers::<usize>().min_value(1).max_value(3)))
+                        .map(|_| path(tc))
+                        .collect(),
+                ))
+            }),
+            hegel::compose!(|tc| { Geometry::Rect(rect(tc)) }),
+            hegel::compose!(|tc| { Geometry::Triangle(triangle(tc)) }),
+            hegel::compose!(|tc| { Geometry::Polygon(triangle(tc).to_polygon()) }),
+            hegel::compose!(|tc| {
+                Geometry::MultiPolygon(MultiPolygon::new(vec![rect(tc).to_polygon()]))
+            }),
+        )
+        .print_as_debug()
+    }
+
+    fn relatable_pairs() -> impl PrintableGenerator<(Geometry<f64>, Geometry<f64>)> {
+        generators::tuples!(relatable_geometries(), relatable_geometries())
+    }
+
+    // `Contains` is documented as the DE-9IM relation the `IntersectionMatrix`
+    // calls `is_contains`, and most impls are generated from `Relate`. The
+    // specialized ones — `Rect`, `Triangle`, `Line`, `Polygon` against points —
+    // have to agree with the general path.
+    #[hegel::test]
+    fn contains_agrees_with_relate(tc: hegel::TestCase) {
+        let (a, b) = tc.draw(relatable_pairs());
+        assert_eq!(a.contains(&b), a.relate(&b).is_contains());
+    }
+
+    #[hegel::test]
+    fn covers_agrees_with_relate(tc: hegel::TestCase) {
+        let (a, b) = tc.draw(relatable_pairs());
+        assert_eq!(a.covers(&b), a.relate(&b).is_covers());
+    }
+
+    #[hegel::test]
+    fn intersects_agrees_with_relate(tc: hegel::TestCase) {
+        let (a, b) = tc.draw(relatable_pairs());
+        assert_eq!(a.intersects(&b), a.relate(&b).is_intersects());
+    }
+
+    // `ContainsProperly` is documented to delegate to
+    // `IntersectionMatrix::is_contains_properly`, with a faster specialized
+    // path "when checking between `Polygon` and `MultiPolygon`". The left-hand
+    // geometry is valid here: the fast path disagrees with `Relate` when it
+    // holds a zero-area member, pinned by
+    // `contains_properly_on_a_degenerate_member_disagrees_with_relate`.
+    #[hegel::test]
+    fn contains_properly_agrees_with_relate(tc: hegel::TestCase) {
+        let a = tc.draw(polygons_with_holes());
+        let b = tc.draw(relatable_geometries());
+        assert_eq!(a.contains_properly(&b), a.relate(&b).is_contains_properly());
+    }
+
+    #[hegel::test]
+    fn multi_polygon_contains_properly_agrees_with_relate(tc: hegel::TestCase) {
+        let a = tc.draw(disjoint_multi_polygons());
+        let b = tc.draw(relatable_geometries());
+        assert_eq!(a.contains_properly(&b), a.relate(&b).is_contains_properly());
+    }
+
+    // `Contains` requires the interior of `rhs` to have "non-empty
+    // (set-theoretic) intersection" with `self`, which is strictly stronger
+    // than `Intersects` — "either boundary or interior of Self has non-empty
+    // intersection with the boundary or interior of Rhs".
+    #[hegel::test]
+    fn contains_implies_intersects(tc: hegel::TestCase) {
+        let (a, b) = tc.draw(relatable_pairs());
+        if a.contains(&b) {
+            assert!(
+                a.intersects(&b),
+                "{a:?} contains {b:?} but does not intersect it"
+            );
+        }
+    }
+
+    // `Covers` "does not distinguish between points in the boundary and in the
+    // interior of geometries", and its first documented mask is exactly the
+    // `is_contains` mask, so containment implies covering.
+    #[hegel::test]
+    fn contains_implies_covers(tc: hegel::TestCase) {
+        let (a, b) = tc.draw(relatable_pairs());
+        if a.contains(&b) {
+            assert!(a.covers(&b), "{a:?} contains {b:?} but does not cover it");
+        }
+    }
+
+    // "If Geometry `b` has any interaction with the boundary of Geometry `a`,
+    // then the result is `false`", so the `is_contains_properly` mask
+    // `T**FF*FF*` is the `is_contains` mask `T*****FF*` with two more cells
+    // forced empty.
+    #[hegel::test]
+    fn contains_properly_implies_contains(tc: hegel::TestCase) {
+        let (a, b) = tc.draw(relatable_pairs());
+        let matrix = a.relate(&b);
+        if matrix.is_contains_properly() {
+            assert!(matrix.is_contains());
+        }
+    }
+
+    // `Within` is documented as "equivalent to `Contains` with the arguments
+    // swapped"; the same swap must show up in the intersection matrix as
+    // `is_within`.
+    #[hegel::test]
+    fn within_is_contains_with_the_arguments_swapped(tc: hegel::TestCase) {
+        let (a, b) = tc.draw(relatable_pairs());
+        assert_eq!(a.is_within(&b), b.contains(&a));
+        assert_eq!(b.relate(&a).is_contains(), a.relate(&b).is_within());
+    }
+
+    // The matrix is indexed by the position of a point of `a` against a point
+    // of `b`, so swapping the arguments transposes it.
+    #[hegel::test]
+    fn swapping_the_arguments_transposes_the_intersection_matrix(tc: hegel::TestCase) {
+        let (a, b) = tc.draw(relatable_pairs());
+        let forward = a.relate(&b);
+        let backward = b.relate(&a);
+        for lhs in [CoordPos::Inside, CoordPos::OnBoundary, CoordPos::Outside] {
+            for rhs in [CoordPos::Inside, CoordPos::OnBoundary, CoordPos::Outside] {
+                assert_eq!(forward.get(lhs, rhs), backward.get(rhs, lhs));
+            }
+        }
+    }
+
+    // `Polygon::contains` for a coordinate is defined as the coordinate being
+    // `Inside`, and `Polygon::intersects` as its not being `Outside`.
+    #[hegel::test]
+    fn coordinate_position_decides_polygon_containment(tc: hegel::TestCase) {
+        let polygon = tc.draw(polygons_with_holes());
+        let coord = tc.draw(coords(2e3));
+        let position = polygon.coordinate_position(&coord);
+        assert_eq!(polygon.contains(&coord), position == CoordPos::Inside);
+        assert_eq!(
+            polygon.intersects(&Point::from(coord)),
+            position != CoordPos::Outside
+        );
+    }
+
+    // KNOWN FAILURE, not filed upstream: `RelateOperation` labels its graph
+    // nodes through a map keyed with `total_cmp`, which separates `-0.0` from
+    // `0.0`, while the segment intersection that creates those nodes compares
+    // with `==`, which does not. A ring holding a negative zero therefore
+    // leaves a node labelled for only one of the two geometries and
+    // `Node::update_intersection_matrix` panics on its own `assert!` — in
+    // release builds as well. Related to georust/geo#1578, which is the same
+    // ordering mismatch in the sweep module.
+    #[test]
+    #[ignore = "Relate panics on a ring containing a negative zero"]
+    fn relate_panics_on_a_ring_holding_a_negative_zero() {
+        let point = Point::new(0.0, 0.0);
+        let polygon = Polygon::new(
+            vec![
+                coord! { x: 1.0, y: 0.0 },
+                coord! { x: 0.0, y: 0.0 },
+                coord! { x: 1.0, y: -0.0 },
+            ]
+            .into(),
+            vec![],
+        );
+        assert!(!point.relate(&polygon).is_contains());
+    }
+
+    // KNOWN FAILURE, not filed upstream: the specialized
+    // `MultiPolygon::contains_properly` path only asks whether the right-hand
+    // geometry's coordinates fall inside some member. Here the right-hand
+    // polygon is a zero-area member of the left-hand multi polygon, so its
+    // point lies on the left-hand boundary and the documented `T**FF*FF*` mask
+    // does not hold; `Relate::is_contains_properly` and `Contains` both say
+    // false.
+    #[test]
+    #[ignore = "MultiPolygon::contains_properly disagrees with Relate on a zero-area member"]
+    fn contains_properly_on_a_degenerate_member_disagrees_with_relate() {
+        let degenerate: Polygon<f64> = Polygon::new(vec![coord! { x: 0.5, y: 0.5 }].into(), vec![]);
+        let triangle: Polygon<f64> = Polygon::new(
+            vec![
+                coord! { x: 0.0, y: 0.0 },
+                coord! { x: 0.0, y: 1.0 },
+                coord! { x: 1.0, y: 0.0 },
+            ]
+            .into(),
+            vec![],
+        );
+        let a = MultiPolygon::new(vec![degenerate.clone(), triangle]);
+        let b = MultiPolygon::new(vec![degenerate]);
+        assert_eq!(a.contains_properly(&b), a.relate(&b).is_contains_properly());
+    }
+
+    // KNOWN FAILURE, not filed upstream: the line string's last segment is
+    // exactly the line, so the line's interior cannot meet the line string's
+    // exterior — but `Relate` reports `EI` as one-dimensional and `II` as a
+    // single point. The line string is self-intersecting (its last segment
+    // crosses its first), which `InvalidLineString` permits.
+    #[test]
+    #[ignore = "Relate mislabels a self-intersecting line string against its own segment"]
+    fn relate_mislabels_a_self_intersecting_line_string() {
+        let line_string: LineString<f64> = vec![
+            coord! { x: 0.0, y: 0.0 },
+            coord! { x: 1.0, y: 0.0 },
+            coord! { x: 0.0, y: -1.0 },
+            coord! { x: 2.0, y: 2.0 },
+        ]
+        .into();
+        let line = Line::new(coord! { x: 0.0, y: -1.0 }, coord! { x: 2.0, y: 2.0 });
+        assert_eq!(
+            line_string.contains(&line),
+            line_string.relate(&line).is_contains()
+        );
+    }
+
+    // KNOWN FAILURE, not filed upstream: `Covers` gives different answers for
+    // the same two geometries depending on whether they are passed as concrete
+    // types or wrapped in the `Geometry` enum, which only dispatches to the
+    // concrete impls.
+    #[test]
+    #[ignore = "Geometry::covers disagrees with the concrete impl it dispatches to"]
+    fn covers_does_not_depend_on_the_geometry_wrapper() {
+        let line_string: LineString<f64> = vec![
+            coord! { x: 0.0, y: 0.0 },
+            coord! { x: 1.0, y: 0.0 },
+            coord! { x: 0.0, y: -1.0 },
+            coord! { x: 2.0, y: 2.0 },
+        ]
+        .into();
+        let line = Line::new(coord! { x: 0.0, y: -1.0 }, coord! { x: 2.0, y: 2.0 });
+        assert_eq!(
+            line_string.covers(&line),
+            Geometry::LineString(line_string.clone()).covers(&Geometry::Line(line))
+        );
+    }
+
+    // KNOWN FAILURE, not filed upstream: a `Rect` with zero height is a
+    // segment, which cannot cover the unit square, and `Covers` agrees — but
+    // `Relate::is_covers` reports that it does. `InvalidRect` only rejects
+    // non-finite coordinates, so a degenerate rect is inside the crate's own
+    // validity model.
+    #[test]
+    #[ignore = "Relate::is_covers is wrong for a degenerate Rect"]
+    fn relate_mislabels_a_degenerate_rect() {
+        let segment = Rect::new(coord! { x: 0.0, y: 0.0 }, coord! { x: 1.0, y: 0.0 });
+        let square = Rect::new(coord! { x: 0.0, y: 0.0 }, coord! { x: 1.0, y: 1.0 });
+        assert_eq!(segment.covers(&square), segment.relate(&square).is_covers());
+    }
+
+    // KNOWN FAILURE, not filed upstream: `Relate` reports a zero-length `Line`
+    // as one-dimensional, so the interior-interior cell disagrees with the
+    // transposed matrix and with `HasDimensions`, which documents a "degenerate
+    // line" as a point. Relating the equivalent `Point` gives the expected
+    // `F0FFFF212`.
+    #[test]
+    #[ignore = "Relate treats a zero-length Line as one-dimensional"]
+    fn relate_treats_a_zero_length_line_as_a_point() {
+        let line = Line::new(coord! { x: 0.0, y: 0.0 }, coord! { x: 0.0, y: 0.0 });
+        let rect = Rect::new(coord! { x: 0.0, y: 0.0 }, coord! { x: 1.0, y: 1.0 });
+        assert_eq!(
+            line.relate(&rect).get(CoordPos::Inside, CoordPos::Inside),
+            rect.relate(&line).get(CoordPos::Inside, CoordPos::Inside)
+        );
+    }
+
+    // KNOWN FAILURE, not filed upstream: a `Polygon` whose exterior is empty is
+    // empty, and `Intersects` agrees when it has no interior rings — but with
+    // interiors present it tests them and reports an intersection that `Relate`
+    // does not.
+    #[test]
+    #[ignore = "Intersects consults the interior rings of an empty polygon"]
+    fn an_empty_polygon_with_interior_rings_intersects_nothing() {
+        let polygon = Polygon::new(
+            crate::LineString::new(vec![]),
+            vec![vec![coord! { x: 0.0, y: 0.0 }].into()],
+        );
+        let point = Point::new(0.0, 0.0);
+        assert_eq!(
+            point.intersects(&polygon),
+            point.relate(&polygon).is_intersects()
+        );
+    }
+}

--- a/geo/src/algorithm/contains/mod.rs
+++ b/geo/src/algorithm/contains/mod.rs
@@ -1014,7 +1014,7 @@ mod test {
 #[cfg(test)]
 mod hegel_props {
     use crate::coordinate_position::CoordPos;
-    use crate::utils::pbt_gens::{coords, disjoint_multi_polygons, polygons_with_holes};
+    use crate::utils::hegel_gens::{coords, disjoint_multi_polygons, polygons_with_holes};
     use crate::{
         Contains, ContainsProperly, Coord, CoordinatePosition, Covers, Geometry, Intersects, Line,
         LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon, Rect, Relate,

--- a/geo/src/algorithm/contains/mod.rs
+++ b/geo/src/algorithm/contains/mod.rs
@@ -1050,7 +1050,8 @@ mod hegel_props {
             (a, b)
         }
         // Rects with a zero-width or zero-height extent are degenerate, and
-        // `Relate` mislabels them — see `relate_mislabels_a_degenerate_rect`.
+        // `Relate` and `Covers` disagree on them — see
+        // `relate_and_covers_disagree_on_a_degenerate_rect`.
         fn rect(tc: &hegel::TestCase) -> Rect<f64> {
             let a = grid(tc);
             let mut b = grid(tc);
@@ -1062,9 +1063,9 @@ mod hegel_props {
             }
             Rect::new(a, b)
         }
-        // Paths are x-monotone, hence simple: `Relate` mislabels a
-        // self-intersecting line string that contains one of its own segments —
-        // see `relate_mislabels_a_self_intersecting_line_string`.
+        // Paths are x-monotone, hence simple: `Relate` and `Contains` disagree
+        // on a self-intersecting line string against one of its own segments —
+        // see `relate_and_contains_disagree_on_a_self_intersecting_line_string`.
         fn path(tc: &hegel::TestCase) -> LineString<f64> {
             let n = tc.draw_silent(generators::integers::<usize>().min_value(2).max_value(6));
             let mut x = -4.0;
@@ -1247,16 +1248,16 @@ mod hegel_props {
         );
     }
 
-    // KNOWN FAILURE, not filed upstream: `RelateOperation` labels its graph
+    // KNOWN FAILURE, raised in #1609: `RelateOperation` labels its graph
     // nodes through a map keyed with `total_cmp`, which separates `-0.0` from
     // `0.0`, while the segment intersection that creates those nodes compares
     // with `==`, which does not. A ring holding a negative zero therefore
     // leaves a node labelled for only one of the two geometries and
     // `Node::update_intersection_matrix` panics on its own `assert!` — in
-    // release builds as well. Related to georust/geo#1578, which is the same
+    // release builds as well. Related to #1578, which is the same
     // ordering mismatch in the sweep module.
     #[test]
-    #[ignore = "Relate panics on a ring containing a negative zero"]
+    #[ignore = "open question, see #1609: Relate panics on a ring containing a negative zero"]
     fn relate_panics_on_a_ring_holding_a_negative_zero() {
         let point = Point::new(0.0, 0.0);
         let polygon = Polygon::new(
@@ -1271,17 +1272,18 @@ mod hegel_props {
         assert!(!point.relate(&polygon).is_contains());
     }
 
-    // KNOWN FAILURE, not filed upstream: the specialized
+    // KNOWN FAILURE, raised in #1609: the specialized
     // `MultiPolygon::contains_properly` path only asks whether the right-hand
     // geometry's coordinates fall inside some member. Here the right-hand
     // polygon is a zero-area member of the left-hand multi polygon, so its
-    // point lies on the left-hand boundary and the documented `T**FF*FF*` mask
-    // does not hold; `Relate::is_contains_properly` and `Contains` both say
-    // false.
+    // point is inside the triangle but also on the left-hand boundary, and the
+    // documented `T**FF*FF*` mask does not hold: `Relate::is_contains_properly`
+    // says false where the specialized path says true.
     #[test]
-    #[ignore = "MultiPolygon::contains_properly disagrees with Relate on a zero-area member"]
+    #[ignore = "open question, see #1609: MultiPolygon::contains_properly disagrees with Relate on a zero-area member"]
     fn contains_properly_on_a_degenerate_member_disagrees_with_relate() {
-        let degenerate: Polygon<f64> = Polygon::new(vec![coord! { x: 0.5, y: 0.5 }].into(), vec![]);
+        let degenerate: Polygon<f64> =
+            Polygon::new(vec![coord! { x: 0.25, y: 0.25 }].into(), vec![]);
         let triangle: Polygon<f64> = Polygon::new(
             vec![
                 coord! { x: 0.0, y: 0.0 },
@@ -1296,14 +1298,14 @@ mod hegel_props {
         assert_eq!(a.contains_properly(&b), a.relate(&b).is_contains_properly());
     }
 
-    // KNOWN FAILURE, not filed upstream: the line string's last segment is
+    // KNOWN FAILURE, raised in #1609: the line string's last segment is
     // exactly the line, so the line's interior cannot meet the line string's
     // exterior — but `Relate` reports `EI` as one-dimensional and `II` as a
     // single point. The line string is self-intersecting (its last segment
     // crosses its first), which `InvalidLineString` permits.
     #[test]
-    #[ignore = "Relate mislabels a self-intersecting line string against its own segment"]
-    fn relate_mislabels_a_self_intersecting_line_string() {
+    #[ignore = "open question, see #1609: Relate and Contains disagree on a self-intersecting line string against its own segment"]
+    fn relate_and_contains_disagree_on_a_self_intersecting_line_string() {
         let line_string: LineString<f64> = vec![
             coord! { x: 0.0, y: 0.0 },
             coord! { x: 1.0, y: 0.0 },
@@ -1318,12 +1320,12 @@ mod hegel_props {
         );
     }
 
-    // KNOWN FAILURE, not filed upstream: `Covers` gives different answers for
+    // KNOWN FAILURE, raised in #1609: `Covers` gives different answers for
     // the same two geometries depending on whether they are passed as concrete
     // types or wrapped in the `Geometry` enum, which only dispatches to the
     // concrete impls.
     #[test]
-    #[ignore = "Geometry::covers disagrees with the concrete impl it dispatches to"]
+    #[ignore = "open question, see #1609: Geometry::covers disagrees with the concrete impl it dispatches to"]
     fn covers_does_not_depend_on_the_geometry_wrapper() {
         let line_string: LineString<f64> = vec![
             coord! { x: 0.0, y: 0.0 },
@@ -1339,26 +1341,26 @@ mod hegel_props {
         );
     }
 
-    // KNOWN FAILURE, not filed upstream: a `Rect` with zero height is a
+    // KNOWN FAILURE, raised in #1609: a `Rect` with zero height is a
     // segment, which cannot cover the unit square, and `Covers` agrees — but
     // `Relate::is_covers` reports that it does. `InvalidRect` only rejects
     // non-finite coordinates, so a degenerate rect is inside the crate's own
     // validity model.
     #[test]
-    #[ignore = "Relate::is_covers is wrong for a degenerate Rect"]
-    fn relate_mislabels_a_degenerate_rect() {
+    #[ignore = "open question, see #1609: Relate::is_covers and Covers disagree on a zero-height Rect"]
+    fn relate_and_covers_disagree_on_a_degenerate_rect() {
         let segment = Rect::new(coord! { x: 0.0, y: 0.0 }, coord! { x: 1.0, y: 0.0 });
         let square = Rect::new(coord! { x: 0.0, y: 0.0 }, coord! { x: 1.0, y: 1.0 });
         assert_eq!(segment.covers(&square), segment.relate(&square).is_covers());
     }
 
-    // KNOWN FAILURE, not filed upstream: `Relate` reports a zero-length `Line`
+    // KNOWN FAILURE, raised in #1609: `Relate` reports a zero-length `Line`
     // as one-dimensional, so the interior-interior cell disagrees with the
     // transposed matrix and with `HasDimensions`, which documents a "degenerate
     // line" as a point. Relating the equivalent `Point` gives the expected
     // `F0FFFF212`.
     #[test]
-    #[ignore = "Relate treats a zero-length Line as one-dimensional"]
+    #[ignore = "open question, see #1609: Relate treats a zero-length Line as one-dimensional"]
     fn relate_treats_a_zero_length_line_as_a_point() {
         let line = Line::new(coord! { x: 0.0, y: 0.0 }, coord! { x: 0.0, y: 0.0 });
         let rect = Rect::new(coord! { x: 0.0, y: 0.0 }, coord! { x: 1.0, y: 1.0 });
@@ -1368,21 +1370,28 @@ mod hegel_props {
         );
     }
 
-    // KNOWN FAILURE, not filed upstream: a `Polygon` whose exterior is empty is
-    // empty, and `Intersects` agrees when it has no interior rings — but with
-    // interiors present it tests them and reports an intersection that `Relate`
-    // does not.
+    // KNOWN FAILURE, raised in #1609: a `Polygon` whose exterior is empty is
+    // empty, and `Relate` agrees. `Intersects` for a `Line` also checks the
+    // interior rings, so with one present it reports an intersection.
     #[test]
-    #[ignore = "Intersects consults the interior rings of an empty polygon"]
+    #[ignore = "open question, see #1609: Intersects and Relate disagree on an empty polygon with interior rings"]
     fn an_empty_polygon_with_interior_rings_intersects_nothing() {
         let polygon = Polygon::new(
-            crate::LineString::new(vec![]),
-            vec![vec![coord! { x: 0.0, y: 0.0 }].into()],
+            LineString::new(vec![]),
+            vec![
+                vec![
+                    coord! { x: 0.0, y: 0.0 },
+                    coord! { x: 0.0, y: 1.0 },
+                    coord! { x: 1.0, y: 1.0 },
+                    coord! { x: 1.0, y: 0.0 },
+                ]
+                .into(),
+            ],
         );
-        let point = Point::new(0.0, 0.0);
+        let line = Line::new(coord! { x: -1.0, y: 0.5 }, coord! { x: 2.0, y: 0.5 });
         assert_eq!(
-            point.intersects(&polygon),
-            point.relate(&polygon).is_intersects()
+            polygon.intersects(&line),
+            polygon.relate(&line).is_intersects()
         );
     }
 }

--- a/geo/src/algorithm/convex_hull/test.rs
+++ b/geo/src/algorithm/convex_hull/test.rs
@@ -311,3 +311,211 @@ fn convex_hull_with_nan_does_not_panic() {
     ]);
     let _ = pts.convex_hull();
 }
+
+/// Hegel property tests for `ConvexHull`.
+///
+/// The trait promises "the convex hull of a geometry. The hull is always
+/// oriented counter-clockwise", so every input point lies on or to the left of
+/// every directed hull edge and consecutive hull vertices never turn clockwise.
+/// Both checks use `robust::orient2d` — the exact predicate `RobustKernel`
+/// wraps — applied directly to the output, so the oracle cannot share an
+/// arithmetic mistake with `quick_hull`.
+mod hegel_props {
+    use crate::geometry::{Coord, MultiPoint, Point};
+    use crate::utils::pbt_gens::{coords, grid_coords};
+    use crate::{ConvexHull, CoordsIter, Polygon};
+    use hegel::generators::{self, Generator, PrintableGenerator};
+
+    fn orient(a: Coord<f64>, b: Coord<f64>, c: Coord<f64>) -> f64 {
+        robust::orient2d(
+            robust::Coord { x: a.x, y: a.y },
+            robust::Coord { x: b.x, y: b.y },
+            robust::Coord { x: c.x, y: c.y },
+        )
+    }
+
+    fn hull_of(coords: &[Coord<f64>]) -> Polygon<f64> {
+        MultiPoint::new(coords.iter().copied().map(Point::from).collect()).convex_hull()
+    }
+
+    /// Point sets on the exact integer grid, where every product and difference
+    /// `quick_hull` forms is representable in f64. The magnitude-dependent
+    /// failures pinned by `hull_at_large_coordinates_leaves_an_input_outside`
+    /// cannot arise here, so orientation properties hold on this domain while
+    /// georust/geo#1566 is open.
+    fn grid_point_sets() -> impl PrintableGenerator<Vec<Coord<f64>>> {
+        generators::vecs(grid_coords()).max_size(64)
+    }
+
+    /// Point sets with arbitrary finite coordinates up to `±1e150`. The bound
+    /// keeps the products `robust::orient2d` forms internally clear of f64
+    /// overflow — beyond it the oracle itself returns NaN — and stays below the
+    /// magnitude at which `convex_hull` panics
+    /// (`hull_panics_at_large_finite_coordinates`).
+    fn point_sets() -> impl PrintableGenerator<Vec<Coord<f64>>> {
+        generators::vecs(coords(1e150)).max_size(64)
+    }
+
+    #[hegel::test]
+    fn every_input_point_is_on_or_left_of_every_hull_edge(tc: hegel::TestCase) {
+        let points = tc.draw(grid_point_sets());
+        let hull = hull_of(&points);
+        for edge in hull.exterior().lines() {
+            for &point in &points {
+                assert!(
+                    orient(edge.start, edge.end, point) >= 0.0,
+                    "input point {point:?} lies strictly right of hull edge {edge:?}"
+                );
+            }
+        }
+    }
+
+    #[hegel::test]
+    fn consecutive_hull_vertices_never_turn_clockwise(tc: hegel::TestCase) {
+        let points = tc.draw(grid_point_sets());
+        let hull = hull_of(&points);
+        let ring = &hull.exterior().0;
+        if ring.is_empty() {
+            return;
+        }
+        // The ring is closed, so drop the repeated last coordinate and walk it
+        // cyclically.
+        let open = &ring[..ring.len() - 1];
+        for i in 0..open.len() {
+            let (a, b, c) = (
+                open[i],
+                open[(i + 1) % open.len()],
+                open[(i + 2) % open.len()],
+            );
+            assert!(
+                orient(a, b, c) >= 0.0,
+                "hull turns clockwise at {b:?} (previous {a:?}, next {c:?})"
+            );
+        }
+    }
+
+    // `quick_hull_indices` expects that "trivial_hull's coord output is a strict
+    // subset of the input", and the hull of a point set can only be built from
+    // points of that set.
+    #[hegel::test]
+    fn every_hull_vertex_is_an_input_point(tc: hegel::TestCase) {
+        let points = tc.draw(point_sets());
+        for vertex in hull_of(&points).exterior() {
+            assert!(
+                points.contains(vertex),
+                "hull vertex {vertex:?} is not one of the input points"
+            );
+        }
+    }
+
+    /// A closed ring rotated to start at its lexicographically least vertex,
+    /// with the repeated closing coordinate dropped. The trait fixes the
+    /// orientation of the hull but not which vertex it starts from.
+    fn canonical_ring(ring: &crate::LineString<f64>) -> Vec<Coord<f64>> {
+        if ring.0.is_empty() {
+            return Vec::new();
+        }
+        let open = &ring.0[..ring.0.len() - 1];
+        let start = crate::utils::least_index(open);
+        open[start..]
+            .iter()
+            .chain(&open[..start])
+            .copied()
+            .collect()
+    }
+
+    // The hull of a convex set is that set, so hulling twice adds nothing.
+    #[hegel::test]
+    fn the_hull_of_a_hull_is_the_hull(tc: hegel::TestCase) {
+        let points = tc.draw(grid_point_sets());
+        let hull = hull_of(&points);
+        assert_eq!(
+            canonical_ring(hull.convex_hull().exterior()),
+            canonical_ring(hull.exterior())
+        );
+    }
+
+    // The hull is a property of the point set, not of the order the points
+    // arrive in.
+    #[hegel::test]
+    fn the_hull_does_not_depend_on_input_order(tc: hegel::TestCase) {
+        let points = tc.draw(grid_point_sets());
+        let shuffled = tc.draw(generators::permutations(points.clone()).print_as_debug());
+        assert_eq!(
+            canonical_ring(hull_of(&shuffled).exterior()),
+            canonical_ring(hull_of(&points).exterior())
+        );
+    }
+
+    // A convex hull is a single filled region: the trait's doc example asserts
+    // `res.interiors() == &[]`.
+    #[hegel::test]
+    fn the_hull_has_no_interior_rings(tc: hegel::TestCase) {
+        let points = tc.draw(point_sets());
+        assert!(hull_of(&points).interiors().is_empty());
+    }
+
+    // `convex_hull_idx` returns "the indices of the input coords (as yielded by
+    // `CoordsIter::exterior_coords_iter`) that form the convex hull, in CCW
+    // order and closed", so mapping the indices through that iterator must
+    // reproduce the hull ring exactly.
+    #[hegel::test]
+    fn convex_hull_idx_indexes_the_hull_ring(tc: hegel::TestCase) {
+        let points = tc.draw(point_sets());
+        let multi_point = MultiPoint::new(points.iter().copied().map(Point::from).collect());
+        let source: Vec<_> = multi_point.exterior_coords_iter().collect();
+        let indexed: Vec<_> = multi_point
+            .convex_hull_idx()
+            .into_iter()
+            .map(|i| source[i])
+            .collect();
+        assert_eq!(indexed, multi_point.convex_hull().exterior().0);
+    }
+
+    // KNOWN FAILURE, georust/geo#1566 (open): `hull_set` picks its pivot with a
+    // naive dot product (`p_orth.x * p_diff.x + p_orth.y * p_diff.y`), so once
+    // candidate scores collide after rounding an interior point can be chosen
+    // and the returned ring is not a hull. Here (63, 0) ends up strictly right
+    // of the edge (0,0) -> (0,1), and the ring visits (0,0) twice.
+    #[test]
+    #[ignore = "georust/geo#1566"]
+    fn hull_at_large_coordinates_leaves_an_input_outside() {
+        let points = [
+            Coord { x: 0.0, y: 0.0 },
+            Coord {
+                x: -1.0,
+                y: 9150170671525436.0,
+            },
+            Coord { x: 63.0, y: 0.0 },
+            Coord { x: 0.0, y: 1.0 },
+        ];
+        let hull = hull_of(&points);
+        for edge in hull.exterior().lines() {
+            for &point in &points {
+                assert!(
+                    orient(edge.start, edge.end, point) >= 0.0,
+                    "input point {point:?} lies strictly right of hull edge {edge:?}"
+                );
+            }
+        }
+    }
+
+    // KNOWN FAILURE, same root cause as georust/geo#1566: the pivot score
+    // overflows to infinity for these finite coordinates, `inf - inf` gives
+    // NaN, and the `max_by(|a, b| a.partial_cmp(b).unwrap())` in `hull_set`
+    // unwraps `None`. Release builds panic too.
+    #[test]
+    #[ignore = "georust/geo#1566"]
+    fn hull_panics_at_large_finite_coordinates() {
+        let points = [
+            Coord { x: 0.0, y: 0.0 },
+            Coord { x: 0.0, y: 0.0 },
+            Coord { x: 1.0, y: 0.0 },
+            Coord {
+                x: -7.076196536963262e206,
+                y: -8.648940011347372e215,
+            },
+        ];
+        assert!(!hull_of(&points).exterior().0.is_empty());
+    }
+}

--- a/geo/src/algorithm/convex_hull/test.rs
+++ b/geo/src/algorithm/convex_hull/test.rs
@@ -342,7 +342,7 @@ mod hegel_props {
     /// `quick_hull` forms is representable in f64. The magnitude-dependent
     /// failures pinned by `hull_at_large_coordinates_leaves_an_input_outside`
     /// cannot arise here, so orientation properties hold on this domain while
-    /// georust/geo#1566 is open.
+    /// #1566 is open.
     fn grid_point_sets() -> impl PrintableGenerator<Vec<Coord<f64>>> {
         generators::vecs(grid_coords()).max_size(64)
     }
@@ -472,13 +472,13 @@ mod hegel_props {
         assert_eq!(indexed, multi_point.convex_hull().exterior().0);
     }
 
-    // KNOWN FAILURE, georust/geo#1566 (open): `hull_set` picks its pivot with a
+    // KNOWN FAILURE, #1566 (open): `hull_set` picks its pivot with a
     // naive dot product (`p_orth.x * p_diff.x + p_orth.y * p_diff.y`), so once
     // candidate scores collide after rounding an interior point can be chosen
     // and the returned ring is not a hull. Here (63, 0) ends up strictly right
     // of the edge (0,0) -> (0,1), and the ring visits (0,0) twice.
     #[test]
-    #[ignore = "georust/geo#1566"]
+    #[ignore = "#1566: convex_hull returns a ring that is not a hull at large coordinates"]
     fn hull_at_large_coordinates_leaves_an_input_outside() {
         let points = [
             Coord { x: 0.0, y: 0.0 },
@@ -500,12 +500,12 @@ mod hegel_props {
         }
     }
 
-    // KNOWN FAILURE, same root cause as georust/geo#1566: the pivot score
+    // KNOWN FAILURE, same root cause as #1566: the pivot score
     // overflows to infinity for these finite coordinates, `inf - inf` gives
     // NaN, and the `max_by(|a, b| a.partial_cmp(b).unwrap())` in `hull_set`
     // unwraps `None`. Release builds panic too.
     #[test]
-    #[ignore = "georust/geo#1566"]
+    #[ignore = "#1566 (same pivot arithmetic): convex_hull panics at large finite coordinates"]
     fn hull_panics_at_large_finite_coordinates() {
         let points = [
             Coord { x: 0.0, y: 0.0 },

--- a/geo/src/algorithm/convex_hull/test.rs
+++ b/geo/src/algorithm/convex_hull/test.rs
@@ -322,7 +322,7 @@ fn convex_hull_with_nan_does_not_panic() {
 /// arithmetic mistake with `quick_hull`.
 mod hegel_props {
     use crate::geometry::{Coord, MultiPoint, Point};
-    use crate::utils::pbt_gens::{coords, grid_coords};
+    use crate::utils::hegel_gens::{coords, grid_coords};
     use crate::{ConvexHull, CoordsIter, Polygon};
     use hegel::generators::{self, Generator, PrintableGenerator};
 

--- a/geo/src/algorithm/extremes.rs
+++ b/geo/src/algorithm/extremes.rs
@@ -129,3 +129,56 @@ mod test {
         assert!(actual.is_none());
     }
 }
+
+#[cfg(test)]
+mod hegel_props {
+    use super::Extremes;
+    use crate::utils::pbt_gens::geometries;
+    use crate::{BoundingRect, CoordsIter};
+
+    // `extremes` reports "the extreme coordinates and indices of a geometry", so
+    // each `Extreme` must name a coordinate that actually attains that bound,
+    // and the index must be the first one that does — the implementation
+    // compares strictly, keeping the earliest.
+    #[hegel::test]
+    fn each_extreme_is_the_first_coord_attaining_that_bound(tc: hegel::TestCase) {
+        let geometry = tc.draw(geometries(1e12));
+        let Some(outcome) = geometry.extremes() else {
+            return;
+        };
+        let coords: Vec<_> = geometry.exterior_coords_iter().collect();
+        for (extreme, key) in [
+            (&outcome.x_min, 0),
+            (&outcome.x_max, 0),
+            (&outcome.y_min, 1),
+            (&outcome.y_max, 1),
+        ] {
+            let component = |c: &crate::Coord<f64>| if key == 0 { c.x } else { c.y };
+            assert_eq!(coords[extreme.index], extreme.coord);
+            let first = coords
+                .iter()
+                .position(|c| component(c) == component(&extreme.coord))
+                .expect("the extreme coord came from this iterator");
+            assert_eq!(first, extreme.index);
+        }
+        for coord in &coords {
+            assert!(coord.x >= outcome.x_min.coord.x && coord.x <= outcome.x_max.coord.x);
+            assert!(coord.y >= outcome.y_min.coord.y && coord.y <= outcome.y_max.coord.y);
+        }
+    }
+
+    // Both traits are blanket-implemented over `CoordsIter`, and both summarise
+    // the same coordinate extremes, so the bounds have to agree.
+    #[hegel::test]
+    fn extremes_agree_with_the_bounding_rect(tc: hegel::TestCase) {
+        let geometry = tc.draw(geometries(1e12));
+        let (Some(outcome), Some(rect)) = (geometry.extremes(), geometry.bounding_rect()) else {
+            assert!(geometry.extremes().is_none() && geometry.bounding_rect().is_none());
+            return;
+        };
+        assert_eq!(outcome.x_min.coord.x, rect.min().x);
+        assert_eq!(outcome.y_min.coord.y, rect.min().y);
+        assert_eq!(outcome.x_max.coord.x, rect.max().x);
+        assert_eq!(outcome.y_max.coord.y, rect.max().y);
+    }
+}

--- a/geo/src/algorithm/extremes.rs
+++ b/geo/src/algorithm/extremes.rs
@@ -133,7 +133,7 @@ mod test {
 #[cfg(test)]
 mod hegel_props {
     use super::Extremes;
-    use crate::utils::pbt_gens::geometries;
+    use crate::utils::hegel_gens::geometries;
     use crate::{BoundingRect, CoordsIter};
 
     // `extremes` reports "the extreme coordinates and indices of a geometry", so

--- a/geo/src/algorithm/hausdorff_distance.rs
+++ b/geo/src/algorithm/hausdorff_distance.rs
@@ -133,3 +133,42 @@ mod test {
         )
     }
 }
+
+#[cfg(test)]
+mod hegel_props {
+    use super::HausdorffDistance;
+    use crate::utils::pbt_gens::monotone_line_strings;
+    use crate::{CoordsIter, Distance, Euclidean};
+
+    // "The maximum of the distances from a point in any of the sets to the
+    // nearest point in the other set" (Rote, 1991), as the crate's own
+    // documentation puts it — an undirected quantity, so it is symmetric.
+    #[hegel::test]
+    fn hausdorff_distance_is_symmetric(tc: hegel::TestCase) {
+        let a = tc.draw(monotone_line_strings(1e3, 10));
+        let b = tc.draw(monotone_line_strings(1e3, 10));
+        assert_eq!(a.hausdorff_distance(&b), b.hausdorff_distance(&a));
+    }
+
+    // The definition is a maximum over one set of a minimum over the other, so
+    // it is reproduced directly here over the coordinates the implementation
+    // iterates.
+    #[hegel::test]
+    fn hausdorff_distance_matches_its_definition(tc: hegel::TestCase) {
+        let a = tc.draw(monotone_line_strings(1e3, 10));
+        let b = tc.draw(monotone_line_strings(1e3, 10));
+        let directed = |from: &crate::LineString<f64>, to: &crate::LineString<f64>| {
+            from.coords_iter()
+                .map(|p| {
+                    to.coords_iter()
+                        .map(|q| Euclidean.distance(p, q))
+                        .fold(f64::INFINITY, f64::min)
+                })
+                .fold(f64::NEG_INFINITY, f64::max)
+        };
+        assert_eq!(
+            a.hausdorff_distance(&b),
+            directed(&a, &b).max(directed(&b, &a))
+        );
+    }
+}

--- a/geo/src/algorithm/hausdorff_distance.rs
+++ b/geo/src/algorithm/hausdorff_distance.rs
@@ -137,7 +137,7 @@ mod test {
 #[cfg(test)]
 mod hegel_props {
     use super::HausdorffDistance;
-    use crate::utils::pbt_gens::monotone_line_strings;
+    use crate::utils::hegel_gens::monotone_line_strings;
     use crate::{CoordsIter, Distance, Euclidean};
 
     // "The maximum of the distances from a point in any of the sets to the

--- a/geo/src/algorithm/interior_point.rs
+++ b/geo/src/algorithm/interior_point.rs
@@ -934,7 +934,7 @@ mod test {
 #[cfg(test)]
 mod hegel_props {
     use super::InteriorPoint;
-    use crate::utils::pbt_gens::{
+    use crate::utils::hegel_gens::{
         disjoint_multi_polygons, geometries, grid_coords, polygons_with_holes,
     };
     use crate::{BoundingRect, Contains, Geometry, HasDimensions, Intersects, MapCoords};

--- a/geo/src/algorithm/interior_point.rs
+++ b/geo/src/algorithm/interior_point.rs
@@ -993,11 +993,11 @@ mod hegel_props {
         );
     }
 
-    // KNOWN FAILURE, georust/geo#1607: the point `Triangle::interior_point`
+    // KNOWN FAILURE, #1607: the point `Triangle::interior_point`
     // returns for a zero-area triangle does not intersect it, though the same
     // segment as a `Line` returns one that does.
     #[test]
-    #[ignore = "geo#1607: Triangle::interior_point can miss a zero-area triangle"]
+    #[ignore = "#1607: Triangle::interior_point can miss a zero-area triangle"]
     fn the_interior_point_of_a_collinear_triangle_misses_it() {
         let triangle = crate::Triangle::new(
             crate::coord! { x: 0.0, y: 0.0 },

--- a/geo/src/algorithm/interior_point.rs
+++ b/geo/src/algorithm/interior_point.rs
@@ -930,3 +930,117 @@ mod test {
         let _ = poly.interior_point();
     }
 }
+
+#[cfg(test)]
+mod hegel_props {
+    use super::InteriorPoint;
+    use crate::utils::pbt_gens::{
+        disjoint_multi_polygons, geometries, grid_coords, polygons_with_holes,
+    };
+    use crate::{BoundingRect, Contains, Geometry, HasDimensions, Intersects, MapCoords};
+    use hegel::generators::{Generator, PrintableGenerator};
+
+    /// Arbitrary geometries with signed zeros normalised away: the interior
+    /// point search reaches `Relate`, which panics on a ring holding a negative
+    /// zero — see
+    /// `contains::hegel_props::relate_panics_on_a_ring_holding_a_negative_zero`.
+    fn normalised_geometries() -> impl PrintableGenerator<Geometry<f64>> {
+        geometries(1e3)
+            .map(|geometry| geometry.map_coords(|c| crate::coord! { x: c.x + 0.0, y: c.y + 0.0 }))
+            .print_as_debug()
+    }
+
+    // "An interior point is a point that's guaranteed to intersect a given
+    // geometry, and will be strictly on the interior of the geometry if
+    // possible, or on the edge if the geometry has zero area."
+    //
+    // `Triangle` is covered separately below: its impl returns the centroid
+    // unconditionally, which rounds outside a sliver or collinear triangle —
+    // pinned by `the_interior_point_of_a_collinear_triangle_misses_it`.
+    #[hegel::test]
+    fn an_interior_point_intersects_its_geometry(tc: hegel::TestCase) {
+        let geometry = tc.draw(normalised_geometries());
+        tc.assume(!matches!(geometry, Geometry::Triangle(_)));
+        if let Some(point) = geometry.interior_point() {
+            assert!(
+                geometry.intersects(&point),
+                "{point:?} does not intersect {geometry:?}"
+            );
+        }
+    }
+
+    // The same guarantee for triangles that are not slivers: vertices on the
+    // integer grid, with the three of them not collinear.
+    #[hegel::test]
+    fn the_interior_point_of_a_fat_triangle_intersects_it(tc: hegel::TestCase) {
+        let triangle = crate::Triangle::new(
+            tc.draw(grid_coords()),
+            tc.draw(grid_coords()),
+            tc.draw(grid_coords()),
+        );
+        let [a, b, c] = triangle.to_array();
+        tc.assume(
+            robust::orient2d(
+                robust::Coord { x: a.x, y: a.y },
+                robust::Coord { x: b.x, y: b.y },
+                robust::Coord { x: c.x, y: c.y },
+            ) != 0.0,
+        );
+        let point = triangle.interior_point();
+        assert!(
+            triangle.intersects(&point),
+            "{point:?} does not intersect {triangle:?}"
+        );
+    }
+
+    // KNOWN FAILURE, georust/geo#1607: the point `Triangle::interior_point`
+    // returns for a zero-area triangle does not intersect it, though the same
+    // segment as a `Line` returns one that does.
+    #[test]
+    #[ignore = "geo#1607: Triangle::interior_point can miss a zero-area triangle"]
+    fn the_interior_point_of_a_collinear_triangle_misses_it() {
+        let triangle = crate::Triangle::new(
+            crate::coord! { x: 0.0, y: 0.0 },
+            crate::coord! { x: 0.0, y: 0.0 },
+            crate::coord! { x: 3.0, y: 87.0 },
+        );
+        let point = triangle.interior_point();
+        assert!(triangle.intersects(&point));
+    }
+
+    #[hegel::test]
+    fn only_empty_geometries_have_no_interior_point(tc: hegel::TestCase) {
+        let geometry = tc.draw(normalised_geometries());
+        if geometry.interior_point().is_none() {
+            assert!(geometry.is_empty(), "{geometry:?} is not empty");
+        }
+    }
+
+    // "strictly on the interior of the geometry if possible": a polygon with
+    // positive area has an interior, so the point lands inside it.
+    #[hegel::test]
+    fn a_polygon_with_area_gets_a_point_strictly_inside(tc: hegel::TestCase) {
+        let polygon = tc.draw(polygons_with_holes());
+        let point = polygon
+            .interior_point()
+            .expect("polygons with area have an interior point");
+        assert!(
+            polygon.contains(&point),
+            "{point:?} is not inside {polygon:?}"
+        );
+    }
+
+    // The point is chosen from a scan line through the geometry's bounding box,
+    // so it cannot fall outside that box.
+    #[hegel::test]
+    fn the_interior_point_lies_within_the_bounding_rect(tc: hegel::TestCase) {
+        let multi_polygon = tc.draw(disjoint_multi_polygons());
+        let point = multi_polygon
+            .interior_point()
+            .expect("members have positive area");
+        let rect = multi_polygon
+            .bounding_rect()
+            .expect("members have coordinates");
+        assert!(rect.intersects(&point), "{point:?} lies outside {rect:?}");
+    }
+}

--- a/geo/src/algorithm/is_convex.rs
+++ b/geo/src/algorithm/is_convex.rs
@@ -507,7 +507,7 @@ mod tests {
 #[cfg(test)]
 mod hegel_props {
     use super::IsConvex;
-    use crate::utils::pbt_gens::{convex_polygons, grid_coords, star_polygons};
+    use crate::utils::hegel_gens::{convex_polygons, grid_coords, star_polygons};
     use crate::{ConvexHull, Coord, LineString, MultiPoint, Point, convex_hull::graham_hull};
     use hegel::generators::{self, PrintableGenerator};
 

--- a/geo/src/algorithm/is_convex.rs
+++ b/geo/src/algorithm/is_convex.rs
@@ -503,3 +503,121 @@ mod tests {
         assert!(!ls.is_convex());
     }
 }
+
+#[cfg(test)]
+mod hegel_props {
+    use super::IsConvex;
+    use crate::utils::pbt_gens::{convex_polygons, grid_coords, star_polygons};
+    use crate::{ConvexHull, Coord, LineString, MultiPoint, Point, convex_hull::graham_hull};
+    use hegel::generators::{self, PrintableGenerator};
+
+    fn grid_point_sets() -> impl PrintableGenerator<Vec<Coord<f64>>> {
+        generators::vecs(grid_coords()).max_size(64)
+    }
+
+    fn all_collinear(points: &[Coord<f64>]) -> bool {
+        points.windows(3).all(|w| {
+            robust::orient2d(
+                robust::Coord {
+                    x: w[0].x,
+                    y: w[0].y,
+                },
+                robust::Coord {
+                    x: w[1].x,
+                    y: w[1].y,
+                },
+                robust::Coord {
+                    x: w[2].x,
+                    y: w[2].y,
+                },
+            ) == 0.0
+        })
+    }
+
+    // The generator places every vertex on a circle in strictly increasing
+    // angular order, which is convex, counter-clockwise, and — since three
+    // distinct points of a circle are never collinear — strictly so.
+    #[hegel::test]
+    fn a_ring_inscribed_in_a_circle_is_strictly_ccw_convex(tc: hegel::TestCase) {
+        let polygon = tc.draw(convex_polygons());
+        assert!(
+            polygon.exterior().is_strictly_ccw_convex(),
+            "{:?} was not reported strictly CCW convex",
+            polygon.exterior()
+        );
+    }
+
+    // "The `ConvexHull` algorithm always returns a strictly convex `LineString`
+    // unless the input is empty or collinear" — the `IsConvex` remarks. Both
+    // exceptions are excluded here by construction.
+    #[hegel::test]
+    fn the_hull_of_non_collinear_points_is_strictly_ccw_convex(tc: hegel::TestCase) {
+        let points = tc.draw(grid_point_sets());
+        tc.assume(!all_collinear(&points));
+        let hull = MultiPoint::new(points.iter().copied().map(Point::from).collect()).convex_hull();
+        assert!(
+            hull.exterior().is_strictly_ccw_convex(),
+            "hull {:?} was not reported strictly CCW convex",
+            hull.exterior()
+        );
+    }
+
+    // `graham_hull` "allows computing all the unique points on the convex hull,
+    // as opposed to a strict convex hull that does not include collinear
+    // points", so with `include_on_hull = false` it must agree with quick hull.
+    // Coordinates are on the exact integer grid, where the two algorithms'
+    // differing arithmetic cannot diverge through rounding.
+    #[hegel::test]
+    fn graham_hull_without_collinear_points_matches_quick_hull(tc: hegel::TestCase) {
+        let mut points = tc.draw(grid_point_sets());
+        let quick = MultiPoint::new(points.iter().copied().map(Point::from).collect())
+            .convex_hull()
+            .exterior()
+            .clone();
+        let graham = graham_hull(&mut points, false);
+        assert_eq!(canonical_ring(&graham), canonical_ring(&quick));
+    }
+
+    /// A closed ring rotated to start at its lexicographically least vertex,
+    /// with the repeated closing coordinate dropped. Neither algorithm promises
+    /// a particular start vertex.
+    fn canonical_ring(ring: &LineString<f64>) -> Vec<Coord<f64>> {
+        if ring.0.is_empty() {
+            return Vec::new();
+        }
+        let open = &ring.0[..ring.0.len() - 1];
+        let start = crate::utils::least_index(open);
+        open[start..]
+            .iter()
+            .chain(&open[..start])
+            .copied()
+            .collect()
+    }
+
+    // Strict convexity forbids collinear consecutive vertices, so it is the
+    // stronger of each pair: `convex_orientation(false, ..)` succeeding implies
+    // `convex_orientation(true, ..)` does.
+    #[hegel::test]
+    fn strict_convexity_implies_convexity(tc: hegel::TestCase) {
+        let ring = tc.draw(star_polygons()).exterior().clone();
+        if ring.is_strictly_ccw_convex() {
+            assert!(ring.is_ccw_convex());
+        }
+        if ring.is_strictly_convex() {
+            assert!(ring.is_convex());
+        }
+    }
+
+    // Convexity is a property of the enclosed set, and reversing a ring only
+    // changes which way round it is wound.
+    #[hegel::test]
+    fn reversing_a_ring_swaps_the_convex_orientation(tc: hegel::TestCase) {
+        let ring = tc.draw(star_polygons()).exterior().clone();
+        let reversed = LineString::new(ring.0.iter().rev().copied().collect());
+        assert_eq!(ring.is_ccw_convex(), reversed.is_cw_convex());
+        assert_eq!(
+            ring.is_strictly_ccw_convex(),
+            reversed.is_strictly_cw_convex()
+        );
+    }
+}

--- a/geo/src/algorithm/kernels/mod.rs
+++ b/geo/src/algorithm/kernels/mod.rs
@@ -61,3 +61,113 @@ pub use self::robust::RobustKernel;
 
 pub mod simple;
 pub use self::simple::SimpleKernel;
+
+#[cfg(test)]
+mod hegel_props {
+    use super::{Kernel, Orientation};
+    use crate::Coord;
+    use crate::kernels::{RobustKernel, SimpleKernel};
+    use crate::utils::pbt_gens::{coords, grid_coords};
+
+    fn inverse(orientation: Orientation) -> Orientation {
+        match orientation {
+            Orientation::CounterClockwise => Orientation::Clockwise,
+            Orientation::Clockwise => Orientation::CounterClockwise,
+            Orientation::Collinear => Orientation::Collinear,
+        }
+    }
+
+    fn triple(tc: &hegel::TestCase) -> (Coord<f64>, Coord<f64>, Coord<f64>) {
+        (
+            tc.draw(coords(1e6)),
+            tc.draw(coords(1e6)),
+            tc.draw(coords(1e6)),
+        )
+    }
+
+    // "Gives the orientation of 3 2-dimensional points": the sign of a
+    // determinant, which is unchanged by a cyclic rotation of its rows.
+    #[hegel::test]
+    fn orient2d_is_invariant_under_cyclic_rotation(tc: hegel::TestCase) {
+        let (p, q, r) = triple(&tc);
+        assert_eq!(
+            RobustKernel::orient2d(p, q, r),
+            RobustKernel::orient2d(q, r, p)
+        );
+        assert_eq!(
+            RobustKernel::orient2d(p, q, r),
+            RobustKernel::orient2d(r, p, q)
+        );
+    }
+
+    // Swapping two of the three points swaps two rows of the determinant, which
+    // flips its sign.
+    #[hegel::test]
+    fn swapping_two_points_inverts_orient2d(tc: hegel::TestCase) {
+        let (p, q, r) = triple(&tc);
+        assert_eq!(
+            RobustKernel::orient2d(p, r, q),
+            inverse(RobustKernel::orient2d(p, q, r))
+        );
+    }
+
+    #[hegel::test]
+    fn a_repeated_point_is_collinear(tc: hegel::TestCase) {
+        let (p, _, r) = triple(&tc);
+        assert_eq!(RobustKernel::orient2d(p, p, r), Orientation::Collinear);
+        assert_eq!(RobustKernel::orient2d(p, r, r), Orientation::Collinear);
+    }
+
+    // Orientation depends only on the shape, not on where it sits, so
+    // translating all three points leaves it alone. Coordinates come from the
+    // integer grid so the translated points are exact.
+    #[hegel::test]
+    fn orient2d_is_invariant_under_translation(tc: hegel::TestCase) {
+        let (p, q, r) = (
+            tc.draw(grid_coords()),
+            tc.draw(grid_coords()),
+            tc.draw(grid_coords()),
+        );
+        let offset = tc.draw(grid_coords());
+        assert_eq!(
+            RobustKernel::orient2d(p, q, r),
+            RobustKernel::orient2d(p + offset, q + offset, r + offset)
+        );
+    }
+
+    // `SimpleKernel` "provides the direct implementation of the predicates.
+    // These are meant to be used with exact arithmetic signed types", and
+    // `RobustKernel` promises robust floating point predicates. On the integer
+    // grid the naive determinant is exact, so the two must agree — which makes
+    // the naive kernel an independent oracle for the robust one.
+    #[hegel::test]
+    fn the_robust_kernel_agrees_with_the_simple_one_on_integer_coords(tc: hegel::TestCase) {
+        let (p, q, r) = (
+            tc.draw(grid_coords()),
+            tc.draw(grid_coords()),
+            tc.draw(grid_coords()),
+        );
+        assert_eq!(
+            RobustKernel::orient2d(p, q, r),
+            SimpleKernel::orient2d(p, q, r)
+        );
+    }
+
+    // "Compute the sign of the dot product of `u` and `v` ... The output is
+    // `CounterClockwise` if the sign is positive, `Clockwise` if negative, and
+    // `Collinear` if zero." On the integer grid the dot product is exact.
+    #[hegel::test]
+    fn dot_product_sign_reports_the_sign_of_the_dot_product(tc: hegel::TestCase) {
+        let u = tc.draw(grid_coords());
+        let v = tc.draw(grid_coords());
+        let dot = u.x * v.x + u.y * v.y;
+        let expected = if dot > 0.0 {
+            Orientation::CounterClockwise
+        } else if dot < 0.0 {
+            Orientation::Clockwise
+        } else {
+            Orientation::Collinear
+        };
+        assert_eq!(RobustKernel::dot_product_sign(u, v), expected);
+    }
+}

--- a/geo/src/algorithm/kernels/mod.rs
+++ b/geo/src/algorithm/kernels/mod.rs
@@ -67,7 +67,7 @@ mod hegel_props {
     use super::{Kernel, Orientation};
     use crate::Coord;
     use crate::kernels::{RobustKernel, SimpleKernel};
-    use crate::utils::pbt_gens::{coords, grid_coords};
+    use crate::utils::hegel_gens::{coords, grid_coords};
 
     fn inverse(orientation: Orientation) -> Orientation {
         match orientation {

--- a/geo/src/algorithm/line_locate_point.rs
+++ b/geo/src/algorithm/line_locate_point.rs
@@ -267,3 +267,73 @@ mod test {
         assert_eq!(line.line_locate_point(&pt), None);
     }
 }
+
+#[cfg(test)]
+mod hegel_props {
+    use super::LineLocatePoint;
+    use crate::utils::pbt_gens::{coords, monotone_line_strings};
+    use crate::{Closest, ClosestPoint, Distance, Euclidean, InterpolateLine, Length, Point};
+
+    // "Returns a (option of the) fraction of the line's total length
+    // representing the location of the closest point on the line", so the
+    // fraction lies in `[0, 1]`; the `Line` impl clamps it there explicitly.
+    #[hegel::test]
+    fn the_located_fraction_lies_between_zero_and_one(tc: hegel::TestCase) {
+        let line_string = tc.draw(monotone_line_strings(1e3, 10));
+        let point = Point::from(tc.draw(coords(2e3)));
+        let fraction = line_string
+            .line_locate_point(&point)
+            .expect("finite coordinates");
+        assert!(
+            (0.0..=1.0).contains(&fraction),
+            "fraction {fraction} is outside [0, 1]"
+        );
+    }
+
+    // "line_locate_point should return the fraction to the closest point, so
+    // interpolating the line with that fraction should yield the closest point"
+    // — the comment on `test_matches_closest_point` in
+    // `line_interpolate_point`.
+    #[hegel::test]
+    fn interpolating_the_located_fraction_gives_the_closest_point(tc: hegel::TestCase) {
+        let line_string = tc.draw(monotone_line_strings(1e3, 10));
+        let point = Point::from(tc.draw(coords(2e3)));
+        let fraction = line_string
+            .line_locate_point(&point)
+            .expect("finite coordinates");
+        let interpolated = Euclidean
+            .point_at_ratio_from_start(&line_string, fraction)
+            .expect("a non-empty line string");
+        let (Closest::SinglePoint(closest) | Closest::Intersection(closest)) =
+            line_string.closest_point(&point)
+        else {
+            return;
+        };
+        let scale = Euclidean.length(&line_string).max(1.0);
+        assert!(
+            Euclidean.distance(&interpolated, &closest) <= 1e-9 * scale,
+            "interpolating {fraction} gave {interpolated:?}, closest point is {closest:?}"
+        );
+    }
+
+    // A vertex of the line string is on it, so the located fraction points back
+    // at that vertex.
+    #[hegel::test]
+    fn locating_a_vertex_returns_a_fraction_that_interpolates_back_to_it(tc: hegel::TestCase) {
+        let line_string = tc.draw(monotone_line_strings(1e3, 10));
+        let index =
+            tc.draw(hegel::generators::integers::<usize>().max_value(line_string.0.len() - 1));
+        let vertex = Point::from(line_string.0[index]);
+        let fraction = line_string
+            .line_locate_point(&vertex)
+            .expect("finite coordinates");
+        let interpolated = Euclidean
+            .point_at_ratio_from_start(&line_string, fraction)
+            .expect("a non-empty line string");
+        let scale = Euclidean.length(&line_string).max(1.0);
+        assert!(
+            Euclidean.distance(&interpolated, &vertex) <= 1e-9 * scale,
+            "vertex {vertex:?} located at {fraction} interpolates to {interpolated:?}"
+        );
+    }
+}

--- a/geo/src/algorithm/line_locate_point.rs
+++ b/geo/src/algorithm/line_locate_point.rs
@@ -271,7 +271,7 @@ mod test {
 #[cfg(test)]
 mod hegel_props {
     use super::LineLocatePoint;
-    use crate::utils::pbt_gens::{coords, monotone_line_strings};
+    use crate::utils::hegel_gens::{coords, monotone_line_strings};
     use crate::{Closest, ClosestPoint, Distance, Euclidean, InterpolateLine, Length, Point};
 
     // "Returns a (option of the) fraction of the line's total length

--- a/geo/src/algorithm/line_measures/densify.rs
+++ b/geo/src/algorithm/line_measures/densify.rs
@@ -542,7 +542,7 @@ mod tests {
 #[cfg(test)]
 mod hegel_props {
     use super::Densify;
-    use crate::utils::pbt_gens::{monotone_line_strings, star_polygons};
+    use crate::utils::pbt_gens::{monotone_line_strings, polygons_with_holes};
     use crate::{Distance, Euclidean, Length};
     use hegel::generators;
 
@@ -595,13 +595,14 @@ mod hegel_props {
         );
     }
 
-    // A polygon is densified ring by ring, so the ring count and hole count are
-    // untouched and each ring stays closed.
+    // A polygon is densified ring by ring, so its holes survive and every ring
+    // stays closed.
     #[hegel::test]
     fn densifying_a_polygon_keeps_its_rings_closed(tc: hegel::TestCase) {
-        let polygon = tc.draw(star_polygons());
+        let polygon = tc.draw(polygons_with_holes());
         let densified = Euclidean.densify(&polygon, max_segment_lengths(&tc));
         assert_eq!(densified.interiors().len(), polygon.interiors().len());
         assert!(densified.exterior().is_closed());
+        assert!(densified.interiors().iter().all(|ring| ring.is_closed()));
     }
 }

--- a/geo/src/algorithm/line_measures/densify.rs
+++ b/geo/src/algorithm/line_measures/densify.rs
@@ -542,7 +542,7 @@ mod tests {
 #[cfg(test)]
 mod hegel_props {
     use super::Densify;
-    use crate::utils::pbt_gens::{monotone_line_strings, polygons_with_holes};
+    use crate::utils::hegel_gens::{monotone_line_strings, polygons_with_holes};
     use crate::{Distance, Euclidean, Length};
     use hegel::generators;
 

--- a/geo/src/algorithm/line_measures/densify.rs
+++ b/geo/src/algorithm/line_measures/densify.rs
@@ -538,3 +538,70 @@ mod tests {
         }
     }
 }
+
+#[cfg(test)]
+mod hegel_props {
+    use super::Densify;
+    use crate::utils::pbt_gens::{monotone_line_strings, star_polygons};
+    use crate::{Distance, Euclidean, Length};
+    use hegel::generators;
+
+    fn max_segment_lengths(tc: &hegel::TestCase) -> f64 {
+        tc.draw(generators::floats::<f64>().min_value(0.1).max_value(1e4))
+    }
+
+    // "Creates a copy of the geometry with additional points inserted as
+    // necessary to ensure there is never more than `max_segment_length` between
+    // points."
+    #[hegel::test]
+    fn no_densified_segment_is_longer_than_the_maximum(tc: hegel::TestCase) {
+        let line_string = tc.draw(monotone_line_strings(1e4, 12));
+        let max_segment_length = max_segment_lengths(&tc);
+        for line in Euclidean.densify(&line_string, max_segment_length).lines() {
+            let length = Euclidean.distance(line.start, line.end);
+            assert!(
+                length <= max_segment_length * (1.0 + 1e-9),
+                "segment of length {length} exceeds the maximum {max_segment_length}"
+            );
+        }
+    }
+
+    // Densifying only inserts points, so the original vertices survive in
+    // order: each segment's `start_point` is pushed unmodified, and the final
+    // coordinate is pushed to finish.
+    #[hegel::test]
+    fn densifying_keeps_the_original_vertices_in_order(tc: hegel::TestCase) {
+        let line_string = tc.draw(monotone_line_strings(1e4, 12));
+        let densified = Euclidean.densify(&line_string, max_segment_lengths(&tc));
+        let mut remaining = densified.0.iter();
+        for coord in &line_string.0 {
+            assert!(
+                remaining.any(|candidate| candidate == coord),
+                "{densified:?} does not contain the vertices of {line_string:?} in order"
+            );
+        }
+    }
+
+    // Inserted points sit on the segment they subdivide, so the Euclidean
+    // length is unchanged.
+    #[hegel::test]
+    fn densifying_preserves_euclidean_length(tc: hegel::TestCase) {
+        let line_string = tc.draw(monotone_line_strings(1e4, 12));
+        let densified = Euclidean.densify(&line_string, max_segment_lengths(&tc));
+        assert_relative_eq!(
+            Euclidean.length(&densified),
+            Euclidean.length(&line_string),
+            max_relative = 1e-9
+        );
+    }
+
+    // A polygon is densified ring by ring, so the ring count and hole count are
+    // untouched and each ring stays closed.
+    #[hegel::test]
+    fn densifying_a_polygon_keeps_its_rings_closed(tc: hegel::TestCase) {
+        let polygon = tc.draw(star_polygons());
+        let densified = Euclidean.densify(&polygon, max_segment_lengths(&tc));
+        assert_eq!(densified.interiors().len(), polygon.interiors().len());
+        assert!(densified.exterior().is_closed());
+    }
+}

--- a/geo/src/algorithm/line_measures/frechet_distance.rs
+++ b/geo/src/algorithm/line_measures/frechet_distance.rs
@@ -225,7 +225,7 @@ mod test {
 #[cfg(test)]
 mod hegel_props {
     use super::FrechetDistance;
-    use crate::utils::pbt_gens::monotone_line_strings;
+    use crate::utils::hegel_gens::monotone_line_strings;
     use crate::{Euclidean, HausdorffDistance};
 
     // The Fréchet distance between two curves does not depend on which is named

--- a/geo/src/algorithm/line_measures/frechet_distance.rs
+++ b/geo/src/algorithm/line_measures/frechet_distance.rs
@@ -221,3 +221,40 @@ mod test {
         assert_relative_eq!(mars_measure.frechet_distance(&ls, &ls), 0.0);
     }
 }
+
+#[cfg(test)]
+mod hegel_props {
+    use super::FrechetDistance;
+    use crate::utils::pbt_gens::monotone_line_strings;
+    use crate::{Euclidean, HausdorffDistance};
+
+    // The Fréchet distance between two curves does not depend on which is named
+    // first. The implementation reorders its arguments by vertex count before
+    // filling the dynamic-programming table, so the two orders take different
+    // paths through it.
+    #[hegel::test]
+    fn frechet_distance_is_symmetric(tc: hegel::TestCase) {
+        let a = tc.draw(monotone_line_strings(1e3, 10));
+        let b = tc.draw(monotone_line_strings(1e3, 10));
+        assert_eq!(
+            Euclidean.frechet_distance(&a, &b),
+            Euclidean.frechet_distance(&b, &a)
+        );
+    }
+
+    // A coupling of the two vertex sequences realises the Fréchet distance, and
+    // every vertex is matched somewhere along it, so the Fréchet distance
+    // bounds the Hausdorff distance from above. Both implementations here work
+    // on vertices only, which is what makes the comparison exact.
+    #[hegel::test]
+    fn frechet_distance_is_at_least_the_hausdorff_distance(tc: hegel::TestCase) {
+        let a = tc.draw(monotone_line_strings(1e3, 10));
+        let b = tc.draw(monotone_line_strings(1e3, 10));
+        let frechet = Euclidean.frechet_distance(&a, &b);
+        let hausdorff = a.hausdorff_distance(&b);
+        assert!(
+            frechet >= hausdorff * (1.0 - 1e-12),
+            "Frechet {frechet} is below Hausdorff {hausdorff}"
+        );
+    }
+}

--- a/geo/src/algorithm/line_measures/metric_spaces/euclidean/distance.rs
+++ b/geo/src/algorithm/line_measures/metric_spaces/euclidean/distance.rs
@@ -1815,7 +1815,7 @@ mod test {
 /// Hegel property tests for `Euclidean.distance`.
 #[cfg(test)]
 mod hegel_props {
-    use crate::utils::pbt_gens::{grid_coords, monotone_line_strings, star_polygons};
+    use crate::utils::hegel_gens::{grid_coords, monotone_line_strings, star_polygons};
     use crate::{Coord, Distance, Euclidean, Line, LineString, Point, Rect, coord};
     use hegel::generators::{self, Generator, PrintableGenerator};
 

--- a/geo/src/algorithm/line_measures/metric_spaces/euclidean/distance.rs
+++ b/geo/src/algorithm/line_measures/metric_spaces/euclidean/distance.rs
@@ -1811,3 +1811,174 @@ mod test {
         }
     }
 }
+
+/// Hegel property tests for `Euclidean.distance`.
+#[cfg(test)]
+mod hegel_props {
+    use crate::utils::pbt_gens::{grid_coords, monotone_line_strings, star_polygons};
+    use crate::{Coord, Distance, Euclidean, Line, LineString, Point, Rect, coord};
+    use hegel::generators::{self, Generator, PrintableGenerator};
+
+    fn line_strings() -> impl PrintableGenerator<LineString<f64>> {
+        monotone_line_strings(1e3, 10)
+    }
+
+    /// Coordinates that are zero or of magnitude in `[1e-6, 1e6]`, the range
+    /// `fuzz/fuzz_targets/separable_distance.rs` restricts itself to: "Outside
+    /// that range the segment-distance primitive that both sides share loses
+    /// precision". Subnormal-scale coordinates also reach a panic inside
+    /// `rstar` — see `distance_between_subnormal_scale_polygons_panics`.
+    fn bounded_coords() -> impl PrintableGenerator<Coord<f64>> {
+        let component = || {
+            hegel::one_of!(
+                generators::just(0.0),
+                generators::floats::<f64>().min_value(1e-6).max_value(1e6),
+                generators::floats::<f64>().min_value(-1e6).max_value(-1e-6),
+            )
+        };
+        generators::tuples!(component(), component())
+            .map(|(x, y)| coord! { x: x, y: y })
+            .print_as_debug()
+    }
+
+    /// Minimum distance between two line strings by brute force over every
+    /// segment pair — the same oracle `fuzz/fuzz_targets/separable_distance.rs`
+    /// uses.
+    fn brute_force(a: &LineString<f64>, b: &LineString<f64>) -> f64 {
+        a.lines()
+            .flat_map(|p| b.lines().map(move |q| Euclidean.distance(&p, &q)))
+            .fold(f64::INFINITY, f64::min)
+    }
+
+    // "Distance is a symmetric operation" — the comment introducing
+    // `symmetric_distance_impl!` above. That macro only covers mixed-type pairs;
+    // the same-type impls have argument-order-dependent bodies, and
+    // `fast_path_prefix_prune_regression` pins symmetry for one of them.
+    #[hegel::test]
+    fn distance_between_line_strings_is_symmetric(tc: hegel::TestCase) {
+        let (a, b) = (tc.draw(line_strings()), tc.draw(line_strings()));
+        assert_eq!(Euclidean.distance(&a, &b), Euclidean.distance(&b, &a));
+    }
+
+    #[hegel::test]
+    fn distance_between_polygons_is_symmetric(tc: hegel::TestCase) {
+        let (a, b) = (tc.draw(star_polygons()), tc.draw(star_polygons()));
+        assert_eq!(Euclidean.distance(&a, &b), Euclidean.distance(&b, &a));
+    }
+
+    // `separable_geometry_distance_fast` is selected when the two bounding
+    // boxes are "strictly separated along an axis"; translating `b` clear of
+    // `a` in x forces it. The fuzz target checks exactly this against a brute
+    // force segment sweep.
+    #[hegel::test]
+    fn the_separable_fast_path_matches_a_brute_force_segment_sweep(tc: hegel::TestCase) {
+        let a = tc.draw(line_strings());
+        let mut b = tc.draw(line_strings());
+        let a_max_x = a.coords().fold(f64::NEG_INFINITY, |acc, c| acc.max(c.x));
+        let b_min_x = b.coords().fold(f64::INFINITY, |acc, c| acc.min(c.x));
+        let shift = (a_max_x + 1.0) - b_min_x;
+        for coord in &mut b.0 {
+            coord.x += shift;
+        }
+        let expected = brute_force(&a, &b);
+        // Both sides evaluate candidate pairs with the same segment primitive,
+        // so they agree to within rounding unless the pruning is unsound — the
+        // tolerance model the fuzz target uses.
+        let tolerance = 1e-9 * (1.0 + expected);
+        assert!(
+            (Euclidean.distance(&a, &b) - expected).abs() <= tolerance,
+            "fast path gave {} where brute force says {expected}",
+            Euclidean.distance(&a, &b)
+        );
+    }
+
+    // "The closed-form Rect-to-Rect distance must agree with the general
+    // polygon-to-polygon path that the other Rect implementations use" — the
+    // doc comment on `distance_rect_rect_agrees_with_polygon_path` above, which
+    // runs the same check over a fixed pseudorandom sample.
+    #[hegel::test]
+    fn the_closed_form_rect_distance_matches_the_polygon_path(tc: hegel::TestCase) {
+        let rect = |tc: &hegel::TestCase| {
+            let (a, b) = (tc.draw(bounded_coords()), tc.draw(bounded_coords()));
+            Rect::new(a, b)
+        };
+        let (a, b) = (rect(&tc), rect(&tc));
+        assert_relative_eq!(
+            Euclidean.distance(&a, &b),
+            Euclidean.distance(&a.to_polygon(), &b.to_polygon()),
+            epsilon = 1e-9
+        );
+    }
+
+    // "Implements Euclidean distance from a Triangle or a Rect to another
+    // geometry type by converting the Triangle or Rect to a polygon."
+    #[hegel::test]
+    fn rect_to_geometry_distance_goes_through_the_polygon(tc: hegel::TestCase) {
+        let rect = Rect::new(tc.draw(bounded_coords()), tc.draw(bounded_coords()));
+        let line_string = tc.draw(line_strings());
+        assert_eq!(
+            Euclidean.distance(&rect, &line_string),
+            Euclidean.distance(&rect.to_polygon(), &line_string)
+        );
+    }
+
+    // `distance_within` "Returns `true` if the minimum distance between
+    // `origin` and `destination` is less than or equal to `distance`".
+    #[hegel::test]
+    fn distance_within_agrees_with_the_measured_distance(tc: hegel::TestCase) {
+        let (a, b) = (tc.draw(line_strings()), tc.draw(line_strings()));
+        let bound = tc.draw(generators::floats::<f64>().min_value(0.0).max_value(1e4));
+        assert_eq!(
+            Euclidean.distance_within(&a, &b, bound),
+            Euclidean.distance(&a, &b) <= bound
+        );
+    }
+
+    // A point on a segment is at zero distance from it, and the crate's own
+    // deprecated `EuclideanDistance` docs spell out the converse cases: "If a
+    // `Point` lies on a `LineString`, the distance is `0.0`". Endpoints are
+    // drawn on the integer grid so the interpolated point is exact.
+    #[hegel::test]
+    fn a_point_on_a_segment_is_at_zero_distance(tc: hegel::TestCase) {
+        let line = Line::new(tc.draw(grid_coords()), tc.draw(grid_coords()));
+        let halves = (line.start + line.end) / 2.0;
+        for coord in [line.start, line.end, halves] {
+            assert_eq!(Euclidean.distance(&Point::from(coord), &line), 0.0);
+        }
+    }
+
+    // Distance from a point to itself is zero, and the triangle inequality
+    // holds for points.
+    #[hegel::test]
+    fn point_distances_satisfy_the_triangle_inequality(tc: hegel::TestCase) {
+        let a = Point::from(tc.draw(bounded_coords()));
+        let b = Point::from(tc.draw(bounded_coords()));
+        let c = Point::from(tc.draw(bounded_coords()));
+        let direct = Euclidean.distance(a, c);
+        let detour = Euclidean.distance(a, b) + Euclidean.distance(b, c);
+        assert!(
+            direct <= detour * (1.0 + 1e-12),
+            "{direct} exceeds the detour {detour}"
+        );
+    }
+
+    // KNOWN FAILURE, georust/geo#1604 (open, the second half of it): the
+    // general polygon-to-polygon path builds an R-tree and calls
+    // `nearest_neighbor`, which unwraps a `None` for these subnormal-scale
+    // coordinates (`rstar-0.13.0`, `algorithm/nearest_neighbor.rs:52`). Every
+    // coordinate is finite, and the panic reaches release builds.
+    #[test]
+    #[ignore = "geo#1604: Euclidean.distance panics inside rstar at subnormal scale"]
+    fn distance_between_subnormal_scale_polygons_panics() {
+        let a = Rect::new(
+            coord! { x: 0.0, y: 0.0 },
+            coord! { x: 9.828413039546407e-237, y: 1.4830465425330546e-162 },
+        );
+        let b = Rect::new(
+            coord! { x: 1.1113793747425387e-162, y: 1.1113793747425387e-162 },
+            coord! { x: 4.914206519773204e-237, y: 2.513455854232436e-88 },
+        );
+        let via_polygons: f64 = Euclidean.distance(&a.to_polygon(), &b.to_polygon());
+        assert!(via_polygons.is_finite());
+    }
+}

--- a/geo/src/algorithm/line_measures/metric_spaces/euclidean/distance.rs
+++ b/geo/src/algorithm/line_measures/metric_spaces/euclidean/distance.rs
@@ -1962,13 +1962,13 @@ mod hegel_props {
         );
     }
 
-    // KNOWN FAILURE, georust/geo#1604 (open, the second half of it): the
+    // KNOWN FAILURE, #1604 (open, the second half of it): the
     // general polygon-to-polygon path builds an R-tree and calls
     // `nearest_neighbor`, which unwraps a `None` for these subnormal-scale
     // coordinates (`rstar-0.13.0`, `algorithm/nearest_neighbor.rs:52`). Every
     // coordinate is finite, and the panic reaches release builds.
     #[test]
-    #[ignore = "geo#1604: Euclidean.distance panics inside rstar at subnormal scale"]
+    #[ignore = "#1604: Euclidean.distance panics inside rstar at subnormal scale"]
     fn distance_between_subnormal_scale_polygons_panics() {
         let a = Rect::new(
             coord! { x: 0.0, y: 0.0 },

--- a/geo/src/algorithm/linestring_segment.rs
+++ b/geo/src/algorithm/linestring_segment.rs
@@ -358,3 +358,63 @@ mod test {
         );
     }
 }
+
+#[cfg(test)]
+mod hegel_props {
+    use super::LineStringSegmentize;
+    use crate::utils::pbt_gens::monotone_line_strings;
+    use crate::{Euclidean, Length};
+    use hegel::generators;
+
+    // "Segments a LineString into `segment_count` equal length LineStrings as a
+    // MultiLineString", and `None` is returned only "when `segment_count` is
+    // equal to 0 or when a point cannot be interpolated on a `Line` segment".
+    #[hegel::test]
+    fn segmentize_returns_the_requested_number_of_segments(tc: hegel::TestCase) {
+        let line_string = tc.draw(monotone_line_strings(1e3, 12));
+        let n = tc.draw(generators::integers::<usize>().min_value(1).max_value(64));
+        let segments = line_string
+            .line_segmentize(n)
+            .expect("a positive count on a finite line string");
+        assert_eq!(segments.0.len(), n);
+    }
+
+    #[hegel::test]
+    fn a_zero_segment_count_is_rejected(tc: hegel::TestCase) {
+        let line_string = tc.draw(monotone_line_strings(1e3, 12));
+        assert!(line_string.line_segmentize(0).is_none());
+    }
+
+    // The segments partition the input, so their lengths add up to it.
+    #[hegel::test]
+    fn segmentize_preserves_total_length(tc: hegel::TestCase) {
+        let line_string = tc.draw(monotone_line_strings(1e3, 12));
+        let n = tc.draw(generators::integers::<usize>().min_value(1).max_value(64));
+        let segments = line_string
+            .line_segmentize(n)
+            .expect("a positive count on a finite line string");
+        assert_relative_eq!(
+            Euclidean.length(&segments),
+            Euclidean.length(&line_string),
+            max_relative = 1e-9
+        );
+    }
+
+    // The segments are of "equal length", and they run end to start so that
+    // together they retrace the input.
+    #[hegel::test]
+    fn the_segments_are_of_equal_length_and_join_up(tc: hegel::TestCase) {
+        let line_string = tc.draw(monotone_line_strings(1e3, 12));
+        let n = tc.draw(generators::integers::<usize>().min_value(1).max_value(64));
+        let segments = line_string
+            .line_segmentize(n)
+            .expect("a positive count on a finite line string");
+        let expected = Euclidean.length(&line_string) / n as f64;
+        for segment in &segments.0 {
+            assert_relative_eq!(Euclidean.length(segment), expected, max_relative = 1e-9);
+        }
+        for pair in segments.0.windows(2) {
+            assert_eq!(pair[0].0.last(), pair[1].0.first());
+        }
+    }
+}

--- a/geo/src/algorithm/linestring_segment.rs
+++ b/geo/src/algorithm/linestring_segment.rs
@@ -362,7 +362,7 @@ mod test {
 #[cfg(test)]
 mod hegel_props {
     use super::LineStringSegmentize;
-    use crate::utils::pbt_gens::monotone_line_strings;
+    use crate::utils::hegel_gens::monotone_line_strings;
     use crate::{Euclidean, Length};
     use hegel::generators;
 

--- a/geo/src/algorithm/minimum_rotated_rect.rs
+++ b/geo/src/algorithm/minimum_rotated_rect.rs
@@ -154,7 +154,7 @@ mod test {
 #[cfg(test)]
 mod hegel_props {
     use super::MinimumRotatedRect;
-    use crate::utils::pbt_gens::grid_coords;
+    use crate::utils::hegel_gens::grid_coords;
     use crate::{Area, BoundingRect, ConvexHull, Coord, Distance, Euclidean, MultiPoint, Point};
     use hegel::generators::{self, PrintableGenerator};
 

--- a/geo/src/algorithm/minimum_rotated_rect.rs
+++ b/geo/src/algorithm/minimum_rotated_rect.rs
@@ -150,3 +150,109 @@ mod test {
         );
     }
 }
+
+#[cfg(test)]
+mod hegel_props {
+    use super::MinimumRotatedRect;
+    use crate::utils::pbt_gens::grid_coords;
+    use crate::{Area, BoundingRect, ConvexHull, Coord, Distance, Euclidean, MultiPoint, Point};
+    use hegel::generators::{self, PrintableGenerator};
+
+    fn point_sets() -> impl PrintableGenerator<Vec<Coord<f64>>> {
+        generators::vecs(grid_coords()).max_size(32)
+    }
+
+    fn multi_point(coords: &[Coord<f64>]) -> MultiPoint<f64> {
+        MultiPoint::new(coords.iter().copied().map(Point::from).collect())
+    }
+
+    // "minimum rotated rect is the rectangle that can enclose all points given
+    // and have smallest area of all enclosing rectangles".
+    #[hegel::test]
+    fn the_minimum_rotated_rect_encloses_every_input_point(tc: hegel::TestCase) {
+        let coords = tc.draw(point_sets());
+        let points = multi_point(&coords);
+        let Some(rect) = points.minimum_rotated_rect() else {
+            return;
+        };
+        // The implementation translates a hull vertex to the origin and back
+        // "to improve precision", so a point on the boundary can land a few
+        // ulps outside. The slack is relative to the extent of the input.
+        let scale = coords
+            .iter()
+            .map(|c| c.x.abs().max(c.y.abs()))
+            .fold(1.0_f64, f64::max);
+        for coord in &coords {
+            let distance = Euclidean.distance(&Point::from(*coord), &rect);
+            assert!(
+                distance <= 1e-9 * scale,
+                "{coord:?} lies {distance} outside {rect:?}"
+            );
+        }
+    }
+
+    // The axis-aligned bounding rect is one of the enclosing rectangles, so the
+    // minimum-area one cannot be larger; and every enclosing rectangle covers
+    // the convex hull, so it cannot be smaller than the hull.
+    #[hegel::test]
+    fn its_area_sits_between_the_hull_and_the_bounding_rect(tc: hegel::TestCase) {
+        let coords = tc.draw(point_sets());
+        let points = multi_point(&coords);
+        let Some(rect) = points.minimum_rotated_rect() else {
+            return;
+        };
+        let area = rect.unsigned_area();
+        let hull_area = points.convex_hull().unsigned_area();
+        let bounding_area = points
+            .bounding_rect()
+            .expect("a non-empty point set")
+            .unsigned_area();
+        assert!(
+            area <= bounding_area * (1.0 + 1e-9) + 1e-9,
+            "minimum rotated rect area {area} exceeds the bounding rect area {bounding_area}"
+        );
+        assert!(
+            area >= hull_area * (1.0 - 1e-9) - 1e-9,
+            "minimum rotated rect area {area} is below the hull area {hull_area}"
+        );
+    }
+
+    // Only the convex hull's vertices can be extreme, and the implementation
+    // runs rotating calipers over the hull, so hulling first leaves the same
+    // rectangle. The two runs pick different hull vertices as their precision
+    // origin, so the corners agree only to within rounding and the comparison
+    // is on area.
+    #[hegel::test]
+    fn it_only_depends_on_the_convex_hull(tc: hegel::TestCase) {
+        let coords = tc.draw(point_sets());
+        let points = multi_point(&coords);
+        let (Some(direct), Some(via_hull)) = (
+            points.minimum_rotated_rect(),
+            points.convex_hull().minimum_rotated_rect(),
+        ) else {
+            assert_eq!(
+                points.minimum_rotated_rect(),
+                points.convex_hull().minimum_rotated_rect()
+            );
+            return;
+        };
+        assert_relative_eq!(
+            direct.unsigned_area(),
+            via_hull.unsigned_area(),
+            max_relative = 1e-9,
+            epsilon = 1e-9
+        );
+    }
+
+    // Rotating calipers returns a closed four-corner ring with no holes.
+    #[hegel::test]
+    fn the_result_is_a_closed_quadrilateral(tc: hegel::TestCase) {
+        let coords = tc.draw(point_sets());
+        let Some(rect) = multi_point(&coords).minimum_rotated_rect() else {
+            return;
+        };
+        assert_eq!(rect.exterior().0.len(), 5);
+        assert!(rect.exterior().is_closed());
+        assert!(rect.interiors().is_empty());
+    }
+}

--- a/geo/src/algorithm/orient.rs
+++ b/geo/src/algorithm/orient.rs
@@ -146,3 +146,58 @@ mod test {
         assert_eq!(oriented.interiors()[0].0, oriented_int_ls.0);
     }
 }
+
+#[cfg(test)]
+mod hegel_props {
+    use super::{Direction, Orient};
+    use crate::utils::pbt_gens::{disjoint_multi_polygons, polygons_with_holes};
+    use crate::{Area, Winding};
+
+    // "By default, the exterior ring of a Polygon is oriented counter-clockwise,
+    // and any interior rings are oriented clockwise"; `Reversed` swaps both.
+    #[hegel::test]
+    fn orient_gives_each_ring_the_documented_winding(tc: hegel::TestCase) {
+        let polygon = tc.draw(polygons_with_holes());
+        let reverse = tc.draw(hegel::generators::booleans());
+        let direction = if reverse {
+            Direction::Reversed
+        } else {
+            Direction::Default
+        };
+        let oriented = polygon.orient(direction);
+        assert_eq!(oriented.exterior().is_cw(), reverse);
+        for interior in oriented.interiors() {
+            assert_eq!(interior.is_ccw(), reverse);
+        }
+    }
+
+    #[hegel::test]
+    fn orient_is_idempotent(tc: hegel::TestCase) {
+        let polygon = tc.draw(polygons_with_holes());
+        let oriented = polygon.orient(Direction::Default);
+        assert_eq!(oriented.orient(Direction::Default), oriented);
+    }
+
+    // Orienting only reverses rings, which leaves the enclosed region — and so
+    // its area — untouched.
+    #[hegel::test]
+    fn orient_preserves_unsigned_area(tc: hegel::TestCase) {
+        let polygon = tc.draw(polygons_with_holes());
+        assert_relative_eq!(
+            polygon.orient(Direction::Reversed).unsigned_area(),
+            polygon.unsigned_area(),
+            max_relative = 1e-12
+        );
+    }
+
+    // The `MultiPolygon` impl orients each member independently.
+    #[hegel::test]
+    fn orienting_a_multi_polygon_orients_each_member(tc: hegel::TestCase) {
+        let multi_polygon = tc.draw(disjoint_multi_polygons());
+        let expected: Vec<_> = multi_polygon
+            .iter()
+            .map(|p| p.orient(Direction::Default))
+            .collect();
+        assert_eq!(multi_polygon.orient(Direction::Default).0, expected);
+    }
+}

--- a/geo/src/algorithm/orient.rs
+++ b/geo/src/algorithm/orient.rs
@@ -150,7 +150,7 @@ mod test {
 #[cfg(test)]
 mod hegel_props {
     use super::{Direction, Orient};
-    use crate::utils::pbt_gens::{disjoint_multi_polygons, polygons_with_holes};
+    use crate::utils::hegel_gens::{disjoint_multi_polygons, polygons_with_holes};
     use crate::{Area, Winding};
 
     // "By default, the exterior ring of a Polygon is oriented counter-clockwise,

--- a/geo/src/algorithm/rect_ops.rs
+++ b/geo/src/algorithm/rect_ops.rs
@@ -109,7 +109,7 @@ mod test {
 #[cfg(test)]
 mod hegel_props {
     use super::RectOps;
-    use crate::utils::pbt_gens::coords;
+    use crate::utils::hegel_gens::coords;
     use crate::{Intersects, Rect};
 
     fn rects(tc: &hegel::TestCase) -> Rect<f64> {

--- a/geo/src/algorithm/rect_ops.rs
+++ b/geo/src/algorithm/rect_ops.rs
@@ -105,3 +105,75 @@ mod test {
         assert_eq!(a.rect_intersection(c), None);
     }
 }
+
+#[cfg(test)]
+mod hegel_props {
+    use super::RectOps;
+    use crate::utils::pbt_gens::coords;
+    use crate::{Intersects, Rect};
+
+    fn rects(tc: &hegel::TestCase) -> Rect<f64> {
+        Rect::new(tc.draw(coords(1e3)), tc.draw(coords(1e3)))
+    }
+
+    // "Calculate the smallest axis-aligned rectangle that contains both
+    // rectangles": it contains both, and shrinking any side would drop a
+    // corner of one of them.
+    #[hegel::test]
+    fn the_union_is_the_smallest_rect_containing_both(tc: hegel::TestCase) {
+        let (a, b) = (rects(&tc), rects(&tc));
+        let union = a.rect_union(b);
+        assert_eq!(union.min().x, a.min().x.min(b.min().x));
+        assert_eq!(union.min().y, a.min().y.min(b.min().y));
+        assert_eq!(union.max().x, a.max().x.max(b.max().x));
+        assert_eq!(union.max().y, a.max().y.max(b.max().y));
+    }
+
+    #[hegel::test]
+    fn the_union_is_commutative_and_idempotent(tc: hegel::TestCase) {
+        let (a, b) = (rects(&tc), rects(&tc));
+        assert_eq!(a.rect_union(b), b.rect_union(a));
+        assert_eq!(a.rect_union(a), a);
+    }
+
+    // "Returns `None` if the rectangles are disjoint" — and the impl gates on
+    // `Intersects`, which for rectangles includes touching boundaries.
+    #[hegel::test]
+    fn the_intersection_is_some_exactly_when_the_rects_intersect(tc: hegel::TestCase) {
+        let (a, b) = (rects(&tc), rects(&tc));
+        assert_eq!(a.rect_intersection(b).is_some(), a.intersects(&b));
+    }
+
+    // "Calculate the axis-aligned rectangle contained in both rectangles":
+    // whatever comes back is inside each of them, so unioning it back in
+    // changes nothing.
+    #[hegel::test]
+    fn the_intersection_is_contained_in_both_rects(tc: hegel::TestCase) {
+        let (a, b) = (rects(&tc), rects(&tc));
+        let Some(intersection) = a.rect_intersection(b) else {
+            return;
+        };
+        assert_eq!(intersection.rect_union(a), a);
+        assert_eq!(intersection.rect_union(b), b);
+    }
+
+    #[hegel::test]
+    fn a_rect_intersected_with_itself_is_itself(tc: hegel::TestCase) {
+        let a = rects(&tc);
+        assert_eq!(a.rect_intersection(a), Some(a));
+    }
+
+    // It is the *largest* such rectangle: each of its four sides is set by
+    // whichever input constrains it.
+    #[hegel::test]
+    fn the_intersection_takes_the_tighter_bound_on_every_side(tc: hegel::TestCase) {
+        let (a, b) = (rects(&tc), rects(&tc));
+        let Some(intersection) = a.rect_intersection(b) else {
+            return;
+        };
+        assert_eq!(intersection.min().x, a.min().x.max(b.min().x));
+        assert_eq!(intersection.min().y, a.min().y.max(b.min().y));
+        assert_eq!(intersection.max().x, a.max().x.min(b.max().x));
+        assert_eq!(intersection.max().y, a.max().y.min(b.max().y));
+    }
+}

--- a/geo/src/algorithm/remove_repeated_points.rs
+++ b/geo/src/algorithm/remove_repeated_points.rs
@@ -476,7 +476,7 @@ mod test {
 #[cfg(test)]
 mod hegel_props {
     use super::RemoveRepeatedPoints;
-    use crate::utils::pbt_gens::{coords, geometries, line_strings};
+    use crate::utils::hegel_gens::{coords, geometries, line_strings};
     use crate::{Geometry, MultiPoint, Point};
     use hegel::generators;
 

--- a/geo/src/algorithm/remove_repeated_points.rs
+++ b/geo/src/algorithm/remove_repeated_points.rs
@@ -472,3 +472,74 @@ mod test {
         assert_eq!(gc, expected);
     }
 }
+
+#[cfg(test)]
+mod hegel_props {
+    use super::RemoveRepeatedPoints;
+    use crate::utils::pbt_gens::{coords, geometries, line_strings};
+    use crate::{Geometry, MultiPoint, Point};
+    use hegel::generators;
+
+    // "Create a new geometry with (consecutive) repeated points removed" versus
+    // "Remove (consecutive) repeated points inplace" — the same operation by
+    // two routes.
+    #[hegel::test]
+    fn the_in_place_form_matches_the_by_value_form(tc: hegel::TestCase) {
+        let geometry = tc.draw(geometries(1e3));
+        let mut in_place = geometry.clone();
+        in_place.remove_repeated_points_mut();
+        assert_eq!(geometry.remove_repeated_points(), in_place);
+    }
+
+    // Nothing is left to remove after the first pass.
+    #[hegel::test]
+    fn removing_repeated_points_is_idempotent(tc: hegel::TestCase) {
+        let geometry = tc.draw(geometries(1e3));
+        let once = geometry.remove_repeated_points();
+        assert_eq!(once.remove_repeated_points(), once);
+    }
+
+    // For a `LineString` the docs say "consecutive" repeated points, so the
+    // output has no two adjacent coordinates equal, and only such coordinates
+    // may have been dropped.
+    #[hegel::test]
+    fn a_line_string_keeps_one_coord_from_each_run(tc: hegel::TestCase) {
+        let line_string = tc.draw(line_strings(1e3, 24));
+        let deduped = line_string.remove_repeated_points();
+        assert!(deduped.0.windows(2).all(|w| w[0] != w[1]));
+        let mut expected = line_string.0.clone();
+        expected.dedup();
+        assert_eq!(deduped.0, expected);
+    }
+
+    // A `MultiPoint` has "repeated points removed" without the "consecutive"
+    // qualifier, so no point may appear twice at all.
+    #[hegel::test]
+    fn a_multi_point_keeps_no_duplicates(tc: hegel::TestCase) {
+        let points: Vec<Point<f64>> = tc
+            .draw(generators::vecs(coords(20.0)).max_size(24))
+            .into_iter()
+            .map(Point::from)
+            .collect();
+        let deduped = MultiPoint::new(points).remove_repeated_points();
+        for (i, point) in deduped.iter().enumerate() {
+            assert!(
+                !deduped.0[..i].contains(point),
+                "{point:?} appears twice in {deduped:?}"
+            );
+        }
+    }
+
+    // "For `Point`, `Line`, `Rect` and `Triangle` the geometry remains the
+    // same."
+    #[hegel::test]
+    fn zero_and_one_dimensional_primitives_are_left_alone(tc: hegel::TestCase) {
+        let geometry = tc.draw(geometries(1e3));
+        if matches!(
+            geometry,
+            Geometry::Point(_) | Geometry::Line(_) | Geometry::Rect(_) | Geometry::Triangle(_)
+        ) {
+            assert_eq!(geometry.remove_repeated_points(), geometry);
+        }
+    }
+}

--- a/geo/src/algorithm/rotate.rs
+++ b/geo/src/algorithm/rotate.rs
@@ -575,3 +575,80 @@ mod test {
         assert_eq!(empty_multipolygon, rotated_empty_multipolygon);
     }
 }
+
+#[cfg(test)]
+mod hegel_props {
+    use super::Rotate;
+    use crate::utils::pbt_gens::{coords, monotone_line_strings, star_polygons};
+    use crate::{AffineOps, AffineTransform, Area, Euclidean, Length, Point};
+    use hegel::generators;
+
+    fn degrees(tc: &hegel::TestCase) -> f64 {
+        tc.draw(
+            generators::floats::<f64>()
+                .min_value(-720.0)
+                .max_value(720.0),
+        )
+    }
+
+    // "a rotated point should always equal itself" — the comment on
+    // `test_rotate_center_and_centroid` above: for a `Point` both pivots are
+    // the point itself, so it is a fixed point of its own rotation. The
+    // comparison is approximate because `AffineTransform::rotate` folds the
+    // pivot into the matrix offsets, so the cancellation is only exact in real
+    // arithmetic (91 degrees about (0, 1) lands one ulp low).
+    #[hegel::test]
+    fn rotating_a_point_about_itself_returns_the_point(tc: hegel::TestCase) {
+        let point = Point::from(tc.draw(coords(1e3)));
+        let angle = degrees(&tc);
+        for rotated in [
+            point.rotate_around_center(angle),
+            point.rotate_around_centroid(angle),
+        ] {
+            let tolerance = 16.0 * f64::EPSILON * point.x().abs().max(point.y().abs()).max(1.0);
+            assert!(
+                (rotated.x() - point.x()).abs() <= tolerance
+                    && (rotated.y() - point.y()).abs() <= tolerance,
+                "{point:?} rotated by {angle} about itself gave {rotated:?}"
+            );
+        }
+    }
+
+    // `rotate_around_point` is implemented as an `AffineTransform::rotate`, and
+    // the trait's performance note tells callers to compose transforms when
+    // they want several at once — which only makes sense if the two routes
+    // agree.
+    #[hegel::test]
+    fn rotate_around_point_matches_the_affine_rotation(tc: hegel::TestCase) {
+        let polygon = tc.draw(star_polygons());
+        let origin = Point::from(tc.draw(coords(1e3)));
+        let angle = degrees(&tc);
+        assert_eq!(
+            polygon.rotate_around_point(angle, origin),
+            polygon.affine_transform(&AffineTransform::rotate(angle, origin))
+        );
+    }
+
+    // Rotation is a rigid motion, so it changes neither lengths nor areas.
+    #[hegel::test]
+    fn rotation_preserves_length(tc: hegel::TestCase) {
+        let line_string = tc.draw(monotone_line_strings(1e3, 12));
+        let angle = degrees(&tc);
+        assert_relative_eq!(
+            Euclidean.length(&line_string.rotate_around_center(angle)),
+            Euclidean.length(&line_string),
+            max_relative = 1e-9
+        );
+    }
+
+    #[hegel::test]
+    fn rotation_preserves_unsigned_area(tc: hegel::TestCase) {
+        let polygon = tc.draw(star_polygons());
+        let angle = degrees(&tc);
+        assert_relative_eq!(
+            polygon.rotate_around_centroid(angle).unsigned_area(),
+            polygon.unsigned_area(),
+            max_relative = 1e-9
+        );
+    }
+}

--- a/geo/src/algorithm/rotate.rs
+++ b/geo/src/algorithm/rotate.rs
@@ -579,7 +579,7 @@ mod test {
 #[cfg(test)]
 mod hegel_props {
     use super::Rotate;
-    use crate::utils::pbt_gens::{coords, monotone_line_strings, star_polygons};
+    use crate::utils::hegel_gens::{coords, monotone_line_strings, star_polygons};
     use crate::{AffineOps, AffineTransform, Area, Euclidean, Length, Point};
     use hegel::generators;
 

--- a/geo/src/algorithm/scale.rs
+++ b/geo/src/algorithm/scale.rs
@@ -128,3 +128,97 @@ where
         self.affine_transform_mut(&affineop)
     }
 }
+
+#[cfg(test)]
+mod hegel_props {
+    use super::Scale;
+    use crate::utils::pbt_gens::{coords, star_polygons};
+    use crate::{AffineOps, AffineTransform, Area, BoundingRect, Point};
+    use hegel::generators;
+
+    fn factor(tc: &hegel::TestCase) -> f64 {
+        tc.draw(generators::floats::<f64>().min_value(0.25).max_value(4.0))
+    }
+
+    // `scale` is documented as scaling "from it's bounding box center", so
+    // scaling by 1 must be a no-op.
+    #[hegel::test]
+    fn scaling_by_one_changes_nothing(tc: hegel::TestCase) {
+        let polygon = tc.draw(star_polygons());
+        assert_eq!(polygon.scale(1.0), polygon);
+    }
+
+    // Scaling by a factor and then by its reciprocal about the same fixed point
+    // returns the original geometry.
+    #[hegel::test]
+    fn scaling_about_a_point_is_undone_by_the_reciprocal_factor(tc: hegel::TestCase) {
+        let polygon = tc.draw(star_polygons());
+        let origin = Point::from(tc.draw(coords(1e3)));
+        let f = factor(&tc);
+        let round_tripped =
+            polygon
+                .scale_around_point(f, f, origin)
+                .scale_around_point(1.0 / f, 1.0 / f, origin);
+        for (before, after) in polygon.exterior().0.iter().zip(&round_tripped.exterior().0) {
+            let tolerance = 1e-9
+                * before
+                    .x
+                    .abs()
+                    .max(before.y.abs())
+                    .max(origin.x().abs())
+                    .max(1.0);
+            assert!(
+                (after.x - before.x).abs() <= tolerance && (after.y - before.y).abs() <= tolerance,
+                "{before:?} came back as {after:?}"
+            );
+        }
+    }
+
+    // "Scale a geometry from it's bounding box center", so the bounding box
+    // centre is the fixed point of `scale_xy`.
+    #[hegel::test]
+    fn scale_xy_fixes_the_bounding_box_centre(tc: hegel::TestCase) {
+        let polygon = tc.draw(star_polygons());
+        let centre = polygon
+            .bounding_rect()
+            .expect("polygons have coords")
+            .center();
+        let scaled = polygon.scale_xy(factor(&tc), factor(&tc));
+        let scaled_centre = scaled
+            .bounding_rect()
+            .expect("polygons have coords")
+            .center();
+        let tolerance = 1e-9 * centre.x.abs().max(centre.y.abs()).max(1.0);
+        assert!(
+            (scaled_centre.x - centre.x).abs() <= tolerance
+                && (scaled_centre.y - centre.y).abs() <= tolerance,
+            "bounding box centre moved from {centre:?} to {scaled_centre:?}"
+        );
+    }
+
+    // Uniform scaling multiplies area by the square of the factor.
+    #[hegel::test]
+    fn uniform_scaling_squares_the_factor_into_the_area(tc: hegel::TestCase) {
+        let polygon = tc.draw(star_polygons());
+        let f = factor(&tc);
+        assert_relative_eq!(
+            polygon.scale(f).unsigned_area(),
+            polygon.unsigned_area() * f * f,
+            max_relative = 1e-9
+        );
+    }
+
+    // `scale_around_point` delegates to `AffineTransform::scale`; the trait's
+    // performance note directs callers to compose transforms instead of
+    // chaining, which relies on the two agreeing.
+    #[hegel::test]
+    fn scale_around_point_matches_the_affine_scaling(tc: hegel::TestCase) {
+        let polygon = tc.draw(star_polygons());
+        let origin = Point::from(tc.draw(coords(1e3)));
+        let (x, y) = (factor(&tc), factor(&tc));
+        assert_eq!(
+            polygon.scale_around_point(x, y, origin),
+            polygon.affine_transform(&AffineTransform::scale(x, y, origin))
+        );
+    }
+}

--- a/geo/src/algorithm/scale.rs
+++ b/geo/src/algorithm/scale.rs
@@ -132,7 +132,7 @@ where
 #[cfg(test)]
 mod hegel_props {
     use super::Scale;
-    use crate::utils::pbt_gens::{coords, star_polygons};
+    use crate::utils::hegel_gens::{coords, star_polygons};
     use crate::{AffineOps, AffineTransform, Area, BoundingRect, Point};
     use hegel::generators;
 

--- a/geo/src/algorithm/simplify.rs
+++ b/geo/src/algorithm/simplify.rs
@@ -628,7 +628,7 @@ mod test {
 #[cfg(test)]
 mod hegel_props {
     use super::Simplify;
-    use crate::utils::pbt_gens::{line_strings, monotone_line_strings, star_polygons};
+    use crate::utils::hegel_gens::{line_strings, monotone_line_strings, star_polygons};
     use crate::{Coord, Euclidean, Length, LineString};
     use hegel::generators;
 

--- a/geo/src/algorithm/simplify.rs
+++ b/geo/src/algorithm/simplify.rs
@@ -624,3 +624,157 @@ mod test {
         assert_eq!(actual, expected);
     }
 }
+
+#[cfg(test)]
+mod hegel_props {
+    use super::Simplify;
+    use crate::utils::pbt_gens::{line_strings, monotone_line_strings, star_polygons};
+    use crate::{Coord, Euclidean, Length, LineString};
+    use hegel::generators;
+
+    fn epsilons(tc: &hegel::TestCase) -> f64 {
+        tc.draw(hegel::one_of!(
+            generators::floats::<f64>().min_value(0.0).max_value(1e4),
+            generators::floats::<f64>().min_value(-1e4).max_value(0.0),
+        ))
+    }
+
+    // `simplify_idx` returns "the indices of the points retained by
+    // `Simplify::simplify`, relative to the input geometry", so mapping the
+    // indices back through the input must reproduce `simplify`'s output, and
+    // the indices must be strictly increasing and in bounds.
+    #[hegel::test]
+    fn simplify_idx_indexes_the_output_of_simplify(tc: hegel::TestCase) {
+        let line_string = tc.draw(line_strings(1e6, 24));
+        let epsilon = epsilons(&tc);
+        let indices = Simplify::simplify_idx(&line_string, epsilon);
+        assert!(
+            indices.windows(2).all(|w| w[0] < w[1]),
+            "indices are not strictly increasing: {indices:?}"
+        );
+        let indexed: Vec<Coord<f64>> = indices.iter().map(|&i| line_string.0[i]).collect();
+        assert_eq!(indexed, line_string.simplify(epsilon).0);
+    }
+
+    // "An `epsilon` less than or equal to zero will return an unaltered version
+    // of the geometry."
+    #[hegel::test]
+    fn a_non_positive_epsilon_leaves_the_geometry_alone(tc: hegel::TestCase) {
+        let line_string = tc.draw(line_strings(1e6, 24));
+        let epsilon = tc.draw(generators::floats::<f64>().min_value(-1e6).max_value(0.0));
+        assert_eq!(line_string.simplify(epsilon), line_string);
+    }
+
+    // RDP only ever drops vertices, so the output is a subsequence of the input.
+    #[hegel::test]
+    fn simplify_retains_a_subsequence_of_the_input(tc: hegel::TestCase) {
+        let line_string = tc.draw(line_strings(1e6, 24));
+        let epsilon = epsilons(&tc);
+        let simplified = line_string.simplify(epsilon);
+        let mut remaining = line_string.0.iter();
+        for coord in &simplified.0 {
+            assert!(
+                remaining.any(|candidate| candidate == coord),
+                "{simplified:?} is not a subsequence of {line_string:?}"
+            );
+        }
+    }
+
+    // Retaining a subsequence of vertices can only shorten the polyline, by the
+    // triangle inequality — the property `fuzz/fuzz_targets/simplify.rs` checks
+    // for polygon rings.
+    //
+    // Coordinates are capped at 1e150 to keep the cross product inside
+    // `Euclidean.distance(coord, &Line)` clear of overflow; see
+    // `simplify_drops_a_point_farther_than_epsilon` below.
+    #[hegel::test]
+    fn simplify_never_lengthens_a_line_string(tc: hegel::TestCase) {
+        let line_string = tc.draw(line_strings(1e150, 24));
+        let epsilon = epsilons(&tc);
+        let simplified = line_string.simplify(epsilon);
+        let before = Euclidean.length(&line_string);
+        let after = Euclidean.length(&simplified);
+        assert!(
+            after <= before * (1.0 + 1e-9) + 1e-9,
+            "simplification lengthened the line string: {before} -> {after}"
+        );
+    }
+
+    // However aggressive the epsilon, a simplified ring keeps enough vertices
+    // to stay a ring: `POLYGON_INITIAL_MIN` is 4, which is what
+    // `simplify_line_string_polygon_initial_min` and `dont_oversimplify` above
+    // pin for particular inputs.
+    #[hegel::test]
+    fn simplifying_a_polygon_leaves_each_ring_with_four_coords(tc: hegel::TestCase) {
+        let polygon = tc.draw(star_polygons());
+        let epsilon = epsilons(&tc);
+        let simplified = polygon.simplify(epsilon);
+        assert!(simplified.exterior().0.len() >= 4);
+        assert!(simplified.exterior().is_closed());
+    }
+
+    // Every retained vertex is at most `epsilon` from the simplified output:
+    // "points closer than `epsilon` distance from the simplified output may be
+    // discarded", so a vertex farther than `epsilon` may not be. Distances are
+    // measured against the output polyline with an independent point-to-segment
+    // formula.
+    //
+    // The input is x-monotone so that the discarded vertex's nearest point on
+    // the output is on a segment RDP actually considered; a self-crossing input
+    // can put a dropped vertex far from the output without RDP being wrong.
+    #[hegel::test]
+    fn discarded_vertices_are_within_epsilon_of_the_output(tc: hegel::TestCase) {
+        let line_string = tc.draw(monotone_line_strings(1e3, 16));
+        let epsilon = tc.draw(generators::floats::<f64>().min_value(1e-3).max_value(1e3));
+        let simplified = line_string.simplify(epsilon);
+        for coord in &line_string.0 {
+            let distance = distance_to_polyline(*coord, &simplified);
+            assert!(
+                distance <= epsilon * (1.0 + 1e-9) + 1e-9,
+                "{coord:?} is {distance} from the simplified output, beyond epsilon {epsilon}"
+            );
+        }
+    }
+
+    /// Least distance from `coord` to any segment of `line_string`, by the
+    /// projection formula, so the check does not reuse the distance code
+    /// `compute_rdp` calls.
+    fn distance_to_polyline(coord: Coord<f64>, line_string: &LineString<f64>) -> f64 {
+        line_string
+            .lines()
+            .map(|line| {
+                let d = line.end - line.start;
+                let length_squared = d.x * d.x + d.y * d.y;
+                let t = if length_squared == 0.0 {
+                    0.0
+                } else {
+                    (((coord - line.start).x * d.x + (coord - line.start).y * d.y) / length_squared)
+                        .clamp(0.0, 1.0)
+                };
+                let nearest = line.start + d * t;
+                (coord - nearest).x.hypot((coord - nearest).y)
+            })
+            .fold(f64::INFINITY, f64::min)
+    }
+
+    // KNOWN FAILURE, georust/geo#1606: `simplify` drops the middle vertex, which
+    // sits about 3.0 from the output, for an `epsilon` of 2.0. Coordinates this
+    // large also trip the library's own `debug_assert_ne!(farthest_index, 0)`
+    // above, so this test panics rather than failing its assertion.
+    #[test]
+    #[ignore = "geo#1606: simplify drops a vertex farther than epsilon at large coordinates"]
+    fn simplify_drops_a_point_farther_than_epsilon() {
+        let line_string = LineString::from(vec![
+            Coord {
+                x: 0.0,
+                y: -8.988465674311469e307,
+            },
+            Coord { x: 0.0, y: 0.0 },
+            Coord { x: 3.0, y: -0.0 },
+        ]);
+        let simplified = line_string.simplify(2.0);
+        for coord in &line_string.0 {
+            assert!(distance_to_polyline(*coord, &simplified) <= 2.0);
+        }
+    }
+}

--- a/geo/src/algorithm/simplify.rs
+++ b/geo/src/algorithm/simplify.rs
@@ -757,12 +757,12 @@ mod hegel_props {
             .fold(f64::INFINITY, f64::min)
     }
 
-    // KNOWN FAILURE, georust/geo#1606: `simplify` drops the middle vertex, which
+    // KNOWN FAILURE, #1606: `simplify` drops the middle vertex, which
     // sits about 3.0 from the output, for an `epsilon` of 2.0. Coordinates this
     // large also trip the library's own `debug_assert_ne!(farthest_index, 0)`
     // above, so this test panics rather than failing its assertion.
     #[test]
-    #[ignore = "geo#1606: simplify drops a vertex farther than epsilon at large coordinates"]
+    #[ignore = "#1606: simplify drops a vertex farther than epsilon at large coordinates"]
     fn simplify_drops_a_point_farther_than_epsilon() {
         let line_string = LineString::from(vec![
             Coord {

--- a/geo/src/algorithm/simplify_vw.rs
+++ b/geo/src/algorithm/simplify_vw.rs
@@ -1217,7 +1217,7 @@ mod hegel_props {
         );
     }
 
-    // KNOWN FAILURE, georust/geo#1605 (open): `simplify_vw` guards `epsilon <= 0` in
+    // KNOWN FAILURE, #1605 (open): `simplify_vw` guards `epsilon <= 0` in
     // `visvalingam`, but `simplify_vw_idx` calls `visvalingam_indices`, which
     // has no such guard. Its removal loop breaks on `area > epsilon`, so a
     // collinear triple has `0.0 > 0.0 == false` and the middle point is dropped
@@ -1225,7 +1225,7 @@ mod hegel_props {
     // an unaltered version of the geometry" and `simplify_vw_idx`'s promise to
     // report the points `simplify_vw` retains.
     #[test]
-    #[ignore = "geo#1605: simplify_vw_idx does not honour a non-positive epsilon"]
+    #[ignore = "#1605: simplify_vw_idx does not honour a non-positive epsilon"]
     fn simplify_vw_idx_ignores_a_zero_epsilon() {
         let line_string = LineString::from(vec![
             Coord { x: 0.0, y: 0.0 },

--- a/geo/src/algorithm/simplify_vw.rs
+++ b/geo/src/algorithm/simplify_vw.rs
@@ -1139,3 +1139,99 @@ mod idx_tests {
         assert!(result[1].interiors().is_empty());
     }
 }
+
+#[cfg(test)]
+mod hegel_props {
+    use super::{SimplifyVw, SimplifyVwPreserve};
+    use crate::utils::pbt_gens::line_strings;
+    use crate::{Coord, LineString};
+    use hegel::generators;
+
+    fn epsilons(tc: &hegel::TestCase) -> f64 {
+        tc.draw(generators::floats::<f64>().min_value(1e-6).max_value(1e6))
+    }
+
+    // `simplify_vw_idx` returns "the indices of the points retained by
+    // `SimplifyVw::simplify_vw`, relative to the input geometry".
+    //
+    // Epsilon is kept strictly positive: at zero the two disagree, pinned by
+    // `simplify_vw_idx_ignores_a_zero_epsilon` below.
+    #[hegel::test]
+    fn simplify_vw_idx_indexes_the_output_of_simplify_vw(tc: hegel::TestCase) {
+        let line_string = tc.draw(line_strings(1e6, 24));
+        let epsilon = epsilons(&tc);
+        let indices = line_string.simplify_vw_idx(epsilon);
+        assert!(
+            indices.windows(2).all(|w| w[0] < w[1]),
+            "indices are not strictly increasing: {indices:?}"
+        );
+        let indexed: Vec<Coord<f64>> = indices.iter().map(|&i| line_string.0[i]).collect();
+        assert_eq!(indexed, line_string.simplify_vw(epsilon).0);
+    }
+
+    #[hegel::test]
+    fn simplify_vw_preserve_idx_indexes_the_output_of_simplify_vw_preserve(tc: hegel::TestCase) {
+        let line_string = tc.draw(line_strings(1e6, 24));
+        let epsilon = epsilons(&tc);
+        let indices = line_string.simplify_vw_preserve_idx(epsilon);
+        let indexed: Vec<Coord<f64>> = indices.iter().map(|&i| line_string.0[i]).collect();
+        assert_eq!(indexed, line_string.simplify_vw_preserve(epsilon).0);
+    }
+
+    // "An `epsilon` less than or equal to zero will return an unaltered version
+    // of the geometry."
+    #[hegel::test]
+    fn a_non_positive_epsilon_leaves_the_geometry_alone(tc: hegel::TestCase) {
+        let line_string = tc.draw(line_strings(1e6, 24));
+        let epsilon = tc.draw(generators::floats::<f64>().min_value(-1e6).max_value(0.0));
+        assert_eq!(line_string.simplify_vw(epsilon), line_string);
+        assert_eq!(line_string.simplify_vw_preserve(epsilon), line_string);
+    }
+
+    // Both variants only drop vertices, so the output is a subsequence of the
+    // input.
+    #[hegel::test]
+    fn simplify_vw_retains_a_subsequence_of_the_input(tc: hegel::TestCase) {
+        let line_string = tc.draw(line_strings(1e6, 24));
+        let simplified = line_string.simplify_vw(epsilons(&tc));
+        let mut remaining = line_string.0.iter();
+        for coord in &simplified.0 {
+            assert!(
+                remaining.any(|candidate| candidate == coord),
+                "{simplified:?} is not a subsequence of {line_string:?}"
+            );
+        }
+    }
+
+    // The removal rule is documented as "if the area of this triangle is less
+    // than `epsilon`, we will remove the point", so a larger epsilon can only
+    // remove more.
+    #[hegel::test]
+    fn a_larger_epsilon_never_retains_more_points(tc: hegel::TestCase) {
+        let line_string = tc.draw(line_strings(1e6, 24));
+        let small = epsilons(&tc);
+        let large = small * tc.draw(generators::floats::<f64>().min_value(1.0).max_value(1e3));
+        assert!(
+            line_string.simplify_vw(large).0.len() <= line_string.simplify_vw(small).0.len(),
+            "epsilon {large} kept more points than {small}"
+        );
+    }
+
+    // KNOWN FAILURE, georust/geo#1605 (open): `simplify_vw` guards `epsilon <= 0` in
+    // `visvalingam`, but `simplify_vw_idx` calls `visvalingam_indices`, which
+    // has no such guard. Its removal loop breaks on `area > epsilon`, so a
+    // collinear triple has `0.0 > 0.0 == false` and the middle point is dropped
+    // — contradicting both "an `epsilon` less than or equal to zero will return
+    // an unaltered version of the geometry" and `simplify_vw_idx`'s promise to
+    // report the points `simplify_vw` retains.
+    #[test]
+    #[ignore = "geo#1605: simplify_vw_idx does not honour a non-positive epsilon"]
+    fn simplify_vw_idx_ignores_a_zero_epsilon() {
+        let line_string = LineString::from(vec![
+            Coord { x: 0.0, y: 0.0 },
+            Coord { x: 1.0, y: 0.0 },
+            Coord { x: 2.0, y: 0.0 },
+        ]);
+        assert_eq!(line_string.simplify_vw_idx(0.0), vec![0, 1, 2]);
+    }
+}

--- a/geo/src/algorithm/simplify_vw.rs
+++ b/geo/src/algorithm/simplify_vw.rs
@@ -1143,7 +1143,7 @@ mod idx_tests {
 #[cfg(test)]
 mod hegel_props {
     use super::{SimplifyVw, SimplifyVwPreserve};
-    use crate::utils::pbt_gens::line_strings;
+    use crate::utils::hegel_gens::line_strings;
     use crate::{Coord, LineString};
     use hegel::generators;
 

--- a/geo/src/algorithm/translate.rs
+++ b/geo/src/algorithm/translate.rs
@@ -154,3 +154,76 @@ mod test {
         assert_eq!(rotated.interiors()[0].0, correct_inside);
     }
 }
+
+#[cfg(test)]
+mod hegel_props {
+    use super::Translate;
+    use crate::utils::pbt_gens::{geometries, star_polygons};
+    use crate::{AffineOps, AffineTransform, Coord, LineString};
+    use hegel::generators::{self, Generator, PrintableGenerator};
+
+    /// Line strings with integer coordinates, where translation is exact.
+    fn integer_line_strings() -> impl PrintableGenerator<LineString<i32>> {
+        generators::vecs(
+            generators::tuples!(generators::integers::<i16>(), generators::integers::<i16>())
+                .map(|(x, y)| Coord {
+                    x: x as i32,
+                    y: y as i32,
+                })
+                .print_as_debug(),
+        )
+        .map(LineString::new)
+        .print_as_debug()
+    }
+
+    // `Translate` is implemented for any `CoordNum`, so on integers the offsets
+    // cancel exactly and translating back must restore the input.
+    #[hegel::test]
+    fn translating_integer_coords_and_back_restores_them(tc: hegel::TestCase) {
+        let line_string = tc.draw(integer_line_strings());
+        let (dx, dy) = tc.draw(generators::tuples!(
+            generators::integers::<i16>(),
+            generators::integers::<i16>()
+        ));
+        assert_eq!(
+            line_string
+                .translate(dx as i32, dy as i32)
+                .translate(-(dx as i32), -(dy as i32)),
+            line_string
+        );
+    }
+
+    // "Translate a Geometry along its axes by the given offsets", so successive
+    // translations add up.
+    #[hegel::test]
+    fn successive_translations_add_their_offsets(tc: hegel::TestCase) {
+        let line_string = tc.draw(integer_line_strings());
+        let a = tc.draw(generators::integers::<i16>()) as i32;
+        let b = tc.draw(generators::integers::<i16>()) as i32;
+        assert_eq!(
+            line_string.translate(a, 0).translate(b, 0),
+            line_string.translate(a + b, 0)
+        );
+    }
+
+    #[hegel::test]
+    fn translate_matches_the_affine_translation(tc: hegel::TestCase) {
+        let polygon = tc.draw(star_polygons());
+        let offset = tc.draw(crate::utils::pbt_gens::coords(1e6));
+        assert_eq!(
+            polygon.translate(offset.x, offset.y),
+            polygon.affine_transform(&AffineTransform::translate(offset.x, offset.y))
+        );
+    }
+
+    // "Apply `transform` immutably, outputting a new geometry" versus "Apply
+    // `transform` to mutate `self`".
+    #[hegel::test]
+    fn translate_mut_matches_translate(tc: hegel::TestCase) {
+        let geometry = tc.draw(geometries(1e6));
+        let offset = tc.draw(crate::utils::pbt_gens::coords(1e6));
+        let mut in_place = geometry.clone();
+        in_place.translate_mut(offset.x, offset.y);
+        assert_eq!(geometry.translate(offset.x, offset.y), in_place);
+    }
+}

--- a/geo/src/algorithm/translate.rs
+++ b/geo/src/algorithm/translate.rs
@@ -158,7 +158,7 @@ mod test {
 #[cfg(test)]
 mod hegel_props {
     use super::Translate;
-    use crate::utils::pbt_gens::{geometries, star_polygons};
+    use crate::utils::hegel_gens::{coords, geometries, star_polygons};
     use crate::{AffineOps, AffineTransform, Coord, LineString};
     use hegel::generators::{self, Generator, PrintableGenerator};
 
@@ -209,7 +209,7 @@ mod hegel_props {
     #[hegel::test]
     fn translate_matches_the_affine_translation(tc: hegel::TestCase) {
         let polygon = tc.draw(star_polygons());
-        let offset = tc.draw(crate::utils::pbt_gens::coords(1e6));
+        let offset = tc.draw(coords(1e6));
         assert_eq!(
             polygon.translate(offset.x, offset.y),
             polygon.affine_transform(&AffineTransform::translate(offset.x, offset.y))
@@ -221,7 +221,7 @@ mod hegel_props {
     #[hegel::test]
     fn translate_mut_matches_translate(tc: hegel::TestCase) {
         let geometry = tc.draw(geometries(1e6));
-        let offset = tc.draw(crate::utils::pbt_gens::coords(1e6));
+        let offset = tc.draw(coords(1e6));
         let mut in_place = geometry.clone();
         in_place.translate_mut(offset.x, offset.y);
         assert_eq!(geometry.translate(offset.x, offset.y), in_place);

--- a/geo/src/algorithm/validation/tests.rs
+++ b/geo/src/algorithm/validation/tests.rs
@@ -488,3 +488,87 @@ mod gdal_test_cases {
         assert!(polygon.is_valid());
     }
 }
+
+mod hegel_props {
+    use crate::algorithm::validation::Validation;
+    use crate::utils::pbt_gens::{
+        convex_polygons, disjoint_multi_polygons, geometries, polygons_with_holes, star_polygons,
+    };
+    use crate::{Geometry, Polygon};
+
+    fn assert_valid(polygon: &Polygon<f64>) {
+        assert!(
+            polygon.is_valid(),
+            "{polygon:?} reported invalid: {:?}",
+            polygon.validation_errors()
+        );
+    }
+
+    // Star-shaped rings are simple by construction (see the generator), so the
+    // rules listed on `InvalidPolygon` are all satisfied and the validator must
+    // accept them. This also guards the generator the other properties rely on.
+    #[hegel::test]
+    fn star_polygons_are_valid(tc: hegel::TestCase) {
+        assert_valid(&tc.draw(star_polygons()));
+    }
+
+    #[hegel::test]
+    fn convex_polygons_are_valid(tc: hegel::TestCase) {
+        assert_valid(&tc.draw(convex_polygons()));
+    }
+
+    // The generator places each hole in its own cell of a grid inscribed in the
+    // exterior, so interior rings are contained in the exterior and pairwise
+    // disjoint.
+    #[hegel::test]
+    fn polygons_with_disjoint_holes_are_valid(tc: hegel::TestCase) {
+        assert_valid(&tc.draw(polygons_with_holes()));
+    }
+
+    // `InvalidMultiPolygon` requires valid, non-overlapping members touching at
+    // most at points; the generator spaces members further apart than their
+    // diameter.
+    #[hegel::test]
+    fn multi_polygons_of_spaced_out_members_are_valid(tc: hegel::TestCase) {
+        let multi_polygon = tc.draw(disjoint_multi_polygons());
+        assert!(
+            multi_polygon.is_valid(),
+            "{multi_polygon:?} reported invalid: {:?}",
+            multi_polygon.validation_errors()
+        );
+    }
+
+    // `Geometry`'s validity is documented as its inner variant's validity:
+    // "e.g. `Geometry::Polygon(polygon)` is valid if and only if `polygon` is
+    // valid."
+    #[hegel::test]
+    fn wrapping_a_geometry_in_the_enum_preserves_validity(tc: hegel::TestCase) {
+        let geometry = tc.draw(geometries(1e3));
+        let inner_valid = match &geometry {
+            Geometry::Point(g) => g.is_valid(),
+            Geometry::Line(g) => g.is_valid(),
+            Geometry::LineString(g) => g.is_valid(),
+            Geometry::Polygon(g) => g.is_valid(),
+            Geometry::MultiPoint(g) => g.is_valid(),
+            Geometry::MultiLineString(g) => g.is_valid(),
+            Geometry::MultiPolygon(g) => g.is_valid(),
+            Geometry::GeometryCollection(g) => g.is_valid(),
+            Geometry::Rect(g) => g.is_valid(),
+            Geometry::Triangle(g) => g.is_valid(),
+        };
+        assert_eq!(geometry.is_valid(), inner_valid);
+    }
+
+    // `check_validation` is documented to "return the first reason of
+    // invalidity", and `validation_errors` to return them all, so the two must
+    // agree on both whether the geometry is valid and on the leading error.
+    #[hegel::test]
+    fn check_validation_reports_the_first_of_all_validation_errors(tc: hegel::TestCase) {
+        let geometry = tc.draw(geometries(1e3));
+        let all = geometry.validation_errors();
+        match geometry.check_validation() {
+            Ok(()) => assert!(all.is_empty(), "valid geometry reported errors: {all:?}"),
+            Err(first) => assert_eq!(Some(&first), all.first()),
+        }
+    }
+}

--- a/geo/src/algorithm/validation/tests.rs
+++ b/geo/src/algorithm/validation/tests.rs
@@ -491,7 +491,7 @@ mod gdal_test_cases {
 
 mod hegel_props {
     use crate::algorithm::validation::Validation;
-    use crate::utils::pbt_gens::{
+    use crate::utils::hegel_gens::{
         convex_polygons, disjoint_multi_polygons, geometries, polygons_with_holes, star_polygons,
     };
     use crate::{Geometry, Polygon};

--- a/geo/src/algorithm/winding_order.rs
+++ b/geo/src/algorithm/winding_order.rs
@@ -278,7 +278,7 @@ mod test {
 #[cfg(test)]
 mod hegel_props {
     use super::{Winding, WindingOrder, triangle_winding_order};
-    use crate::utils::pbt_gens::{grid_coords, star_polygons};
+    use crate::utils::hegel_gens::{grid_coords, star_polygons};
     use crate::{LineString, Triangle, coord};
 
     // The generator walks its vertices at strictly increasing angles about a

--- a/geo/src/algorithm/winding_order.rs
+++ b/geo/src/algorithm/winding_order.rs
@@ -274,3 +274,114 @@ mod test {
         assert_eq!(&ls.points_ccw().collect::<Vec<_>>(), &ccw_ls,);
     }
 }
+
+#[cfg(test)]
+mod hegel_props {
+    use super::{Winding, WindingOrder, triangle_winding_order};
+    use crate::utils::pbt_gens::{grid_coords, star_polygons};
+    use crate::{LineString, Triangle, coord};
+
+    // The generator walks its vertices at strictly increasing angles about a
+    // centre, which is counter-clockwise.
+    #[hegel::test]
+    fn a_ring_traced_at_increasing_angles_is_counter_clockwise(tc: hegel::TestCase) {
+        let ring = tc.draw(star_polygons()).exterior().clone();
+        assert_eq!(ring.winding_order(), Some(WindingOrder::CounterClockwise));
+    }
+
+    #[hegel::test]
+    fn reversing_a_ring_inverts_its_winding_order(tc: hegel::TestCase) {
+        let ring = tc.draw(star_polygons()).exterior().clone();
+        let reversed = LineString::new(ring.0.iter().rev().copied().collect());
+        assert_eq!(
+            reversed.winding_order(),
+            ring.winding_order().map(|order| order.inverse())
+        );
+    }
+
+    // `is_cw` and `is_ccw` are documented as "True iff this is wound
+    // clockwise"/"counterclockwise", and `WindingOrder` has no third variant, so
+    // at most one of them can hold.
+    #[hegel::test]
+    fn at_most_one_winding_predicate_holds(tc: hegel::TestCase) {
+        let ring = tc.draw(star_polygons()).exterior().clone();
+        assert_eq!(
+            ring.is_cw(),
+            ring.winding_order() == Some(WindingOrder::Clockwise)
+        );
+        assert_eq!(
+            ring.is_ccw(),
+            ring.winding_order() == Some(WindingOrder::CounterClockwise)
+        );
+        assert!(!(ring.is_cw() && ring.is_ccw()));
+    }
+
+    // `make_winding_order` changes "the winding order so that it is in this
+    // winding order", and the only way to do that without moving vertices is to
+    // leave the ring alone or reverse it wholesale.
+    #[hegel::test]
+    fn make_winding_order_either_keeps_or_reverses_the_coords(tc: hegel::TestCase) {
+        let ring = tc.draw(star_polygons()).exterior().clone();
+        let order = if tc.draw(hegel::generators::booleans()) {
+            WindingOrder::Clockwise
+        } else {
+            WindingOrder::CounterClockwise
+        };
+        let mut rewound = ring.clone();
+        rewound.make_winding_order(order);
+        assert_eq!(rewound.winding_order(), Some(order));
+        let reversed: Vec<_> = ring.0.iter().rev().copied().collect();
+        assert!(rewound.0 == ring.0 || rewound.0 == reversed);
+    }
+
+    // `points_cw` and `points_ccw` return the points "either in order, or in
+    // reverse order", so for a ring with a defined winding they are exact
+    // reverses of one another.
+    #[hegel::test]
+    fn points_cw_is_the_reverse_of_points_ccw(tc: hegel::TestCase) {
+        let ring = tc.draw(star_polygons()).exterior().clone();
+        let cw: Vec<_> = ring.points_cw().collect();
+        let ccw: Vec<_> = ring.points_ccw().collect();
+        assert_eq!(cw, ccw.into_iter().rev().collect::<Vec<_>>());
+    }
+
+    // `triangle_winding_order` is a "special cased algorithm" using a plain
+    // cross product, while `LineString::winding_order` goes through the kernel.
+    // On the exact integer grid the cross product is exact, so the two must
+    // agree. Collinear triangles are excluded: they disagree there, pinned by
+    // `a_degenerate_triangle_has_no_winding_order` below.
+    #[hegel::test]
+    fn triangle_winding_order_agrees_with_its_rings_winding(tc: hegel::TestCase) {
+        let triangle = Triangle::new(
+            tc.draw(grid_coords()),
+            tc.draw(grid_coords()),
+            tc.draw(grid_coords()),
+        );
+        let [a, b, c] = triangle.to_array();
+        tc.assume(
+            robust::orient2d(
+                robust::Coord { x: a.x, y: a.y },
+                robust::Coord { x: b.x, y: b.y },
+                robust::Coord { x: c.x, y: c.y },
+            ) != 0.0,
+        );
+        assert_eq!(
+            triangle_winding_order(&triangle),
+            triangle.to_polygon().exterior().winding_order()
+        );
+    }
+
+    // KNOWN FAILURE, georust/geo#1608: `triangle_winding_order` reports a
+    // triangle with two distinct vertices as clockwise, where the same
+    // triangle's exterior ring reports no winding order.
+    #[test]
+    #[ignore = "geo#1608: triangle_winding_order reports a two-vertex triangle as clockwise"]
+    fn a_degenerate_triangle_has_no_winding_order() {
+        let triangle = Triangle::new(
+            coord! { x: 0.0, y: 0.0 },
+            coord! { x: 0.0, y: 0.0 },
+            coord! { x: 0.0, y: -1.0 },
+        );
+        assert_eq!(triangle_winding_order(&triangle), None);
+    }
+}

--- a/geo/src/algorithm/winding_order.rs
+++ b/geo/src/algorithm/winding_order.rs
@@ -371,11 +371,11 @@ mod hegel_props {
         );
     }
 
-    // KNOWN FAILURE, georust/geo#1608: `triangle_winding_order` reports a
+    // KNOWN FAILURE, #1608: `triangle_winding_order` reports a
     // triangle with two distinct vertices as clockwise, where the same
     // triangle's exterior ring reports no winding order.
     #[test]
-    #[ignore = "geo#1608: triangle_winding_order reports a two-vertex triangle as clockwise"]
+    #[ignore = "#1608: triangle_winding_order reports a two-vertex triangle as clockwise"]
     fn a_degenerate_triangle_has_no_winding_order() {
         let triangle = Triangle::new(
             coord! { x: 0.0, y: 0.0 },

--- a/geo/src/utils.rs
+++ b/geo/src/utils.rs
@@ -117,6 +117,324 @@ pub fn normalize_longitude<T: CoordFloat + FromPrimitive>(coord: T) -> T {
     ((coord + five_forty) % three_sixty) - one_eighty
 }
 
+/// Generators shared by the hegel property tests throughout the crate.
+///
+/// Geometry types are foreign to hegel, so nothing here can implement
+/// `PrettyPrintable`: each generator ends in `print_as_debug()`, and the draws
+/// it makes internally are silent so that a counterexample reports the
+/// assembled geometry rather than the floats it was built from.
+#[cfg(test)]
+pub(crate) mod pbt_gens {
+    use crate::{
+        Coord, Geometry, GeometryCollection, Line, LineString, MultiLineString, MultiPoint,
+        MultiPolygon, Point, Polygon, Rect, Triangle, coord,
+    };
+    use hegel::compose;
+    use hegel::generators::{self, Generator, PrintableGenerator};
+    use std::f64::consts::TAU;
+
+    fn float(min: f64, max: f64) -> impl PrintableGenerator<f64> {
+        generators::floats::<f64>().min_value(min).max_value(max)
+    }
+
+    fn draw_coord(tc: &hegel::TestCase, max_coord: f64) -> Coord<f64> {
+        let (x, y) = tc.draw_silent(generators::tuples!(
+            float(-max_coord, max_coord),
+            float(-max_coord, max_coord)
+        ));
+        coord! { x: x, y: y }
+    }
+
+    /// `n` angular gaps summing to a full turn, each strictly less than half a
+    /// turn.
+    ///
+    /// Raw gaps come from `[0.5, 0.99]`. With `n >= 3` the gaps other than the
+    /// largest sum to at least `1.0 > 0.99`, so after normalisation no gap
+    /// reaches `pi`. Vertices at the cumulative angles are then in strictly
+    /// increasing angular order with no gap spanning a half turn, which makes
+    /// the ring star-shaped about its centre and hence simple.
+    fn draw_angular_gaps(tc: &hegel::TestCase, n: usize) -> Vec<f64> {
+        let raw: Vec<f64> =
+            tc.draw_silent(generators::vecs(float(0.5, 0.99)).min_size(n).max_size(n));
+        let total: f64 = raw.iter().sum();
+        raw.into_iter().map(|gap| gap / total * TAU).collect()
+    }
+
+    fn ring(centre: Coord<f64>, gaps: &[f64], radii: &[f64]) -> LineString<f64> {
+        let mut angle = 0.0_f64;
+        LineString::new(
+            gaps.iter()
+                .zip(radii)
+                .map(|(gap, radius)| {
+                    angle += gap;
+                    coord! {
+                        x: centre.x + radius * angle.cos(),
+                        y: centre.y + radius * angle.sin(),
+                    }
+                })
+                .collect(),
+        )
+    }
+
+    /// A simple star-shaped ring about `centre` with 3 to 24 vertices at radii
+    /// in `[min_radius, max_radius]`.
+    fn draw_star_ring(
+        tc: &hegel::TestCase,
+        centre: Coord<f64>,
+        min_radius: f64,
+        max_radius: f64,
+    ) -> LineString<f64> {
+        let n = tc.draw_silent(generators::integers::<usize>().min_value(3).max_value(24));
+        let gaps = draw_angular_gaps(tc, n);
+        let radii: Vec<f64> = tc.draw_silent(
+            generators::vecs(float(min_radius, max_radius))
+                .min_size(n)
+                .max_size(n),
+        );
+        ring(centre, &gaps, &radii)
+    }
+
+    /// Simple polygons without holes.
+    ///
+    /// The centre (`±1e3`) and radius (`0.5..=1e3`) bounds keep areas and
+    /// perimeters well clear of f64 rounding noise, which is what the
+    /// tolerances in the area- and length-comparison properties are sized
+    /// against; they are not claims about the library's domain.
+    pub(crate) fn star_polygons() -> impl PrintableGenerator<Polygon<f64>> {
+        compose!(|tc| {
+            let centre = draw_coord(tc, 1e3);
+            Polygon::new(draw_star_ring(tc, centre, 0.5, 1e3), vec![])
+        })
+        .print_as_debug()
+    }
+
+    /// The pieces of a cyclic polygon: the exterior ring and the radius of its
+    /// inscribed circle.
+    ///
+    /// All vertices share one radius, so the vertices lie on a circle in
+    /// angular order and the ring is convex. The inscribed circle then has
+    /// radius `radius * min(cos(gap / 2))`, the least distance from the centre
+    /// to a chord.
+    fn draw_cyclic_ring(tc: &hegel::TestCase, centre: Coord<f64>) -> (LineString<f64>, f64) {
+        let radius = tc.draw_silent(float(1.0, 1e3));
+        let n = tc.draw_silent(generators::integers::<usize>().min_value(3).max_value(24));
+        let gaps = draw_angular_gaps(tc, n);
+        let inscribed = gaps
+            .iter()
+            .map(|gap| radius * (gap / 2.0).cos())
+            .fold(f64::INFINITY, f64::min);
+        (ring(centre, &gaps, &vec![radius; n]), inscribed)
+    }
+
+    /// Convex polygons without holes.
+    pub(crate) fn convex_polygons() -> impl PrintableGenerator<Polygon<f64>> {
+        compose!(|tc| {
+            let centre = draw_coord(tc, 1e3);
+            Polygon::new(draw_cyclic_ring(tc, centre).0, vec![])
+        })
+        .print_as_debug()
+    }
+
+    /// Polygons with 0 to 4 holes, valid by construction.
+    ///
+    /// The exterior is convex, and each hole is a star ring confined to its own
+    /// cell of a 2x2 grid inscribed in the exterior's inscribed circle, so
+    /// holes lie strictly inside the exterior and never meet one another —
+    /// what `InvalidPolygon` requires of interior rings.
+    pub(crate) fn polygons_with_holes() -> impl PrintableGenerator<Polygon<f64>> {
+        compose!(|tc| {
+            let centre = draw_coord(tc, 1e3);
+            let (exterior, inscribed) = draw_cyclic_ring(tc, centre);
+            // The largest axis-aligned square inside the inscribed circle has
+            // side `inscribed * sqrt(2)`, so a 2x2 grid of `inscribed * 0.7`
+            // cells fits with room to spare.
+            let cell = inscribed * 0.7;
+            let cells = tc.draw_silent(generators::subsequences(vec![
+                (0, 0),
+                (0, 1),
+                (1, 0),
+                (1, 1),
+            ]));
+            let interiors = cells
+                .into_iter()
+                .map(|(i, j)| {
+                    let hole_centre = coord! {
+                        x: centre.x + (i as f64 - 0.5) * cell,
+                        y: centre.y + (j as f64 - 0.5) * cell,
+                    };
+                    // Radii below half the cell size keep each hole inside its
+                    // own cell.
+                    draw_star_ring(tc, hole_centre, cell * 0.05, cell * 0.4)
+                })
+                .collect();
+            Polygon::new(exterior, interiors)
+        })
+        .print_as_debug()
+    }
+
+    /// Multi polygons of 1 to 6 pairwise disjoint star polygons.
+    ///
+    /// Members sit on a grid whose spacing is three times the maximum radius,
+    /// so no two can touch — the non-overlap condition
+    /// `InvalidMultiPolygon` checks.
+    pub(crate) fn disjoint_multi_polygons() -> impl PrintableGenerator<MultiPolygon<f64>> {
+        compose!(|tc| {
+            let origin = draw_coord(tc, 1e3);
+            let radius = tc.draw_silent(float(0.5, 1e2));
+            let cells = tc.draw_silent(
+                generators::subsequences(vec![(0, 0), (0, 1), (1, 0), (1, 1), (2, 0), (2, 1)])
+                    .min_size(1),
+            );
+            MultiPolygon::new(
+                cells
+                    .into_iter()
+                    .map(|(i, j)| {
+                        let centre = coord! {
+                            x: origin.x + i as f64 * 3.0 * radius,
+                            y: origin.y + j as f64 * 3.0 * radius,
+                        };
+                        Polygon::new(draw_star_ring(tc, centre, radius * 0.2, radius), vec![])
+                    })
+                    .collect(),
+            )
+        })
+        .print_as_debug()
+    }
+
+    /// Finite coordinates with both components in `[-max_coord, max_coord]`.
+    pub(crate) fn coords(max_coord: f64) -> impl PrintableGenerator<Coord<f64>> {
+        compose!(|tc| { draw_coord(tc, max_coord) }).print_as_debug()
+    }
+
+    /// Coordinates on the integer grid `[-64, 64]^2`.
+    ///
+    /// Such coordinates and every difference and product of two of them are
+    /// exact in f64, so duplicate and exactly-collinear points are common and
+    /// a property can compare against exact arithmetic.
+    pub(crate) fn grid_coords() -> impl PrintableGenerator<Coord<f64>> {
+        compose!(|tc| {
+            let component = || generators::integers::<i8>().min_value(-64).max_value(64);
+            let (x, y) = tc.draw_silent(generators::tuples!(component(), component()));
+            coord! { x: x as f64, y: y as f64 }
+        })
+        .print_as_debug()
+    }
+
+    /// Line strings of up to `max_len` finite coordinates, possibly empty and
+    /// possibly with repeated coordinates.
+    pub(crate) fn line_strings(
+        max_coord: f64,
+        max_len: usize,
+    ) -> impl PrintableGenerator<LineString<f64>> {
+        compose!(|tc| {
+            let n = tc.draw_silent(generators::integers::<usize>().max_value(max_len));
+            LineString::new((0..n).map(|_| draw_coord(tc, max_coord)).collect())
+        })
+        .print_as_debug()
+    }
+
+    /// Line strings of 2 to `max_len` coordinates whose x values strictly
+    /// increase.
+    ///
+    /// Consecutive segments therefore have disjoint x ranges apart from their
+    /// shared endpoint, so the string is simple and never retraces itself —
+    /// what set operations on 1-D geometry need to preserve length.
+    pub(crate) fn monotone_line_strings(
+        max_coord: f64,
+        max_len: usize,
+    ) -> impl PrintableGenerator<LineString<f64>> {
+        compose!(|tc| {
+            let n = tc.draw_silent(
+                generators::integers::<usize>()
+                    .min_value(2)
+                    .max_value(max_len),
+            );
+            let mut x = tc.draw_silent(float(-max_coord, max_coord));
+            let step = max_coord / max_len as f64;
+            LineString::new(
+                (0..n)
+                    .map(|i| {
+                        if i > 0 {
+                            x += tc.draw_silent(float(step * 0.01, step));
+                        }
+                        coord! { x: x, y: tc.draw_silent(float(-max_coord, max_coord)) }
+                    })
+                    .collect(),
+            )
+        })
+        .print_as_debug()
+    }
+
+    /// Any of the ten `Geometry` variants, with finite coordinates bounded by
+    /// `max_coord`. Rings are arbitrary rather than simple, so this covers
+    /// properties that hold for any geometry rather than only valid ones.
+    pub(crate) fn geometries(max_coord: f64) -> impl PrintableGenerator<Geometry<f64>> {
+        fn ring(tc: &hegel::TestCase, max_coord: f64) -> LineString<f64> {
+            tc.draw_silent(line_strings(max_coord, 8))
+        }
+        fn point(tc: &hegel::TestCase, max_coord: f64) -> Point<f64> {
+            Point::from(draw_coord(tc, max_coord))
+        }
+        fn count(tc: &hegel::TestCase) -> usize {
+            tc.draw_silent(generators::integers::<usize>().max_value(3))
+        }
+        hegel::one_of!(
+            compose!(|tc| { Geometry::Point(point(tc, max_coord)) }),
+            compose!(|tc| {
+                Geometry::Line(Line::new(
+                    draw_coord(tc, max_coord),
+                    draw_coord(tc, max_coord),
+                ))
+            }),
+            compose!(|tc| { Geometry::LineString(tc.draw_silent(line_strings(max_coord, 12))) }),
+            compose!(|tc| {
+                Geometry::Polygon(Polygon::new(
+                    ring(tc, max_coord),
+                    (0..count(tc)).map(|_| ring(tc, max_coord)).collect(),
+                ))
+            }),
+            compose!(|tc| {
+                Geometry::MultiPoint(MultiPoint::new(
+                    (0..count(tc)).map(|_| point(tc, max_coord)).collect(),
+                ))
+            }),
+            compose!(|tc| {
+                Geometry::MultiLineString(MultiLineString::new(
+                    (0..count(tc)).map(|_| ring(tc, max_coord)).collect(),
+                ))
+            }),
+            compose!(|tc| {
+                Geometry::MultiPolygon(MultiPolygon::new(
+                    (0..count(tc))
+                        .map(|_| Polygon::new(ring(tc, max_coord), vec![]))
+                        .collect(),
+                ))
+            }),
+            compose!(|tc| {
+                Geometry::Rect(Rect::new(
+                    draw_coord(tc, max_coord),
+                    draw_coord(tc, max_coord),
+                ))
+            }),
+            compose!(|tc| {
+                Geometry::Triangle(Triangle::new(
+                    draw_coord(tc, max_coord),
+                    draw_coord(tc, max_coord),
+                    draw_coord(tc, max_coord),
+                ))
+            }),
+            compose!(|tc| {
+                Geometry::GeometryCollection(GeometryCollection::new_from(
+                    (0..count(tc))
+                        .map(|_| Geometry::Point(point(tc, max_coord)))
+                        .collect(),
+                ))
+            }),
+        )
+        .print_as_debug()
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::{partial_max, partial_min};

--- a/geo/src/utils.rs
+++ b/geo/src/utils.rs
@@ -135,7 +135,7 @@ pub fn normalize_longitude<T: CoordFloat + FromPrimitive>(coord: T) -> T {
 /// than the floats it was built from. `hegel::compose!` turns a closure that
 /// draws from `tc` into a generator.
 #[cfg(test)]
-pub(crate) mod pbt_gens {
+pub(crate) mod hegel_gens {
     use crate::{
         Coord, Geometry, GeometryCollection, Line, LineString, MultiLineString, MultiPoint,
         MultiPolygon, Point, Polygon, Rect, Triangle, coord,

--- a/geo/src/utils.rs
+++ b/geo/src/utils.rs
@@ -119,17 +119,27 @@ pub fn normalize_longitude<T: CoordFloat + FromPrimitive>(coord: T) -> T {
 
 /// Generators shared by the hegel property tests throughout the crate.
 ///
-/// Geometry types are foreign to hegel, so nothing here can implement
-/// `PrettyPrintable`: each generator ends in `print_as_debug()`, and the draws
-/// it makes internally are silent so that a counterexample reports the
-/// assembled geometry rather than the floats it was built from.
+/// hegel is the library of the `hegeltest` dev-dependency, documented at
+/// <https://docs.rs/hegeltest>. A `#[hegel::test]` function is an ordinary
+/// `#[test]` whose body runs 100 times over inputs drawn from generators like
+/// these with `tc.draw(..)`. When a run panics, hegel shrinks the inputs and
+/// prints them as `let` bindings above the panic message, so a failing case can
+/// be pasted into a plain `#[test]`. It also saves the case under `.hegel/`
+/// (gitignored, and not written in CI) and replays it first on the next run.
+/// `tc.assume(cond)` rejects the current input when `cond` is false. Rejected
+/// inputs do not count towards the 100, and a test that rejects most of its
+/// inputs fails a health check.
+///
+/// Every generator here ends in `print_as_debug()` and draws its parts
+/// silently, so a counterexample is printed as the assembled geometry rather
+/// than the floats it was built from. `hegel::compose!` turns a closure that
+/// draws from `tc` into a generator.
 #[cfg(test)]
 pub(crate) mod pbt_gens {
     use crate::{
         Coord, Geometry, GeometryCollection, Line, LineString, MultiLineString, MultiPoint,
         MultiPolygon, Point, Polygon, Rect, Triangle, coord,
     };
-    use hegel::compose;
     use hegel::generators::{self, Generator, PrintableGenerator};
     use std::f64::consts::TAU;
 
@@ -201,7 +211,7 @@ pub(crate) mod pbt_gens {
     /// tolerances in the area- and length-comparison properties are sized
     /// against; they are not claims about the library's domain.
     pub(crate) fn star_polygons() -> impl PrintableGenerator<Polygon<f64>> {
-        compose!(|tc| {
+        hegel::compose!(|tc| {
             let centre = draw_coord(tc, 1e3);
             Polygon::new(draw_star_ring(tc, centre, 0.5, 1e3), vec![])
         })
@@ -228,7 +238,7 @@ pub(crate) mod pbt_gens {
 
     /// Convex polygons without holes.
     pub(crate) fn convex_polygons() -> impl PrintableGenerator<Polygon<f64>> {
-        compose!(|tc| {
+        hegel::compose!(|tc| {
             let centre = draw_coord(tc, 1e3);
             Polygon::new(draw_cyclic_ring(tc, centre).0, vec![])
         })
@@ -242,7 +252,7 @@ pub(crate) mod pbt_gens {
     /// holes lie strictly inside the exterior and never meet one another —
     /// what `InvalidPolygon` requires of interior rings.
     pub(crate) fn polygons_with_holes() -> impl PrintableGenerator<Polygon<f64>> {
-        compose!(|tc| {
+        hegel::compose!(|tc| {
             let centre = draw_coord(tc, 1e3);
             let (exterior, inscribed) = draw_cyclic_ring(tc, centre);
             // The largest axis-aligned square inside the inscribed circle has
@@ -278,7 +288,7 @@ pub(crate) mod pbt_gens {
     /// so no two can touch — the non-overlap condition
     /// `InvalidMultiPolygon` checks.
     pub(crate) fn disjoint_multi_polygons() -> impl PrintableGenerator<MultiPolygon<f64>> {
-        compose!(|tc| {
+        hegel::compose!(|tc| {
             let origin = draw_coord(tc, 1e3);
             let radius = tc.draw_silent(float(0.5, 1e2));
             let cells = tc.draw_silent(
@@ -303,7 +313,7 @@ pub(crate) mod pbt_gens {
 
     /// Finite coordinates with both components in `[-max_coord, max_coord]`.
     pub(crate) fn coords(max_coord: f64) -> impl PrintableGenerator<Coord<f64>> {
-        compose!(|tc| { draw_coord(tc, max_coord) }).print_as_debug()
+        hegel::compose!(|tc| { draw_coord(tc, max_coord) }).print_as_debug()
     }
 
     /// Coordinates on the integer grid `[-64, 64]^2`.
@@ -312,7 +322,7 @@ pub(crate) mod pbt_gens {
     /// exact in f64, so duplicate and exactly-collinear points are common and
     /// a property can compare against exact arithmetic.
     pub(crate) fn grid_coords() -> impl PrintableGenerator<Coord<f64>> {
-        compose!(|tc| {
+        hegel::compose!(|tc| {
             let component = || generators::integers::<i8>().min_value(-64).max_value(64);
             let (x, y) = tc.draw_silent(generators::tuples!(component(), component()));
             coord! { x: x as f64, y: y as f64 }
@@ -326,7 +336,7 @@ pub(crate) mod pbt_gens {
         max_coord: f64,
         max_len: usize,
     ) -> impl PrintableGenerator<LineString<f64>> {
-        compose!(|tc| {
+        hegel::compose!(|tc| {
             let n = tc.draw_silent(generators::integers::<usize>().max_value(max_len));
             LineString::new((0..n).map(|_| draw_coord(tc, max_coord)).collect())
         })
@@ -343,7 +353,7 @@ pub(crate) mod pbt_gens {
         max_coord: f64,
         max_len: usize,
     ) -> impl PrintableGenerator<LineString<f64>> {
-        compose!(|tc| {
+        hegel::compose!(|tc| {
             let n = tc.draw_silent(
                 generators::integers::<usize>()
                     .min_value(2)
@@ -379,51 +389,53 @@ pub(crate) mod pbt_gens {
             tc.draw_silent(generators::integers::<usize>().max_value(3))
         }
         hegel::one_of!(
-            compose!(|tc| { Geometry::Point(point(tc, max_coord)) }),
-            compose!(|tc| {
+            hegel::compose!(|tc| { Geometry::Point(point(tc, max_coord)) }),
+            hegel::compose!(|tc| {
                 Geometry::Line(Line::new(
                     draw_coord(tc, max_coord),
                     draw_coord(tc, max_coord),
                 ))
             }),
-            compose!(|tc| { Geometry::LineString(tc.draw_silent(line_strings(max_coord, 12))) }),
-            compose!(|tc| {
+            hegel::compose!(|tc| {
+                Geometry::LineString(tc.draw_silent(line_strings(max_coord, 12)))
+            }),
+            hegel::compose!(|tc| {
                 Geometry::Polygon(Polygon::new(
                     ring(tc, max_coord),
                     (0..count(tc)).map(|_| ring(tc, max_coord)).collect(),
                 ))
             }),
-            compose!(|tc| {
+            hegel::compose!(|tc| {
                 Geometry::MultiPoint(MultiPoint::new(
                     (0..count(tc)).map(|_| point(tc, max_coord)).collect(),
                 ))
             }),
-            compose!(|tc| {
+            hegel::compose!(|tc| {
                 Geometry::MultiLineString(MultiLineString::new(
                     (0..count(tc)).map(|_| ring(tc, max_coord)).collect(),
                 ))
             }),
-            compose!(|tc| {
+            hegel::compose!(|tc| {
                 Geometry::MultiPolygon(MultiPolygon::new(
                     (0..count(tc))
                         .map(|_| Polygon::new(ring(tc, max_coord), vec![]))
                         .collect(),
                 ))
             }),
-            compose!(|tc| {
+            hegel::compose!(|tc| {
                 Geometry::Rect(Rect::new(
                     draw_coord(tc, max_coord),
                     draw_coord(tc, max_coord),
                 ))
             }),
-            compose!(|tc| {
+            hegel::compose!(|tc| {
                 Geometry::Triangle(Triangle::new(
                     draw_coord(tc, max_coord),
                     draw_coord(tc, max_coord),
                     draw_coord(tc, max_coord),
                 ))
             }),
-            compose!(|tc| {
+            hegel::compose!(|tc| {
                 Geometry::GeometryCollection(GeometryCollection::new_from(
                     (0..count(tc))
                         .map(|_| Geometry::Point(point(tc, max_coord)))


### PR DESCRIPTION
Here are the promised Hegel tests for geo. I apologise for the fact that they're really quite a lot.

These were written by Claude Fable, under relatively light guidance from me on the specifics. I've got quite broad guidance on how to do this well, and I've spot checked individual tests to make sure they seem sane to me, but I do not understand geo well enough to be completely confident in them. The best I can say is that I've fixed every problem I've seen, the rest of what I've looked at looks reasonable-to-good, and they found a lot of bugs (which they currently have ignored tests for, associated with the specific issues).

As well as the ones I've already filed, there are a bunch of ignored cases in mod.rs that I don't fully understand the design considerations of. Here's what Claude had to say about them:

> Seven of the ignored tests in contains/mod.rs deliberately have no issue link. Each is a deterministic reproducer for a disagreement between Relate and the specialized Contains/Covers/Intersects implementations on degenerate or self-intersecting input: a zero-height Rect, a zero-length Line, a self-intersecting LineString, a zero-area MultiPolygon member, a polygon with an empty exterior but non-empty interior rings, and a ring holding -0.0, which panics in release builds. I haven't filed them because I don't know where you draw the line: InvalidRect only rejects non-finite coordinates and InvalidLineString permits self-intersection, so these inputs sit inside the crate's own validity model, but #1596 shows the question is live and the answers there weren't unanimous. The generators the property tests use stay inside the domain that model admits, so the suite is green as it stands and these seven are parked questions rather than failures. Tell me which you consider bugs and I'll file those and drop the rest. Two of them look like internal inconsistencies regardless of how the validity question lands: Geometry::covers disagreeing with the concrete impl it dispatches to, and Intersects consulting the interior rings of an empty polygon.

Anyway, I will be 0% offended if your response is "man this is way too much code, we can't possibly merge this". I was slightly startled when I realised how much there was here, but I guess geo has quite a broad test surface well suited to property-based testing.

If you would like me to attempt to triage it down into something smaller I can do my best, but I think most of these tests probably really are pulling their weight.

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).

