### PR TITLE
Ensure `Triangle::interior_point` is always within triangle bounds (hegel)

### DIFF
--- a/geo-types/CHANGES.md
+++ b/geo-types/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## Unreleased
+
+- Add `Triangle::center`, the mean of the triangle's vertices, mirroring `Rect::center`.
+
 ## 0.7.20 - 2026-07-31
 
 - Add support for `rstar` 0.13 via the `rstar_0_13` feature, alongside the existing `rstar` versions.

--- a/geo-types/src/geometry/triangle.rs
+++ b/geo-types/src/geometry/triangle.rs
@@ -1,4 +1,4 @@
-use crate::{polygon, Coord, CoordNum, Line, Point, Polygon};
+use crate::{coord, polygon, Coord, CoordFloat, CoordNum, Line, Point, Polygon};
 use core::cmp::Ordering;
 
 /// A bounded 2D area whose three vertices are defined by
@@ -110,6 +110,32 @@ impl<T: CoordNum> Triangle<T> {
     /// ```
     pub fn to_polygon(self) -> Polygon<T> {
         polygon![self.0, self.1, self.2, self.0]
+    }
+}
+
+impl<T: CoordFloat> Triangle<T> {
+    /// Returns the center `Coord` of the `Triangle`: the mean of its three vertices.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use geo_types::{coord, Triangle};
+    ///
+    /// let triangle = Triangle::new(
+    ///     coord! { x: 0., y: 0. },
+    ///     coord! { x: 3., y: 0. },
+    ///     coord! { x: 0., y: 3. },
+    /// );
+    ///
+    /// assert_eq!(triangle.center(), coord! { x: 1., y: 1. });
+    /// ```
+    pub fn center(self) -> Coord<T> {
+        let three = T::one() + T::one() + T::one();
+        let (v1, v2, v3) = (self.v1(), self.v2(), self.v3());
+        coord! {
+            x: (v1.x + v2.x + v3.x) / three,
+            y: (v1.y + v2.y + v3.y) / three,
+        }
     }
 }
 

--- a/geo/Cargo.toml
+++ b/geo/Cargo.toml
@@ -44,10 +44,12 @@ i_overlay = { version = "4.5.1, < 4.6.0", default-features = false }
 sif-itree = "0.4.0"
 rand = { version = "0.10.0", default-features = false, features = [ "alloc" ] }
 rand_pcg = "0.10.1"
+hegeltest = "0.41.3"
 
 [dev-dependencies]
 approx = ">= 0.4.0, < 0.6.0"
 geo-test-fixtures = { path = "../geo-test-fixtures" }
+hegeltest = "0.41.3"
 jts-test-runner = { path = "../jts-test-runner" }
 pretty_env_logger = "0.4"
 wkt = "0.14.0"

