### PR TITLE
Make `Contains<Rect> for Rect` conform to DE-9IM standard

### DIFF
--- a/geo/CHANGES.md
+++ b/geo/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- `Contains<Rect>` now conforms to DE-9IM semantics, meaning that one or zero dimensional rectangles may react differently. See diagrams in `geo/src/algorithm/contains/rect.rs`.
+
 - BREAKING: `GeoNum` (and therefore `GeoFloat`) now requires `Send + Sync`. This lets algorithms behind the `multithreading` feature share coordinates across threads without per-algorithm bounds. All supported primitive scalar types already satisfy the bound; only downstream `GeoNum` implementations on non-thread-safe types are affected.
 
 - Add `Intersects<Coord>` and `Intersects<Point>` implementations for `IntervalTreeMultiPolygon`. Unlike the existing `Contains` impls, these return `true` for points on the polygon's boundary.

--- a/geo/src/algorithm/contains/rect.rs
+++ b/geo/src/algorithm/contains/rect.rs
@@ -1,6 +1,7 @@
 use geo_types::CoordFloat;
 
 use super::{Contains, impl_contains_from_relate, impl_contains_geometry_for};
+use crate::dimensions::Dimensions;
 use crate::{Area, CoordsIter, HasDimensions, Intersects, geometry::*};
 use crate::{CoordNum, GeoFloat};
 
@@ -31,12 +32,109 @@ where
     T: CoordNum,
 {
     fn contains(&self, other: &Rect<T>) -> bool {
-        // TODO: check for degenerate rectangle (which is a line or a point)
-        // All points of LineString must be in the polygon ?
-        self.min().x <= other.min().x
-            && self.max().x >= other.max().x
-            && self.min().y <= other.min().y
-            && self.max().y >= other.max().y
+        use Dimensions::*;
+
+        // We need to handle dimensions seperately to properly conform to DE-9IM
+        match (self.dimensions(), other.dimensions()) {
+            (TwoDimensional, TwoDimensional) => {
+                self.min().x <= other.min().x
+                    && other.max().x <= self.max().x
+                    && self.min().y <= other.min().y
+                    && other.max().y <= self.max().y
+            }
+
+            (TwoDimensional, OneDimensional) => {
+                let inside_bounds = self.min().x <= other.min().x
+                    && other.max().x <= self.max().x
+                    && self.min().y <= other.min().y
+                    && other.max().y <= self.max().y;
+
+                // If the line is not contained at all, early return.
+                if !inside_bounds {
+                    return false;
+                }
+
+                if other.min().x == other.max().x {
+                    // Vertical line (| represent the line, ==== for rect)
+                    //
+                    // DE-9IM does not accept this as contained (as it is on the boundary)
+                    // │═════════════╗
+                    // │             ║
+                    // │             ║
+                    // │             ║
+                    // │═════════════╝
+                    //
+                    // however, this is.
+                    // ╔═══════│═════╗
+                    // ║       │     ║
+                    // ║       │     ║
+                    // ║       │     ║
+                    // ╚═══════│═════╝
+
+                    self.min().x < other.min().x && other.min().x < self.max().x
+                } else {
+                    // Horizontal line (| represent the line, ==== for rect)
+                    //
+                    // DE-9IM does not accept this as contained (as it is on the boundary)
+                    // ───────────────
+                    // ║             ║
+                    // ║             ║
+                    // ║             ║
+                    // ╚═════════════╝
+                    //
+                    // however, this is.
+                    // ╔═════════════╗
+                    // ║             ║
+                    // ║ ─────────── ║
+                    // ║             ║
+                    // ╚═════════════╝
+
+                    self.min().y < other.min().y && other.min().y < self.max().y
+                }
+            }
+
+            (TwoDimensional, ZeroDimensional) => {
+                let p = other.min();
+
+                self.min().x < p.x && p.x < self.max().x && self.min().y < p.y && p.y < self.max().y
+            }
+
+            (OneDimensional, OneDimensional) => {
+                if self.min().x == self.max().x {
+                    // If the line is vertical we need the other line to also be vertical as well as bounds on y
+                    other.min().x == self.min().x
+                        && other.max().x == self.max().x
+                        && self.min().y <= other.min().y
+                        && other.max().y <= self.max().y
+                } else {
+                    other.min().y == self.min().y
+                        && other.max().y == self.max().y
+                        && self.min().x <= other.min().x
+                        && other.max().x <= self.max().x
+                }
+            }
+
+            (OneDimensional, ZeroDimensional) => {
+                let p = other.min();
+
+                // Need point not on the boundary of the line
+                if self.min().x == self.max().x {
+                    // Vertical line
+                    p.x == self.min().x && self.min().y < p.y && p.y < self.max().y
+                } else {
+                    // Horizontal line
+                    p.y == self.min().y && self.min().x < p.x && p.x < self.max().x
+                }
+            }
+
+            (ZeroDimensional, ZeroDimensional) => self.min() == other.min(),
+
+            // A geometry cannot contain a higher-dimensional geometry.
+            (ZeroDimensional, OneDimensional | TwoDimensional)
+            | (OneDimensional, TwoDimensional) => false,
+
+            (Empty, _) | (_, Empty) => unreachable!("Empty dimension, should not be possible."),
+        }
     }
 }
 


### PR DESCRIPTION
We change `Contains<Rect<T>> for Rect<T>` conform to DE-9IM standards by handling degenerate cases explicitly.

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.

Part of #1611.