--- a/geo/src/algorithm/interior_point.rs
+++ b/geo/src/algorithm/interior_point.rs
@@ -5,6 +5,8 @@ use crate::algorithm::{
     centroid::Centroid,
     coords_iter::CoordsIter,
     dimensions::HasDimensions,
+    intersects::Intersects,
+    kernels::{Kernel, Orientation},
     line_intersection::LineIntersection,
     line_measures::{Distance, Euclidean},
     lines_iter::LinesIter,
@@ -14,6 +16,7 @@ use crate::geometry::*;
 // use crate::old_sweep::{Intersections, SweepPoint};
 use crate::GeoFloat;
 use crate::sweep::Intersections;
+use crate::utils::lex_cmp;
 
 /// Calculation of interior points.
 ///
@@ -372,18 +375,43 @@ where
     type Output = Point<T>;
 
     fn interior_point(&self) -> Self::Output {
-        self.centroid()
+        let candidate =
+            if T::Ker::orient2d(self.v1(), self.v2(), self.v3()) == Orientation::Collinear {
+                // A triangle like this is degenerate in some way, for example, it could be that
+                // all the points are on a straight line. We use the midpoint of the longest
+                // distance edge in this case.
+                let vertices = self.to_array();
+                let start = vertices
+                    .iter()
+                    .min_by(|a, b| lex_cmp(a, b))
+                    .expect("A triangle has three vertices");
+                let end = vertices
+                    .iter()
+                    .max_by(|a, b| lex_cmp(a, b))
+                    .expect("A triangle has three vertices");
+                (*start + *end) / (T::one() + T::one())
+            } else {
+                self.center()
+            };
+
+        // Rounding can still push the candidate off a very thin or degenerate triangle.
+        if self.intersects(&candidate) {
+            candidate.into()
+        } else {
+            // Just use the first vertex if we cannot do anything else.
+            self.v1().into()
+        }
     }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::utils::property_tests::draw_valid_triangle;
     use crate::{
         algorithm::{contains::Contains, intersects::Intersects},
         coord, line_string, point, polygon,
     };
-    use crate::utils::property_tests::draw_valid_triangle;
     use hegel::TestCase;
 
     /// small helper to create a coordinate

--- a/geo/src/algorithm/interior_point.rs
+++ b/geo/src/algorithm/interior_point.rs
@@ -383,6 +383,8 @@ mod test {
         algorithm::{contains::Contains, intersects::Intersects},
         coord, line_string, point, polygon,
     };
+    use crate::utils::property_tests::draw_valid_triangle;
+    use hegel::TestCase;
 
     /// small helper to create a coordinate
     fn c<T: GeoFloat>(x: T, y: T) -> Coord<T> {
@@ -758,38 +760,6 @@ mod test {
             mixed_shapes.interior_point().unwrap()
         )
     }
-    #[test]
-    fn triangles() {
-        // boring triangle
-        assert_eq!(
-            Triangle::new(c(0., 0.), c(3., 0.), c(1.5, 3.)).interior_point(),
-            point!(x: 1.5, y: 1.0)
-        );
-
-        // flat triangle
-        assert_eq!(
-            Triangle::new(c(0., 0.), c(3., 0.), c(1., 0.)).interior_point(),
-            point!(x: 1.5, y: 0.0)
-        );
-
-        // flat triangle that's not axis-aligned
-        assert_eq!(
-            Triangle::new(c(0., 0.), c(3., 3.), c(1., 1.)).interior_point(),
-            point!(x: 1.5, y: 1.5)
-        );
-
-        // triangle with some repeated points
-        assert_eq!(
-            Triangle::new(c(0., 0.), c(0., 0.), c(1., 0.)).interior_point(),
-            point!(x: 0.5, y: 0.0)
-        );
-
-        // triangle with all repeated points
-        assert_eq!(
-            Triangle::new(c(0., 0.5), c(0., 0.5), c(0., 0.5)).interior_point(),
-            point!(x: 0., y: 0.5)
-        )
-    }
 
     #[test]
     fn degenerate_triangle_like_ring() {
@@ -928,5 +898,12 @@ mod test {
             ],
         );
         let _ = poly.interior_point();
+    }
+
+    #[hegel::test]
+    fn triangles(tc: TestCase) {
+        let triangle = draw_valid_triangle(&tc);
+        let point = triangle.interior_point();
+        assert!(triangle.intersects(&point), "{point:?}");
     }
 }

--- a/geo/src/utils.rs
+++ b/geo/src/utils.rs
@@ -133,3 +133,26 @@ mod test {
         assert_eq!(4, partial_min(4, 4));
     }
 }
+/// Generators and helpers shared by the property-based tests that run under `hegel`.
+#[cfg(test)]
+pub(crate) mod property_tests {
+    use crate::{Coord, Triangle, Validation};
+    use hegel::TestCase;
+
+    hegel::derive_generator!(CoordGenerator for Coord {
+        x: f64,
+        y: f64,
+    });
+
+    /// Draws a triangle from three arbitrary coordinates, rejecting the test case if it is not
+    /// valid.
+    pub(crate) fn draw_valid_triangle(tc: &TestCase) -> Triangle<f64> {
+        let triangle = Triangle::new(
+            tc.draw(CoordGenerator::new()),
+            tc.draw(CoordGenerator::new()),
+            tc.draw(CoordGenerator::new()),
+        );
+        tc.assume(triangle.check_validation().is_ok());
+        triangle
+    }
+}


### PR DESCRIPTION
Fixes #1607. This PR adds a Hegel test for ensuring `triangle.intersects(&triangle.interior_point())`.
We fix the sliver issue by adding `center` for `Triangle` (mirroring `Rect` which already had it).
Furthermore, we explicitly handle degenerate (straight line) triangles by setting the midpoint to the long edge.

This PR was prepared with the help of Claude Fable 5.1.


- [X] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [X] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
